### PR TITLE
simd: update simd type names

### DIFF
--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -63,22 +63,22 @@ export {
   namespace Kokkos::Experimental {
   using ::Kokkos::Experimental::all_of;
   using ::Kokkos::Experimental::any_of;
-  using ::Kokkos::Experimental::basic_simd;
-  using ::Kokkos::Experimental::basic_simd_mask;
+  using ::Kokkos::Experimental::basic_mask;
+  using ::Kokkos::Experimental::basic_vec;
   using ::Kokkos::Experimental::condition;
+  using ::Kokkos::Experimental::mask;
   using ::Kokkos::Experimental::none_of;
   using ::Kokkos::Experimental::reduce;
   using ::Kokkos::Experimental::reduce_max;
   using ::Kokkos::Experimental::reduce_min;
   using ::Kokkos::Experimental::round_half_to_nearest_even;
-  using ::Kokkos::Experimental::simd;
   using ::Kokkos::Experimental::simd_flag_aligned;
   using ::Kokkos::Experimental::simd_flag_default;
-  using ::Kokkos::Experimental::simd_mask;
   using ::Kokkos::Experimental::simd_partial_load;
   using ::Kokkos::Experimental::simd_partial_store;
   using ::Kokkos::Experimental::simd_unchecked_load;
   using ::Kokkos::Experimental::simd_unchecked_store;
+  using ::Kokkos::Experimental::vec;
 
   using ::Kokkos::Experimental::operator+=;
   using ::Kokkos::Experimental::operator*=;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -242,45 +242,52 @@ using native = ForSpace<T, Kokkos::DefaultExecutionSpace>;
 
 }  // namespace simd_abi
 
+template <class T, int N = 0>
+using vec = basic_vec<T, simd_abi::Impl::native_abi<T, N>>;
+
+template <class T, int N = 0>
+using mask = basic_mask<T, simd_abi::Impl::native_abi<T, N>>;
+
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T>
 using native_simd KOKKOS_DEPRECATED_WITH_COMMENT("Use simd<T> instead") =
-    basic_simd<T, simd_abi::native<T>>;
+    basic_vec<T, simd_abi::native<T>>;
 template <class T>
 using native_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use simd_mask<T> instead") = basic_simd_mask<T, simd_abi::native<T>>;
+    "Use simd_mask<T> instead") = basic_mask<T, simd_abi::native<T>>;
+
+template <class T, int N = 0>
+using simd KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::Experimental::vec instead") = vec<T, N>;
+
+template <class T, int N = 0>
+using simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::Experimental::mask instead") = mask<T, N>;
 #endif
-
-template <class T, int N = 0>
-using simd = basic_simd<T, simd_abi::Impl::native_abi<T, N>>;
-
-template <class T, int N = 0>
-using simd_mask = basic_simd_mask<T, simd_abi::Impl::native_abi<T, N>>;
 
 template <
     typename T, typename... Flags,
     std::enable_if_t<
-        !std::is_same_v<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>,
-                        basic_simd<T, simd_abi::scalar>>,
+        !std::is_same_v<basic_vec<T, simd_abi::Impl::host_fixed_native<T>>,
+                        basic_vec<T, simd_abi::scalar>>,
         bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
+    basic_vec<T, simd_abi::Impl::host_fixed_native<T>>
     simd_unchecked_load(const T* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
   return simd_unchecked_load<
-      basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(ptr, flag);
+      basic_vec<T, simd_abi::Impl::host_fixed_native<T>>>(ptr, flag);
 }
 
-template <
-    typename T, typename... Flags,
-    std::enable_if_t<
-        std::is_same_v<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>,
-                       basic_simd<T, simd_abi::scalar>>,
-        bool> = false>
-KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar>
+template <typename T, typename... Flags,
+          std::enable_if_t<
+              std::is_same_v<basic_vec<T, simd_abi::Impl::host_fixed_native<T>>,
+                             basic_vec<T, simd_abi::scalar>>,
+              bool> = false>
+KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec<T, simd_abi::scalar>
 simd_unchecked_load(const T* ptr,
                     simd_flags<Flags...> flag = simd_flag_default) {
-  return simd_unchecked_load<basic_simd<T, simd_abi::scalar>>(ptr, flag);
+  return simd_unchecked_load<basic_vec<T, simd_abi::scalar>>(ptr, flag);
 }
 
 namespace Impl {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -42,7 +42,7 @@ class avx2_fixed_size {};
 }  // namespace simd_abi
 
 template <>
-class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
+class basic_mask<double, simd_abi::avx2_fixed_size<4>> {
   __m256d m_value;
 
  public:
@@ -53,26 +53,26 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value)))) {
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask(
             [&](std::size_t i) { return static_cast<double>(other[i]); }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(
+      basic_mask<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m256d const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
@@ -80,7 +80,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -93,10 +93,9 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m256d>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_pd(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m256d>(basic_mask(true));
+    return basic_mask(_mm256_andnot_pd(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
@@ -104,28 +103,28 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_movemask_pd(lhs.m_value) ==
-                           _mm256_movemask_pd(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_movemask_pd(lhs.m_value) ==
+                      _mm256_movemask_pd(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
+class basic_mask<float, simd_abi::avx2_fixed_size<4>> {
   __m128 m_value;
 
  public:
@@ -136,19 +135,19 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask(
             [&](std::size_t i) { return static_cast<float>(other[i]); }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m128 const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
@@ -156,7 +155,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -169,10 +168,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m128>(basic_simd_mask(true));
-    return basic_simd_mask(_mm_andnot_ps(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m128>(basic_mask(true));
+    return basic_mask(_mm_andnot_ps(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
@@ -180,28 +178,28 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_movemask_ps(lhs.m_value) ==
-                           _mm_movemask_ps(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_movemask_ps(lhs.m_value) ==
+                      _mm_movemask_ps(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
+class basic_mask<float, simd_abi::avx2_fixed_size<8>> {
   __m256 m_value;
 
  public:
@@ -212,26 +210,26 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask(
             [&](std::size_t i) { return static_cast<float>(other[i]); }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -248,10 +246,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m256>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_ps(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m256>(basic_mask(true));
+    return basic_mask(_mm256_andnot_ps(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
@@ -259,28 +256,28 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_movemask_ps(lhs.m_value) ==
-                           _mm256_movemask_ps(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_movemask_ps(lhs.m_value) ==
+                      _mm256_movemask_ps(rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
+class basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
  public:
@@ -291,19 +288,19 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask([&](std::size_t i) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask([&](std::size_t i) {
           return static_cast<std::int32_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m128i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
@@ -311,7 +308,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -324,10 +321,9 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m128i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm_andnot_si128(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m128i>(basic_mask(true));
+    return basic_mask(_mm_andnot_si128(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
@@ -335,28 +331,28 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_movemask_ps(_mm_castsi128_ps(lhs.m_value)) ==
-                           _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm_movemask_ps(_mm_castsi128_ps(lhs.m_value)) ==
+                      _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+class basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   __m256i m_value;
 
  public:
@@ -367,19 +363,19 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask([&](std::size_t i) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask([&](std::size_t i) {
           return static_cast<std::int32_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class G,
@@ -387,7 +383,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -404,10 +400,9 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m256i>(basic_mask(true));
+    return basic_mask(_mm256_andnot_si256(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -415,29 +410,28 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_ps(_mm256_castsi256_ps(lhs.m_value)) ==
-        _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_movemask_ps(_mm256_castsi256_ps(lhs.m_value)) ==
+                      _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
@@ -448,31 +442,31 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask([&](std::size_t i) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask([&](std::size_t i) {
           return static_cast<std::int64_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(
+      basic_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -485,10 +479,9 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m256i>(basic_mask(true));
+    return basic_mask(_mm256_andnot_si256(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -496,29 +489,28 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
-        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+                      _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
@@ -529,31 +521,31 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<U, abi_type> const& other) noexcept
-      : basic_simd_mask([&](std::size_t i) {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<U, abi_type> const& other) noexcept
+      : basic_mask([&](std::size_t i) {
           return static_cast<std::uint64_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(
+      basic_mask<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
+      basic_mask<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<std::size_t, 0>())),
@@ -566,10 +558,9 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    auto const true_value = static_cast<__m256i>(basic_mask(true));
+    return basic_mask(_mm256_andnot_si256(m_value, true_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -577,143 +568,142 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
-        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
+                      _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
     return !operator==(lhs, rhs);
   }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+basic_mask<double, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<float, abi_type> const& other) noexcept
     : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+basic_mask<double, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+basic_mask<double, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int64_t, abi_type> const& other) noexcept
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+basic_mask<double, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::uint64_t, abi_type> const& other) noexcept
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+basic_mask<float, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+basic_mask<float, simd_abi::avx2_fixed_size<8>>::basic_mask(
+    basic_mask<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<float, abi_type> const& other) noexcept
     : m_value(_mm_castps_si128(static_cast<__m128>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_mask(
+    basic_mask<float, abi_type> const& other) noexcept
     : m_value(_mm256_castps_si256(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<double, abi_type> const& other) noexcept
+basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<double, abi_type> const& other) noexcept
     : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::uint64_t, abi_type> const& other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<double, abi_type> const& other) noexcept
+basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<double, abi_type> const& other) noexcept
     : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_mask(
+    basic_mask<std::int64_t, abi_type> const& other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 template <>
-class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
+class basic_vec<double, simd_abi::avx2_fixed_size<4>> {
   __m256d m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256d const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm256_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -721,7 +711,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -731,7 +721,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm256_maskload_pd(
         ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)));
@@ -772,59 +762,59 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(
         _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
@@ -833,141 +823,141 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+copysign(Experimental::basic_vec<
              double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
                     _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> abs(
+    Experimental::basic_vec<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_vec<
       double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_vec<
      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_vec<
       double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_vec<
       double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_round_pd(static_cast<__m256d>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-sqrt(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+sqrt(Experimental::basic_vec<
      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_sqrt_pd(static_cast<__m256d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-cbrt(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+cbrt(Experimental::basic_vec<
      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cbrt_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-exp(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> exp(
+    Experimental::basic_vec<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_exp_pd(static_cast<__m256d>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-log(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> log(
+    Experimental::basic_vec<
+        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_log_pd(static_cast<__m256d>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-fma(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> fma(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
                       static_cast<__m256d>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> max(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>> min(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
 }
 
@@ -978,20 +968,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
+    basic_vec<double, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const double* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, flag);
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
+    basic_vec<double, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -999,40 +989,38 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
+    basic_vec<double, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<double,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_partial_load(const double* ptr,
+                  basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<double,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_partial_load(const double* ptr,
+                  basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
+    basic_vec<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -1044,84 +1032,82 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask, FlagType) {
   _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
                       static_cast<__m256d>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask, FlagType) {
   _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
                       static_cast<__m256d>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(
+basic_vec<double, simd_abi::avx2_fixed_size<4>> condition(
+    basic_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_vec<double, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_vec<double, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_vec<double, simd_abi::avx2_fixed_size<4>>(
       _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
                        static_cast<__m256d>(a)));
 }
 
 template <>
-class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
+class basic_vec<float, simd_abi::avx2_fixed_size<4>> {
   __m128 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m128 const& value_in) noexcept
       : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen) noexcept
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
                             gen(std::integral_constant<std::size_t, 2>()),
                             gen(std::integral_constant<std::size_t, 3>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1131,7 +1117,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)));
   }
@@ -1171,49 +1157,49 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_div_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm_div_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
   }
 };
@@ -1221,141 +1207,141 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_xor_ps(_mm_andnot_ps(sign_mask, static_cast<__m128>(a)),
                  _mm_and_ps(sign_mask, static_cast<__m128>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> ceil(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_round_ps(static_cast<__m128>(a),
                    (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> sqrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_sqrt_ps(static_cast<__m128>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-cbrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> cbrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_cbrt_ps(static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_exp_ps(static_cast<__m128>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_log_ps(static_cast<__m128>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
                    static_cast<__m128>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
 }
 
@@ -1366,61 +1352,57 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
+    basic_vec<float, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, flag);
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<4>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -1432,75 +1414,73 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask, FlagType) {
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask, FlagType) {
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
+basic_vec<float, simd_abi::avx2_fixed_size<4>> condition(
+    basic_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_vec<float, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_vec<float, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
       static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
 }
 
 template <>
-class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
+class basic_vec<float, simd_abi::avx2_fixed_size<8>> {
   __m256 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
@@ -1511,7 +1491,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1521,7 +1501,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value =
         _mm256_maskload_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)));
@@ -1562,54 +1542,54 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
@@ -1618,141 +1598,141 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> abs(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> abs(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+floor(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> ceil(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+round(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+trunc(Experimental::basic_vec<
       float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_round_ps(static_cast<__m256>(a),
                       (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> sqrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-cbrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> cbrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> exp(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> exp(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> log(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> log(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_log_ps(static_cast<__m256>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> fma(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> fma(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
                       static_cast<__m256>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> max(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> max(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> min(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> min(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
@@ -1763,61 +1743,57 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
+    basic_vec<float, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, flag);
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<8>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<8>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<8>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx2_fixed_size<8>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -1829,77 +1805,75 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask, FlagType) {
   _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
                       static_cast<__m256>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask, FlagType) {
   _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
                       static_cast<__m256>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& b,
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+basic_vec<float, simd_abi::avx2_fixed_size<8>> condition(
+    basic_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
+    basic_vec<float, simd_abi::avx2_fixed_size<8>> const& b,
+    basic_vec<float, simd_abi::avx2_fixed_size<8>> const& c) {
+  return basic_vec<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
       static_cast<__m256>(c), static_cast<__m256>(b), static_cast<__m256>(a)));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
+class basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   __m128i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m128i const& value_in) noexcept
       : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -1907,7 +1881,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
                                gen(std::integral_constant<std::size_t, 3>()))) {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1917,7 +1891,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask));
   }
@@ -1966,64 +1940,64 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
@@ -2031,49 +2005,49 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   __m128i const rhs = static_cast<__m128i>(a);
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm_abs_epi32(rhs));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_vec<
      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
 }
 
@@ -2084,21 +2058,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2106,24 +2079,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2131,18 +2102,17 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2156,9 +2126,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
@@ -2166,70 +2136,69 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_castps_si128(
-          _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
-                        _mm_castsi128_ps(static_cast<__m128i>(b)),
-                        _mm_castsi128_ps(static_cast<__m128i>(a)))));
+basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(_mm_castps_si128(
+      _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
+                    _mm_castsi128_ps(static_cast<__m128i>(b)),
+                    _mm_castsi128_ps(static_cast<__m128i>(a)))));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
+class basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -2241,7 +2210,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2251,7 +2220,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask));
   }
@@ -2298,113 +2267,113 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs >= rhs);
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-ceil(Experimental::basic_simd<
-     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>> ceil(
+    Experimental::basic_vec<
+        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx2_fixed_size<8>>
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx2_fixed_size<8>>(
       _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
 }
 
@@ -2415,21 +2384,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2437,24 +2405,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2462,18 +2428,17 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+        basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2487,9 +2452,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
@@ -2497,20 +2462,20 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(
       _mm256_castps_si256(
           _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
                            _mm256_castsi256_ps(static_cast<__m256i>(b)),
@@ -2518,7 +2483,7 @@ basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
 }
 
 template <>
-class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
   static_assert(sizeof(long long) == 8);
@@ -2526,45 +2491,45 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -2572,7 +2537,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2582,7 +2547,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
@@ -2635,74 +2600,74 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  // fallback basic_simd multiplication using generator constructor
+  // fallback basic_vec multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  // fallback basic_simd shift right arithmetic using generator constructor
+  // fallback basic_vec shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] >> rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
   }
-  // fallback basic_simd shift right arithmetic using generator constructor
+  // fallback basic_vec shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] >> rhs; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] >> rhs; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs > rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return (lhs < rhs) || (lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return rhs > lhs;
   }
 };
@@ -2711,48 +2676,48 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<std::int64_t,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       [&](std::size_t i) { return (a[i] < 0) ? -a[i] : a[i]; });
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_vec<
      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
@@ -2763,21 +2728,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::int64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2785,24 +2749,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2810,18 +2772,17 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2835,9 +2796,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
@@ -2846,9 +2807,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
@@ -2856,11 +2817,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_castpd_si256(
           _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
                            _mm256_castsi256_pd(static_cast<__m256i>(b)),
@@ -2868,52 +2829,52 @@ basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
 }
 
 template <>
-class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
+class basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   __m256i m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(basic_vec const&) =
+      default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_vec(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -2921,7 +2882,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<std::size_t, 2>()),
             gen(std::integral_constant<std::size_t, 3>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2931,7 +2892,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
@@ -2984,104 +2945,104 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  // fallback basic_simd multiplication using generator constructor
+  // fallback basic_vec multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator&(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm256_and_si256(static_cast<__m256i>(lhs),
                             static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator|(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm256_or_si256(static_cast<__m256i>(lhs),
                            static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
                              static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
     return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
     return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
   return a;
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+floor(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+ceil(Experimental::basic_vec<
      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+round(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::avx2_fixed_size<4>>
+trunc(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx2_fixed_size<4>>(
       _mm256_setr_pd(a[0], a[1], a[2], a[3]));
 }
 
@@ -3092,65 +3053,65 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::uint64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx2_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -3164,9 +3125,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
@@ -3175,9 +3136,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
     FlagType) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
@@ -3185,11 +3146,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
+    basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
+  return basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
       _mm256_castpd_si256(
           _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
                            _mm256_castsi256_pd(static_cast<__m256i>(b)),
@@ -3197,75 +3158,75 @@ basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+basic_vec<double, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<float, abi_type> const& other) noexcept
     : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+basic_vec<double, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<double, abi_type> const& other) noexcept
+basic_vec<float, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<double, abi_type> const& other) noexcept
     : m_value(_mm256_cvtpd_ps(static_cast<__m256d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+basic_vec<float, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+basic_vec<float, simd_abi::avx2_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<float, abi_type> const& other) noexcept
     : m_value(_mm_cvtps_epi32(static_cast<__m128>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<double, abi_type> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<double, abi_type> const& other) noexcept
     : m_value(_mm256_cvtpd_epi32(static_cast<__m256d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_vec(
+    basic_vec<float, abi_type> const& other) noexcept
     : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, abi_type> const& other) noexcept
+basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::uint64_t, abi_type> const& other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::int32_t, abi_type> const& other) noexcept
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int64_t, abi_type> const& other) noexcept
+basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_vec(
+    basic_vec<std::int64_t, abi_type> const& other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_mask<double, simd_abi::avx2_fixed_size<4>>,
+                           basic_vec<double, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = basic_simd<double, abi_type>;
-  using mask_type  = basic_simd_mask<double, abi_type>;
+  using value_type = basic_vec<double, abi_type>;
+  using mask_type  = basic_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3287,7 +3248,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(double* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
                       index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3306,15 +3267,15 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-                     basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+    where_expression<basic_mask<double, simd_abi::avx2_fixed_size<4>>,
+                     basic_vec<double, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>,
-          basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
+          basic_mask<double, simd_abi::avx2_fixed_size<4>>,
+          basic_vec<double, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      basic_simd<double, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_mask<double, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_vec<double, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -3329,7 +3290,7 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_pd(
         static_cast<__m256d>(m_value), mem, static_cast<__m128i>(index),
         static_cast<__m256d>(m_mask), 8));
@@ -3337,13 +3298,13 @@ class KOKKOS_DEPRECATED
   template <
       class U,
       std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<double, simd_abi::avx2_fixed_size<4>>>,
+                           U, basic_vec<double, simd_abi::avx2_fixed_size<4>>>,
                        bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<double, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_vec<double, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = basic_simd<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
+    m_value = basic_vec<double, simd_abi::avx2_fixed_size<4>>(_mm256_blendv_pd(
         static_cast<__m256d>(m_value), static_cast<__m256d>(x_as_value_type),
         static_cast<__m256d>(m_mask)));
   }
@@ -3351,12 +3312,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    const_where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-                           basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
+    const_where_expression<basic_mask<float, simd_abi::avx2_fixed_size<4>>,
+                           basic_vec<float, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3378,7 +3339,7 @@ class KOKKOS_DEPRECATED
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(float* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
                       index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3397,15 +3358,15 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-                     basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+    where_expression<basic_mask<float, simd_abi::avx2_fixed_size<4>>,
+                     basic_vec<float, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>,
-          basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
+          basic_mask<float, simd_abi::avx2_fixed_size<4>>,
+          basic_vec<float, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask_arg,
-      basic_simd<float, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_mask<float, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_vec<float, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -3420,21 +3381,20 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm_mask_i32gather_ps(static_cast<__m128>(m_value),
                                                mem, static_cast<__m128i>(index),
                                                static_cast<__m128>(m_mask), 4));
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<float, simd_abi::avx2_fixed_size<4>>>,
-                       bool> = false>
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, basic_vec<float, simd_abi::avx2_fixed_size<4>>>,
+                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_vec<float, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
+    m_value = basic_vec<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
         static_cast<__m128>(m_value), static_cast<__m128>(x_as_value_type),
         static_cast<__m128>(m_mask)));
   }
@@ -3442,12 +3402,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    const_where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-                           basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
+    const_where_expression<basic_mask<float, simd_abi::avx2_fixed_size<8>>,
+                           basic_vec<float, simd_abi::avx2_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3469,7 +3429,7 @@ class KOKKOS_DEPRECATED
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(float* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
                       index) const {
     for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3488,15 +3448,15 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-                     basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+    where_expression<basic_mask<float, simd_abi::avx2_fixed_size<8>>,
+                     basic_vec<float, simd_abi::avx2_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>,
-          basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
+          basic_mask<float, simd_abi::avx2_fixed_size<8>>,
+          basic_vec<float, simd_abi::avx2_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask_arg,
-      basic_simd<float, simd_abi::avx2_fixed_size<8>>& value_arg)
+      basic_mask<float, simd_abi::avx2_fixed_size<8>> const& mask_arg,
+      basic_vec<float, simd_abi::avx2_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -3510,21 +3470,20 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_ps(
         static_cast<__m256>(m_value), mem, static_cast<__m256i>(index),
         static_cast<__m256>(m_mask), 4));
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<float, simd_abi::avx2_fixed_size<8>>>,
-                       bool> = false>
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, basic_vec<float, simd_abi::avx2_fixed_size<8>>>,
+                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::avx2_fixed_size<8>>>(
+        static_cast<basic_vec<float, simd_abi::avx2_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
+    m_value = basic_vec<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
         static_cast<__m256>(m_value), static_cast<__m256>(x_as_value_type),
         static_cast<__m256>(m_mask)));
   }
@@ -3532,12 +3491,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3560,7 +3519,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int32_t* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
                       index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3578,17 +3537,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+                     basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
-          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>,
+          basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -3602,7 +3560,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm_mask_i32gather_epi32(
         static_cast<__m128i>(m_value), mem, static_cast<__m128i>(index),
         static_cast<__m128i>(m_mask), 4));
@@ -3610,13 +3568,13 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>,
+                    U, basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+    m_value = basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>>(
         _mm_castps_si128(_mm_blendv_ps(
             _mm_castsi128_ps(static_cast<__m128i>(m_value)),
             _mm_castsi128_ps(static_cast<__m128i>(x_as_value_type)),
@@ -3626,12 +3584,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+    basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+    basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<8>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3653,7 +3611,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int32_t* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
                       index) const {
     for (std::size_t lane = 0; lane < value_type::size(); ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3671,17 +3629,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+                     basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
-          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+          basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>,
+          basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -3696,7 +3653,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi32(
         static_cast<__m256i>(m_value), mem, static_cast<__m256i>(index),
         static_cast<__m256i>(m_mask), 4));
@@ -3704,13 +3661,13 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>,
+                    U, basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>(
+        static_cast<basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+    m_value = basic_vec<std::int32_t, simd_abi::avx2_fixed_size<8>>(
         _mm256_castps_si256(_mm256_blendv_ps(
             _mm256_castsi256_ps(static_cast<__m256i>(m_value)),
             _mm256_castsi256_ps(static_cast<__m256i>(x_as_value_type)),
@@ -3720,12 +3677,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = basic_simd<std::int64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_vec<std::int64_t, abi_type>;
+  using mask_type  = basic_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3750,7 +3707,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int64_t* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
                       index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3768,17 +3725,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+                     basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
-          basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>,
+          basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const&
-          mask_arg,
-      basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::int64_t const* mem,
                                                        element_aligned_tag) {
@@ -3794,7 +3750,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi64(
         static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
         static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
@@ -3802,13 +3758,13 @@ class KOKKOS_DEPRECATED where_expression<
   template <class u,
             std::enable_if_t<
                 std::is_convertible_v<
-                    u, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>,
+                    u, basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(u&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<u>(x));
-    m_value = basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+    m_value = basic_vec<std::int64_t, simd_abi::avx2_fixed_size<4>>(
         _mm256_castpd_si256(_mm256_blendv_pd(
             _mm256_castsi256_pd(static_cast<__m256i>(m_value)),
             _mm256_castsi256_pd(static_cast<__m256i>(x_as_value_type)),
@@ -3818,12 +3774,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+    basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+    basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::avx2_fixed_size<4>;
-  using value_type = basic_simd<std::uint64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_vec<std::uint64_t, abi_type>;
+  using mask_type  = basic_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3848,7 +3804,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::uint64_t* mem,
-                  basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const&
                       index) const {
     for (std::size_t lane = 0; lane < 4; ++lane) {
       if (m_mask[lane]) mem[index[lane]] = m_value[lane];
@@ -3866,17 +3822,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+                     basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
-          basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+          basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>,
+          basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const&
-          mask_arg,
-      basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
+      basic_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask_arg,
+      basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(std::uint64_t const* mem,
                                                        element_aligned_tag) {
@@ -3892,7 +3847,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx2_fixed_size<4>> const& index) {
     m_value = value_type(_mm256_mask_i32gather_epi64(
         static_cast<__m256i>(m_value), reinterpret_cast<long long const*>(mem),
         static_cast<__m128i>(index), static_cast<__m256i>(m_mask), 8));
@@ -3900,13 +3855,13 @@ class KOKKOS_DEPRECATED where_expression<
   template <class u,
             std::enable_if_t<
                 std::is_convertible_v<
-                    u, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>,
+                    u, basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(u&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>(
+        static_cast<basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>>(
             std::forward<u>(x));
-    m_value = basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+    m_value = basic_vec<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
         _mm256_castpd_si256(_mm256_blendv_pd(
             _mm256_castsi256_pd(static_cast<__m256i>(m_value)),
             _mm256_castsi256_pd(static_cast<__m256i>(x_as_value_type)),

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -870,9 +870,9 @@ abs(Experimental::basic_vec<
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    floor(Experimental::basic_vec<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+floor(Experimental::basic_vec<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
   return Experimental::basic_vec<float,
                                  Experimental::simd_abi::avx512_fixed_size<8>>(
@@ -880,9 +880,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    ceil(Experimental::basic_vec<
-         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+ceil(Experimental::basic_vec<
+     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
   return Experimental::basic_vec<float,
                                  Experimental::simd_abi::avx512_fixed_size<8>>(
@@ -890,9 +890,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    round(Experimental::basic_vec<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+round(Experimental::basic_vec<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
   return Experimental::basic_vec<float,
                                  Experimental::simd_abi::avx512_fixed_size<8>>(
@@ -900,9 +900,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
-    trunc(Experimental::basic_vec<
-          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+trunc(Experimental::basic_vec<
+      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
   return Experimental::basic_vec<float,
                                  Experimental::simd_abi::avx512_fixed_size<8>>(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -41,7 +41,7 @@ class avx512_fixed_size {};
 }  // namespace simd_abi
 
 template <class T>
-class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
+class basic_mask<T, simd_abi::avx512_fixed_size<8>> {
   __mmask8 m_value;
 
  public:
@@ -52,23 +52,23 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(-std::int16_t(value)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __mmask8 const& value_in)
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(
+      basic_mask<U, simd_abi::avx512_fixed_size<8>> const& other) noexcept
       : m_value(static_cast<__mmask8>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
                   ? m_value | 0x01
@@ -102,11 +102,9 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
     return (m_value & bit_mask) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    static const __mmask8 true_value(
-        static_cast<__mmask8>(basic_simd_mask(true)));
-    return basic_simd_mask(_kxor_mask8(true_value, m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    static const __mmask8 true_value(static_cast<__mmask8>(basic_mask(true)));
+    return basic_mask(_kxor_mask8(true_value, m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
@@ -114,27 +112,27 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kand_mask8(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_kand_mask8(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kor_mask8(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_kor_mask8(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(lhs.m_value == rhs.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(lhs.m_value == rhs.m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(lhs.m_value != rhs.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(lhs.m_value != rhs.m_value);
   }
 };
 
 template <class T>
-class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
+class basic_mask<T, simd_abi::avx512_fixed_size<16>> {
   __mmask16 m_value;
 
  public:
@@ -145,23 +143,23 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     return 16;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(
       value_type value) noexcept
       : m_value(-std::int32_t(value)) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       __mmask16 const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
-      basic_simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(
+      basic_mask<U, simd_abi::avx512_fixed_size<16>> const& other) noexcept
       : m_value(static_cast<__mmask16>(other)) {}
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
                   ? m_value | 0x0001
@@ -225,11 +223,9 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     return (m_value & bit_mask) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    static const __mmask16 true_value(
-        static_cast<__mmask16>(basic_simd_mask(true)));
-    return basic_simd_mask(_kxor_mask16(true_value, m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask operator!() const noexcept {
+    static const __mmask16 true_value(static_cast<__mmask16>(basic_mask(true)));
+    return basic_mask(_kxor_mask16(true_value, m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
@@ -237,71 +233,71 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kor_mask16(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_kor_mask16(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kand_mask16(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(_kand_mask16(lhs.m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(lhs.m_value == rhs.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator==(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(lhs.m_value == rhs.m_value);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(lhs.m_value != rhs.m_value);
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_mask operator!=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(lhs.m_value != rhs.m_value);
   }
 };
 
 template <>
-class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<double, simd_abi::avx512_fixed_size<8>> {
   __m512d m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m512d const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -309,7 +305,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm512_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -321,7 +317,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -331,7 +327,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -371,8 +367,8 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     return _mm512_cvtsd_f64(tmp);
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm512_sub_pd(_mm512_set1_pd(0.0), m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512d()
@@ -380,54 +376,54 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_add_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_sub_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_mul_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_div_pd(static_cast<__m512d>(lhs), static_cast<__m512d>(rhs)));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(
         static_cast<__m512d>(lhs), static_cast<__m512d>(rhs), _CMP_NEQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
                                         static_cast<__m512d>(lhs), _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
                                         static_cast<__m512d>(rhs), _CMP_LT_OS));
   }
@@ -435,18 +431,18 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-copysign(Experimental::basic_simd<
+copysign(Experimental::basic_vec<
              double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
   static const __m512i sign_mask =
       reinterpret_cast<__m512i>(static_cast<__m512d>(
-          Experimental::basic_simd<
+          Experimental::basic_vec<
               double, Experimental::simd_abi::avx512_fixed_size<8>>(-0.0)));
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       reinterpret_cast<__m512d>(_mm512_xor_epi64(
           _mm512_andnot_epi64(
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(a))),
@@ -454,136 +450,136 @@ copysign(Experimental::basic_simd<
               sign_mask, reinterpret_cast<__m512i>(static_cast<__m512d>(b))))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const rhs = static_cast<__m512d>(a);
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 830)
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       (__m512d)_mm512_and_epi64((__m512i)rhs,
                                 _mm512_set1_epi64(0x7fffffffffffffffLL)));
 #else
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_pd(rhs));
 #endif
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEG_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_POS_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512d const val = static_cast<__m512d>(a);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_roundscale_pd(val, _MM_FROUND_TO_ZERO));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-sqrt(Experimental::basic_simd<
+sqrt(Experimental::basic_vec<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_sqrt_pd(static_cast<__m512d>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-cbrt(Experimental::basic_simd<
+cbrt(Experimental::basic_vec<
      double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cbrt_pd(static_cast<__m512d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-exp(Experimental::basic_simd<
+exp(Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_exp_pd(static_cast<__m512d>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-log(Experimental::basic_simd<
+log(Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_log_pd(static_cast<__m512d>(a)));
 }
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-fma(Experimental::basic_simd<
+fma(Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_fmadd_pd(static_cast<__m512d>(a), static_cast<__m512d>(b),
                       static_cast<__m512d>(c)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-max(Experimental::basic_simd<
+max(Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_max_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-min(Experimental::basic_simd<
+min(Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_min_pd(static_cast<__m512d>(a), static_cast<__m512d>(b)));
 }
 
@@ -594,20 +590,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    basic_vec<double, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const double* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    basic_vec<double, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -615,22 +611,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    basic_vec<double, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    basic_vec<double, simd_abi::avx512_fixed_size<8>>
     simd_partial_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -638,17 +634,17 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>
+    basic_vec<double, simd_abi::avx512_fixed_size<8>>
     simd_partial_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -660,84 +656,82 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask, FlagType) {
   _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m512d>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask, FlagType) {
   _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m512d>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<double, simd_abi::avx512_fixed_size<8>>(
+basic_vec<double, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<double, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_pd(static_cast<__mmask8>(a), static_cast<__m512d>(c),
                            static_cast<__m512d>(b)));
 }
 
 template <>
-class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<float, simd_abi::avx512_fixed_size<8>> {
   __m256 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256 const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen) noexcept
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
                                gen(std::integral_constant<std::size_t, 2>()),
@@ -748,7 +742,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
                                gen(std::integral_constant<std::size_t, 7>()))) {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -758,7 +752,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -803,49 +797,49 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_div_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
@@ -853,141 +847,141 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
                     _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+abs(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    float, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    floor(Experimental::basic_vec<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    float, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    ceil(Experimental::basic_vec<
+         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    float, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    round(Experimental::basic_vec<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    float, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+    trunc(Experimental::basic_vec<
+          float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256 const val = static_cast<__m256>(a);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_roundscale_ps(val, _MM_FROUND_TO_ZERO));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-sqrt(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+sqrt(Experimental::basic_vec<
      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_sqrt_ps(static_cast<__m256>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-cbrt(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+cbrt(Experimental::basic_vec<
      float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_cbrt_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-exp(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+exp(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_exp_ps(static_cast<__m256>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-log(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+log(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_log_ps(static_cast<__m256>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-fma(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+fma(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
                       static_cast<__m256>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-max(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+max(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<8>>
-min(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<8>>
+min(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
 }
 
@@ -998,20 +992,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>
+    basic_vec<float, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>
+    basic_vec<float, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1019,40 +1013,38 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>
+    basic_vec<float, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx512_fixed_size<8>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::avx512_fixed_size<8>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -1064,78 +1056,76 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask, FlagType) {
   _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m256>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask, FlagType) {
   _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m256>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<8>>(
+basic_vec<float, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<float, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_ps(static_cast<__mmask8>(a), static_cast<__m256>(c),
                            static_cast<__m256>(b)));
 }
 
 template <>
-class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
+class basic_vec<float, simd_abi::avx512_fixed_size<16>> {
   __m512 m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m512 const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen) noexcept
       : m_value(
             _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                            gen(std::integral_constant<std::size_t, 1>()),
@@ -1154,7 +1144,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
                            gen(std::integral_constant<std::size_t, 14>()),
                            gen(std::integral_constant<std::size_t, 15>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1164,7 +1154,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1209,49 +1199,49 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm512_sub_ps(_mm512_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_add_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_add_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_sub_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_sub_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mul_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_mul_ps(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_div_ps(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_div_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_EQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_NEQ_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmp_ps_mask(lhs.m_value, rhs.m_value, _CMP_LT_OS));
   }
 };
@@ -1259,140 +1249,141 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
   __m512 const sign_mask = _mm512_set1_ps(-0.0);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_xor_ps(_mm512_andnot_ps(sign_mask, static_cast<__m512>(a)),
                     _mm512_and_ps(sign_mask, static_cast<__m512>(b))));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-abs(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+abs(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const sign_mask = _mm512_set1_ps(-0.0);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_andnot_ps(sign_mask, static_cast<__m512>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEG_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_POS_INF));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_NEAREST_INT));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512 const val = static_cast<__m512>(a);
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_roundscale_ps(val, _MM_FROUND_TO_ZERO));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-sqrt(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+sqrt(Experimental::basic_vec<
      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_sqrt_ps(static_cast<__m512>(a)));
 }
 
 #ifdef __INTEL_COMPILER
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-cbrt(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+cbrt(Experimental::basic_vec<
      float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cbrt_ps(static_cast<__m512>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-exp(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+exp(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_exp_ps(static_cast<__m512>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-log(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+log(Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_log_ps(static_cast<__m512>(a)));
 }
 
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-fma(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+fma(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& c) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(_mm512_fmadd_ps(
-      static_cast<__m512>(a), static_cast<__m512>(b), static_cast<__m512>(c)));
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
+      _mm512_fmadd_ps(static_cast<__m512>(a), static_cast<__m512>(b),
+                      static_cast<__m512>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-max(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+max(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_max_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx512_fixed_size<16>>
-min(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::avx512_fixed_size<16>>
+min(Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::avx512_fixed_size<16>> const& b) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_min_ps(static_cast<__m512>(a), static_cast<__m512>(b)));
 }
 
@@ -1403,20 +1394,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>
+    basic_vec<float, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>
+    basic_vec<float, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1424,22 +1415,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>
+    basic_vec<float, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>
+    basic_vec<float, simd_abi::avx512_fixed_size<16>>
     simd_partial_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1447,17 +1438,17 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>
+    basic_vec<float, simd_abi::avx512_fixed_size<16>>
     simd_partial_load(
         const float* ptr,
-        basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
+        basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -1469,78 +1460,76 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask, FlagType) {
   _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
                        static_cast<__m512>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask, FlagType) {
   _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
                        static_cast<__m512>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& b,
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& c) {
-  return basic_simd<float, simd_abi::avx512_fixed_size<16>>(
+basic_vec<float, simd_abi::avx512_fixed_size<16>> condition(
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& b,
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_vec<float, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_ps(static_cast<__mmask16>(a), static_cast<__m512>(c),
                            static_cast<__m512>(b)));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1548,7 +1537,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1560,7 +1549,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1572,7 +1561,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1629,71 +1618,71 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epi32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmple_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epi32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
@@ -1701,49 +1690,49 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm256_abs_epi32(rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi32_pd(static_cast<__m256i>(a)));
 }
 
@@ -1754,68 +1743,67 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  using mask_type =
-      basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>;
+  using mask_type = basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>;
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -1828,9 +1816,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
@@ -1838,64 +1826,64 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
+class basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   __m512i m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_epi32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -1903,7 +1891,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -1923,7 +1911,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1934,7 +1922,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -1986,8 +1974,8 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm512_sub_epi32(_mm512_set1_epi32(0), m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
@@ -1995,67 +1983,67 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_srav_epi32(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm512_srai_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_srav_epi32(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -2063,49 +2051,49 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
-  return Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_abs_epi32(rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepi32_ps(static_cast<__m512i>(a)));
 }
 
@@ -2116,72 +2104,72 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::avx512_fixed_size<16>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::avx512_fixed_size<16>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::avx512_fixed_size<16>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::avx512_fixed_size<16>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
   } else {
-    typename basic_simd<std::int32_t,
-                        simd_abi::avx512_fixed_size<16>>::mask_type mask(true);
+    typename basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>::mask_type
+        mask(true);
     _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask),
                              static_cast<__m512i>(simd));
   }
@@ -2189,9 +2177,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2205,72 +2193,72 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
   _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
                           static_cast<__m512i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& b,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
                               static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   __m256i m_value;
 
  public:
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm256_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2278,7 +2266,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(
             _mm256_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -2290,7 +2278,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2302,7 +2290,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2359,67 +2347,67 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm256_srlv_epi32(static_cast<__m256i>(lhs),
+                                       static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm256_srli_epi32(static_cast<__m256i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpeq_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmpneq_epu32_mask(static_cast<__m256i>(lhs),
                                               static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmple_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(rhs),
                                              static_cast<__m256i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm256_cmplt_epu32_mask(static_cast<__m256i>(lhs),
                                              static_cast<__m256i>(rhs)));
   }
@@ -2427,46 +2415,46 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu32_pd(static_cast<__m256i>(a)));
 }
 
@@ -2477,68 +2465,67 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::uint32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  using mask_type =
-      basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>;
+  using mask_type = basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>;
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -2551,9 +2538,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
@@ -2561,65 +2548,65 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
       _mm256_mask_blend_epi32(static_cast<__mmask8>(a), static_cast<__m256i>(c),
                               static_cast<__m256i>(b)));
 }
 
 template <>
-class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
+class basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   __m512i m_value;
 
  public:
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 16;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -2627,7 +2614,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
             gen(std::integral_constant<std::size_t, 0>()),
@@ -2647,7 +2634,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<std::size_t, 14>()),
             gen(std::integral_constant<std::size_t, 15>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2658,7 +2645,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -2715,67 +2702,67 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_add_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_sub_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_sllv_epi32(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_srlv_epi32(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm512_slli_epi32(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(_mm512_srli_epi32(static_cast<__m512i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu32_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu32_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -2783,46 +2770,46 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::avx512_fixed_size<16>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint32_t, Experimental::simd_abi::avx512_fixed_size<16>> const& a) {
-  return Experimental::basic_simd<
-      float, Experimental::simd_abi::avx512_fixed_size<16>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::avx512_fixed_size<16>>(
       _mm512_cvtepu32_ps(static_cast<__m512i>(a)));
 }
 
@@ -2833,72 +2820,72 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const std::uint32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, flag);
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::avx512_fixed_size<16>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                    flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                   flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::avx512_fixed_size<16>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                    flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                   flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::avx512_fixed_size<16>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                    flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                   flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<16>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::avx512_fixed_size<16>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
-                                                                    flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(ptr, mask,
+                                                                   flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
   } else {
-    typename basic_simd<std::uint32_t,
-                        simd_abi::avx512_fixed_size<16>>::mask_type mask(true);
+    typename basic_vec<std::uint32_t,
+                       simd_abi::avx512_fixed_size<16>>::mask_type mask(true);
     _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask),
                              static_cast<__m512i>(simd));
   }
@@ -2906,9 +2893,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2922,9 +2909,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
@@ -2936,63 +2923,62 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::avx512_fixed_size<16>>
-condition(
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& b,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& c) {
-  return basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<std::uint32_t,
+                                                simd_abi::avx512_fixed_size<16>>
+condition(basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& a,
+          basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& b,
+          basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& c) {
+  return basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
       _mm512_mask_blend_epi32(static_cast<__mmask16>(a),
                               static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   __m512i m_value;
 
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_epi64(value_type(value))) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -3001,7 +2987,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(
             _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
@@ -3013,7 +2999,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -3023,7 +3009,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -3056,7 +3042,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   }
 #endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_vec(
       __m512i const& value_in)
       : m_value(value_in) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
@@ -3066,8 +3052,8 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return tmp[i];
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(_mm512_sub_epi64(_mm512_set1_epi64(0), m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m512i()
@@ -3075,67 +3061,67 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) {
-    return basic_simd(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
                                         static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) {
-    return basic_simd(_mm512_srav_epi64(static_cast<__m512i>(lhs),
-                                        static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) {
+    return basic_vec(_mm512_sllv_epi64(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) {
-    return basic_simd(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) {
+    return basic_vec(_mm512_srav_epi64(static_cast<__m512i>(lhs),
+                                       static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) {
-    return basic_simd(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) {
+    return basic_vec(_mm512_slli_epi64(static_cast<__m512i>(lhs), rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) {
+    return basic_vec(_mm512_srai_epi64(static_cast<__m512i>(lhs), rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epi64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epi64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -3143,49 +3129,49 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   __m512i const rhs = static_cast<__m512i>(a);
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<std::int64_t,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_abs_epi64(rhs));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepi64_pd(static_cast<__m512i>(a)));
 }
 
@@ -3196,68 +3182,67 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::int64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::int64_t* ptr,
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::int64_t* ptr,
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::int64_t* ptr,
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                  flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::int64_t* ptr,
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                 flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  using mask_type =
-      basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>;
+  using mask_type = basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>;
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -3270,9 +3255,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m512i>(simd));
@@ -3280,73 +3265,73 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m512i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 template <>
-class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
+class basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   __m512i m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 8;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(_mm512_set1_epi64(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_vec(
       __m512i const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
   template <class G,
             std::enable_if_t<
@@ -3355,7 +3340,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : m_value(
             _mm512_setr_epi64(gen(std::integral_constant<std::size_t, 0>()),
@@ -3367,7 +3352,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
                               gen(std::integral_constant<std::size_t, 6>()),
                               gen(std::integral_constant<std::size_t, 7>()))) {}
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -3377,7 +3362,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     }
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
@@ -3422,77 +3407,77 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_add_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         _mm512_sub_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
-                                         static_cast<__m512i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
+                                        static_cast<__m512i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator&(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm512_and_epi64(static_cast<__m512i>(lhs),
                             static_cast<__m512i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator|(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm512_or_epi64(static_cast<__m512i>(lhs),
                            static_cast<__m512i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
     return _mm512_srli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm512_srlv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
     return _mm512_slli_epi64(static_cast<__m512i>(lhs), rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return _mm512_sllv_epi64(static_cast<__m512i>(lhs),
                              static_cast<__m512i>(rhs));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpeq_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmpneq_epu64_mask(static_cast<__m512i>(lhs),
                                               static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmple_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(rhs),
                                              static_cast<__m512i>(lhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(_mm512_cmplt_epu64_mask(static_cast<__m512i>(lhs),
                                              static_cast<__m512i>(rhs)));
   }
@@ -3500,46 +3485,46 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::avx512_fixed_size<8>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::avx512_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx512_fixed_size<8>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::avx512_fixed_size<8>>(
       _mm512_cvtepu64_pd(static_cast<__m512i>(a)));
 }
 
@@ -3550,68 +3535,67 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::uint64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::avx512_fixed_size<8>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx512_fixed_size<8>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  using mask_type =
-      basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>;
+  using mask_type = basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>;
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
@@ -3624,9 +3608,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m512i>(simd));
@@ -3634,238 +3618,238 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
   _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m512i>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
-  return basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& b,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& c) {
+  return basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
       _mm512_mask_blend_epi64(static_cast<__mmask8>(a), static_cast<__m512i>(c),
                               static_cast<__m512i>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<double, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtps_pd(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<double, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_pd(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<double, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu64_pd(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<double, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi32_pd(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<double, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu32_pd(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<float, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtpd_ps(static_cast<__m512d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_ps(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu64_ps(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         other) noexcept
     : m_value(_mm512_cvtepi32_ps(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+basic_vec<float, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         other) noexcept
     : m_value(_mm512_cvtepu32_ps(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtpd_epi32(static_cast<__m512d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
     : m_value(_mm512_cvtps_epi32(static_cast<__m512>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtpd_epu32(static_cast<__m512d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm256_cvtps_epu32(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi64_epi32(static_cast<__m512i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& other) noexcept
     : m_value(_mm512_cvtps_epu32(static_cast<__m512>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtpd_epi64(static_cast<__m512d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtps_epi64(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtpd_epu64(static_cast<__m512d>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(static_cast<__m512i>(other)) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& other) noexcept
     : m_value(_mm512_cvtps_epu64(static_cast<__m256>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepi32_epi64(static_cast<__m256i>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_vec(
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<double, simd_abi::avx512_fixed_size<8>>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_mask<double, simd_abi::avx512_fixed_size<8>>,
+                           basic_vec<double, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<double, abi_type>;
-  using mask_type  = basic_simd_mask<double, abi_type>;
+  using value_type = basic_vec<double, abi_type>;
+  using mask_type  = basic_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3886,10 +3870,9 @@ class KOKKOS_DEPRECATED const_where_expression<
                          static_cast<__m512d>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      double* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(double* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm512_mask_i32scatter_pd(mem, static_cast<__mmask8>(m_mask),
                               static_cast<__m256i>(index),
                               static_cast<__m512d>(m_value), 8);
@@ -3907,15 +3890,15 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-                     basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+    where_expression<basic_mask<double, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<double, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<double, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<double, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<double, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      basic_simd<double, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<double, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<double, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -3930,7 +3913,7 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_pd(
         static_cast<__m512d>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
@@ -3938,27 +3921,27 @@ class KOKKOS_DEPRECATED
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<double, simd_abi::avx512_fixed_size<8>>>,
+                    U, basic_vec<double, simd_abi::avx512_fixed_size<8>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<double, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<double, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
     m_value =
-        basic_simd<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
+        basic_vec<double, simd_abi::avx512_fixed_size<8>>(_mm512_mask_blend_pd(
             static_cast<__mmask8>(m_mask), static_cast<__m512d>(m_value),
             static_cast<__m512d>(x_as_value_type)));
   }
 };
 
 template <>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<float, simd_abi::avx512_fixed_size<8>>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_mask<float, simd_abi::avx512_fixed_size<8>>,
+                           basic_vec<float, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3979,10 +3962,9 @@ class KOKKOS_DEPRECATED const_where_expression<
                          static_cast<__m256>(m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      float* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(float* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm256_mask_i32scatter_ps(mem, static_cast<__mmask8>(m_mask),
                               static_cast<__m256i>(index),
                               static_cast<__m256>(m_value), 4);
@@ -4000,15 +3982,15 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-                     basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+    where_expression<basic_mask<float, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<float, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<float, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<float, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<float, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask_arg,
-      basic_simd<float, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<float, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<float, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -4022,37 +4004,37 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     __m256 on   = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
     __m256 mask = _mm256_maskz_mov_ps(static_cast<__mmask8>(m_mask), on);
     m_value     = value_type(
         _mm256_mask_i32gather_ps(static_cast<__m256>(m_value), mem,
                                      static_cast<__m256i>(index), mask, 4));
   }
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, basic_simd<float, simd_abi::avx512_fixed_size<8>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_vec<float, simd_abi::avx512_fixed_size<8>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<float, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
     m_value =
-        basic_simd<float, simd_abi::avx512_fixed_size<8>>(_mm256_mask_blend_ps(
+        basic_vec<float, simd_abi::avx512_fixed_size<8>>(_mm256_mask_blend_ps(
             static_cast<__mmask8>(m_mask), static_cast<__m256>(m_value),
             static_cast<__m256>(x_as_value_type)));
   }
 };
 
 template <>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-    basic_simd<float, simd_abi::avx512_fixed_size<16>>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_mask<float, simd_abi::avx512_fixed_size<16>>,
+                           basic_vec<float, simd_abi::avx512_fixed_size<16>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4075,7 +4057,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
       const {
     _mm512_mask_i32scatter_ps(mem, static_cast<__mmask16>(m_mask),
                               static_cast<__m512i>(index),
@@ -4094,15 +4076,15 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-                     basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+    where_expression<basic_mask<float, simd_abi::avx512_fixed_size<16>>,
+                     basic_vec<float, simd_abi::avx512_fixed_size<16>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::avx512_fixed_size<16>>,
-          basic_simd<float, simd_abi::avx512_fixed_size<16>>> {
+          basic_mask<float, simd_abi::avx512_fixed_size<16>>,
+          basic_vec<float, simd_abi::avx512_fixed_size<16>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask_arg,
-      basic_simd<float, simd_abi::avx512_fixed_size<16>>& value_arg)
+      basic_mask<float, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      basic_vec<float, simd_abi::avx512_fixed_size<16>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -4117,7 +4099,7 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_ps(
         static_cast<__m512>(m_value), static_cast<__mmask16>(m_mask),
         static_cast<__m512i>(index), mem, 4));
@@ -4125,14 +4107,14 @@ class KOKKOS_DEPRECATED
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<float, simd_abi::avx512_fixed_size<16>>>,
+                    U, basic_vec<float, simd_abi::avx512_fixed_size<16>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::avx512_fixed_size<16>>>(
+        static_cast<basic_vec<float, simd_abi::avx512_fixed_size<16>>>(
             std::forward<U>(x));
     m_value =
-        basic_simd<float, simd_abi::avx512_fixed_size<16>>(_mm512_mask_blend_ps(
+        basic_vec<float, simd_abi::avx512_fixed_size<16>>(_mm512_mask_blend_ps(
             static_cast<__mmask16>(m_mask), static_cast<__m512>(m_value),
             static_cast<__m512>(x_as_value_type)));
   }
@@ -4140,12 +4122,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4167,10 +4149,9 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int32_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(std::int32_t* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m256i>(m_value), 4);
@@ -4187,17 +4168,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -4212,23 +4192,22 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mmask_i32gather_epi32(
         static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 4));
   }
 
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<
-              U, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>,
-          bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
                                 static_cast<__m256i>(m_value),
                                 static_cast<__m256i>(x_as_value_type)));
@@ -4237,12 +4216,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4265,7 +4244,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
       const {
     _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
                                  static_cast<__m512i>(index),
@@ -4283,17 +4262,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+                     basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
+          basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>>,
+          basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -4308,7 +4286,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi32(
         static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
         static_cast<__m512i>(index), mem, 4));
@@ -4317,13 +4295,13 @@ class KOKKOS_DEPRECATED where_expression<
       class U,
       std::enable_if_t<
           std::is_convertible_v<
-              U, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>,
+              U, basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>>,
           bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>(
+        static_cast<basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
+    m_value = basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -4332,12 +4310,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<std::uint32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint32_t, abi_type>;
+  using value_type = basic_vec<std::uint32_t, abi_type>;
+  using mask_type  = basic_mask<std::uint32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4359,10 +4337,9 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint32_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(std::uint32_t* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm256_mask_i32scatter_epi32(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m256i>(m_value), 4);
@@ -4379,17 +4356,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
-          mask_arg,
-      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint32_t const* mem, element_aligned_tag) {
@@ -4405,7 +4381,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm256_mmask_i32gather_epi32(
         static_cast<__m256i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 4));
@@ -4415,13 +4391,13 @@ class KOKKOS_DEPRECATED where_expression<
       class U,
       std::enable_if_t<
           std::is_convertible_v<
-              U, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>,
+              U, basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>>,
           bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>(
         _mm256_mask_blend_epi32(static_cast<__mmask8>(m_mask),
                                 static_cast<__m256i>(m_value),
                                 static_cast<__m256i>(x_as_value_type)));
@@ -4430,12 +4406,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<16>;
-  using value_type = basic_simd<std::uint32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint32_t, abi_type>;
+  using value_type = basic_vec<std::uint32_t, abi_type>;
+  using mask_type  = basic_mask<std::uint32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4458,7 +4434,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint32_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index)
       const {
     _mm512_mask_i32scatter_epi32(mem, static_cast<__mmask16>(m_mask),
                                  static_cast<__m512i>(index),
@@ -4476,17 +4452,17 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+                     basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
-          basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
+          basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>>,
+          basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+      basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
           mask_arg,
-      basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
+      basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint32_t const* mem, element_aligned_tag) {
@@ -4501,7 +4477,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi32(
         static_cast<__m512i>(m_value), static_cast<__mmask16>(m_mask),
         static_cast<__m512i>(index), mem, 4));
@@ -4510,13 +4486,13 @@ class KOKKOS_DEPRECATED where_expression<
       class U,
       std::enable_if_t<
           std::is_convertible_v<
-              U, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>,
+              U, basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>>,
           bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>(
+        static_cast<basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
+    m_value = basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>>(
         _mm512_mask_blend_epi32(static_cast<__mmask16>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -4525,12 +4501,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<std::int64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_vec<std::int64_t, abi_type>;
+  using mask_type  = basic_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4552,10 +4528,9 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::int64_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(std::int64_t* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
@@ -4572,17 +4547,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
-          mask_arg,
-      basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
@@ -4598,23 +4572,22 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
   }
 
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<
-              U, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
-          bool> = false>
+  template <class U,
+            std::enable_if_t<
+                std::is_convertible_v<
+                    U, basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>>,
+                bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>(
         _mm512_mask_blend_epi64(static_cast<__mmask8>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -4623,12 +4596,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   using abi_type   = simd_abi::avx512_fixed_size<8>;
-  using value_type = basic_simd<std::uint64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_vec<std::uint64_t, abi_type>;
+  using mask_type  = basic_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4650,10 +4623,9 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  void scatter_to(
-      std::uint64_t* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index)
-      const {
+  void scatter_to(std::uint64_t* mem,
+                  basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+                      index) const {
     _mm512_mask_i32scatter_epi64(mem, static_cast<__mmask8>(m_mask),
                                  static_cast<__m256i>(index),
                                  static_cast<__m512i>(m_value), 8);
@@ -4670,17 +4642,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+                     basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-          basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
+          basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+          basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
-          mask_arg,
-      basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
+      basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask_arg,
+      basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
@@ -4695,7 +4666,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
+      basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& index) {
     m_value = value_type(_mm512_mask_i32gather_epi64(
         static_cast<__m512i>(m_value), static_cast<__mmask8>(m_mask),
         static_cast<__m256i>(index), mem, 8));
@@ -4705,13 +4676,13 @@ class KOKKOS_DEPRECATED where_expression<
       class U,
       std::enable_if_t<
           std::is_convertible_v<
-              U, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>,
+              U, basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>>,
           bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>(
+        static_cast<basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>>(
             std::forward<U>(x));
-    m_value = basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
+    m_value = basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>(
         _mm512_mask_blend_epi64(static_cast<__mmask8>(m_mask),
                                 static_cast<__m512i>(m_value),
                                 static_cast<__m512i>(x_as_value_type)));
@@ -4721,8 +4692,8 @@ class KOKKOS_DEPRECATED where_expression<
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
     const_where_expression<
-        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int32_t>::max();
   }
@@ -4734,8 +4705,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmax(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmin(
     const_where_expression<
-        basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int32_t>::min();
   }
@@ -4747,8 +4718,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t hmin(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmax(
     const_where_expression<
-        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint32_t>::max();
   }
@@ -4760,8 +4731,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmax(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmin(
     const_where_expression<
-        basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint32_t>::min();
   }
@@ -4771,8 +4742,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t hmin(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint32_t>::min();
@@ -4785,8 +4756,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmax(
     const_where_expression<
-        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int64_t>::max();
   }
@@ -4797,8 +4768,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmax(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmin(
     const_where_expression<
-        basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::int64_t>::min();
   }
@@ -4809,8 +4780,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t hmin(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmax(
     const_where_expression<
-        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint64_t>::max();
   }
@@ -4821,8 +4792,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmax(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmin(
     const_where_expression<
-        basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
-        basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
+        basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>,
+        basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<std::uint64_t>::min();
   }
@@ -4833,8 +4804,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t hmin(
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 double hmax(const_where_expression<
-            basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-            basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+            basic_mask<double, simd_abi::avx512_fixed_size<8>>,
+            basic_vec<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::max();
   }
@@ -4845,8 +4816,8 @@ double hmax(const_where_expression<
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 float hmax(const_where_expression<
-           basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-           basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+           basic_mask<float, simd_abi::avx512_fixed_size<8>>,
+           basic_vec<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::max();
   }
@@ -4858,8 +4829,8 @@ float hmax(const_where_expression<
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 double hmin(const_where_expression<
-            basic_simd_mask<double, simd_abi::avx512_fixed_size<8>>,
-            basic_simd<double, simd_abi::avx512_fixed_size<8>>> const& x) {
+            basic_mask<double, simd_abi::avx512_fixed_size<8>>,
+            basic_vec<double, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<double>::min();
   }
@@ -4870,8 +4841,8 @@ double hmin(const_where_expression<
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead.")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 float hmin(const_where_expression<
-           basic_simd_mask<float, simd_abi::avx512_fixed_size<8>>,
-           basic_simd<float, simd_abi::avx512_fixed_size<8>>> const& x) {
+           basic_mask<float, simd_abi::avx512_fixed_size<8>>,
+           basic_vec<float, simd_abi::avx512_fixed_size<8>>> const& x) {
   if (none_of(x.impl_get_mask())) {
     return Kokkos::reduction_identity<float>::min();
   }
@@ -4883,8 +4854,8 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int32_t>::max();
@@ -4895,8 +4866,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int32_t>::min();
@@ -4907,8 +4878,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int32_t>::max();
@@ -4918,8 +4889,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int32_t>::min();
@@ -4929,8 +4900,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint32_t>::max();
@@ -4941,8 +4912,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint32_t>::max();
@@ -4952,8 +4923,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
-    basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
+    basic_vec<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint32_t>::min();
@@ -4963,8 +4934,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint32_t reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int64_t>::max();
@@ -4974,8 +4945,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::int64_t>::min();
@@ -4985,8 +4956,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint64_t>::max();
@@ -4996,8 +4967,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
-    basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
+    basic_vec<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const&
         m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<std::uint64_t>::min();
@@ -5007,8 +4978,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::uint64_t reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<double>::max();
   }
@@ -5017,8 +4988,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<double>::min();
   }
@@ -5027,8 +4998,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<float>::max();
   }
@@ -5037,8 +5008,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> const& m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<float>::min();
   }
@@ -5047,8 +5018,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<float>::max();
   }
@@ -5057,8 +5028,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_max(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> const& m) noexcept {
   if (none_of(m)) {
     return Kokkos::reduction_identity<float>::min();
   }
@@ -5067,8 +5038,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce_min(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& m,
     std::int32_t identity, std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
@@ -5079,8 +5050,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
-    basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
+    basic_vec<std::int32_t, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& m,
     std::int32_t identity, std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
@@ -5090,8 +5061,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int32_t reduce(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
-    basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
+    basic_vec<std::int64_t, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& m,
     std::int64_t identity, std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
@@ -5101,8 +5072,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION std::int64_t reduce(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
-    basic_simd<double, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& m,
+    basic_vec<double, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<double, simd_abi::avx512_fixed_size<8>> const& m,
     double identity, std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
@@ -5112,9 +5083,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION double reduce(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    basic_simd<float, simd_abi::avx512_fixed_size<8>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& m,
-    float identity, std::plus<>) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<8>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<8>> const& m, float identity,
+    std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
   }
@@ -5123,9 +5094,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION float reduce(
-    basic_simd<float, simd_abi::avx512_fixed_size<16>> const& v,
-    basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& m,
-    float identity, std::plus<>) noexcept {
+    basic_vec<float, simd_abi::avx512_fixed_size<16>> const& v,
+    basic_mask<float, simd_abi::avx512_fixed_size<16>> const& m, float identity,
+    std::plus<>) noexcept {
   if (none_of(m)) {
     return identity;
   }

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -30,10 +30,10 @@ class scalar;
 }
 
 template <class T, class Abi>
-class basic_simd;
+class basic_vec;
 
 template <class T, class Abi>
-class basic_simd_mask;
+class basic_mask;
 
 class simd_alignment_vector_aligned {};
 
@@ -47,6 +47,14 @@ using element_aligned_tag = simd_flags<>;
 using vector_aligned_tag  = simd_flags<simd_alignment_vector_aligned>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class T, class Abi>
+using basic_simd KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::Experimental::basic_vec instead") = basic_vec<T, Abi>;
+
+template <class T, class Abi>
+using basic_simd_mask KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::Experimental::basic_mask instead") = basic_mask<T, Abi>;
+
 // class template declarations for const_where_expression and where_expression
 
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
@@ -108,17 +116,17 @@ class KOKKOS_DEPRECATED where_expression<bool, T>
 
 template <class T, class Abi>
 KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
-    where(typename basic_simd<T, Abi>::mask_type const& mask,
-          basic_simd<T, Abi>& value) {
+    where_expression<basic_mask<T, Abi>, basic_vec<T, Abi>>
+    where(typename basic_vec<T, Abi>::mask_type const& mask,
+          basic_vec<T, Abi>& value) {
   return where_expression(mask, value);
 }
 
 template <class T, class Abi>
 KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    const_where_expression<basic_simd_mask<T, Abi>, basic_simd<T, Abi>>
-    where(typename basic_simd<T, Abi>::mask_type const& mask,
-          basic_simd<T, Abi> const& value) {
+    const_where_expression<basic_mask<T, Abi>, basic_vec<T, Abi>>
+    where(typename basic_vec<T, Abi>::mask_type const& mask,
+          basic_vec<T, Abi> const& value) {
   return const_where_expression(mask, value);
 }
 
@@ -138,33 +146,33 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
 // The code below provides:
-// operator@(basic_simd<T, Abi>, Arithmetic)
-// operator@(Arithmetic, basic_simd<T, Abi>)
-// operator@=(basic_simd<T, Abi>&, U&&)
+// operator@(basic_vec<T, Abi>, Arithmetic)
+// operator@(Arithmetic, basic_vec<T, Abi>)
+// operator@=(basic_vec<T, Abi>&, U&&)
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_vec<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
-  return Experimental::basic_simd<result_member, Abi>(lhs) +
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) +
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_vec<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
-  return Experimental::basic_simd<result_member, Abi>(lhs) +
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) +
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator+=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
 }
@@ -183,26 +191,26 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_vec<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
-  return Experimental::basic_simd<result_member, Abi>(lhs) -
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) -
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_vec<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
-  return Experimental::basic_simd<result_member, Abi>(lhs) -
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) -
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator-=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
@@ -221,26 +229,26 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_vec<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
-  return Experimental::basic_simd<result_member, Abi>(lhs) *
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) *
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_vec<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
-  return Experimental::basic_simd<result_member, Abi>(lhs) *
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) *
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator*=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
@@ -259,35 +267,35 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 template <class T, class Abi,
           std::enable_if_t<std::is_integral_v<T>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::basic_simd<T, Abi> const& lhs,
-    Experimental::basic_simd<T, Abi> const& rhs) {
-  return Experimental::basic_simd<T, Abi>(
+    Experimental::basic_vec<T, Abi> const& lhs,
+    Experimental::basic_vec<T, Abi> const& rhs) {
+  return Experimental::basic_vec<T, Abi>(
       [&](std::size_t i) { return lhs[i] / rhs[i]; });
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+    Experimental::basic_vec<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
-  return Experimental::basic_simd<result_member, Abi>(lhs) /
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) /
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <class T, class U, class Abi,
           std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+    U lhs, Experimental::basic_vec<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
-  return Experimental::basic_simd<result_member, Abi>(lhs) /
-         Experimental::basic_simd<result_member, Abi>(rhs);
+  return Experimental::basic_vec<result_member, Abi>(lhs) /
+         Experimental::basic_vec<result_member, Abi>(rhs);
 }
 
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator/=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
@@ -306,8 +314,8 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator>>=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs >> std::forward<U>(rhs);
   return lhs;
 }
@@ -315,14 +323,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
 template <
     class T, class U, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>& operator<<=(
+    basic_vec<T, Abi>& lhs, U&& rhs) {
   lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
 
 // implement mask reductions for type bool to allow generic code to accept
-// both basic_simd<double, Abi> and just double
+// both basic_vec<double, Abi> and just double
 
 KOKKOS_FORCEINLINE_FUNCTION bool all_of(bool a) { return a; }
 
@@ -330,21 +338,19 @@ KOKKOS_FORCEINLINE_FUNCTION bool any_of(bool a) { return a; }
 
 KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
 
-// fallback implementations of reductions across basic_simd_mask:
+// fallback implementations of reductions across basic_mask:
 
 template <class T, class Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
-    basic_simd_mask<T, Abi> const& a) {
-  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(basic_mask<T, Abi> const& a) {
+  for (size_t i = 0; i < basic_mask<T, Abi>::size(); ++i) {
     if (!a[i]) return false;
   }
   return true;
 }
 
 template <class T, class Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
-    basic_simd_mask<T, Abi> const& a) {
-  for (size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(basic_mask<T, Abi> const& a) {
+  for (size_t i = 0; i < basic_mask<T, Abi>::size(); ++i) {
     if (a[i]) return true;
   }
   return false;
@@ -352,7 +358,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
 
 template <class T, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
-    basic_simd_mask<T, Abi> const& a) {
+    basic_mask<T, Abi> const& a) {
   return !any_of(a);
 }
 
@@ -442,7 +448,7 @@ constexpr bool needs_explicit_conversion_v =
 
 // common implementations of host only simd reductions:
 template <class T, class Abi, class BinaryOperation = std::plus<>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(const basic_simd<T, Abi>& x,
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(const basic_vec<T, Abi>& x,
                                                BinaryOperation binary_op = {}) {
   T result = x[0];
   for (std::size_t i = 1; i < x.size(); ++i) {
@@ -453,14 +459,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(const basic_simd<T, Abi>& x,
 
 template <class T, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce_min(const basic_simd<T, Abi>& x) noexcept {
-  return reduce_min(x, typename basic_simd<T, Abi>::mask_type(true));
+reduce_min(const basic_vec<T, Abi>& x) noexcept {
+  return reduce_min(x, typename basic_vec<T, Abi>::mask_type(true));
 }
 
 template <class T, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce_max(const basic_simd<T, Abi>& x) noexcept {
-  return reduce_max(x, typename basic_simd<T, Abi>::mask_type(true));
+reduce_max(const basic_vec<T, Abi>& x) noexcept {
+  return reduce_max(x, typename basic_vec<T, Abi>::mask_type(true));
 }
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -28,10 +28,10 @@ class scalar;
 }
 
 template <class T, class Abi>
-class basic_simd;
+class basic_vec;
 
 template <class T, class Abi>
-class basic_simd_mask;
+class basic_mask;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
@@ -40,9 +40,8 @@ class const_where_expression;
 
 template <typename T, typename Abi>
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-    hmin(const_where_expression<basic_simd_mask<T, Abi>,
-                                basic_simd<T, Abi>> const& x) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmin(
+    const_where_expression<basic_mask<T, Abi>, basic_vec<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::min();
@@ -54,9 +53,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 
 template <class T, class Abi>
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-    hmax(const_where_expression<basic_simd_mask<T, Abi>,
-                                basic_simd<T, Abi>> const& x) {
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T hmax(
+    const_where_expression<basic_mask<T, Abi>, basic_vec<T, Abi>> const& x) {
   auto const& v = x.impl_get_value();
   auto const& m = x.impl_get_mask();
   auto result   = Kokkos::reduction_identity<T>::max();
@@ -72,8 +70,8 @@ template <
     typename T, typename Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce_min(basic_simd<T, Abi> const& v,
-           typename basic_simd<T, Abi>::mask_type const& m) {
+reduce_min(basic_vec<T, Abi> const& v,
+           typename basic_vec<T, Abi>::mask_type const& m) {
   auto result = Kokkos::reduction_identity<T>::min();
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = Kokkos::min(result, v[i]);
@@ -85,8 +83,8 @@ template <
     class T, class Abi,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce_max(basic_simd<T, Abi> const& v,
-           typename basic_simd<T, Abi>::mask_type const& m) {
+reduce_max(basic_vec<T, Abi> const& v,
+           typename basic_vec<T, Abi>::mask_type const& m) {
   auto result = Kokkos::reduction_identity<T>::max();
   for (std::size_t i = 0; i < v.size(); ++i) {
     if (m[i]) result = Kokkos::max(result, v[i]);
@@ -98,8 +96,8 @@ template <
     class T, class Abi, class BinaryOperation = std::plus<>,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-reduce(basic_simd<T, Abi> const& v,
-       typename basic_simd<T, Abi>::mask_type const& m, BinaryOperation op = {},
+reduce(basic_vec<T, Abi> const& v,
+       typename basic_vec<T, Abi>::mask_type const& m, BinaryOperation op = {},
        T identity = Impl::Identity<T, BinaryOperation>()) {
   if (none_of(m)) {
     return identity;
@@ -116,10 +114,10 @@ template <
     class T, class Abi, class BinaryOperation = std::plus<>,
     std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
 KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use reduce(basic_simd, basic_simd_mask, op, identity) instead")
+    "Use reduce(basic_vec, basic_mask, op, identity) instead")
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-    reduce(basic_simd<T, Abi> const& v,
-           typename basic_simd<T, Abi>::mask_type const& m, T identity,
+    reduce(basic_vec<T, Abi> const& v,
+           typename basic_vec<T, Abi>::mask_type const& m, T identity,
            BinaryOperation op = {}) {
   return reduce(v, m, op, identity);
 }
@@ -130,10 +128,10 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 template <class T, class Abi,
           std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
-    Experimental::basic_simd<T, Abi> const& a,
-    Experimental::basic_simd<T, Abi> const& b) {
-  using simd_type           = Experimental::basic_simd<T, Abi>;
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> min(
+    Experimental::basic_vec<T, Abi> const& a,
+    Experimental::basic_vec<T, Abi> const& b) {
+  using simd_type           = Experimental::basic_vec<T, Abi>;
   T vals[simd_type::size()] = {0};
   for (std::size_t i = 0; i < simd_type::size(); ++i) {
     vals[i] = Kokkos::min(a[i], b[i]);
@@ -146,9 +144,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
 namespace Experimental {
 template <class T, class Abi>
 KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Abi>
-    min(Experimental::basic_simd<T, Abi> const& a,
-        Experimental::basic_simd<T, Abi> const& b) {
+    Experimental::basic_vec<T, Abi>
+    min(Experimental::basic_vec<T, Abi> const& a,
+        Experimental::basic_vec<T, Abi> const& b) {
   return Kokkos::min(a, b);
 }
 }  // namespace Experimental
@@ -157,10 +155,10 @@ KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 template <class T, class Abi,
           std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
-    Experimental::basic_simd<T, Abi> const& a,
-    Experimental::basic_simd<T, Abi> const& b) {
-  using simd_type           = Experimental::basic_simd<T, Abi>;
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> max(
+    Experimental::basic_vec<T, Abi> const& a,
+    Experimental::basic_vec<T, Abi> const& b) {
+  using simd_type           = Experimental::basic_vec<T, Abi>;
   T vals[simd_type::size()] = {0};
   for (std::size_t i = 0; i < simd_type::size(); ++i) {
     vals[i] = Kokkos::max(a[i], b[i]);
@@ -173,9 +171,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
 namespace Experimental {
 template <class T, class Abi>
 KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    Experimental::basic_simd<T, Abi>
-    max(Experimental::basic_simd<T, Abi> const& a,
-        Experimental::basic_simd<T, Abi> const& b) {
+    Experimental::basic_vec<T, Abi>
+    max(Experimental::basic_vec<T, Abi> const& a,
+        Experimental::basic_vec<T, Abi> const& b) {
   return Kokkos::max(a, b);
 }
 }  // namespace Experimental
@@ -186,59 +184,59 @@ KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 // implementations.
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                  \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i]);                                            \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a) {                             \
-    return Kokkos::FUNC(a[0]);                                                 \
-  }                                                                            \
-  namespace Experimental {                                                     \
-  template <class T, class Abi>                                                \
-  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
-  FUNC(basic_simd<T, Abi> const& a) {                                          \
-    return Kokkos::FUNC(a);                                                    \
-  }                                                                            \
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                 \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i]);                                           \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a) {                             \
+    return Kokkos::FUNC(a[0]);                                                \
+  }                                                                           \
+  namespace Experimental {                                                    \
+  template <class T, class Abi>                                               \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>   \
+  FUNC(basic_vec<T, Abi> const& a) {                                          \
+    return Kokkos::FUNC(a);                                                   \
+  }                                                                           \
   }
 #else
-#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                  \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i]);                                            \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a) {                             \
-    return Kokkos::FUNC(a[0]);                                                 \
+#define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                 \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i]);                                           \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a) {                             \
+    return Kokkos::FUNC(a[0]);                                                \
   }
 #endif
 
@@ -268,63 +266,63 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(tgamma)
 KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                 \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i], b[i]);                                      \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b) {                             \
-    return Kokkos::FUNC(a[0], b[0]);                                           \
-  }                                                                            \
-  namespace Experimental {                                                     \
-  template <class T, class Abi>                                                \
-  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
-  FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b) {             \
-    return Kokkos::FUNC(a, b);                                                 \
-  }                                                                            \
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i], b[i]);                                     \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b) {                             \
+    return Kokkos::FUNC(a[0], b[0]);                                          \
+  }                                                                           \
+  namespace Experimental {                                                    \
+  template <class T, class Abi>                                               \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>   \
+  FUNC(basic_vec<T, Abi> const& a, basic_vec<T, Abi> const& b) {              \
+    return Kokkos::FUNC(a, b);                                                \
+  }                                                                           \
   }
 #else
-#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                 \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i], b[i]);                                      \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b) {                             \
-    return Kokkos::FUNC(a[0], b[0]);                                           \
+#define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i], b[i]);                                     \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b) {                             \
+    return Kokkos::FUNC(a[0], b[0]);                                          \
   }
 #endif
 
@@ -334,68 +332,68 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(atan2)
 KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                                \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b,                               \
-      Experimental::basic_simd<T, Abi> const& c) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                                \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b,                               \
-      Experimental::basic_simd<T, Abi> const& c) {                             \
-    return Kokkos::FUNC(a[0], b[0], c[0]);                                     \
-  }                                                                            \
-  namespace Experimental {                                                     \
-  template <class T, class Abi>                                                \
-  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>   \
-  FUNC(basic_simd<T, Abi> const& a, basic_simd<T, Abi> const& b,               \
-       basic_simd<T, Abi> const& c) {                                          \
-    return Kokkos::FUNC(a, b, c);                                              \
-  }                                                                            \
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                               \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b,                               \
+      Experimental::basic_vec<T, Abi> const& c) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                               \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b,                               \
+      Experimental::basic_vec<T, Abi> const& c) {                             \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                    \
+  }                                                                           \
+  namespace Experimental {                                                    \
+  template <class T, class Abi>                                               \
+  KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<T, Abi>   \
+  FUNC(basic_vec<T, Abi> const& a, basic_vec<T, Abi> const& b,                \
+       basic_vec<T, Abi> const& c) {                                          \
+    return Kokkos::FUNC(a, b, c);                                             \
+  }                                                                           \
   }
 #else
-#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                                \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b,                               \
-      Experimental::basic_simd<T, Abi> const& c) {                             \
-    using simd_type           = Experimental::basic_simd<T, Abi>;              \
-    T vals[simd_type::size()] = {0};                                           \
-    for (std::size_t i = 0; i < simd_type::size(); ++i) {                      \
-      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                                \
-    }                                                                          \
-    return Experimental::simd_unchecked_load<simd_type>(                       \
-        vals, Experimental::simd_flag_default);                                \
-  }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
-      Experimental::basic_simd<T, Abi> const& a,                               \
-      Experimental::basic_simd<T, Abi> const& b,                               \
-      Experimental::basic_simd<T, Abi> const& c) {                             \
-    return Kokkos::FUNC(a[0], b[0], c[0]);                                     \
+#define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                               \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,  \
+                       bool> = false>                                         \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b,                               \
+      Experimental::basic_vec<T, Abi> const& c) {                             \
+    using simd_type           = Experimental::basic_vec<T, Abi>;              \
+    T vals[simd_type::size()] = {0};                                          \
+    for (std::size_t i = 0; i < simd_type::size(); ++i) {                     \
+      vals[i] = Kokkos::FUNC(a[i], b[i], c[i]);                               \
+    }                                                                         \
+    return Experimental::simd_unchecked_load<simd_type>(                      \
+        vals, Experimental::simd_flag_default);                               \
+  }                                                                           \
+  template <                                                                  \
+      class T, class Abi,                                                     \
+      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
+                       bool> = false>                                         \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<T, Abi> FUNC( \
+      Experimental::basic_vec<T, Abi> const& a,                               \
+      Experimental::basic_vec<T, Abi> const& b,                               \
+      Experimental::basic_vec<T, Abi> const& c) {                             \
+    return Kokkos::FUNC(a[0], b[0], c[0]);                                    \
   }
 #endif
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -322,39 +322,38 @@ class neon_mask<Derived, 32, 4> {
 
 }  // namespace Impl
 
-#define INSTANTIATE_SIMD_MASK_NEON(T, LANES_IN_VECTOR)                        \
-  template <>                                                                 \
-  class basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>        \
-      : public Impl::neon_mask<                                               \
-            basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,   \
-            sizeof(T) * 8, LANES_IN_VECTOR> {                                 \
-    using base_type = Impl::neon_mask<                                        \
-        basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,       \
-        sizeof(T) * 8, LANES_IN_VECTOR>;                                      \
-    using implementation_type = typename base_type::implementation_type;      \
-                                                                              \
-   public:                                                                    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =        \
-        default;                                                              \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        bool value) noexcept                                                  \
-        : base_type(value) {}                                                 \
-    template <class U>                                                        \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        basic_simd_mask<U, simd_abi::neon_fixed_size<LANES_IN_VECTOR>> const& \
-            other) noexcept                                                   \
-        : base_type(other) {}                                                 \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        implementation_type const& value) noexcept                            \
-        : base_type(value) {}                                                 \
-    template <class G,                                                        \
-              std::enable_if_t<std::is_invocable_r_v<                         \
-                                   typename base_type::value_type, G,         \
-                                   std::integral_constant<std::size_t, 0>>,   \
-                               bool> = false>                                 \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        G&& gen) noexcept                                                     \
-        : base_type(gen) {}                                                   \
+#define INSTANTIATE_SIMD_MASK_NEON(T, LANES_IN_VECTOR)                      \
+  template <>                                                               \
+  class basic_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>           \
+      : public Impl::neon_mask<                                             \
+            basic_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,      \
+            sizeof(T) * 8, LANES_IN_VECTOR> {                               \
+    using base_type = Impl::neon_mask<                                      \
+        basic_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,          \
+        sizeof(T) * 8, LANES_IN_VECTOR>;                                    \
+    using implementation_type = typename base_type::implementation_type;    \
+                                                                            \
+   public:                                                                  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(              \
+        bool value) noexcept                                                \
+        : base_type(value) {}                                               \
+    template <class U>                                                      \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(              \
+        basic_mask<U, simd_abi::neon_fixed_size<LANES_IN_VECTOR>> const&    \
+            other) noexcept                                                 \
+        : base_type(other) {}                                               \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(    \
+        implementation_type const& value) noexcept                          \
+        : base_type(value) {}                                               \
+    template <class G,                                                      \
+              std::enable_if_t<std::is_invocable_r_v<                       \
+                                   typename base_type::value_type, G,       \
+                                   std::integral_constant<std::size_t, 0>>, \
+                               bool> = false>                               \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(    \
+        G&& gen) noexcept                                                   \
+        : base_type(gen) {}                                                 \
   }
 
 INSTANTIATE_SIMD_MASK_NEON(std::int32_t, 2);
@@ -370,43 +369,43 @@ INSTANTIATE_SIMD_MASK_NEON(float, 4);
 INSTANTIATE_SIMD_MASK_NEON(double, 2);
 
 template <>
-class basic_simd<double, simd_abi::neon_fixed_size<2>> {
+class basic_vec<double, simd_abi::neon_fixed_size<2>> {
   float64x2_t m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmovq_n_f64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       float64x2_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 // basically, can you do { value_type r =
@@ -414,7 +413,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -422,14 +421,14 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
                              m_value, 1);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1q_f64(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<float64x2_t>(basic_simd(
+    m_value = static_cast<float64x2_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -470,8 +469,8 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vnegq_f64(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vnegq_f64(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
@@ -479,54 +478,54 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vaddq_f64(static_cast<float64x2_t>(lhs),
-                                static_cast<float64x2_t>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vaddq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vsubq_f64(static_cast<float64x2_t>(lhs),
-                                static_cast<float64x2_t>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vsubq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vmulq_f64(static_cast<float64x2_t>(lhs),
-                                static_cast<float64x2_t>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vmulq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vdivq_f64(static_cast<float64x2_t>(lhs),
-                                static_cast<float64x2_t>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vdivq_f64(static_cast<float64x2_t>(lhs),
+                               static_cast<float64x2_t>(rhs)));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vceqq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcgeq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcleq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcgtq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcltq_f64(static_cast<float64x2_t>(lhs),
                                static_cast<float64x2_t>(rhs)));
   }
@@ -535,59 +534,59 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-abs(Experimental::basic_simd<
-    double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>> abs(
+    Experimental::basic_vec<
+        double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_vec<
       double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndmq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+ceil(Experimental::basic_vec<
      double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndpq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_vec<
       double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndxq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_vec<
       double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+copysign(Experimental::basic_vec<
              double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint64x2_t const sign_mask = vreinterpretq_u64_f64(vmovq_n_f64(-0.0));
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vreinterpretq_f64_u64(vorrq_u64(
           vreinterpretq_u64_f64(static_cast<float64x2_t>(abs(a))),
           vandq_u64(sign_mask,
@@ -595,47 +594,47 @@ copysign(Experimental::basic_simd<
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-sqrt(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>>
+sqrt(Experimental::basic_vec<
      double, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrtq_f64(static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-fma(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>> fma(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vfmaq_f64(static_cast<float64x2_t>(c), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-max(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>> max(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vmaxq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::neon_fixed_size<2>>
-min(Experimental::basic_simd<
+Experimental::basic_vec<double, Experimental::simd_abi::neon_fixed_size<2>> min(
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         double, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<double,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vminq_f64(static_cast<float64x2_t>(a), static_cast<float64x2_t>(b)));
 }
 
@@ -646,20 +645,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
+    basic_vec<double, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const double* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, flag);
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
+    basic_vec<double, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -667,130 +666,126 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
+    basic_vec<double, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<double,
+                                                simd_abi::neon_fixed_size<2>>
+simd_partial_load(const double* ptr,
+                  basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::neon_fixed_size<2>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<double,
+                                                simd_abi::neon_fixed_size<2>>
+simd_partial_load(const double* ptr,
+                  basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1q_f64(ptr, static_cast<float64x2_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
+    basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::neon_fixed_size<2>> condition(
-    basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& b,
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& c) {
-  return basic_simd<double, simd_abi::neon_fixed_size<2>>(
+basic_vec<double, simd_abi::neon_fixed_size<2>> condition(
+    basic_mask<double, simd_abi::neon_fixed_size<2>> const& a,
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& b,
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_vec<double, simd_abi::neon_fixed_size<2>>(
       vbslq_f64(static_cast<uint64x2_t>(a), static_cast<float64x2_t>(b),
                 static_cast<float64x2_t>(c)));
 }
 
 template <>
-class basic_simd<float, simd_abi::neon_fixed_size<2>> {
+class basic_vec<float, simd_abi::neon_fixed_size<2>> {
   float32x2_t m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value)
       : m_value(vmov_n_f32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       float32x2_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen) noexcept {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
                             m_value, 1);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1_f32(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<float32x2_t>(basic_simd(
+    m_value = static_cast<float32x2_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -830,8 +825,8 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vneg_f32(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vneg_f32(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
@@ -839,45 +834,45 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vadd_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vadd_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vsub_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vsub_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vmul_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vmul_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vdiv_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vdiv_f32(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vceq_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcge_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcle_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcgt_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vclt_f32(lhs.m_value, rhs.m_value));
   }
 };
@@ -885,59 +880,59 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> abs(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> abs(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>>
+floor(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndm_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> ceil(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndp_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>>
+round(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrndx_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>>
+trunc(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vrnd_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
   uint32x2_t const sign_mask = vreinterpret_u32_f32(vmov_n_f32(-0.0));
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vreinterpret_f32_u32(vorr_u32(
           vreinterpret_u32_f32(static_cast<float32x2_t>(abs(a))),
           vand_u32(sign_mask,
@@ -945,47 +940,47 @@ copysign(Experimental::basic_simd<
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> sqrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vsqrt_f32(static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> fma(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> fma(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vfma_f32(static_cast<float32x2_t>(c), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> max(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> max(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vmax_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> min(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<2>> min(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<2>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vmin_f32(static_cast<float32x2_t>(a), static_cast<float32x2_t>(b)));
 }
 
@@ -996,127 +991,121 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
+    basic_vec<float, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, flag);
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<2>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<2>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<2>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<2>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<2>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1_f32(ptr, static_cast<float32x2_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::neon_fixed_size<2>> condition(
-    basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& a,
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& b,
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& c) {
-  return basic_simd<float, simd_abi::neon_fixed_size<2>>(
+basic_vec<float, simd_abi::neon_fixed_size<2>> condition(
+    basic_mask<float, simd_abi::neon_fixed_size<2>> const& a,
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& b,
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_vec<float, simd_abi::neon_fixed_size<2>>(
       vbsl_f32(static_cast<uint32x2_t>(a), static_cast<float32x2_t>(b),
                static_cast<float32x2_t>(c)));
 }
 
 template <>
-class basic_simd<float, simd_abi::neon_fixed_size<4>> {
+class basic_vec<float, simd_abi::neon_fixed_size<4>> {
   float32x4_t m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmovq_n_f32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       float32x4_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
   template <class G,
@@ -1124,7 +1113,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(G&& gen) noexcept {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 1>()),
@@ -1135,14 +1124,14 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
                              m_value, 3);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1q_f32(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<float32x4_t>(basic_simd(
+    m_value = static_cast<float32x4_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -1184,8 +1173,8 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vnegq_f32(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vnegq_f32(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
@@ -1193,45 +1182,45 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vaddq_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vaddq_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vsubq_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vsubq_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vmulq_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vmulq_f32(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vdivq_f32(lhs.m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vdivq_f32(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vceqq_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcgeq_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcleq_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcgtq_f32(lhs.m_value, rhs.m_value));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(vcltq_f32(lhs.m_value, rhs.m_value));
   }
 };
@@ -1239,59 +1228,59 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
 }  // namespace Experimental
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> abs(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> abs(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vabsq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-floor(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>>
+floor(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vrndmq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> ceil(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vrndpq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-round(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>>
+round(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vrndxq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-trunc(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>>
+trunc(Experimental::basic_vec<
       float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vrndq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-copysign(Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>>
+copysign(Experimental::basic_vec<
              float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-         Experimental::basic_simd<
+         Experimental::basic_vec<
              float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
   uint32x4_t const sign_mask = vreinterpretq_u32_f32(vmovq_n_f32(-0.0));
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vreinterpretq_f32_u32(vorrq_u32(
           vreinterpretq_u32_f32(static_cast<float32x4_t>(abs(a))),
           vandq_u32(sign_mask,
@@ -1299,47 +1288,47 @@ copysign(Experimental::basic_simd<
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> sqrt(
+    Experimental::basic_vec<
+        float, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vsqrtq_f32(static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> fma(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> fma(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vfmaq_f32(static_cast<float32x4_t>(c), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(a)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> max(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> max(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vmaxq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> min(
-    Experimental::basic_simd<
+Experimental::basic_vec<float, Experimental::simd_abi::neon_fixed_size<4>> min(
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         float, Experimental::simd_abi::neon_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<float,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vminq_f32(static_cast<float32x4_t>(a), static_cast<float32x4_t>(b)));
 }
 
@@ -1350,70 +1339,65 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
+    basic_vec<float, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, flag);
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<4>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<4>>
+simd_unchecked_load(const float* ptr,
+                    basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
+                    simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<4>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::neon_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<float,
+                                                simd_abi::neon_fixed_size<4>>
+simd_partial_load(const float* ptr,
+                  basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
+                  simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
+    basic_vec<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
     [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1q_f32(ptr, static_cast<float32x4_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
@@ -1422,9 +1406,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    basic_vec<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
+    basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask, FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
@@ -1432,61 +1415,61 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::neon_fixed_size<4>> condition(
-    basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
-    basic_simd<float, simd_abi::neon_fixed_size<4>> const& b,
-    basic_simd<float, simd_abi::neon_fixed_size<4>> const& c) {
-  return basic_simd<float, simd_abi::neon_fixed_size<4>>(
+basic_vec<float, simd_abi::neon_fixed_size<4>> condition(
+    basic_mask<float, simd_abi::neon_fixed_size<4>> const& a,
+    basic_vec<float, simd_abi::neon_fixed_size<4>> const& b,
+    basic_vec<float, simd_abi::neon_fixed_size<4>> const& c) {
+  return basic_vec<float, simd_abi::neon_fixed_size<4>>(
       vbslq_f32(static_cast<uint32x4_t>(a), static_cast<float32x4_t>(b),
                 static_cast<float32x4_t>(c)));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
+class basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> {
   int32x2_t m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmov_n_s32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       int32x2_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
@@ -1494,14 +1477,14 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
                             m_value, 1);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1_s32(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<int32x2_t>(basic_simd(
+    m_value = static_cast<int32x2_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -1541,8 +1524,8 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vneg_s32(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vneg_s32(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x2_t()
@@ -1550,68 +1533,68 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vadd_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vsub_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vmul_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vshl_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
-                               vneg_s32(static_cast<int32x2_t>(rhs))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vshl_s32(static_cast<int32x2_t>(lhs),
+                              vneg_s32(static_cast<int32x2_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(
         vshl_s32(static_cast<int32x2_t>(lhs), vmov_n_s32(std::int32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(vshl_s32(static_cast<int32x2_t>(lhs),
-                               vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(vshl_s32(static_cast<int32x2_t>(lhs),
+                              vneg_s32(vmov_n_s32(std::int32_t(rhs)))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vceq_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcge_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcle_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcgt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vclt_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
@@ -1619,39 +1602,39 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vabs_s32(static_cast<int32x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
@@ -1663,21 +1646,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1685,24 +1667,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1710,27 +1690,26 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1_s32(ptr, static_cast<int32x2_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
@@ -1738,58 +1717,58 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>(
+basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>(
       vbsl_s32(static_cast<uint32x2_t>(a), static_cast<int32x2_t>(b),
                static_cast<int32x2_t>(c)));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
+class basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> {
   int32x4_t m_value;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 4;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmovq_n_s32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       int32x4_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
   template <class G,
@@ -1797,7 +1776,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -1809,14 +1788,14 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
                              m_value, 3);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1q_s32(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<int32x4_t>(basic_simd(
+    m_value = static_cast<int32x4_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -1858,8 +1837,8 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vnegq_s32(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vnegq_s32(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x4_t()
@@ -1867,68 +1846,68 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vaddq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vsubq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vmulq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vshlq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
-                                vnegq_s32(static_cast<int32x4_t>(rhs))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vshlq_s32(static_cast<int32x4_t>(lhs),
+                               vnegq_s32(static_cast<int32x4_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(
         vshlq_s32(static_cast<int32x4_t>(lhs), vmovq_n_s32(std::int32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(vshlq_s32(static_cast<int32x4_t>(lhs),
-                                vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(vshlq_s32(static_cast<int32x4_t>(lhs),
+                               vnegq_s32(vmovq_n_s32(std::int32_t(rhs)))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vceqq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcgeq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcleq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcgtq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcltq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
@@ -1936,39 +1915,39 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::neon_fixed_size<4>>(
+  return Experimental::basic_vec<std::int32_t,
+                                 Experimental::simd_abi::neon_fixed_size<4>>(
       vabsq_s32(static_cast<int32x4_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::neon_fixed_size<4>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int32_t, Experimental::simd_abi::neon_fixed_size<4>> const& a) {
   return a;
 }
@@ -1980,21 +1959,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2002,24 +1980,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2027,27 +2003,26 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<4>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_partial_load(
         const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+        basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1q_s32(ptr, static_cast<int32x4_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
@@ -2057,9 +2032,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
@@ -2068,61 +2043,61 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>(
+basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& b,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>(
       vbslq_s32(static_cast<uint32x4_t>(a), static_cast<int32x4_t>(b),
                 static_cast<int32x4_t>(c)));
 }
 
 template <>
-class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
+class basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> {
   int64x2_t m_value;
 
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmovq_n_s64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       int64x2_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -2130,14 +2105,14 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
                              m_value, 1);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1q_s64(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<int64x2_t>(basic_simd(
+    m_value = static_cast<int64x2_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -2177,8 +2152,8 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(vnegq_s64(m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(vnegq_s64(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int64x2_t()
@@ -2186,67 +2161,67 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vaddq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vsubq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vshlq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
-                                vnegq_s64(static_cast<int64x2_t>(rhs))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vshlq_s64(static_cast<int64x2_t>(lhs),
+                               vnegq_s64(static_cast<int64x2_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(
         vshlq_s64(static_cast<int64x2_t>(lhs), vmovq_n_s64(std::int64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(vshlq_s64(static_cast<int64x2_t>(lhs),
-                                vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(vshlq_s64(static_cast<int64x2_t>(lhs),
+                               vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vceqq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcgeq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcleq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcgtq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vcltq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
@@ -2254,39 +2229,39 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::neon_fixed_size<2>>(
+  return Experimental::basic_vec<std::int64_t,
+                                 Experimental::simd_abi::neon_fixed_size<2>>(
       vabsq_s64(static_cast<int64x2_t>(a)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
@@ -2298,21 +2273,20 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::int64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2320,24 +2294,22 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2345,27 +2317,26 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                flag);
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1q_s64(ptr, static_cast<int64x2_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
@@ -2373,70 +2344,70 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
-    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>(
+basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_s64(static_cast<uint64x2_t>(a), static_cast<int64x2_t>(b),
                 static_cast<int64x2_t>(c)));
 }
 
 template <>
-class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
+class basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   uint64x2_t m_value;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return 2;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(vmovq_n_u64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       uint64x2_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -2444,14 +2415,14 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
                              m_value, 1);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = vld1q_u64(ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = static_cast<uint64x2_t>(basic_simd(
+    m_value = static_cast<uint64x2_t>(basic_vec(
         [=](std::size_t i) { return (mask[i]) ? ptr[i] : value_type(); }));
   }
 
@@ -2491,9 +2462,9 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
 
@@ -2502,91 +2473,91 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec([&](std::size_t i) { return lhs[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator&(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vandq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator|(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vorrq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(
         vshlq_u64(static_cast<uint64x2_t>(lhs),
                   vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(vshlq_u64(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(vshlq_u64(
         static_cast<uint64x2_t>(lhs),
         vnegq_s64(vreinterpretq_s64_u64(static_cast<uint64x2_t>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
-                                vmovq_n_s64(std::int64_t(rhs))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                               vmovq_n_s64(std::int64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(vshlq_u64(static_cast<uint64x2_t>(lhs),
-                                vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(vshlq_u64(static_cast<uint64x2_t>(lhs),
+                               vnegq_s64(vmovq_n_s64(std::int64_t(rhs)))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(
         vceqq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(lhs == rhs);
   }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
+basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> abs(
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint64_t, Experimental::simd_abi::neon_fixed_size<2>> const& a) {
   return a;
 }
@@ -2598,74 +2569,74 @@ template <typename SimdType, typename... Flags,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::uint64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::neon_fixed_size<2>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::neon_fixed_size<2>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    simd_unchecked_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::neon_fixed_size<2>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename SimdType, typename... Flags,
           std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
                                           simd_abi::neon_fixed_size<2>>,
                            bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::neon_fixed_size<2>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
-                                                                 flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>
+    simd_partial_load(
+        const std::uint64_t* ptr,
+        basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(ptr, mask,
+                                                                flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   vst1q_u64(ptr, static_cast<uint64x2_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
@@ -2673,82 +2644,78 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
+    basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
-  return basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>(
+basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(
+    basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& a,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& b,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const& c) {
+  return basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>(
       vbslq_u64(static_cast<uint64x2_t>(a), static_cast<uint64x2_t>(b),
                 static_cast<uint64x2_t>(c)));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
+basic_vec<double, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<float, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vcvt_f64_f32(static_cast<float32x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
+basic_vec<float, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<double, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vcvtx_f32_f64(static_cast<float64x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
+basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vmovn_s64(static_cast<int64x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
+basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
         other) noexcept
     : m_value(vreinterpret_s32_u32(vmovn_u64(static_cast<uint64x2_t>(other)))) {
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
+basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
         other) noexcept
     : m_value(vreinterpretq_s64_u64(static_cast<uint64x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
+basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vmovl_s32(static_cast<int32x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
+basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vreinterpretq_u64_s64(static_cast<int64x2_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_simd(
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
-        other) noexcept
+basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>::basic_vec(
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& other) noexcept
     : m_value(vreinterpretq_u64_s64(vmovl_s32(static_cast<int32x2_t>(other)))) {
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
-    basic_simd<double, simd_abi::neon_fixed_size<2>>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_mask<double, simd_abi::neon_fixed_size<2>>,
+                           basic_vec<double, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = basic_simd<double, abi_type>;
-  using mask_type  = basic_simd_mask<double, abi_type>;
+  using value_type = basic_vec<double, abi_type>;
+  using mask_type  = basic_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2770,7 +2737,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(double* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -2788,15 +2755,15 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
-                     basic_simd<double, simd_abi::neon_fixed_size<2>>>
+    where_expression<basic_mask<double, simd_abi::neon_fixed_size<2>>,
+                     basic_vec<double, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          basic_simd_mask<double, simd_abi::neon_fixed_size<2>>,
-          basic_simd<double, simd_abi::neon_fixed_size<2>>> {
+          basic_mask<double, simd_abi::neon_fixed_size<2>>,
+          basic_vec<double, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      basic_simd<double, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_mask<double, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_vec<double, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(double const* mem, element_aligned_tag) {
@@ -2813,7 +2780,7 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
@@ -2821,13 +2788,13 @@ class KOKKOS_DEPRECATED
   template <
       class U,
       std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<double, simd_abi::neon_fixed_size<2>>>,
+                           U, basic_vec<double, simd_abi::neon_fixed_size<2>>>,
                        bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<double, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<double, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<basic_simd<double, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_vec<double, simd_abi::neon_fixed_size<2>>>(
         vbslq_f64(static_cast<uint64x2_t>(m_mask),
                   static_cast<float64x2_t>(x_as_value_type),
                   static_cast<float64x2_t>(m_value)));
@@ -2836,12 +2803,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    const_where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                           basic_simd<float, simd_abi::neon_fixed_size<2>>> {
+    const_where_expression<basic_mask<float, simd_abi::neon_fixed_size<2>>,
+                           basic_vec<float, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2863,7 +2830,7 @@ class KOKKOS_DEPRECATED
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(float* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -2881,15 +2848,15 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
-                     basic_simd<float, simd_abi::neon_fixed_size<2>>>
+    where_expression<basic_mask<float, simd_abi::neon_fixed_size<2>>,
+                     basic_vec<float, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::neon_fixed_size<2>>,
-          basic_simd<float, simd_abi::neon_fixed_size<2>>> {
+          basic_mask<float, simd_abi::neon_fixed_size<2>>,
+          basic_vec<float, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask_arg,
-      basic_simd<float, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_mask<float, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_vec<float, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -2905,21 +2872,20 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<float, simd_abi::neon_fixed_size<2>>>,
-                       bool> = false>
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, basic_vec<float, simd_abi::neon_fixed_size<2>>>,
+                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<float, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<basic_simd<float, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_vec<float, simd_abi::neon_fixed_size<2>>>(
         vbsl_f32(static_cast<uint32x2_t>(m_mask),
                  static_cast<float32x2_t>(x_as_value_type),
                  static_cast<float32x2_t>(m_value)));
@@ -2928,12 +2894,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    const_where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                           basic_simd<float, simd_abi::neon_fixed_size<4>>> {
+    const_where_expression<basic_mask<float, simd_abi::neon_fixed_size<4>>,
+                           basic_vec<float, simd_abi::neon_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -2959,7 +2925,7 @@ class KOKKOS_DEPRECATED
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(float* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -2979,15 +2945,15 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED
-    where_expression<basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
-                     basic_simd<float, simd_abi::neon_fixed_size<4>>>
+    where_expression<basic_mask<float, simd_abi::neon_fixed_size<4>>,
+                     basic_vec<float, simd_abi::neon_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::neon_fixed_size<4>>,
-          basic_simd<float, simd_abi::neon_fixed_size<4>>> {
+          basic_mask<float, simd_abi::neon_fixed_size<4>>,
+          basic_vec<float, simd_abi::neon_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask_arg,
-      basic_simd<float, simd_abi::neon_fixed_size<4>>& value_arg)
+      basic_mask<float, simd_abi::neon_fixed_size<4>> const& mask_arg,
+      basic_vec<float, simd_abi::neon_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(float const* mem, element_aligned_tag) {
@@ -3004,21 +2970,20 @@ class KOKKOS_DEPRECATED
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
-  template <
-      class U,
-      std::enable_if_t<std::is_convertible_v<
-                           U, basic_simd<float, simd_abi::neon_fixed_size<4>>>,
-                       bool> = false>
+  template <class U, std::enable_if_t<
+                         std::is_convertible_v<
+                             U, basic_vec<float, simd_abi::neon_fixed_size<4>>>,
+                         bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<float, simd_abi::neon_fixed_size<4>>>(
+        static_cast<basic_vec<float, simd_abi::neon_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = static_cast<basic_simd<float, simd_abi::neon_fixed_size<4>>>(
+    m_value = static_cast<basic_vec<float, simd_abi::neon_fixed_size<4>>>(
         vbslq_f32(static_cast<uint32x4_t>(m_mask),
                   static_cast<float32x4_t>(x_as_value_type),
                   static_cast<float32x4_t>(m_value)));
@@ -3027,12 +2992,12 @@ class KOKKOS_DEPRECATED
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3055,7 +3020,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int32_t* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -3072,17 +3037,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+                     basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
-          basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>> {
+          basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>>,
+          basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -3100,22 +3064,22 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
 
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_vec<int32_t, simd_abi::neon_fixed_size<2>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<int32_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
-    m_value = static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<2>>>(
+    m_value = static_cast<basic_vec<int32_t, simd_abi::neon_fixed_size<2>>>(
         vbsl_s32(static_cast<uint32x2_t>(m_mask),
                  static_cast<int32x2_t>(x_as_value_type),
                  static_cast<int32x2_t>(m_value)));
@@ -3124,12 +3088,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+    basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+    basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<4>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3155,7 +3119,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int32_t* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -3174,17 +3138,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-    basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+                     basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
-          basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>> {
+          basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>>,
+          basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>& value_arg)
+      basic_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int32_t const* mem, element_aligned_tag) {
@@ -3201,21 +3164,21 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<4>> const& index) {
     m_value = value_type([mem, index, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
   }
-  template <class U,
-            std::enable_if_t<
-                std::is_convertible_v<
-                    U, basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>,
-                bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<
+                           U, basic_vec<int32_t, simd_abi::neon_fixed_size<4>>>,
+                       bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+        static_cast<basic_vec<int32_t, simd_abi::neon_fixed_size<4>>>(
             std::forward<U>(x));
-    m_value = static_cast<basic_simd<int32_t, simd_abi::neon_fixed_size<4>>>(
+    m_value = static_cast<basic_vec<int32_t, simd_abi::neon_fixed_size<4>>>(
         vbslq_s32(static_cast<uint32x4_t>(m_mask),
                   static_cast<int32x4_t>(x_as_value_type),
                   static_cast<int32x4_t>(m_value)));
@@ -3224,12 +3187,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+    basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+    basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = basic_simd<std::int64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_vec<std::int64_t, abi_type>;
+  using mask_type  = basic_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3252,7 +3215,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::int64_t* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -3269,17 +3232,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+                     basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
-          basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>> {
+          basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>>,
+          basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const&
-          mask_arg,
-      basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::int64_t const* mem, element_aligned_tag) {
@@ -3297,7 +3259,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
@@ -3306,14 +3268,14 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>,
+                    U, basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
     m_value =
-        static_cast<basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<std::int64_t, simd_abi::neon_fixed_size<2>>>(
             vbslq_s64(static_cast<uint64x2_t>(m_mask),
                       static_cast<int64x2_t>(x_as_value_type),
                       static_cast<int64x2_t>(m_value)));
@@ -3322,12 +3284,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+    basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+    basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   using abi_type   = simd_abi::neon_fixed_size<2>;
-  using value_type = basic_simd<std::uint64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_vec<std::uint64_t, abi_type>;
+  using mask_type  = basic_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3350,7 +3312,7 @@ class KOKKOS_DEPRECATED const_where_expression<
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(std::uint64_t* mem,
-                  basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const&
+                  basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const&
                       index) const {
     if (m_mask[0]) mem[index[0]] = m_value[0];
     if (m_mask[1]) mem[index[1]] = m_value[1];
@@ -3367,17 +3329,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <>
-class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-    basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+class KOKKOS_DEPRECATED
+    where_expression<basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+                     basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
-          basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
+          basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>>,
+          basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const&
-          mask_arg,
-      basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>& value_arg)
+      basic_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask_arg,
+      basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>& value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
@@ -3395,7 +3356,7 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
+      basic_vec<std::int32_t, simd_abi::neon_fixed_size<2>> const& index) {
     m_value = value_type([index, mem, this](std::size_t i) {
       return (m_mask[i]) ? mem[index[i]] : m_value[i];
     });
@@ -3404,14 +3365,14 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
+                    U, basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
             std::forward<U>(x));
     m_value =
-        static_cast<basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
+        static_cast<basic_vec<std::uint64_t, simd_abi::neon_fixed_size<2>>>(
             vbslq_u64(static_cast<uint64x2_t>(m_mask),
                       static_cast<uint64x2_t>(x_as_value_type),
                       static_cast<uint64x2_t>(m_value)));

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -337,38 +337,37 @@ class sve_mask<Derived, 32> {
 
 }  // namespace Impl
 
-#define INSTANTIATE_SIMD_MASK_SVE(T, SVE_T_IN_VECTOR)                         \
-  template <>                                                                 \
-  class basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>         \
-      : public Impl::sve_mask<                                                \
-            basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,    \
-            sizeof(T) * 8> {                                                  \
-    using base_type = Impl::sve_mask<                                         \
-        basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,        \
-        sizeof(T) * 8>;                                                       \
-                                                                              \
-   public:                                                                    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =        \
-        default;                                                              \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        bool value) noexcept                                                  \
-        : base_type(value) {}                                                 \
-    template <class U>                                                        \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(                    \
-        basic_simd_mask<U, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>> const&  \
-            other) noexcept                                                   \
-        : base_type(static_cast<base_type::implementation_type>(other)) {}    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        vls_bool_t const& value_in) noexcept                                  \
-        : base_type(value_in) {}                                              \
-    template <class G,                                                        \
-              std::enable_if_t<std::is_invocable_r_v<                         \
-                                   typename base_type::value_type, G,         \
-                                   std::integral_constant<std::size_t, 0>>,   \
-                               bool> = false>                                 \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        G&& gen) noexcept                                                     \
-        : base_type(gen) {}                                                   \
+#define INSTANTIATE_SIMD_MASK_SVE(T, SVE_T_IN_VECTOR)                       \
+  template <>                                                               \
+  class basic_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>            \
+      : public Impl::sve_mask<                                              \
+            basic_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,       \
+            sizeof(T) * 8> {                                                \
+    using base_type = Impl::sve_mask<                                       \
+        basic_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,           \
+        sizeof(T) * 8>;                                                     \
+                                                                            \
+   public:                                                                  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask() noexcept = default;  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_mask(              \
+        bool value) noexcept                                                \
+        : base_type(value) {}                                               \
+    template <class U>                                                      \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_mask(                       \
+        basic_mask<U, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>> const&     \
+            other) noexcept                                                 \
+        : base_type(static_cast<base_type::implementation_type>(other)) {}  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(    \
+        vls_bool_t const& value_in) noexcept                                \
+        : base_type(value_in) {}                                            \
+    template <class G,                                                      \
+              std::enable_if_t<std::is_invocable_r_v<                       \
+                                   typename base_type::value_type, G,       \
+                                   std::integral_constant<std::size_t, 0>>, \
+                               bool> = false>                               \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_mask(    \
+        G&& gen) noexcept                                                   \
+        : base_type(gen) {}                                                 \
   }
 
 INSTANTIATE_SIMD_MASK_SVE(std::int32_t, SVE_WORDS_IN_VECTOR);
@@ -381,7 +380,7 @@ INSTANTIATE_SIMD_MASK_SVE(float, SVE_WORDS_IN_VECTOR);
 INSTANTIATE_SIMD_MASK_SVE(double, SVE_DOUBLES_IN_VECTOR);
 
 template <>
-class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
+class basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   vls_float64_t m_value;
 
  protected:
@@ -390,46 +389,46 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
  public:
   using value_type = double;
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_DOUBLES_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
 
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_f64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_float64_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -453,12 +452,12 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -495,134 +494,133 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   operator vls_float64_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b64(), m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                 static_cast<vls_float64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-abs(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& a) {
+abs(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svabs_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-floor(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                           SVE_DOUBLES_IN_VECTOR>> const& a) {
+floor(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                          SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svrintm_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-ceil(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                          SVE_DOUBLES_IN_VECTOR>> const& a) {
+ceil(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                         SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svrintp_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-round(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                           SVE_DOUBLES_IN_VECTOR>> const& a) {
+round(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                          SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svrintx_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-trunc(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                           SVE_DOUBLES_IN_VECTOR>> const& a) {
+trunc(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                          SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svrintz_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-copysign(
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& b) {
+copysign(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                             SVE_DOUBLES_IN_VECTOR>> const& a,
+         Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                             SVE_DOUBLES_IN_VECTOR>> const& b) {
   vls_uint64_t const sign_mask = svreinterpret_u64(svdup_f64(-0.0));
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svreinterpret_f64(svorr_m(
           svptrue_b64(),
@@ -633,51 +631,51 @@ copysign(
                       (to_sve_vla<double>)static_cast<vls_float64_t>(b)))))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-sqrt(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                          SVE_DOUBLES_IN_VECTOR>> const& a) {
+sqrt(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                         SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_float64_t aa = static_cast<vls_float64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svsqrt_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-fma(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& b,
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& c) {
-  return Experimental::basic_simd<
+fma(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& a,
+    Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& b,
+    Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& c) {
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svmad_m(
           svptrue_b64(), static_cast<vls_float64_t>(a),
           static_cast<vls_float64_t>(b), static_cast<vls_float64_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-max(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+max(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& a,
+    Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& b) {
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svmax_m(svptrue_b64(),
                                          static_cast<vls_float64_t>(a),
                                          static_cast<vls_float64_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-min(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_DOUBLES_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+min(Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& a,
+    Experimental::basic_vec<double, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_DOUBLES_IN_VECTOR>> const& b) {
+  return Experimental::basic_vec<
       double, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svmin_m(svptrue_b64(),
                                          static_cast<vls_float64_t>(a),
@@ -692,23 +690,22 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const double* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<double,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
@@ -718,27 +715,25 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const double* ptr,
-        basic_simd_mask<double,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<double,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const double* ptr,
-        basic_simd_mask<double,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<double,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
@@ -748,20 +743,19 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const double* ptr,
-        basic_simd_mask<double,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<double,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
     double* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b64(), ptr, static_cast<vls_float64_t>(simd));
@@ -769,43 +763,42 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
     double* ptr,
-    basic_simd_mask<
-        double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+        mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
     double* ptr,
-    basic_simd_mask<
-        double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+        mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
-    basic_simd_mask<double,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        b,
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+    basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+        a,
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         c) {
-  return basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+  return basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_float64_t>(svsel(static_cast<vls_bool_t>(a),
                                        static_cast<vls_float64_t>(b),
                                        static_cast<vls_float64_t>(c))));
 }
 
 template <>
-class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
+class basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   vls_float32_t m_value;
 
  protected:
@@ -814,45 +807,45 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
  public:
   using value_type = float;
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_WORDS_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_f32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_float32_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -884,12 +877,12 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -926,133 +919,133 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   operator vls_float32_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b32(), m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b32(), static_cast<vls_float32_t>(lhs),
                 static_cast<vls_float32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-abs(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& a) {
+abs(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svabs_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-floor(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                          SVE_WORDS_IN_VECTOR>> const& a) {
+floor(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                         SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svrintm_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-ceil(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_WORDS_IN_VECTOR>> const& a) {
+ceil(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svrintp_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-round(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                          SVE_WORDS_IN_VECTOR>> const& a) {
+round(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                         SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svrintx_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-trunc(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                          SVE_WORDS_IN_VECTOR>> const& a) {
+trunc(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                         SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svrintz_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-copysign(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                             SVE_WORDS_IN_VECTOR>> const& a,
-         Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                             SVE_WORDS_IN_VECTOR>> const& b) {
+copysign(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                            SVE_WORDS_IN_VECTOR>> const& a,
+         Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                            SVE_WORDS_IN_VECTOR>> const& b) {
   vls_uint32_t const sign_mask = svreinterpret_u32(svdup_f32(-0.0));
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svreinterpret_f32(svorr_m(
           svptrue_b32(),
@@ -1063,51 +1056,51 @@ copysign(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
                       (to_sve_vla<float>)static_cast<vls_float32_t>(b)))))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-sqrt(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                         SVE_WORDS_IN_VECTOR>> const& a) {
+sqrt(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                        SVE_WORDS_IN_VECTOR>> const& a) {
   vls_float32_t aa = static_cast<vls_float32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svsqrt_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-fma(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& b,
-    Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& c) {
-  return Experimental::basic_simd<
+fma(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& a,
+    Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& b,
+    Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& c) {
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svmad_m(
           svptrue_b32(), static_cast<vls_float32_t>(a),
           static_cast<vls_float32_t>(b), static_cast<vls_float32_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-max(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+max(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& a,
+    Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& b) {
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svmax_m(svptrue_b32(),
                                          static_cast<vls_float32_t>(a),
                                          static_cast<vls_float32_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-min(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
-                                        SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+min(Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& a,
+    Experimental::basic_vec<float, Experimental::simd_abi::sve_fixed_size<
+                                       SVE_WORDS_IN_VECTOR>> const& b) {
+  return Experimental::basic_vec<
       float, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svmin_m(svptrue_b32(),
                                          static_cast<vls_float32_t>(a),
@@ -1122,22 +1115,22 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const float* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr,
-                                                                          flag);
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr,
+                                                                         flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const float* ptr,
+        basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
@@ -1146,26 +1139,26 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const float* ptr,
+        basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const float* ptr,
+        basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
@@ -1174,31 +1167,29 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const float* ptr,
+        basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+            mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        simd,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     float* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_float32_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        simd,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+    basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
@@ -1206,30 +1197,28 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        simd,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     float* ptr,
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+    basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 condition(
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-        a,
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
-  return basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+    basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
+  return basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_float32_t>(svsel(static_cast<vls_bool_t>(a),
                                        static_cast<vls_float32_t>(b),
                                        static_cast<vls_float32_t>(c))));
 }
 
 template <>
-class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
+class basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   vls_int32_t m_value;
 
  protected:
@@ -1238,45 +1227,45 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_WORDS_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_s32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_int32_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -1308,12 +1297,12 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -1350,94 +1339,94 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   operator vls_int32_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b32(), m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svasr_m(svptrue_b32(), static_cast<implementation_type>(lhs),
                 std::uint32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svasr_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svasr_m(
         svptrue_b32(), static_cast<implementation_type>(lhs),
         svreinterpret_u32(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsl_m(svptrue_b32(), static_cast<implementation_type>(lhs),
                 std::uint32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsl_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsl_m(
         svptrue_b32(), static_cast<implementation_type>(lhs),
         svreinterpret_u32(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
@@ -1446,93 +1435,93 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int32_t,
     Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
   vls_int32_t aa = static_cast<vls_int32_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(svabs_m(aa, svptrue_b32(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int32_t,
      Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 copysign(
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
   vls_bool_t positivity_b =
       svcmpge(svptrue_b32(), static_cast<vls_int32_t>(b), std::int32_t(0));
   vls_int32_t sign_b = svsel(positivity_b, svdup_s32(1), svdup_s32(-1));
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(
           svmul_m(svptrue_b32(), static_cast<vls_int32_t>(abs(a)), sign_b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-fma(Experimental::basic_simd<
+fma(Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(
@@ -1540,15 +1529,15 @@ fma(Experimental::basic_simd<
                   static_cast<vls_int32_t>(b), static_cast<vls_int32_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-max(Experimental::basic_simd<
+max(Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(svmax_m(svptrue_b32(),
@@ -1556,15 +1545,15 @@ max(Experimental::basic_simd<
                                        static_cast<vls_int32_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-min(Experimental::basic_simd<
+min(Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(svmin_m(svptrue_b32(),
@@ -1580,24 +1569,23 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, flag);
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+      ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+      ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1605,29 +1593,27 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+      ptr, mask, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+      ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -1635,66 +1621,63 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const std::int32_t* ptr,
+        basic_mask<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+      ptr, mask, flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_int32_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+    basic_mask<std::int32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+    basic_mask<std::int32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-condition(
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+condition(basic_mask<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
+          basic_vec<std::int32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
+          basic_vec<std::int32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
+  return basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_int32_t>(svsel(static_cast<vls_bool_t>(a),
                                      static_cast<vls_int32_t>(b),
                                      static_cast<vls_int32_t>(c))));
 }
 
 template <>
-class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
+class basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   vls_uint32_t m_value;
 
  protected:
@@ -1703,45 +1686,45 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
  public:
   using value_type = std::uint32_t;
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_WORDS_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_u32(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_uint32_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<float, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -1773,12 +1756,12 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -1815,93 +1798,93 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   operator vls_uint32_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(svundef_u32()));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(svundef_u32()));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsr_m(svptrue_b32(), static_cast<implementation_type>(lhs),
                 std::uint32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsr_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsr_m(
         svptrue_b32(), static_cast<implementation_type>(lhs),
         svreinterpret_u32(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsl_m(svptrue_b32(), static_cast<implementation_type>(lhs),
                 std::uint32_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsl_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsl_m(
         svptrue_b32(), static_cast<implementation_type>(lhs),
         svreinterpret_u32(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
@@ -1910,83 +1893,83 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint32_t,
     Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint32_t,
      Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 copysign(
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
   (void)b;
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-fma(Experimental::basic_simd<
+fma(Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(
@@ -1994,15 +1977,15 @@ fma(Experimental::basic_simd<
                   static_cast<vls_uint32_t>(b), static_cast<vls_uint32_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-max(Experimental::basic_simd<
+max(Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(svmax_m(svptrue_b32(),
@@ -2010,15 +1993,15 @@ max(Experimental::basic_simd<
                                         static_cast<vls_uint32_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint32_t, Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-min(Experimental::basic_simd<
+min(Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint32_t,
         Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint32_t,
       Experimental::simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(svmin_m(svptrue_b32(),
@@ -2034,24 +2017,24 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const std::uint32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, flag);
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2059,29 +2042,29 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_unchecked_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_unchecked_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2089,67 +2072,65 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-simd_partial_load(
-    const std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
-                                                                   flag);
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+    simd_partial_load(
+        const std::uint32_t* ptr,
+        basic_mask<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+        simd_flags<Flags...> flag = simd_flag_default) {
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(ptr, mask,
+                                                                  flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::uint32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_uint32_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::uint32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+    basic_mask<std::uint32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
+    basic_vec<std::uint32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::uint32_t* ptr,
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
+    basic_mask<std::uint32_t,
+               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
-condition(
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
-  return basic_simd<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
+basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
+condition(basic_mask<std::uint32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& a,
+          basic_vec<std::uint32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& b,
+          basic_vec<std::uint32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& c) {
+  return basic_vec<std::uint32_t,
+                   simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>(
       static_cast<vls_uint32_t>(svsel(static_cast<vls_bool_t>(a),
                                       static_cast<vls_uint32_t>(b),
                                       static_cast<vls_uint32_t>(c))));
 }
 
 template <>
-class basic_simd<std::int64_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
+class basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   vls_int64_t m_value;
 
  protected:
@@ -2158,45 +2139,45 @@ class basic_simd<std::int64_t,
  public:
   using value_type = std::int64_t;
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_DOUBLES_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_s64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_int64_t const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -2220,12 +2201,12 @@ class basic_simd<std::int64_t,
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -2262,94 +2243,94 @@ class basic_simd<std::int64_t,
   operator vls_int64_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b64(), m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svasr_m(svptrue_b64(), static_cast<implementation_type>(lhs),
                 std::uint64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svasr_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svasr_m(
         svptrue_b64(), static_cast<implementation_type>(lhs),
         svreinterpret_u64(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsl_m(svptrue_b64(), static_cast<implementation_type>(lhs),
                 std::uint64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsl_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsl_m(
         svptrue_b64(), static_cast<implementation_type>(lhs),
         svreinterpret_u64(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
@@ -2358,95 +2339,95 @@ class basic_simd<std::int64_t,
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::int64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
   vls_int64_t aa = static_cast<vls_int64_t>(a);
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(svabs_m(aa, svptrue_b64(), aa)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::int64_t,
      Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 copysign(
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
   vls_bool_t positivity_b =
       svcmpge(svptrue_b64(), static_cast<vls_int64_t>(b), std::int64_t(0));
   vls_int64_t sign_b = svsel(positivity_b, svdup_s64(1), svdup_s64(-1));
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(
           svmul_m(svptrue_b64(), static_cast<vls_int64_t>(abs(a)), sign_b)));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-fma(Experimental::basic_simd<
+fma(Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         c) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(
@@ -2454,16 +2435,16 @@ fma(Experimental::basic_simd<
                   static_cast<vls_int64_t>(b), static_cast<vls_int64_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-max(Experimental::basic_simd<
+max(Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(svmax_m(svptrue_b64(),
@@ -2471,16 +2452,16 @@ max(Experimental::basic_simd<
                                        static_cast<vls_int64_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::int64_t, Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-min(Experimental::basic_simd<
+min(Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::int64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::int64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(svmin_m(svptrue_b64(),
@@ -2496,25 +2477,24 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::int64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2523,30 +2503,28 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2555,69 +2533,66 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_int64_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::int64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int64_t* ptr,
-    basic_simd_mask<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::int64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-condition(
-    basic_simd_mask<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
-  return basic_simd<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    condition(
+        basic_mask<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+        basic_vec<std::int64_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+        basic_vec<std::int64_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+  return basic_vec<std::int64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(svsel(static_cast<vls_bool_t>(a),
                                      static_cast<vls_int64_t>(b),
                                      static_cast<vls_int64_t>(c))));
 }
 
 template <>
-class basic_simd<std::uint64_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
+class basic_vec<std::uint64_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   vls_uint64_t m_value;
 
  protected:
@@ -2626,47 +2601,47 @@ class basic_simd<std::uint64_t,
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using mask_type  = basic_simd_mask<value_type, abi_type>;
+  using mask_type  = basic_mask<value_type, abi_type>;
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static constexpr std::size_t size() {
     return SVE_DOUBLES_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : m_value(svdup_u64(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       vls_uint64_t const& value_in) noexcept
       : m_value(value_in) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int32_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int32_t, abi_type> const& other) noexcept;
   template <typename U>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
-      : m_value(basic_simd([&](std::size_t i) {
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
+      : m_value(basic_vec([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::int64_t, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<double, abi_type> const& other) noexcept;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::int64_t, abi_type> const& other) noexcept;
   template <class G,
             std::enable_if_t<
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
     value_type temp[] = {
@@ -2690,12 +2665,12 @@ class basic_simd<std::uint64_t,
   }
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
@@ -2732,93 +2707,93 @@ class basic_simd<std::uint64_t,
   operator vls_uint64_t() const noexcept {
     return m_value;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(static_cast<implementation_type>(svundef_u64()));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec operator-() const noexcept {
+    return basic_vec(static_cast<implementation_type>(svundef_u64()));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svmul_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svdiv_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svadd_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svsub_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmplt(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpgt(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmple(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpge(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(static_cast<vls_bool_t>(
         svcmpeq(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return !(operator==(lhs, rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsr_m(svptrue_b64(), static_cast<implementation_type>(lhs),
                 std::uint64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsr_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsr_m(
         svptrue_b64(), static_cast<implementation_type>(lhs),
         svreinterpret_u64(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(
         svlsl_m(svptrue_b64(), static_cast<implementation_type>(lhs),
                 std::uint64_t(rhs))));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(static_cast<implementation_type>(svlsl_m(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(static_cast<implementation_type>(svlsl_m(
         svptrue_b64(), static_cast<implementation_type>(lhs),
         svreinterpret_u64(
             (to_sve_vla<value_type>)static_cast<implementation_type>(rhs)))));
@@ -2827,71 +2802,71 @@ class basic_simd<std::uint64_t,
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-abs(Experimental::basic_simd<
+abs(Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-floor(Experimental::basic_simd<
+floor(Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-ceil(Experimental::basic_simd<
+ceil(Experimental::basic_vec<
      std::uint64_t,
      Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-round(Experimental::basic_simd<
+round(Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-trunc(Experimental::basic_simd<
+trunc(Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(a));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 copysign(
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
@@ -2899,20 +2874,20 @@ copysign(
   return a;
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-fma(Experimental::basic_simd<
+fma(Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         c) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(
@@ -2920,17 +2895,17 @@ fma(Experimental::basic_simd<
                   static_cast<vls_uint64_t>(b), static_cast<vls_uint64_t>(c))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-max(Experimental::basic_simd<
+max(Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(svmax_m(svptrue_b64(),
@@ -2938,17 +2913,17 @@ max(Experimental::basic_simd<
                                         static_cast<vls_uint64_t>(b))));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_vec<
     std::uint64_t,
     Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-min(Experimental::basic_simd<
+min(Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    Experimental::basic_simd<
+    Experimental::basic_vec<
         std::uint64_t,
         Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         b) {
-  return Experimental::basic_simd<
+  return Experimental::basic_vec<
       std::uint64_t,
       Experimental::simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(svmin_m(svptrue_b64(),
@@ -2964,25 +2939,24 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::uint64_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const std::uint64_t* ptr,
-        basic_simd_mask<std::uint64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -2991,30 +2965,28 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
         const std::uint64_t* ptr,
-        basic_simd_mask<std::uint64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const std::uint64_t* ptr,
-        basic_simd_mask<std::uint64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -3023,61 +2995,58 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
         const std::uint64_t* ptr,
-        basic_simd_mask<std::uint64_t,
-                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
+        basic_mask<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
-                                                                     flag);
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, mask,
+                                                                    flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::uint64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_uint64_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::uint64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::uint64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::uint64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::uint64_t,
+               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-condition(
-    basic_simd_mask<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
-  return basic_simd<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    condition(
+        basic_mask<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+        basic_vec<std::uint64_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+        basic_vec<std::uint64_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+  return basic_vec<std::uint64_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(svsel(static_cast<vls_bool_t>(a),
                                       static_cast<vls_uint64_t>(b),
                                       static_cast<vls_uint64_t>(c))));
@@ -3100,17 +3069,18 @@ condition(
 //   where half-size vector = 256-bit, while Neon vector is only 128-bit.
 
 // template <>
-// class basic_simd_mask<std::int32_t,
+// class basic_mask<std::int32_t,
 // simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-//     : public Experimental::basic_simd_mask<
+//     : public Experimental::basic_mask<
 //           std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> {};
 
 template <>
-class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    : public Experimental::basic_simd<
+class basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    : public Experimental::basic_vec<
           std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
-  using base_type = Experimental::basic_simd<
-      std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>;
+  using base_type =
+      Experimental::basic_vec<std::int32_t,
+                              simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>;
   using base_abi_type = base_type::abi_type;
 
  protected:
@@ -3127,22 +3097,22 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     return SVE_DOUBLES_IN_VECTOR;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd const&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec() noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec const&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(basic_simd&&) noexcept =
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(basic_vec&&) noexcept =
       default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd const&) noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
-      basic_simd&&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec const&) noexcept = default;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec& operator=(
+      basic_vec&&) noexcept = default;
 
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec(U&& value) noexcept
       : base_type(value) {}
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       implementation_type const& value_in) noexcept
       : base_type(value_in) {}
 
@@ -3151,26 +3121,26 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       G&& gen) noexcept
       : base_type(gen) {}
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       value_type const* ptr, FlagType) noexcept
       : base_type(ptr, FlagType{}) {}
 
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       const value_type* ptr, mask_type const& mask, FlagType) noexcept
       : base_type(ptr, mask, FlagType{}) {}
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
-      basic_simd<std::uint64_t, abi_type> const& other) noexcept
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_vec(
+      basic_vec<std::uint64_t, abi_type> const& other) noexcept
       : base_type(
 #if SVE_DOUBLES_IN_VECTOR == 2
-            basic_simd<std::uint64_t,
-                       simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+            basic_vec<std::uint64_t,
+                      simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
                 svget_neonq_u64(static_cast<vls_uint64_t>(other)))
 #elif SVE_DOUBLES_IN_VECTOR == 4
             svget_neonq_s32(svuzp1_s32(
@@ -3210,11 +3180,10 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<std::int32_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            other) noexcept
+basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_vec(basic_vec<std::int32_t,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svreinterpret_u64(other.to_s64())) {}
 
 #endif  // #if SVE_DOUBLES_IN_VECTOR >= 8
@@ -3229,115 +3198,111 @@ template <typename SimdType, typename... Flags,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::int32_t* ptr,
                         simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_simd(
-    basic_simd<std::int64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_vec(
+    basic_vec<std::int64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         other) noexcept
     : m_value(svcvt_f64_z(svptrue_b64(), static_cast<vls_int64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_simd(
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::basic_vec(
+    basic_vec<std::uint64_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         other) noexcept
     : m_value(svcvt_f64_z(svptrue_b64(), static_cast<vls_uint64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_simd(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_vec(
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         other) noexcept
     : m_value(svcvt_f32_z(svptrue_b32(), static_cast<vls_int32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_simd(
-    basic_simd<std::uint32_t,
-               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::basic_vec(
+    basic_vec<std::uint32_t,
+              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         other) noexcept
     : m_value(svcvt_f32_z(svptrue_b32(), static_cast<vls_uint32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_vec(
+        basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
             other) noexcept
     : m_value(svcvt_s32_z(svptrue_b32(), static_cast<vls_float32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
-    basic_simd(basic_simd<std::uint32_t,
-                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-                   other) noexcept
+basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_vec(basic_vec<std::uint32_t,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svreinterpret_s32_u32(static_cast<vls_uint32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_vec(
+        basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
             other) noexcept
     : m_value(svcvt_u32_z(svptrue_b32(), static_cast<vls_float32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
-    basic_simd(basic_simd<std::int32_t,
-                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-                   other) noexcept
+basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>::
+    basic_vec(basic_vec<std::int32_t,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svreinterpret_u32_s32(static_cast<vls_int32_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(basic_simd<
-               double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-                   other) noexcept
+basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_vec(basic_vec<double,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svcvt_s64_z(svptrue_b64(), static_cast<vls_float64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<std::uint64_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            other) noexcept
+basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_vec(basic_vec<std::uint64_t,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svreinterpret_s64_u64(static_cast<vls_uint64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(basic_simd<
-               double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-                   other) noexcept
+basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_vec(basic_vec<double,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svcvt_u64_z(svptrue_b64(), static_cast<vls_float64_t>(other))) {}
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
-    basic_simd(
-        basic_simd<std::int64_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            other) noexcept
+basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
+    basic_vec(basic_vec<std::int64_t,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+                  other) noexcept
     : m_value(svreinterpret_u64_s64(static_cast<vls_int64_t>(other))) {}
 
 // FIXME should be converted to use sve mask
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    simd_unchecked_load(
-        const double* ptr,
-        basic_simd_mask<std::int32_t,
-                        simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
+    std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+simd_unchecked_load(
+    const double* ptr,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
-                                                                     flag);
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
+                                                                    flag);
 }
 
 // FIXME should be converted to use sve mask
@@ -3346,38 +3311,34 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    simd_unchecked_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t,
-                        simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
+    std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+simd_unchecked_load(
+    const std::int32_t* ptr,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
-                                                                     flag);
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
+                                                                    flag);
 }
 
 // FIXME should be converted to use sve mask
 template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t,
-                        simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
+    std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+simd_partial_load(
+    const std::int32_t* ptr,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
-                                                                     flag);
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
+                                                                    flag);
 }
 
 // FIXME should be converted to use sve mask
@@ -3386,26 +3347,24 @@ template <typename SimdType, typename... Flags,
               std::is_same_v<typename SimdType::abi_type,
                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
               bool> = false>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t,
-                        simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-            mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_vec<
+    std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+simd_partial_load(
+    const std::int32_t* ptr,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
-                                                                     flag);
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(ptr, nmask,
+                                                                    flag);
 }
 
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
   simd_unchecked_store<std::int32_t,
                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
@@ -3415,15 +3374,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 // FIXME should be converted to use sve mask
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
   simd_unchecked_store<std::int32_t,
                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
@@ -3433,15 +3390,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
 // FIXME should be converted to use sve mask
 template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
+    basic_vec<std::int32_t,
+              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
-    basic_simd_mask<std::int32_t,
-                    simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-        mask,
+    basic_mask<std::int32_t,
+               simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
     FlagType) {
-  basic_simd_mask<std::int32_t,
-                  simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+  basic_mask<std::int32_t, simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](std::size_t i) { return mask[i]; });
   simd_partial_store<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
@@ -3449,17 +3404,17 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 // FIXME should be converted to use sve mask
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
-    std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-condition(
-    basic_simd_mask<std::int32_t,
-                    simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-    basic_simd<std::int32_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
-  return basic_simd<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+    condition(
+        basic_mask<std::int32_t,
+                   simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+        basic_vec<std::int32_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+        basic_vec<std::int32_t,
+                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+  return basic_vec<std::int32_t,
+                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       [=](std::size_t i) { return a[i] ? b[i] : c[i]; });
 }
 
@@ -3467,12 +3422,12 @@ condition(
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+    basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using value_type = basic_simd<double, abi_type>;
-  using mask_type  = basic_simd_mask<double, abi_type>;
+  using value_type = basic_vec<double, abi_type>;
+  using mask_type  = basic_mask<double, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3495,8 +3450,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       double* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem, index.to_s64(),
                         static_cast<vls_float64_t>(m_value));
@@ -3514,18 +3469,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+    basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<double,
-                          simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-          basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+          basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+          basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<double,
-                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+      basic_mask<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
           mask_arg,
-      basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>&
+      basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>&
           value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3541,9 +3494,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       double const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-          index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -3555,15 +3507,15 @@ class KOKKOS_DEPRECATED where_expression<
   }
   template <class U, std::enable_if_t<
                          std::is_convertible_v<
-                             U, basic_simd<double, simd_abi::sve_fixed_size<
-                                                       SVE_DOUBLES_IN_VECTOR>>>,
+                             U, basic_vec<double, simd_abi::sve_fixed_size<
+                                                      SVE_DOUBLES_IN_VECTOR>>>,
                          bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type = static_cast<
-        basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+        basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
         std::forward<U>(x));
     m_value = static_cast<
-        basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+        basic_vec<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
         static_cast<vls_float64_t>(
             svsel(static_cast<vls_bool_t>(m_mask),
                   static_cast<vls_float64_t>(x_as_value_type),
@@ -3573,12 +3525,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+    basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using value_type = basic_simd<float, abi_type>;
-  using mask_type  = basic_simd_mask<float, abi_type>;
+  using value_type = basic_vec<float, abi_type>;
+  using mask_type  = basic_mask<float, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3601,8 +3553,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       float* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem,
                         static_cast<vls_int32_t>(index),
@@ -3621,16 +3573,16 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+    basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-          basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+          basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+          basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<
-          float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask_arg,
-      basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
+      basic_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
+          mask_arg,
+      basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
           value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3646,8 +3598,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       float const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -3657,18 +3609,17 @@ class KOKKOS_DEPRECATED where_expression<
         static_cast<vls_float32_t>(svsel(static_cast<vls_bool_t>(m_mask), tmp,
                                                    static_cast<vls_float32_t>(m_value))));
   }
-  template <
-      class U,
-      std::enable_if_t<
-          std::is_convertible_v<U, basic_simd<float, simd_abi::sve_fixed_size<
+  template <class U,
+            std::enable_if_t<std::is_convertible_v<
+                                 U, basic_vec<float, simd_abi::sve_fixed_size<
                                                          SVE_WORDS_IN_VECTOR>>>,
-          bool> = false>
+                             bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type = static_cast<
-        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
         std::forward<U>(x));
     m_value = static_cast<
-        basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        basic_vec<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
         static_cast<vls_float32_t>(
             svsel(static_cast<vls_bool_t>(m_mask),
                   static_cast<vls_float32_t>(x_as_value_type),
@@ -3678,13 +3629,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+    basic_mask<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using value_type = basic_simd<std::int32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int32_t, abi_type>;
+  using value_type = basic_vec<std::int32_t, abi_type>;
+  using mask_type  = basic_mask<std::int32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3707,8 +3657,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int32_t* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem,
                         static_cast<vls_int32_t>(index),
@@ -3727,20 +3677,18 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+    basic_mask<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<std::int32_t,
-                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-          basic_simd<std::int32_t,
-                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+          basic_mask<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+          basic_vec<std::int32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int32_t,
-                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-          mask_arg,
-      basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
+      basic_mask<std::int32_t,
+                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask_arg,
+      basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
           value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3756,8 +3704,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int32_t const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -3770,33 +3718,30 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                    SVE_WORDS_IN_VECTOR>>>,
+                    U, basic_vec<std::int32_t, simd_abi::sve_fixed_size<
+                                                   SVE_WORDS_IN_VECTOR>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
-    auto const x_as_value_type =
-        static_cast<basic_simd<std::int32_t,
-                               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
-            std::forward<U>(x));
-    m_value =
-        static_cast<basic_simd<std::int32_t,
-                               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
-            static_cast<vls_int32_t>(
-                svsel(static_cast<vls_bool_t>(m_mask),
-                      static_cast<vls_int32_t>(x_as_value_type),
-                      static_cast<vls_int32_t>(m_value))));
+    auto const x_as_value_type = static_cast<
+        basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        std::forward<U>(x));
+    m_value = static_cast<
+        basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        static_cast<vls_int32_t>(
+            svsel(static_cast<vls_bool_t>(m_mask),
+                  static_cast<vls_int32_t>(x_as_value_type),
+                  static_cast<vls_int32_t>(m_value))));
   }
 };
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+    basic_mask<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>;
-  using value_type = basic_simd<std::uint32_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint32_t, abi_type>;
+  using value_type = basic_vec<std::uint32_t, abi_type>;
+  using mask_type  = basic_mask<std::uint32_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3819,8 +3764,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint32_t* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem,
                         static_cast<vls_int32_t>(index),
@@ -3839,20 +3784,18 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint32_t,
-                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-    basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+    basic_mask<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+    basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint32_t,
-                          simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-          basic_simd<std::uint32_t,
-                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
+          basic_mask<std::uint32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
+          basic_vec<std::uint32_t,
+                    simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint32_t,
-                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
-          mask_arg,
-      basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
+      basic_mask<std::uint32_t,
+                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask_arg,
+      basic_vec<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>&
           value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3868,8 +3811,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint32_t const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -3882,17 +3825,17 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                     SVE_WORDS_IN_VECTOR>>>,
+                    U, basic_vec<std::uint32_t, simd_abi::sve_fixed_size<
+                                                    SVE_WORDS_IN_VECTOR>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
     auto const x_as_value_type =
-        static_cast<basic_simd<std::uint32_t,
-                               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        static_cast<basic_vec<std::uint32_t,
+                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
             std::forward<U>(x));
     m_value =
-        static_cast<basic_simd<std::uint32_t,
-                               simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
+        static_cast<basic_vec<std::uint32_t,
+                              simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>(
             static_cast<vls_uint32_t>(
                 svsel(static_cast<vls_bool_t>(m_mask),
                       static_cast<vls_uint32_t>(x_as_value_type),
@@ -3902,13 +3845,12 @@ class KOKKOS_DEPRECATED where_expression<
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+    basic_mask<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using value_type = basic_simd<std::int64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::int64_t, abi_type>;
+  using value_type = basic_vec<std::int64_t, abi_type>;
+  using mask_type  = basic_mask<std::int64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -3931,8 +3873,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::int64_t* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem, index.to_s64(),
                         static_cast<vls_int64_t>(m_value));
@@ -3950,20 +3892,19 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::int64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+    basic_mask<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<std::int64_t,
-                          simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-          basic_simd<std::int64_t,
-                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+          basic_mask<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+          basic_vec<std::int64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<std::int64_t,
-                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+      basic_mask<std::int64_t,
+                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
           mask_arg,
-      basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>&
+      basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>&
           value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3979,9 +3920,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::int64_t const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-          index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -3994,32 +3934,32 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                    SVE_DOUBLES_IN_VECTOR>>>,
+                    U, basic_vec<std::int64_t, simd_abi::sve_fixed_size<
+                                                   SVE_DOUBLES_IN_VECTOR>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
-    auto const x_as_value_type = static_cast<basic_simd<
-        std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
-        std::forward<U>(x));
-    m_value = static_cast<basic_simd<
-        std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
-        static_cast<vls_int64_t>(
-            svsel(static_cast<vls_bool_t>(m_mask),
-                  static_cast<vls_int64_t>(x_as_value_type),
-                  static_cast<vls_int64_t>(m_value))));
+    auto const x_as_value_type =
+        static_cast<basic_vec<std::int64_t,
+                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+            std::forward<U>(x));
+    m_value =
+        static_cast<basic_vec<std::int64_t,
+                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+            static_cast<vls_int64_t>(
+                svsel(static_cast<vls_bool_t>(m_mask),
+                      static_cast<vls_int64_t>(x_as_value_type),
+                      static_cast<vls_int64_t>(m_value))));
   }
 };
 
 template <>
 class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<std::uint64_t,
-               simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+    basic_mask<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   using abi_type   = simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>;
-  using value_type = basic_simd<std::uint64_t, abi_type>;
-  using mask_type  = basic_simd_mask<std::uint64_t, abi_type>;
+  using value_type = basic_vec<std::uint64_t, abi_type>;
+  using mask_type  = basic_mask<std::uint64_t, abi_type>;
 
  protected:
   value_type& m_value;
@@ -4042,8 +3982,8 @@ class KOKKOS_DEPRECATED const_where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void scatter_to(
       std::uint64_t* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index)
       const {
     svst1_scatter_index(static_cast<vls_bool_t>(m_mask), mem, index.to_s64(),
                         static_cast<vls_uint64_t>(m_value));
@@ -4061,21 +4001,20 @@ class KOKKOS_DEPRECATED const_where_expression<
 
 template <>
 class KOKKOS_DEPRECATED where_expression<
-    basic_simd_mask<std::uint64_t,
-                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-    basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+    basic_mask<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
     : public const_where_expression<
-          basic_simd_mask<std::uint64_t,
-                          simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-          basic_simd<std::uint64_t,
-                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
+          basic_mask<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
+          basic_vec<std::uint64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>> {
  public:
   where_expression(
-      basic_simd_mask<std::uint64_t,
-                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
+      basic_mask<std::uint64_t,
+                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
           mask_arg,
-      basic_simd<std::uint64_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>& value_arg)
+      basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>&
+          value_arg)
       : const_where_expression(mask_arg, value_arg) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void copy_from(std::uint64_t const* mem, element_aligned_tag) {
@@ -4090,9 +4029,8 @@ class KOKKOS_DEPRECATED where_expression<
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   void gather_from(
       std::uint64_t const* mem,
-      basic_simd<std::int32_t,
-                 simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
-          index) {
+      basic_vec<std::int32_t,
+                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& index) {
     // NOTE: Since SVE does not support "Gather-and-select" operation like x86
     // (inactive elements are zero-ed instead). We must use an extra select
     // to keep original value of inactive elements.
@@ -4105,19 +4043,21 @@ class KOKKOS_DEPRECATED where_expression<
   template <class U,
             std::enable_if_t<
                 std::is_convertible_v<
-                    U, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<
-                                                     SVE_DOUBLES_IN_VECTOR>>>,
+                    U, basic_vec<std::uint64_t, simd_abi::sve_fixed_size<
+                                                    SVE_DOUBLES_IN_VECTOR>>>,
                 bool> = false>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void operator=(U&& x) {
-    auto const x_as_value_type = static_cast<basic_simd<
-        std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
-        std::forward<U>(x));
-    m_value = static_cast<basic_simd<
-        std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
-        static_cast<vls_uint64_t>(
-            svsel(static_cast<vls_bool_t>(m_mask),
-                  static_cast<vls_uint64_t>(x_as_value_type),
-                  static_cast<vls_uint64_t>(m_value))));
+    auto const x_as_value_type =
+        static_cast<basic_vec<std::uint64_t,
+                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+            std::forward<U>(x));
+    m_value =
+        static_cast<basic_vec<std::uint64_t,
+                              simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>(
+            static_cast<vls_uint64_t>(
+                svsel(static_cast<vls_bool_t>(m_mask),
+                      static_cast<vls_uint64_t>(x_as_value_type),
+                      static_cast<vls_uint64_t>(m_value))));
   }
 };
 

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -2575,14 +2575,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    condition(
-        basic_mask<std::int64_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-        basic_vec<std::int64_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-        basic_vec<std::int64_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+basic_vec<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+condition(basic_mask<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+          basic_vec<std::int64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+          basic_vec<std::int64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
   return basic_vec<std::int64_t,
                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_int64_t>(svsel(static_cast<vls_bool_t>(a),
@@ -3037,14 +3036,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    condition(
-        basic_mask<std::uint64_t,
-                   simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-        basic_vec<std::uint64_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-        basic_vec<std::uint64_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+basic_vec<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+condition(basic_mask<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+          basic_vec<std::uint64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+          basic_vec<std::uint64_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
   return basic_vec<std::uint64_t,
                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       static_cast<vls_uint64_t>(svsel(static_cast<vls_bool_t>(a),
@@ -3405,14 +3403,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
 
 // FIXME should be converted to use sve mask
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
-    condition(
-        basic_mask<std::int32_t,
-                   simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
-        basic_vec<std::int32_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
-        basic_vec<std::int32_t,
-                  simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
+basic_vec<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
+condition(basic_mask<std::int32_t,
+                     simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& a,
+          basic_vec<std::int32_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& b,
+          basic_vec<std::int32_t,
+                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& c) {
   return basic_vec<std::int32_t,
                    simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       [=](std::size_t i) { return a[i] ? b[i] : c[i]; });

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -38,32 +38,31 @@ class scalar {};
 }  // namespace simd_abi
 
 template <class T>
-class basic_simd_mask<T, simd_abi::scalar> {
+class basic_mask<T, simd_abi::scalar> {
   bool m_value;
 
  public:
   using value_type = bool;
-  using simd_type  = basic_simd<T, simd_abi::scalar>;
+  using simd_type  = basic_vec<T, simd_abi::scalar>;
   using abi_type   = simd_abi::scalar;
 
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_mask() noexcept = default;
 
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
       value_type value) noexcept
       : m_value(value) {}
   template <class U>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      basic_simd_mask<U, simd_abi::scalar> const& other) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_mask(
+      basic_mask<U, simd_abi::scalar> const& other) noexcept
       : m_value(static_cast<bool>(other)) {}
   template <
       class G,
       std::enable_if_t<std::is_invocable_r_v<
                            value_type, G, std::integral_constant<bool, false>>,
                        bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_mask(G&& gen) noexcept
       : m_value(gen(0)) {}
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr value_type operator[](
@@ -71,9 +70,8 @@ class basic_simd_mask<T, simd_abi::scalar> {
     return m_value;
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd_mask operator!()
-      const noexcept {
-    return basic_simd_mask(!m_value);
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_mask operator!() const noexcept {
+    return basic_mask(!m_value);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool()
@@ -81,120 +79,115 @@ class basic_simd_mask<T, simd_abi::scalar> {
     return m_value;
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) && static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator&&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) && static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) || static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator||(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) || static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) & static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator&(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) & static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) | static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator|(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) | static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) ^ static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator^(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) ^ static_cast<bool>(rhs));
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator&=(
-      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask& operator&=(
+      basic_mask& lhs, basic_mask const& rhs) noexcept {
     lhs &= rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator|=(
-      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask& operator|=(
+      basic_mask& lhs, basic_mask const& rhs) noexcept {
     lhs |= rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator^=(
-      basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask& operator^=(
+      basic_mask& lhs, basic_mask const& rhs) noexcept {
     lhs ^= rhs;
     return lhs;
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION bool operator==(
-      basic_simd_mask const& other) const {
+  KOKKOS_FORCEINLINE_FUNCTION bool operator==(basic_mask const& other) const {
     return m_value == other.m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION bool operator!=(
-      basic_simd_mask const& other) const {
+  KOKKOS_FORCEINLINE_FUNCTION bool operator!=(basic_mask const& other) const {
     return m_value != other.m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator>=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) >= static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator>=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) >= static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator<=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) <= static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator<=(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) <= static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator>(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) > static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator>(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) > static_cast<bool>(rhs));
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator<(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) < static_cast<bool>(rhs));
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_mask operator<(
+      basic_mask const& lhs, basic_mask const& rhs) noexcept {
+    return basic_mask(static_cast<bool>(lhs) < static_cast<bool>(rhs));
   }
 };
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr bool all_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
-        a) noexcept {
+    basic_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) noexcept {
   return static_cast<bool>(
-      a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(true));
+      a == basic_mask<T, Kokkos::Experimental::simd_abi::scalar>(true));
 }
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr bool any_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
-        a) noexcept {
+    basic_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) noexcept {
   return static_cast<bool>(
-      a != basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
+      a != basic_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
 }
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar> const&
-        a) noexcept {
+    basic_mask<T, Kokkos::Experimental::simd_abi::scalar> const& a) noexcept {
   return static_cast<bool>(
-      a == basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
+      a == basic_mask<T, Kokkos::Experimental::simd_abi::scalar>(false));
 }
 
 template <class T>
-class basic_simd<T, simd_abi::scalar> {
+class basic_vec<T, simd_abi::scalar> {
   T m_value;
 
  public:
   using value_type = T;
   using abi_type   = simd_abi::scalar;
-  using mask_type  = basic_simd_mask<T, abi_type>;
+  using mask_type  = basic_mask<T, abi_type>;
 
   KOKKOS_FORCEINLINE_FUNCTION static constexpr std::size_t size() { return 1; }
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd() noexcept         = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd(basic_simd const&) = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd(basic_simd&&)      = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd& operator=(basic_simd const&) =
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_vec() noexcept        = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_vec(basic_vec const&) = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_vec(basic_vec&&)      = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_vec& operator=(basic_vec const&) =
       default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd& operator=(basic_simd&&) =
+  KOKKOS_DEFAULTED_FUNCTION constexpr basic_vec& operator=(basic_vec&&) =
       default;
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec(U&& value) noexcept
       : m_value(value) {}
   template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
                                       bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      basic_vec(basic_vec<U, abi_type> const& other) noexcept
       : m_value(static_cast<U>(other)) {}
   template <class G,
             std::enable_if_t<
@@ -203,14 +196,14 @@ class basic_simd<T, simd_abi::scalar> {
                 std::is_invocable_r_v<value_type, G,
                                       std::integral_constant<std::size_t, 0>>,
                 bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_vec(G&& gen) noexcept
       : m_value(gen(0)) {}
   template <typename FlagType>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(T const* ptr,
-                                                            FlagType) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_vec(T const* ptr,
+                                                           FlagType) noexcept
       : m_value(*ptr) {}
   template <typename FlagType>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_vec(
       T const* ptr, mask_type const& mask, FlagType) noexcept {
     m_value = (mask) ? *ptr : T();
   }
@@ -247,124 +240,124 @@ class basic_simd<T, simd_abi::scalar> {
     return m_value;
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd operator-() const noexcept {
-    return basic_simd(-m_value);
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec operator-() const noexcept {
+    return basic_vec(-m_value);
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value + rhs.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator+(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value + rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
-      basic_simd const& lhs, U rhs) {
-    return lhs.m_value + basic_simd(rhs);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator+(
+      basic_vec const& lhs, U rhs) {
+    return lhs.m_value + basic_vec(rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value - rhs.m_value);
-  }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
-      basic_simd const& lhs, U rhs) {
-    return lhs.m_value - basic_simd(rhs);
-  }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value * rhs.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator-(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value - rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
-      basic_simd const& lhs, U rhs) {
-    return lhs.m_value * basic_simd(rhs);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator-(
+      basic_vec const& lhs, U rhs) {
+    return lhs.m_value - basic_vec(rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value / rhs.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator*(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value * rhs.m_value);
   }
   template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
-      basic_simd const& lhs, U rhs) {
-    return lhs.m_value / basic_simd(rhs);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator*(
+      basic_vec const& lhs, U rhs) {
+    return lhs.m_value * basic_vec(rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator/(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value / rhs.m_value);
+  }
+  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator/(
+      basic_vec const& lhs, U rhs) {
+    return lhs.m_value / basic_vec(rhs);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator&(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return lhs.m_value & rhs.m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator|(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return lhs.m_value | rhs.m_value;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(lhs.m_value << rhs);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator<<(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(lhs.m_value << rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value << rhs.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator<<(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value << rhs.m_value);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>(
-      basic_simd const& lhs, int rhs) noexcept {
-    return basic_simd(lhs.m_value >> rhs);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator>>(
+      basic_vec const& lhs, int rhs) noexcept {
+    return basic_vec(lhs.m_value >> rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(lhs.m_value >> rhs.m_value);
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator>>(
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
+    return basic_vec(lhs.m_value >> rhs.m_value);
   }
 
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator+=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs + rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator-=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs - rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator*=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs * rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator/=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs / rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator<<=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs << rhs;
     return lhs;
   }
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator>>=(
-      basic_simd& lhs, basic_simd const& rhs) noexcept {
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_vec operator>>=(
+      basic_vec& lhs, basic_vec const& rhs) noexcept {
     lhs = lhs >> rhs;
     return lhs;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value == rhs.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value != rhs.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value >= rhs.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value <= rhs.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value > rhs.m_value);
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+      basic_vec const& lhs, basic_vec const& rhs) noexcept {
     return mask_type(lhs.m_value < rhs.m_value);
   }
 };
@@ -372,9 +365,9 @@ class basic_simd<T, simd_abi::scalar> {
 }  // namespace Experimental
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+abs(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
   if constexpr (std::is_signed_v<T>) {
     return (a < 0 ? -a : a);
   }
@@ -383,59 +376,59 @@ abs(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
 
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr auto floor(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_vec<data_type, Experimental::simd_abi::scalar>(
       Kokkos::floor(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr auto ceil(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_vec<data_type, Experimental::simd_abi::scalar>(
       Kokkos::ceil(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr auto round(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_vec<data_type, Experimental::simd_abi::scalar>(
       Experimental::round_half_to_nearest_even(static_cast<data_type>(a[0])));
 }
 
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr auto trunc(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
   using data_type = std::conditional_t<std::is_floating_point_v<T>, T, double>;
-  return Experimental::basic_simd<data_type, Experimental::simd_abi::scalar>(
+  return Experimental::basic_vec<data_type, Experimental::simd_abi::scalar>(
       Kokkos::trunc(static_cast<data_type>(a[0])));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-sqrt(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a) {
-  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+sqrt(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a) {
+  return Experimental::basic_vec<T, Experimental::simd_abi::scalar>(
       Kokkos::sqrt(static_cast<T>(a)));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-fma(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& y,
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& z) {
-  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+fma(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& y,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& z) {
+  return Experimental::basic_vec<T, Experimental::simd_abi::scalar>(
       Kokkos::fma(static_cast<T>(x), static_cast<T>(y), static_cast<T>(z)));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-copysign(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
-         Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
+copysign(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a,
+         Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& b) {
   return Kokkos::copysign(static_cast<T>(a), static_cast<T>(b));
 }
 
@@ -452,11 +445,10 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_unchecked_load(
 }
 
 template <typename T, typename... Flags>
-KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar>
-simd_unchecked_load(const T* ptr,
-                    basic_simd_mask<T, simd_abi::scalar> const& mask,
+KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec<T, simd_abi::scalar>
+simd_unchecked_load(const T* ptr, basic_mask<T, simd_abi::scalar> const& mask,
                     simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<T, simd_abi::scalar>(ptr, mask, flag);
+  return basic_vec<T, simd_abi::scalar>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -471,11 +463,10 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_unchecked_load(
 }
 
 template <typename T, typename... Flags>
-KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar>
-simd_partial_load(const T* ptr,
-                  basic_simd_mask<T, simd_abi::scalar> const& mask,
+KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec<T, simd_abi::scalar>
+simd_partial_load(const T* ptr, basic_mask<T, simd_abi::scalar> const& mask,
                   simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<T, simd_abi::scalar>(ptr, mask, flag);
+  return basic_vec<T, simd_abi::scalar>(ptr, mask, flag);
 }
 
 template <typename SimdType, typename... Flags,
@@ -491,15 +482,15 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_partial_load(
 
 template <typename T, typename... Flags>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_unchecked_store(
-    basic_simd<T, simd_abi::scalar> const& simd, T* ptr,
+    basic_vec<T, simd_abi::scalar> const& simd, T* ptr,
     [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {
   *ptr = simd[0];
 }
 
 template <typename T, typename... Flags>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_unchecked_store(
-    basic_simd<T, simd_abi::scalar> const& simd, T* ptr,
-    typename basic_simd<T, simd_abi::scalar>::mask_type const& mask,
+    basic_vec<T, simd_abi::scalar> const& simd, T* ptr,
+    typename basic_vec<T, simd_abi::scalar>::mask_type const& mask,
     [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {
   if (mask) {
     *ptr = simd[0];
@@ -508,8 +499,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_unchecked_store(
 
 template <typename T, typename... Flags>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
-    basic_simd<T, simd_abi::scalar> const& simd, T* ptr,
-    typename basic_simd<T, simd_abi::scalar>::mask_type const& mask,
+    basic_vec<T, simd_abi::scalar> const& simd, T* ptr,
+    typename basic_vec<T, simd_abi::scalar>::mask_type const& mask,
     [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {
   if (mask) {
     *ptr = simd[0];
@@ -517,27 +508,26 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
+KOKKOS_FORCEINLINE_FUNCTION constexpr basic_vec<T, simd_abi::scalar> condition(
     desul::Impl::dont_deduce_this_parameter_t<
-        basic_simd_mask<T, simd_abi::scalar>> const& a,
-    basic_simd<T, simd_abi::scalar> const& b,
-    basic_simd<T, simd_abi::scalar> const& c) {
-  return basic_simd<T, simd_abi::scalar>(
+        basic_mask<T, simd_abi::scalar>> const& a,
+    basic_vec<T, simd_abi::scalar> const& b,
+    basic_vec<T, simd_abi::scalar> const& c) {
+  return basic_vec<T, simd_abi::scalar>(
       static_cast<bool>(a) ? static_cast<T>(b) : static_cast<T>(c));
 }
 
 template <class T, class BinaryOperation = std::plus<>>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
     BinaryOperation = {}) noexcept {
   return x[0];
 }
 
 template <class T, class BinaryOperation = std::plus<>>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
-        mask,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_mask<T, Experimental::simd_abi::scalar> const& mask,
     BinaryOperation = {},
     T identity      = Impl::Identity<T, BinaryOperation>()) noexcept {
   if (!mask) return identity;
@@ -547,20 +537,19 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 template <class T, class BinaryOperation = std::plus<>>
 KOKKOS_DEPRECATED_WITH_COMMENT(
-    "Use reduce(basic_simd, basic_simd_mask, op, identity) instead")
+    "Use reduce(basic_vec, basic_mask, op, identity) instead")
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
-        mask,
-    T, BinaryOperation = {}) noexcept {
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_mask<T, Experimental::simd_abi::scalar> const& mask, T,
+    BinaryOperation = {}) noexcept {
   return reduce(x, mask);
 }
 #endif
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
   if (!mask) return Kokkos::reduction_identity<T>::min();
   return x[0];
@@ -568,15 +557,15 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION T
-reduce_min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
+reduce_min(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
   return x[0];
 }
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
-    Experimental::basic_simd_mask<T, Experimental::simd_abi::scalar> const&
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& x,
+    Experimental::basic_mask<T, Experimental::simd_abi::scalar> const&
         mask) noexcept {
   if (!mask) return Kokkos::reduction_identity<T>::max();
   return x[0];
@@ -584,38 +573,38 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
 
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION T
-reduce_max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const&
+reduce_max(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const&
                x) noexcept {
   return x[0];
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-min(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
-  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+min(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& b) {
+  return Experimental::basic_vec<T, Experimental::simd_abi::scalar>(
       Kokkos::min(a[0], b[0]));
 }
 
 template <class T>
-KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<
+KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_vec<
     T, Experimental::simd_abi::scalar>
-max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
-    Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& b) {
-  return Experimental::basic_simd<T, Experimental::simd_abi::scalar>(
+max(Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& a,
+    Experimental::basic_vec<T, Experimental::simd_abi::scalar> const& b) {
+  return Experimental::basic_vec<T, Experimental::simd_abi::scalar>(
       Kokkos::max(a[0], b[0]));
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <class T>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<T, simd_abi::scalar>, basic_simd<T, simd_abi::scalar>> {
+class KOKKOS_DEPRECATED const_where_expression<basic_mask<T, simd_abi::scalar>,
+                                               basic_vec<T, simd_abi::scalar>> {
  public:
   using abi_type   = simd_abi::scalar;
-  using value_type = basic_simd<T, abi_type>;
-  using mask_type  = basic_simd_mask<T, abi_type>;
+  using value_type = basic_vec<T, abi_type>;
+  using mask_type  = basic_mask<T, abi_type>;
 
  protected:
   value_type& m_value;
@@ -636,8 +625,7 @@ class KOKKOS_DEPRECATED const_where_expression<
   }
   template <class Integral>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<Integral>>
-  scatter_to(T* mem,
-             basic_simd<Integral, simd_abi::scalar> const& index) const {
+  scatter_to(T* mem, basic_vec<Integral, simd_abi::scalar> const& index) const {
     if (static_cast<bool>(m_mask))
       mem[static_cast<Integral>(index)] = static_cast<T>(m_value);
   }
@@ -652,18 +640,18 @@ class KOKKOS_DEPRECATED const_where_expression<
 };
 
 template <class T>
-class KOKKOS_DEPRECATED where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                         basic_simd<T, simd_abi::scalar>>
-    : public const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                    basic_simd<T, simd_abi::scalar>> {
-  using base_type = const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                           basic_simd<T, simd_abi::scalar>>;
+class KOKKOS_DEPRECATED where_expression<basic_mask<T, simd_abi::scalar>,
+                                         basic_vec<T, simd_abi::scalar>>
+    : public const_where_expression<basic_mask<T, simd_abi::scalar>,
+                                    basic_vec<T, simd_abi::scalar>> {
+  using base_type = const_where_expression<basic_mask<T, simd_abi::scalar>,
+                                           basic_vec<T, simd_abi::scalar>>;
 
  public:
   using typename base_type::value_type;
   KOKKOS_FORCEINLINE_FUNCTION
-  where_expression(basic_simd_mask<T, simd_abi::scalar> const& mask_arg,
-                   basic_simd<T, simd_abi::scalar>& value_arg)
+  where_expression(basic_mask<T, simd_abi::scalar> const& mask_arg,
+                   basic_vec<T, simd_abi::scalar>& value_arg)
       : base_type(mask_arg, value_arg) {}
   KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_partial_load() instead")
   KOKKOS_FORCEINLINE_FUNCTION
@@ -677,45 +665,46 @@ class KOKKOS_DEPRECATED where_expression<basic_simd_mask<T, simd_abi::scalar>,
   template <class Integral>
   KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_integral_v<Integral>>
   gather_from(T const* mem,
-              basic_simd<Integral, simd_abi::scalar> const& index) {
+              basic_vec<Integral, simd_abi::scalar> const& index) {
     if (static_cast<bool>(this->m_mask))
       this->m_value = mem[static_cast<Integral>(index)];
   }
-  template <class U, std::enable_if_t<std::is_convertible_v<
-                                          U, basic_simd<T, simd_abi::scalar>>,
-                                      bool> = false>
+  template <
+      class U,
+      std::enable_if_t<std::is_convertible_v<U, basic_vec<T, simd_abi::scalar>>,
+                       bool> = false>
   KOKKOS_FORCEINLINE_FUNCTION void operator=(U&& x) {
     if (static_cast<bool>(this->m_mask))
       this->m_value =
-          static_cast<basic_simd<T, simd_abi::scalar>>(std::forward<U>(x));
+          static_cast<basic_vec<T, simd_abi::scalar>>(std::forward<U>(x));
   }
 };
 
 template <class T>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION
-    where_expression<basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
-                     basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
-    where(typename basic_simd<
+    where_expression<basic_mask<T, Kokkos::Experimental::simd_abi::scalar>,
+                     basic_vec<T, Kokkos::Experimental::simd_abi::scalar>>
+    where(typename basic_vec<
               T, Kokkos::Experimental::simd_abi::scalar>::mask_type const& mask,
-          basic_simd<T, Kokkos::Experimental::simd_abi::scalar>& value) {
+          basic_vec<T, Kokkos::Experimental::simd_abi::scalar>& value) {
   return where_expression(mask, value);
 }
 
 template <class T>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION const_where_expression<
-    basic_simd_mask<T, Kokkos::Experimental::simd_abi::scalar>,
-    basic_simd<T, Kokkos::Experimental::simd_abi::scalar>>
-where(typename basic_simd<
+    basic_mask<T, Kokkos::Experimental::simd_abi::scalar>,
+    basic_vec<T, Kokkos::Experimental::simd_abi::scalar>>
+where(typename basic_vec<
           T, Kokkos::Experimental::simd_abi::scalar>::mask_type const& mask,
-      basic_simd<T, Kokkos::Experimental::simd_abi::scalar> const& value) {
+      basic_vec<T, Kokkos::Experimental::simd_abi::scalar> const& value) {
   return const_where_expression(mask, value);
 }
 
 template <class T>
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_max() instead")
 KOKKOS_FORCEINLINE_FUNCTION T
-    hmax(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                basic_simd<T, simd_abi::scalar>> const& x) {
+    hmax(const_where_expression<basic_mask<T, simd_abi::scalar>,
+                                basic_vec<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
@@ -723,8 +712,8 @@ KOKKOS_FORCEINLINE_FUNCTION T
 
 template <class T>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
-    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                           basic_simd<T, simd_abi::scalar>> const& x,
+    const_where_expression<basic_mask<T, simd_abi::scalar>,
+                           basic_vec<T, simd_abi::scalar>> const& x,
     T identity_element, std::plus<>) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
@@ -733,8 +722,8 @@ KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
 
 template <class T>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
-    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                           basic_simd<T, simd_abi::scalar>> const& x) noexcept {
+    const_where_expression<basic_mask<T, simd_abi::scalar>,
+                           basic_vec<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::max();
@@ -743,8 +732,8 @@ KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_max(
 template <class T>
 KOKKOS_DEPRECATED_WITH_COMMENT("Use reduce_min() instead")
 KOKKOS_FORCEINLINE_FUNCTION T
-    hmin(const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                                basic_simd<T, simd_abi::scalar>> const& x) {
+    hmin(const_where_expression<basic_mask<T, simd_abi::scalar>,
+                                basic_vec<T, simd_abi::scalar>> const& x) {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();
@@ -752,8 +741,8 @@ KOKKOS_FORCEINLINE_FUNCTION T
 
 template <class T>
 KOKKOS_DEPRECATED KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce_min(
-    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                           basic_simd<T, simd_abi::scalar>> const& x) noexcept {
+    const_where_expression<basic_mask<T, simd_abi::scalar>,
+                           basic_vec<T, simd_abi::scalar>> const& x) noexcept {
   return static_cast<bool>(x.impl_get_mask())
              ? static_cast<T>(x.impl_get_value())
              : Kokkos::reduction_identity<T>::min();

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -67,8 +67,8 @@ class kokkos_checker {
 
 template <class T, class Abi>
 inline void host_check_equality(
-    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& computed_result,
     std::size_t nlanes) {
   gtest_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
@@ -78,8 +78,8 @@ inline void host_check_equality(
 
 template <class T, class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_equality(
-    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& computed_result,
     std::size_t nlanes) {
   kokkos_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
@@ -89,8 +89,8 @@ KOKKOS_INLINE_FUNCTION void device_check_equality(
 
 template <typename T, typename Abi>
 KOKKOS_INLINE_FUNCTION void check_equality(
-    Kokkos::Experimental::basic_simd<T, Abi> const& expected_result,
-    Kokkos::Experimental::basic_simd<T, Abi> const& computed_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_vec<T, Abi> const& computed_result,
     std::size_t nlanes) {
   KOKKOS_IF_ON_HOST(
       (host_check_equality(expected_result, computed_result, nlanes);))
@@ -102,9 +102,9 @@ class load_element_aligned {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     if (n < result.size()) return false;
-    using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+    using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
     result          = Kokkos::Experimental::simd_unchecked_load<simd_type>(
         mem, Kokkos::Experimental::simd_flag_default);
     return true;
@@ -112,9 +112,9 @@ class load_element_aligned {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     if (n < result.size()) return false;
-    using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+    using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
     result          = Kokkos::Experimental::simd_unchecked_load<simd_type>(
         mem, Kokkos::Experimental::simd_flag_default);
     return true;
@@ -125,9 +125,9 @@ class load_vector_aligned {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     if (n < result.size()) return false;
-    using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+    using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
     result          = Kokkos::Experimental::simd_unchecked_load<simd_type>(
         mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
@@ -135,9 +135,9 @@ class load_vector_aligned {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     if (n < result.size()) return false;
-    using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+    using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
     result          = Kokkos::Experimental::simd_unchecked_load<simd_type>(
         mem, Kokkos::Experimental::simd_flag_aligned);
     return true;
@@ -148,9 +148,9 @@ class load_masked {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+                 Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     using mask_type =
-        typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
+        typename Kokkos::Experimental::basic_vec<T, Abi>::mask_type;
     mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < n; });
     result =
         simd_partial_load(mem, mask, Kokkos::Experimental::simd_flag_default);
@@ -159,9 +159,9 @@ class load_masked {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
+      Kokkos::Experimental::basic_vec<T, Abi>& result) const {
     using mask_type =
-        typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
+        typename Kokkos::Experimental::basic_vec<T, Abi>::mask_type;
     mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i < n; });
     result =
         simd_partial_load(mem, mask, Kokkos::Experimental::simd_flag_default);
@@ -173,8 +173,8 @@ class load_as_scalars {
  public:
   template <class T, class Abi>
   bool host_load(T const* mem, std::size_t n,
-                 Kokkos::Experimental::basic_simd<T, Abi>& result) const {
-    Kokkos::Experimental::basic_simd<T, Abi> init(
+                 Kokkos::Experimental::basic_vec<T, Abi>& result) const {
+    Kokkos::Experimental::basic_vec<T, Abi> init(
         KOKKOS_LAMBDA(std::size_t i) { return (i < n) ? mem[i] : T(0); });
     result = init;
 
@@ -183,8 +183,8 @@ class load_as_scalars {
   template <class T, class Abi>
   KOKKOS_INLINE_FUNCTION bool device_load(
       T const* mem, std::size_t n,
-      Kokkos::Experimental::basic_simd<T, Abi>& result) const {
-    Kokkos::Experimental::basic_simd<T, Abi> init(
+      Kokkos::Experimental::basic_vec<T, Abi>& result) const {
+    Kokkos::Experimental::basic_vec<T, Abi> init(
         KOKKOS_LAMBDA(std::size_t i) { return (i < n) ? mem[i] : T(0); });
 
     result = init;
@@ -206,7 +206,7 @@ constexpr bool is_type_v<T, decltype(void(sizeof(T)))> = true;
 // same-capability 'simd_mask' type
 template <typename DataType, typename Abi>
 constexpr bool is_simd_avail_v =
-    is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>> &&
-    is_type_v<Kokkos::Experimental::basic_simd_mask<DataType, Abi>>;
+    is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>> &&
+    is_type_v<Kokkos::Experimental::basic_mask<DataType, Abi>>;
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_Condition.hpp
+++ b/simd/unit_tests/include/TestSIMD_Condition.hpp
@@ -28,7 +28,7 @@ import kokkos.simd;
 template <typename Abi, typename DataType>
 inline void host_check_condition() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using simd_type = typename Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using simd_type = typename Kokkos::Experimental::basic_vec<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
 
     auto condition_op = [](mask_type const& mask, simd_type const& a,
@@ -61,8 +61,8 @@ inline void host_check_condition_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_condition() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
-    using simd_type = typename Kokkos::Experimental::basic_simd<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
+    using simd_type = typename Kokkos::Experimental::basic_vec<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
     kokkos_checker checker;
 

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -29,7 +29,7 @@ using Kokkos::Experimental::all_of;
 
 template <typename Abi, typename DataType>
 inline void host_test_simd_traits() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
 
   static_assert(std::is_nothrow_default_constructible_v<simd_type>);
   static_assert(std::is_nothrow_copy_assignable_v<simd_type>);
@@ -48,7 +48,7 @@ inline void host_test_simd_traits() {
 
 template <typename Abi, typename DataType>
 inline void host_test_mask_traits() {
-  using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+  using mask_type = Kokkos::Experimental::basic_mask<DataType, Abi>;
 
   static_assert(std::is_nothrow_default_constructible_v<mask_type>);
   static_assert(std::is_nothrow_copy_assignable_v<mask_type>);
@@ -68,30 +68,30 @@ inline void host_test_mask_traits() {
 
 template <typename Abi, typename DataType>
 inline void host_test_simd_alias() {
-  using basic_simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using basic_vec_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   using native_fixed_abi =
       Kokkos::Experimental::simd_abi::Impl::native_fixed_abi<DataType>;
   using native_abi =
       Kokkos::Experimental::simd_abi::Impl::native_abi<DataType,
-                                                       basic_simd_type::size()>;
+                                                       basic_vec_type::size()>;
 
   if constexpr (std::is_same_v<Abi, native_fixed_abi>) {
     using simd_type =
-        Kokkos::Experimental::simd<DataType, basic_simd_type::size()>;
+        Kokkos::Experimental::vec<DataType, basic_vec_type::size()>;
     using simd_mask_type =
-        Kokkos::Experimental::simd_mask<DataType, basic_simd_type::size()>;
-    static_assert(std::is_same_v<basic_simd_type, simd_type>);
+        Kokkos::Experimental::mask<DataType, basic_vec_type::size()>;
+    static_assert(std::is_same_v<basic_vec_type, simd_type>);
     static_assert(
-        std::is_same_v<typename basic_simd_type::mask_type, simd_mask_type>);
+        std::is_same_v<typename basic_vec_type::mask_type, simd_mask_type>);
   }
   if constexpr (std::is_same_v<Abi, native_abi>) {
     using simd_type =
-        Kokkos::Experimental::simd<DataType, basic_simd_type::size()>;
+        Kokkos::Experimental::vec<DataType, basic_vec_type::size()>;
     using simd_mask_type =
-        Kokkos::Experimental::simd_mask<DataType, basic_simd_type::size()>;
-    static_assert(std::is_same_v<basic_simd_type, simd_type>);
+        Kokkos::Experimental::mask<DataType, basic_vec_type::size()>;
+    static_assert(std::is_same_v<basic_vec_type, simd_type>);
     static_assert(
-        std::is_same_v<typename basic_simd_type::mask_type, simd_mask_type>);
+        std::is_same_v<typename basic_vec_type::mask_type, simd_mask_type>);
   }
 }
 
@@ -119,7 +119,7 @@ inline void host_check_construction_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
 
   simd_type default_simd, result;
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
@@ -134,7 +134,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
-  using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+  using mask_type = Kokkos::Experimental::basic_mask<DataType, Abi>;
 
   mask_type default_mask(false);
   mask_type result(false);
@@ -150,7 +150,7 @@ KOKKOS_INLINE_FUNCTION void device_test_mask_traits() {
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_construction() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
     device_test_simd_traits<Abi, DataType>();
     device_test_mask_traits<Abi, DataType>();
   }

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -36,20 +36,19 @@ inline void host_check_conversions() {
                                                                      : 213;
     bool test_mask_val = true;
     {
-      auto from = Kokkos::Experimental::basic_simd<DataTypeA, Abi>(test_val);
-      auto to   = Kokkos::Experimental::basic_simd<DataTypeB, Abi>(from);
-      auto expected =
-          Kokkos::Experimental::basic_simd<DataTypeB, Abi>(test_val);
+      auto from     = Kokkos::Experimental::basic_vec<DataTypeA, Abi>(test_val);
+      auto to       = Kokkos::Experimental::basic_vec<DataTypeB, Abi>(from);
+      auto expected = Kokkos::Experimental::basic_vec<DataTypeB, Abi>(test_val);
       EXPECT_EQ(from.size(), to.size());
       host_check_equality(to, decltype(to)(test_val), to.size());
       host_check_equality(to, expected, to.size());
     }
     {
       auto from =
-          Kokkos::Experimental::basic_simd_mask<DataTypeA, Abi>(test_mask_val);
-      auto to = Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(from);
+          Kokkos::Experimental::basic_mask<DataTypeA, Abi>(test_mask_val);
+      auto to = Kokkos::Experimental::basic_mask<DataTypeB, Abi>(from);
       auto expected =
-          Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(test_mask_val);
+          Kokkos::Experimental::basic_mask<DataTypeB, Abi>(test_mask_val);
       EXPECT_EQ(from.size(), to.size());
       EXPECT_TRUE(all_of(to == decltype(to)(test_mask_val)));
       EXPECT_TRUE(all_of(to == expected));
@@ -87,20 +86,19 @@ KOKKOS_INLINE_FUNCTION void device_check_conversions() {
     bool test_mask_val = true;
     kokkos_checker checker;
     {
-      auto from = Kokkos::Experimental::basic_simd<DataTypeA, Abi>(test_val);
-      auto to   = Kokkos::Experimental::basic_simd<DataTypeB, Abi>(from);
-      auto expected =
-          Kokkos::Experimental::basic_simd<DataTypeB, Abi>(test_val);
+      auto from     = Kokkos::Experimental::basic_vec<DataTypeA, Abi>(test_val);
+      auto to       = Kokkos::Experimental::basic_vec<DataTypeB, Abi>(from);
+      auto expected = Kokkos::Experimental::basic_vec<DataTypeB, Abi>(test_val);
       checker.truth(from.size() == to.size());
       device_check_equality(to, decltype(to)(test_val), to.size());
       device_check_equality(to, expected, to.size());
     }
     {
       auto from =
-          Kokkos::Experimental::basic_simd_mask<DataTypeA, Abi>(test_mask_val);
-      auto to = Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(from);
+          Kokkos::Experimental::basic_mask<DataTypeA, Abi>(test_mask_val);
+      auto to = Kokkos::Experimental::basic_mask<DataTypeB, Abi>(from);
       auto expected =
-          Kokkos::Experimental::basic_simd_mask<DataTypeB, Abi>(test_mask_val);
+          Kokkos::Experimental::basic_mask<DataTypeB, Abi>(test_mask_val);
       checker.truth(from.size() == to.size());
       checker.truth(all_of(to == decltype(to)(test_mask_val)));
       checker.truth(all_of(to == expected));

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -28,7 +28,7 @@ import kokkos.simd;
 template <typename Abi, typename DataType>
 inline void host_check_gen_ctor() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
     constexpr std::size_t lanes = simd_type::size();
 
@@ -87,8 +87,8 @@ inline void host_check_gen_ctors_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_gen_ctor() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
-    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
+    using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
     using mask_type = typename simd_type::mask_type;
     constexpr std::size_t lanes = simd_type::size();
 

--- a/simd/unit_tests/include/TestSIMD_LoadStore.hpp
+++ b/simd/unit_tests/include/TestSIMD_LoadStore.hpp
@@ -74,7 +74,7 @@ inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
 
 template <typename Abi, typename DataType>
 inline void host_test_simd_loadstore() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
 
   mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i % 2 == 0; });
@@ -176,7 +176,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
 
   mask_type mask([=](std::size_t i) { return i % 2 == 0; });

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -28,7 +28,7 @@ import kokkos.simd;
 template <typename Abi, typename DataType>
 inline void host_check_mask_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+    using mask_type = Kokkos::Experimental::basic_mask<DataType, Abi>;
 
     EXPECT_FALSE(none_of(mask_type(true)));
     EXPECT_TRUE(none_of(mask_type(false)));
@@ -67,8 +67,8 @@ inline void host_check_mask_ops_all_abis(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_mask_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
-    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
+    using mask_type = Kokkos::Experimental::basic_mask<DataType, Abi>;
     kokkos_checker checker;
     checker.truth(!none_of(mask_type(true)));
     checker.truth(none_of(mask_type(false)));

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -30,7 +30,7 @@ void host_check_math_op_one_loader(TernaryOp ternary_op, std::size_t n,
                                    T const* first_args, T const* second_args,
                                    T const* third_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -66,7 +66,7 @@ template <class Abi, class Loader, class BinaryOp, class T>
 void host_check_math_op_one_loader(BinaryOp binary_op, std::size_t n,
                                    T const* first_args, T const* second_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -106,7 +106,7 @@ template <class Abi, class Loader, class UnaryOp, class T>
 void host_check_math_op_one_loader(UnaryOp unary_op, std::size_t n,
                                    T const* args) {
   Loader loader;
-  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
 
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
@@ -230,7 +230,7 @@ inline void host_check_all_math_ops(const DataType (&first_args)[n],
 
 template <typename Abi, typename DataType>
 inline void host_check_abi_size() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
   static_assert(simd_type::size() == mask_type::size());
 }
@@ -239,7 +239,7 @@ template <typename Abi, typename DataType>
 inline void host_check_math_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     constexpr size_t alignment =
-        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        Kokkos::Experimental::basic_vec<DataType, Abi>::size() *
         sizeof(DataType);
 
     host_check_abi_size<Abi, DataType>();
@@ -295,7 +295,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
     TernaryOp ternary_op, std::size_t n, T const* first_args,
     T const* second_args, T const* third_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -327,7 +327,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(
     BinaryOp binary_op, std::size_t n, T const* first_args,
     T const* second_args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -364,7 +364,7 @@ KOKKOS_INLINE_FUNCTION void device_check_math_op_one_loader(UnaryOp unary_op,
                                                             std::size_t n,
                                                             T const* args) {
   Loader loader;
-  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<T, Abi>;
   constexpr std::size_t width = simd_type::size();
   for (std::size_t i = 0; i < n; i += width) {
     std::size_t const nremaining = n - i;
@@ -485,14 +485,14 @@ KOKKOS_INLINE_FUNCTION void device_check_all_math_ops(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_abi_size() {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   using mask_type = typename simd_type::mask_type;
   static_assert(simd_type::size() == mask_type::size());
 }
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_math_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
     device_check_abi_size<Abi, DataType>();
 
     if constexpr (!std::is_integral_v<DataType>) {

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -41,9 +41,8 @@ template <typename Abi, typename Loader, typename ReductionOp, typename T>
 inline void host_check_reduction_one_loader(ReductionOp reduce_op,
                                             std::size_t n, T const* args) {
   Loader loader;
-  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
-  using mask_type =
-      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
+  using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
+  using mask_type = typename Kokkos::Experimental::basic_vec<T, Abi>::mask_type;
   constexpr std::size_t width = simd_type::size();
 
   for (std::size_t i = 0; i < n; i += width) {
@@ -140,9 +139,8 @@ template <typename Abi, typename Loader, typename ReductionOp, typename T>
 KOKKOS_INLINE_FUNCTION void device_check_reduction_one_loader(
     ReductionOp reduce_op, std::size_t n, T const* args) {
   Loader loader;
-  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
-  using mask_type =
-      typename Kokkos::Experimental::basic_simd<T, Abi>::mask_type;
+  using simd_type = Kokkos::Experimental::basic_vec<T, Abi>;
+  using mask_type = typename Kokkos::Experimental::basic_vec<T, Abi>::mask_type;
   constexpr std::size_t width = simd_type::size();
 
   T true_identity = get_identity<T, ReductionOp>{}();
@@ -195,7 +193,7 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_reductions() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
     constexpr size_t n = 16;
 
     if constexpr (std::is_signed_v<DataType>) {

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -29,7 +29,7 @@ template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 inline void host_check_shift_on_one_loader(ShiftOp shift_op,
                                            DataType test_vals[],
                                            DataType shift_by[], std::size_t n) {
-  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -59,8 +59,8 @@ inline void host_check_shift_on_one_loader(ShiftOp shift_op,
 template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 inline void host_check_shift_by_lanes_on_one_loader(
     ShiftOp shift_op, DataType test_vals[],
-    Kokkos::Experimental::basic_simd<DataType, Abi>& shift_by) {
-  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    Kokkos::Experimental::basic_vec<DataType, Abi>& shift_by) {
+  using simd_type             = Kokkos::Experimental::basic_vec<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -96,7 +96,7 @@ inline void host_check_shift_op_all_loaders(ShiftOp shift_op,
   host_check_shift_on_one_loader<Abi, load_vector_aligned>(shift_op, test_vals,
                                                            shift_by, n);
 
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   simd_type shift_by_lanes =
       Kokkos::Experimental::simd_unchecked_load<simd_type>(
           shift_by, Kokkos::Experimental::simd_flag_default);
@@ -115,11 +115,11 @@ template <typename Abi, typename DataType>
 inline void host_check_shift_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     if constexpr (std::is_integral_v<DataType>) {
-      using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+      using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
       constexpr std::size_t width     = simd_type::size();
       constexpr std::size_t num_cases = 16;
       constexpr size_t alignment =
-          Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+          Kokkos::Experimental::basic_vec<DataType, Abi>::size() *
           sizeof(DataType);
 
       DataType max = std::numeric_limits<DataType>::max();
@@ -170,7 +170,7 @@ template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
     ShiftOp shift_op, DataType test_vals[], DataType shift_by[],
     std::size_t n) {
-  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type             = Kokkos::Experimental::basic_vec<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
 
@@ -194,8 +194,8 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_on_one_loader(
 template <typename Abi, typename Loader, typename ShiftOp, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_by_lanes_on_one_loader(
     ShiftOp shift_op, DataType test_vals[],
-    Kokkos::Experimental::basic_simd<DataType, Abi>& shift_by) {
-  using simd_type             = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    Kokkos::Experimental::basic_vec<DataType, Abi>& shift_by) {
+  using simd_type             = Kokkos::Experimental::basic_vec<DataType, Abi>;
   constexpr std::size_t width = simd_type::size();
   Loader loader;
   simd_type simd_vals;
@@ -223,7 +223,7 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
   device_check_shift_on_one_loader<Abi, load_vector_aligned>(
       shift_op, test_vals, shift_by, n);
 
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
   simd_type shift_by_lanes =
       Kokkos::Experimental::simd_unchecked_load<simd_type>(
           shift_by, Kokkos::Experimental::simd_flag_default);
@@ -240,9 +240,9 @@ KOKKOS_INLINE_FUNCTION void device_check_shift_op_all_loaders(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_shift_ops() {
-  if constexpr (is_type_v<Kokkos::Experimental::basic_simd<DataType, Abi>>) {
+  if constexpr (is_type_v<Kokkos::Experimental::basic_vec<DataType, Abi>>) {
     if constexpr (std::is_integral_v<DataType>) {
-      using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+      using simd_type = Kokkos::Experimental::basic_vec<DataType, Abi>;
       constexpr std::size_t width     = simd_type::size();
       constexpr std::size_t num_cases = 16;
 


### PR DESCRIPTION
Renamed `basic_simd` to `basic_vec` and `basic_simd_mask` to `basic_mask` to follow the updated naming convention of std::simd. `basic_simd` and `basic_simd_mask` are now deprecated type aliases of respective replacing types. 

Deprecated `Kokkos::Experimental::simd` and `Kokkos::Experimental::simd_mask` in favor of `Kokkos::Experimental::vec` and `Kokkos::Experimental::mask`.

Eventually, all symbols with `simd_` prefix will drop prefixes when moved to a namespace `Kokkos::simd::` such that types are `Kokkos::simd::vec`, `Kokkos::simd::mask`, `Kokkos::simd::partial_load`, etc. But for now, with `Kokkos::Experimental::simd` being an already defined type alias, an experimental simd namespace can't be introduced at the moment. So, this PR aims to deprecate `Kokkos::Experimental::simd` asap to avoid future conflicts in simd symbols when simd is promoted from `Experimental`.