### PR TITLE
simd: replace sfinae with concepts

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -257,12 +257,8 @@ using simd = basic_simd<T, simd_abi::Impl::native_abi<T, N>>;
 template <class T, int N = 0>
 using simd_mask = basic_simd_mask<T, simd_abi::Impl::native_abi<T, N>>;
 
-template <
-    typename T, typename... Flags,
-    std::enable_if_t<
-        !std::is_same_v<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>,
-                        basic_simd<T, simd_abi::scalar>>,
-        bool> = false>
+template <typename T, typename... Flags>
+  requires Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
     simd_unchecked_load(const T* ptr,
@@ -271,12 +267,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(ptr, flag);
 }
 
-template <
-    typename T, typename... Flags,
-    std::enable_if_t<
-        std::is_same_v<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>,
-                       basic_simd<T, simd_abi::scalar>>,
-        bool> = false>
+template <typename T, typename... Flags>
+  requires Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar>
 simd_unchecked_load(const T* ptr,
                     simd_flags<Flags...> flag = simd_flag_default) {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -78,6 +78,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
@@ -152,6 +153,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
@@ -225,6 +227,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
@@ -303,6 +306,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(
@@ -377,6 +381,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi32(
@@ -460,6 +465,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -539,6 +545,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -678,6 +685,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -697,6 +705,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
@@ -1078,6 +1087,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <typename U>
@@ -1094,6 +1104,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
@@ -1457,6 +1468,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1474,6 +1486,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -1852,6 +1865,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
   template <typename U>
@@ -1868,6 +1882,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -2179,6 +2194,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <typename U>
@@ -2193,6 +2209,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -2507,6 +2524,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
   template <typename U>
@@ -2523,6 +2541,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -2847,6 +2866,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
@@ -2867,6 +2887,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -75,11 +75,9 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256d const& value_in) noexcept
       : m_value(value_in) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
@@ -151,11 +149,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128 const& value_in) noexcept
       : m_value(value_in) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
@@ -226,11 +222,9 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
             [&](std::size_t i) { return static_cast<float>(other[i]); }) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
@@ -306,11 +300,9 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m128i const& value_in) noexcept
       : m_value(value_in) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(
@@ -382,11 +374,9 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi32(
@@ -467,11 +457,9 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd_mask<double, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -548,11 +536,9 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd_mask<double, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -690,8 +676,8 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -708,11 +694,9 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
@@ -973,10 +957,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const double* ptr,
@@ -994,10 +977,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
@@ -1017,10 +999,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
@@ -1095,8 +1076,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128 const& value_in) noexcept
       : m_value(value_in) {}
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_ps(value_type(value))) {}
   template <typename U>
@@ -1110,11 +1091,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                             gen(std::integral_constant<std::size_t, 1>()),
@@ -1361,10 +1340,9 @@ Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const float* ptr,
@@ -1382,10 +1360,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
@@ -1405,10 +1382,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
@@ -1479,8 +1455,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1495,11 +1471,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
         })) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -1758,10 +1732,9 @@ Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> min(
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(const float* ptr,
@@ -1779,10 +1752,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(
@@ -1802,10 +1774,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<8>>
     simd_partial_load(
@@ -1879,8 +1850,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m128i const& value_in) noexcept
       : m_value(value_in) {}
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(_mm_set1_epi32(value_type(value))) {}
   template <typename U>
@@ -1894,11 +1865,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm_setr_epi32(gen(std::integral_constant<std::size_t, 0>()),
@@ -2079,10 +2048,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -2101,10 +2069,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
@@ -2126,10 +2093,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
@@ -2211,8 +2177,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   template <typename U>
@@ -2224,11 +2190,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
         })) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -2410,10 +2374,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -2432,10 +2395,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(
@@ -2457,10 +2419,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     simd_partial_load(
@@ -2544,8 +2505,8 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       __m256i const& value_in) noexcept
       : m_value(value_in) {}
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(value_type(value))) {}
   template <typename U>
@@ -2559,11 +2520,9 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -2758,10 +2717,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::int64_t* ptr,
@@ -2780,10 +2738,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(
@@ -2805,10 +2762,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     simd_partial_load(
@@ -2889,8 +2845,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd const&) = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
@@ -2908,11 +2864,9 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm256_setr_epi64x(
@@ -3087,10 +3041,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     simd_unchecked_load(const std::uint64_t* ptr,
@@ -3109,10 +3062,9 @@ simd_unchecked_load(
                                                                  flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::avx2_fixed_size<4>>
 simd_unchecked_load(
@@ -3134,10 +3086,9 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx2_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx2_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::avx2_fixed_size<4>>
 simd_partial_load(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -66,6 +66,7 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
@@ -157,6 +158,7 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
@@ -276,6 +278,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -301,6 +304,7 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
@@ -699,6 +703,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -724,6 +729,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -1098,6 +1104,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1117,6 +1124,7 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(
             _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
@@ -1498,6 +1506,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1523,6 +1532,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -1852,6 +1862,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1871,6 +1882,7 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
@@ -2213,6 +2225,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
@@ -2239,6 +2252,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -2561,6 +2575,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
@@ -2581,6 +2596,7 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
@@ -2923,6 +2939,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(value_type(value))) {}
   template <typename U>
@@ -2948,6 +2965,7 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -3266,6 +3284,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
@@ -3295,6 +3314,7 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -63,11 +63,9 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<U, simd_abi::avx512_fixed_size<8>> const& other) noexcept
       : m_value(static_cast<__mmask8>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
@@ -156,11 +154,9 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<U, simd_abi::avx512_fixed_size<16>> const& other) noexcept
       : m_value(static_cast<__mmask16>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(G&& gen) noexcept
       : m_value(false) {
     m_value = (static_cast<bool>(gen(std::integral_constant<std::size_t, 0>())))
@@ -278,8 +274,8 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_pd(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -302,13 +298,9 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_pd(gen(std::integral_constant<std::size_t, 0>()),
@@ -589,10 +581,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const double* ptr,
@@ -610,10 +601,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
@@ -633,10 +623,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::avx512_fixed_size<8>>
     simd_partial_load(
@@ -708,8 +697,8 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -732,11 +721,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(_mm256_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
                                gen(std::integral_constant<std::size_t, 1>()),
@@ -993,10 +980,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const float* ptr,
@@ -1014,10 +1000,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(
@@ -1037,10 +1022,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<8>>
     simd_partial_load(
@@ -1112,8 +1096,8 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_ps(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1130,11 +1114,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
       : m_value(
             _mm512_setr_ps(gen(std::integral_constant<std::size_t, 0>()),
@@ -1398,10 +1380,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const float* ptr,
@@ -1419,10 +1400,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(
@@ -1442,10 +1422,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx512_fixed_size<16>>
     simd_partial_load(
@@ -1517,8 +1496,8 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1541,13 +1520,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -1749,10 +1724,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -1771,10 +1745,9 @@ simd_unchecked_load(
                                                                   flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_unchecked_load(
@@ -1796,10 +1769,9 @@ simd_partial_load(
                                                                   flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int32_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_partial_load(
@@ -1878,8 +1850,8 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1896,13 +1868,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
@@ -2111,10 +2079,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -2133,10 +2100,9 @@ simd_unchecked_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int32_t, simd_abi::avx512_fixed_size<16>>
 simd_unchecked_load(
@@ -2158,10 +2124,9 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int32_t, simd_abi::avx512_fixed_size<16>>
 simd_partial_load(
@@ -2246,8 +2211,8 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm256_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
@@ -2271,13 +2236,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -2472,10 +2433,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::uint32_t* ptr,
@@ -2494,10 +2454,9 @@ simd_unchecked_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_unchecked_load(
@@ -2519,10 +2478,9 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint32_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_partial_load(
@@ -2601,8 +2559,8 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi32(
             Kokkos::bit_cast<std::int32_t>(value_type(value)))) {}
@@ -2620,13 +2578,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(_mm512_setr_epi32(
@@ -2828,10 +2782,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>
     simd_unchecked_load(const std::uint32_t* ptr,
@@ -2850,10 +2803,9 @@ simd_unchecked_load(
                                                                     flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
 simd_unchecked_load(
@@ -2875,10 +2827,9 @@ simd_partial_load(
                                                                     flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<16>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<16>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
 simd_partial_load(
@@ -2970,8 +2921,8 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(value_type(value))) {}
   template <typename U>
@@ -2994,13 +2945,9 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -3191,10 +3138,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::int64_t* ptr,
@@ -3213,10 +3159,9 @@ simd_unchecked_load(
                                                                   flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_unchecked_load(
@@ -3238,10 +3183,9 @@ simd_partial_load(
                                                                   flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::int64_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_partial_load(
@@ -3320,8 +3264,8 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(_mm512_set1_epi64(
             Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
@@ -3348,13 +3292,9 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
           other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : m_value(
@@ -3545,10 +3485,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>
     simd_unchecked_load(const std::uint64_t* ptr,
@@ -3567,10 +3506,9 @@ simd_unchecked_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_unchecked_load(
@@ -3592,10 +3530,9 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::avx512_fixed_size<8>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::avx512_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::avx512_fixed_size<8>>
 simd_partial_load(

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -46,25 +46,6 @@ inline constexpr simd_flags<simd_alignment_vector_aligned> simd_flag_aligned{};
 using element_aligned_tag = simd_flags<>;
 using vector_aligned_tag  = simd_flags<simd_alignment_vector_aligned>;
 
-template <typename V>
-concept simd_vec_type =
-    std::same_as<V, basic_simd<typename V::value_type, typename V::abi_type>> &&
-    std::is_default_constructible_v<V>;
-
-template <typename V>
-concept simd_mask_type =
-    std::same_as<
-        V, basic_simd_mask<typename V::value_type, typename V::abi_type>> &&
-    std::is_default_constructible_v<V>;
-
-template <typename V>
-concept simd_floating_point =
-    simd_vec_type<V> && std::floating_point<typename V::value_type>;
-
-template <typename V>
-concept simd_integral =
-    simd_vec_type<V> && std::integral<typename V::value_type>;
-
 namespace Impl {
 
 template <class BinaryOperation>

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -125,9 +125,7 @@ template <typename Abi>
 concept NonScalarAbi = !std::same_as<Abi, simd_abi::scalar>;
 
 template <typename G, typename R, typename... Args>
-concept InvocableWithReturnType =
-    std::invocable<G, Args...> &&
-    std::is_convertible_v<std::invoke_result_t<G, Args...>, R>;
+concept InvocableWithReturnType = std::is_invocable_r_v<R, G, Args...>;
 
 }  // namespace Impl
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -46,6 +46,110 @@ inline constexpr simd_flags<simd_alignment_vector_aligned> simd_flag_aligned{};
 using element_aligned_tag = simd_flags<>;
 using vector_aligned_tag  = simd_flags<simd_alignment_vector_aligned>;
 
+template <typename V>
+concept simd_vec_type =
+    std::same_as<V, basic_simd<typename V::value_type, typename V::abi_type>> &&
+    std::is_default_constructible_v<V>;
+
+template <typename V>
+concept simd_mask_type =
+    std::same_as<
+        V, basic_simd_mask<typename V::value_type, typename V::abi_type>> &&
+    std::is_default_constructible_v<V>;
+
+template <typename V>
+concept simd_floating_point =
+    simd_vec_type<V> && std::floating_point<typename V::value_type>;
+
+template <typename V>
+concept simd_integral =
+    simd_vec_type<V> && std::integral<typename V::value_type>;
+
+namespace Impl {
+
+template <class BinaryOperation>
+struct is_basic_reduction_op {
+  static constexpr bool value =
+      std::is_same_v<BinaryOperation, std::plus<>> ||
+      std::is_same_v<BinaryOperation, std::multiplies<>> ||
+      std::is_same_v<BinaryOperation, std::bit_and<>> ||
+      std::is_same_v<BinaryOperation, std::bit_or<>> ||
+      std::is_same_v<BinaryOperation, std::bit_xor<>>;
+};
+
+template <class BinaryOperation>
+constexpr bool is_basic_reduction_op_v =
+    is_basic_reduction_op<BinaryOperation>::value;
+
+template <class T, class BinaryOperation>
+struct Identity {
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr operator T() {
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+    if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
+      return T();
+    } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
+      return T(1);
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
+      return T(~T());
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
+      return T();
+    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
+      return T();
+    } else {
+      return T();
+    }
+    // NOLINTNEXTLINE(bugprone-branch-clone)
+  }
+};
+
+template <typename From, typename To>
+struct is_value_preserving_conversion {
+  static constexpr bool value =
+      (std::is_integral_v<From> && std::is_integral_v<To>) ||
+      (std::is_floating_point_v<From> && std::is_floating_point_v<To>);
+};
+
+template <typename From, typename To>
+constexpr bool is_value_preserving_conversion_v =
+    is_value_preserving_conversion<From, To>::value;
+
+template <typename From, typename To>
+struct is_narrowing_conversion {
+  static constexpr bool value =
+      (is_value_preserving_conversion_v<From, To>)&&(sizeof(To) < sizeof(From));
+};
+
+template <typename From, typename To>
+constexpr bool is_narrowing_conversion_v =
+    is_narrowing_conversion<From, To>::value;
+
+template <typename From, typename To>
+struct needs_explicit_conversion
+    : std::integral_constant<bool,
+                             !is_value_preserving_conversion_v<From, To> ||
+                                 is_narrowing_conversion_v<From, To>> {};
+
+template <typename From, typename To>
+constexpr bool needs_explicit_conversion_v =
+    needs_explicit_conversion<From, To>::value;
+
+template <typename V>
+concept Arithmetic = std::is_arithmetic_v<V>;
+
+template <typename Abi>
+concept ScalarAbi = std::same_as<Abi, simd_abi::scalar>;
+
+template <typename Abi>
+concept NonScalarAbi = !std::same_as<Abi, simd_abi::scalar>;
+
+template <typename G, typename R, typename... Args>
+concept InvocableWithReturnType =
+    std::invocable<G, Args...> &&
+    std::is_convertible_v<std::invoke_result_t<G, Args...>, R>;
+
+}  // namespace Impl
+
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 // class template declarations for const_where_expression and where_expression
 
@@ -142,8 +246,7 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 // operator@(Arithmetic, basic_simd<T, Abi>)
 // operator@=(basic_simd<T, Abi>&, U&&)
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
@@ -151,8 +254,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
@@ -160,9 +262,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
@@ -180,8 +280,7 @@ operator+=(where_expression<M, T>& lhs, U&& rhs) {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
@@ -189,8 +288,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
@@ -198,9 +296,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
@@ -218,8 +314,7 @@ operator-=(where_expression<M, T>& lhs, U&& rhs) {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
@@ -227,8 +322,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
@@ -236,9 +330,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
@@ -256,8 +348,7 @@ operator*=(where_expression<M, T>& lhs, U&& rhs) {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
-template <class T, class Abi,
-          std::enable_if_t<std::is_integral_v<T>, bool> = false>
+template <std::integral T, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::basic_simd<T, Abi> const& lhs,
     Experimental::basic_simd<T, Abi> const& rhs) {
@@ -265,8 +356,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
       [&](std::size_t i) { return lhs[i] / rhs[i]; });
 }
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
@@ -274,8 +364,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <class T, class U, class Abi,
-          std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+template <class T, Impl::Arithmetic U, class Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
     U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
@@ -283,9 +372,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
@@ -303,18 +390,14 @@ operator/=(where_expression<M, T>& lhs, U&& rhs) {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs >> std::forward<U>(rhs);
   return lhs;
 }
 
-template <
-    class T, class U, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
     basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs << std::forward<U>(rhs);
@@ -368,77 +451,6 @@ KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(T const& x) {
   }
   return Kokkos::round(x);
 }
-
-namespace Impl {
-
-template <class BinaryOperation>
-struct is_basic_reduction_op {
-  static constexpr bool value =
-      std::is_same_v<BinaryOperation, std::plus<>> ||
-      std::is_same_v<BinaryOperation, std::multiplies<>> ||
-      std::is_same_v<BinaryOperation, std::bit_and<>> ||
-      std::is_same_v<BinaryOperation, std::bit_or<>> ||
-      std::is_same_v<BinaryOperation, std::bit_xor<>>;
-};
-
-template <class BinaryOperation>
-constexpr bool is_basic_reduction_op_v =
-    is_basic_reduction_op<BinaryOperation>::value;
-
-template <class T, class BinaryOperation>
-struct Identity {
-  KOKKOS_FORCEINLINE_FUNCTION
-  constexpr operator T() {
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-    if constexpr (std::is_same_v<BinaryOperation, std::plus<>>) {
-      return T();
-    } else if constexpr (std::is_same_v<BinaryOperation, std::multiplies<>>) {
-      return T(1);
-    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_and<>>) {
-      return T(~T());
-    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_or<>>) {
-      return T();
-    } else if constexpr (std::is_same_v<BinaryOperation, std::bit_xor<>>) {
-      return T();
-    } else {
-      return T();
-    }
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  }
-};
-
-template <typename From, typename To>
-struct is_value_preserving_conversion {
-  static constexpr bool value =
-      (std::is_integral_v<From> && std::is_integral_v<To>) ||
-      (std::is_floating_point_v<From> && std::is_floating_point_v<To>);
-};
-
-template <typename From, typename To>
-constexpr bool is_value_preserving_conversion_v =
-    is_value_preserving_conversion<From, To>::value;
-
-template <typename From, typename To>
-struct is_narrowing_conversion {
-  static constexpr bool value =
-      (is_value_preserving_conversion_v<From, To>)&&(sizeof(To) < sizeof(From));
-};
-
-template <typename From, typename To>
-constexpr bool is_narrowing_conversion_v =
-    is_narrowing_conversion<From, To>::value;
-
-template <typename From, typename To>
-struct needs_explicit_conversion
-    : std::integral_constant<bool,
-                             !is_value_preserving_conversion_v<From, To> ||
-                                 is_narrowing_conversion_v<From, To>> {};
-
-template <typename From, typename To>
-constexpr bool needs_explicit_conversion_v =
-    needs_explicit_conversion<From, To>::value;
-
-}  // namespace Impl
 
 // common implementations of host only simd reductions:
 template <class T, class Abi, class BinaryOperation = std::plus<>>

--- a/simd/src/Kokkos_SIMD_Common_Math.hpp
+++ b/simd/src/Kokkos_SIMD_Common_Math.hpp
@@ -68,9 +68,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
-template <
-    typename T, typename Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <typename T, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_min(basic_simd<T, Abi> const& v,
            typename basic_simd<T, Abi>::mask_type const& m) {
@@ -81,9 +79,7 @@ reduce_min(basic_simd<T, Abi> const& v,
   return result;
 }
 
-template <
-    class T, class Abi,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce_max(basic_simd<T, Abi> const& v,
            typename basic_simd<T, Abi>::mask_type const& m) {
@@ -94,9 +90,7 @@ reduce_max(basic_simd<T, Abi> const& v,
   return result;
 }
 
-template <
-    class T, class Abi, class BinaryOperation = std::plus<>,
-    std::enable_if_t<!std::is_same_v<Abi, simd_abi::scalar>, bool> = false>
+template <class T, Impl::NonScalarAbi Abi, class BinaryOperation = std::plus<>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 reduce(basic_simd<T, Abi> const& v,
        typename basic_simd<T, Abi>::mask_type const& m, BinaryOperation op = {},
@@ -127,9 +121,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
 
 }  // namespace Experimental
 
-template <class T, class Abi,
-          std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
-                           bool> = false>
+template <class T, Experimental::Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> min(
     Experimental::basic_simd<T, Abi> const& a,
     Experimental::basic_simd<T, Abi> const& b) {
@@ -154,9 +146,7 @@ KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }  // namespace Experimental
 #endif
 
-template <class T, class Abi,
-          std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,
-                           bool> = false>
+template <class T, Experimental::Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> max(
     Experimental::basic_simd<T, Abi> const& a,
     Experimental::basic_simd<T, Abi> const& b) {
@@ -218,10 +208,7 @@ KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   }
 #else
 #define KOKKOS_IMPL_SIMD_UNARY_FUNCTION(FUNC)                                  \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::NonScalarAbi Abi>                     \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a) {                             \
     using simd_type           = Experimental::basic_simd<T, Abi>;              \
@@ -232,10 +219,7 @@ KOKKOS_DEPRECATED KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     return Experimental::simd_unchecked_load<simd_type>(                       \
         vals, Experimental::simd_flag_default);                                \
   }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::ScalarAbi Abi>                        \
   KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a) {                             \
     return Kokkos::FUNC(a[0]);                                                 \
@@ -302,10 +286,7 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
   }
 #else
 #define KOKKOS_IMPL_SIMD_BINARY_FUNCTION(FUNC)                                 \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::NonScalarAbi Abi>                     \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a,                               \
       Experimental::basic_simd<T, Abi> const& b) {                             \
@@ -317,10 +298,7 @@ KOKKOS_IMPL_SIMD_UNARY_FUNCTION(lgamma)
     return Experimental::simd_unchecked_load<simd_type>(                       \
         vals, Experimental::simd_flag_default);                                \
   }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::ScalarAbi Abi>                        \
   KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a,                               \
       Experimental::basic_simd<T, Abi> const& b) {                             \
@@ -371,10 +349,7 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
   }
 #else
 #define KOKKOS_IMPL_SIMD_TERNARY_FUNCTION(FUNC)                                \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<!std::is_same_v<Abi, Experimental::simd_abi::scalar>,   \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::NonScalarAbi Abi>                     \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a,                               \
       Experimental::basic_simd<T, Abi> const& b,                               \
@@ -387,10 +362,7 @@ KOKKOS_IMPL_SIMD_BINARY_FUNCTION(copysign)
     return Experimental::simd_unchecked_load<simd_type>(                       \
         vals, Experimental::simd_flag_default);                                \
   }                                                                            \
-  template <                                                                   \
-      class T, class Abi,                                                      \
-      std::enable_if_t<std::is_same_v<Abi, Experimental::simd_abi::scalar>,    \
-                       bool> = false>                                          \
+  template <class T, Experimental::Impl::ScalarAbi Abi>                        \
   KOKKOS_FORCEINLINE_FUNCTION constexpr Experimental::basic_simd<T, Abi> FUNC( \
       Experimental::basic_simd<T, Abi> const& a,                               \
       Experimental::basic_simd<T, Abi> const& b,                               \

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -79,11 +79,9 @@ class neon_mask<Derived, 64, 2> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(
       neon_mask<U, 64, 2> const& other) noexcept
       : neon_mask(static_cast<uint64x2_t>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64((gen(std::integral_constant<std::size_t, 0>())
@@ -170,11 +168,9 @@ class neon_mask<Derived, 32, 2> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(
       neon_mask<U, 32, 2> const& other) noexcept
       : m_value(static_cast<uint32x2_t>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vset_lane_u32(
@@ -254,11 +250,9 @@ class neon_mask<Derived, 32, 4> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit neon_mask(
       neon_mask<U, 32, 4> const& other) noexcept
       : m_value(static_cast<uint32x4_t>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vsetq_lane_u32(
@@ -347,11 +341,9 @@ class neon_mask<Derived, 32, 4> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
         implementation_type const& value) noexcept                            \
         : base_type(value) {}                                                 \
-    template <class G,                                                        \
-              std::enable_if_t<std::is_invocable_r_v<                         \
-                                   typename base_type::value_type, G,         \
-                                   std::integral_constant<std::size_t, 0>>,   \
-                               bool> = false>                                 \
+    template <class G>                                                        \
+      requires Impl::InvocableWithReturnType<                                 \
+          G, base_type::value_type, std::integral_constant<std::size_t, 0>>   \
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
         G&& gen) noexcept                                                     \
         : base_type(gen) {}                                                   \
@@ -391,8 +383,8 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_f64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -407,13 +399,9 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
         })) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()),
@@ -641,10 +629,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const double* ptr,
@@ -662,10 +649,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
@@ -685,10 +671,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
@@ -755,8 +740,8 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmov_n_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -771,11 +756,9 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
         })) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
@@ -991,10 +974,9 @@ Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<2>> min(
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const float* ptr,
@@ -1012,10 +994,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
@@ -1035,10 +1016,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
@@ -1105,8 +1085,8 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1119,11 +1099,9 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       : m_value(basic_simd([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -1345,10 +1323,9 @@ Experimental::basic_simd<float, Experimental::simd_abi::neon_fixed_size<4>> min(
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(const float* ptr,
@@ -1366,10 +1343,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(
@@ -1389,10 +1365,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::neon_fixed_size<4>>
     simd_partial_load(
@@ -1463,8 +1438,8 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmov_n_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1481,11 +1456,9 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1658,10 +1631,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -1680,10 +1652,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
@@ -1705,10 +1676,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
@@ -1778,8 +1748,8 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1792,11 +1762,9 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       : m_value(basic_simd([&](std::size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1975,10 +1943,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -1997,10 +1964,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_unchecked_load(
@@ -2022,10 +1988,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<4>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<4>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>
     simd_partial_load(
@@ -2099,8 +2064,8 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_s64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2117,11 +2082,9 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()),
@@ -2293,10 +2256,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::int64_t* ptr,
@@ -2315,10 +2277,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(
@@ -2340,10 +2301,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>
     simd_partial_load(
@@ -2413,8 +2373,8 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_u64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2431,11 +2391,9 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()),
@@ -2593,10 +2551,9 @@ trunc(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>
     simd_unchecked_load(const std::uint64_t* ptr,
@@ -2615,10 +2572,9 @@ simd_unchecked_load(
                                                                  flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::neon_fixed_size<2>>
 simd_unchecked_load(
@@ -2640,10 +2596,9 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<std::is_same_v<typename SimdType::abi_type,
-                                          simd_abi::neon_fixed_size<2>>,
-                           bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::neon_fixed_size<2>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
                                                  simd_abi::neon_fixed_size<2>>
 simd_partial_load(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -82,6 +82,7 @@ class neon_mask<Derived, 64, 2> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64((gen(std::integral_constant<std::size_t, 0>())
@@ -171,6 +172,7 @@ class neon_mask<Derived, 32, 2> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vset_lane_u32(
@@ -253,6 +255,7 @@ class neon_mask<Derived, 32, 4> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit neon_mask(
       G&& gen) noexcept {
     m_value = vsetq_lane_u32(
@@ -316,37 +319,40 @@ class neon_mask<Derived, 32, 4> {
 
 }  // namespace Impl
 
-#define INSTANTIATE_SIMD_MASK_NEON(T, LANES_IN_VECTOR)                        \
-  template <>                                                                 \
-  class basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>        \
-      : public Impl::neon_mask<                                               \
-            basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,   \
-            sizeof(T) * 8, LANES_IN_VECTOR> {                                 \
-    using base_type = Impl::neon_mask<                                        \
-        basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,       \
-        sizeof(T) * 8, LANES_IN_VECTOR>;                                      \
-    using implementation_type = typename base_type::implementation_type;      \
-                                                                              \
-   public:                                                                    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =        \
-        default;                                                              \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        bool value) noexcept                                                  \
-        : base_type(value) {}                                                 \
-    template <class U>                                                        \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        basic_simd_mask<U, simd_abi::neon_fixed_size<LANES_IN_VECTOR>> const& \
-            other) noexcept                                                   \
-        : base_type(other) {}                                                 \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        implementation_type const& value) noexcept                            \
-        : base_type(value) {}                                                 \
-    template <class G>                                                        \
-      requires Impl::InvocableWithReturnType<                                 \
-          G, base_type::value_type, std::integral_constant<std::size_t, 0>>   \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        G&& gen) noexcept                                                     \
-        : base_type(gen) {}                                                   \
+#define INSTANTIATE_SIMD_MASK_NEON(T, LANES_IN_VECTOR)                         \
+  template <>                                                                  \
+  class basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>         \
+      : public Impl::neon_mask<                                                \
+            basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,    \
+            sizeof(T) * 8, LANES_IN_VECTOR> {                                  \
+    using base_type = Impl::neon_mask<                                         \
+        basic_simd_mask<T, simd_abi::neon_fixed_size<LANES_IN_VECTOR>>,        \
+        sizeof(T) * 8, LANES_IN_VECTOR>;                                       \
+    using implementation_type = typename base_type::implementation_type;       \
+                                                                               \
+   public:                                                                     \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =         \
+        default;                                                               \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(            \
+        bool value) noexcept                                                   \
+        : base_type(value) {}                                                  \
+    template <class U>                                                         \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(            \
+        basic_simd_mask<U, simd_abi::neon_fixed_size<LANES_IN_VECTOR>> const&  \
+            other) noexcept                                                    \
+        : base_type(other) {}                                                  \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(  \
+        implementation_type const& value) noexcept                             \
+        : base_type(value) {}                                                  \
+    template <class G>                                                         \
+      requires Impl::InvocableWithReturnType<                                  \
+          G, base_type::value_type,                                            \
+          std::integral_constant<                                              \
+              std::size_t,                                                     \
+              0>> /* NOLINTNEXTLINE(bugprone-forwarding-reference-overload) */ \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(  \
+        G&& gen) noexcept                                                      \
+        : base_type(gen) {}                                                    \
   }
 
 INSTANTIATE_SIMD_MASK_NEON(std::int32_t, 2);
@@ -385,6 +391,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_f64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -402,6 +409,7 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_f64(gen(std::integral_constant<std::size_t, 0>()),
@@ -742,6 +750,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
       : m_value(vmov_n_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -759,6 +768,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
     m_value = vset_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                             m_value, 0);
@@ -1087,6 +1097,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1102,6 +1113,7 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept {
     m_value = vsetq_lane_f32(gen(std::integral_constant<std::size_t, 0>()),
                              m_value, 0);
@@ -1440,6 +1452,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmov_n_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1459,6 +1472,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vset_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
@@ -1750,6 +1764,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1765,6 +1780,7 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s32(gen(std::integral_constant<std::size_t, 0>()),
@@ -2066,6 +2082,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_s64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2085,6 +2102,7 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_s64(gen(std::integral_constant<std::size_t, 0>()),
@@ -2375,6 +2393,7 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(vmovq_n_u64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2394,6 +2413,7 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     m_value = vsetq_lane_u64(gen(std::integral_constant<std::size_t, 0>()),

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -136,11 +136,9 @@ class sve_mask<Derived, 64> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit sve_mask(
       value_type value) noexcept
       : m_value(svdup_b64(value)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit sve_mask(
       G&& gen) noexcept {
     // https://dougallj.github.io/asil/doc/zip1_p_pp_64.html
@@ -238,11 +236,9 @@ class sve_mask<Derived, 32> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit sve_mask(
       value_type value) noexcept
       : m_value(svdup_b32(value)) {}
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit sve_mask(
       G&& gen) noexcept {
     // https://dougallj.github.io/asil/doc/zip1_p_pp_32.html
@@ -361,11 +357,9 @@ class sve_mask<Derived, 32> {
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
         vls_bool_t const& value_in) noexcept                                  \
         : base_type(value_in) {}                                              \
-    template <class G,                                                        \
-              std::enable_if_t<std::is_invocable_r_v<                         \
-                                   typename base_type::value_type, G,         \
-                                   std::integral_constant<std::size_t, 0>>,   \
-                               bool> = false>                                 \
+    template <class G>                                                        \
+      requires Impl::InvocableWithReturnType<                                 \
+          G, value_type, std::integral_constant<std::size_t, 0>>              \
     KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
         G&& gen) noexcept                                                     \
         : base_type(gen) {}                                                   \
@@ -406,8 +400,8 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
 
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_f64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -424,11 +418,9 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -686,11 +678,9 @@ min(Experimental::basic_simd<double, Experimental::simd_abi::sve_fixed_size<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const double* ptr,
@@ -712,11 +702,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
       ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
@@ -742,11 +730,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
       ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
@@ -829,8 +815,8 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -847,11 +833,9 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -1116,11 +1100,9 @@ min(Experimental::basic_simd<float, Experimental::simd_abi::sve_fixed_size<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const float* ptr,
@@ -1141,11 +1123,9 @@ simd_unchecked_load(
       ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_unchecked_load(
@@ -1169,11 +1149,9 @@ simd_partial_load(
       ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_partial_load(
@@ -1253,8 +1231,8 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1271,11 +1249,9 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -1574,11 +1550,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -1600,11 +1574,9 @@ simd_unchecked_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_unchecked_load(
@@ -1630,11 +1602,9 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_partial_load(
@@ -1718,8 +1688,8 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_u32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1736,11 +1706,9 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd<float, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -2028,11 +1996,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
     simd_unchecked_load(const std::uint32_t* ptr,
@@ -2054,11 +2020,9 @@ simd_unchecked_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_unchecked_load(
@@ -2084,11 +2048,9 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 simd_partial_load(
@@ -2173,8 +2135,8 @@ class basic_simd<std::int64_t,
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_s64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2191,11 +2153,9 @@ class basic_simd<std::int64_t,
       basic_simd<double, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -2490,11 +2450,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::int64_t* ptr,
@@ -2517,11 +2475,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
@@ -2549,11 +2505,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
@@ -2641,8 +2595,8 @@ class basic_simd<std::uint64_t,
       basic_simd const&) noexcept = default;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_u64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2661,11 +2615,9 @@ class basic_simd<std::uint64_t,
       basic_simd<double, abi_type> const& other) noexcept;
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -2958,11 +2910,9 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::uint64_t* ptr,
@@ -2985,11 +2935,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
@@ -3017,11 +2965,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(
@@ -3137,8 +3083,8 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd& operator=(
       basic_simd&&) noexcept = default;
 
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : base_type(value) {}
 
@@ -3146,11 +3092,9 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       implementation_type const& value_in) noexcept
       : base_type(value_in) {}
 
-  template <class G,
-            std::enable_if_t<
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : base_type(gen) {}
@@ -3223,11 +3167,9 @@ basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>::
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(const std::int32_t* ptr,
@@ -3341,11 +3283,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }
 
 // FIXME should be converted to use sve mask
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_unchecked_load(
@@ -3381,11 +3321,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 }
 
 // FIXME should be converted to use sve mask
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires std::same_as<typename SimdType::abi_type,
+                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
     simd_partial_load(

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -139,6 +139,7 @@ class sve_mask<Derived, 64> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit sve_mask(
       G&& gen) noexcept {
     // https://dougallj.github.io/asil/doc/zip1_p_pp_64.html
@@ -239,6 +240,7 @@ class sve_mask<Derived, 32> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit sve_mask(
       G&& gen) noexcept {
     // https://dougallj.github.io/asil/doc/zip1_p_pp_32.html
@@ -333,36 +335,39 @@ class sve_mask<Derived, 32> {
 
 }  // namespace Impl
 
-#define INSTANTIATE_SIMD_MASK_SVE(T, SVE_T_IN_VECTOR)                         \
-  template <>                                                                 \
-  class basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>         \
-      : public Impl::sve_mask<                                                \
-            basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,    \
-            sizeof(T) * 8> {                                                  \
-    using base_type = Impl::sve_mask<                                         \
-        basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,        \
-        sizeof(T) * 8>;                                                       \
-                                                                              \
-   public:                                                                    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =        \
-        default;                                                              \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(           \
-        bool value) noexcept                                                  \
-        : base_type(value) {}                                                 \
-    template <class U>                                                        \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(                    \
-        basic_simd_mask<U, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>> const&  \
-            other) noexcept                                                   \
-        : base_type(static_cast<base_type::implementation_type>(other)) {}    \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        vls_bool_t const& value_in) noexcept                                  \
-        : base_type(value_in) {}                                              \
-    template <class G>                                                        \
-      requires Impl::InvocableWithReturnType<                                 \
-          G, value_type, std::integral_constant<std::size_t, 0>>              \
-    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask( \
-        G&& gen) noexcept                                                     \
-        : base_type(gen) {}                                                   \
+#define INSTANTIATE_SIMD_MASK_SVE(T, SVE_T_IN_VECTOR)                          \
+  template <>                                                                  \
+  class basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>          \
+      : public Impl::sve_mask<                                                 \
+            basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,     \
+            sizeof(T) * 8> {                                                   \
+    using base_type = Impl::sve_mask<                                          \
+        basic_simd_mask<T, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>>,         \
+        sizeof(T) * 8>;                                                        \
+                                                                               \
+   public:                                                                     \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept =         \
+        default;                                                               \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(            \
+        bool value) noexcept                                                   \
+        : base_type(value) {}                                                  \
+    template <class U>                                                         \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(                     \
+        basic_simd_mask<U, simd_abi::sve_fixed_size<SVE_T_IN_VECTOR>> const&   \
+            other) noexcept                                                    \
+        : base_type(static_cast<base_type::implementation_type>(other)) {}     \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(  \
+        vls_bool_t const& value_in) noexcept                                   \
+        : base_type(value_in) {}                                               \
+    template <class G>                                                         \
+      requires Impl::InvocableWithReturnType<                                  \
+          G, value_type,                                                       \
+          std::integral_constant<                                              \
+              std::size_t,                                                     \
+              0>> /* NOLINTNEXTLINE(bugprone-forwarding-reference-overload) */ \
+    KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(  \
+        G&& gen) noexcept                                                      \
+        : base_type(gen) {}                                                    \
   }
 
 INSTANTIATE_SIMD_MASK_SVE(std::int32_t, SVE_WORDS_IN_VECTOR);
@@ -402,6 +407,7 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
 
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_f64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -421,6 +427,7 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -817,6 +824,7 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_f32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -836,6 +844,7 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -1233,6 +1242,7 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_s32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1252,6 +1262,7 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -1690,6 +1701,7 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_u32(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -1709,6 +1721,7 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -2137,6 +2150,7 @@ class basic_simd<std::int64_t,
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_s64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2156,6 +2170,7 @@ class basic_simd<std::int64_t,
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -2597,6 +2612,7 @@ class basic_simd<std::uint64_t,
       basic_simd&&) noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : m_value(svdup_u64(value_type(value))) {}
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
@@ -2618,6 +2634,7 @@ class basic_simd<std::uint64_t,
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
     // TODO: use set-lane instead of load
@@ -3085,6 +3102,7 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
       : base_type(value) {}
 
@@ -3095,6 +3113,7 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept
       : base_type(gen) {}

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -57,11 +57,9 @@ class basic_simd_mask<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       basic_simd_mask<U, simd_abi::scalar> const& other) noexcept
       : m_value(static_cast<bool>(other)) {}
-  template <
-      class G,
-      std::enable_if_t<std::is_invocable_r_v<
-                           value_type, G, std::integral_constant<bool, false>>,
-                       bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<G, value_type,
+                                           std::integral_constant<bool, false>>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(gen(0)) {}
@@ -186,23 +184,19 @@ class basic_simd<T, simd_abi::scalar> {
       default;
   KOKKOS_DEFAULTED_FUNCTION constexpr basic_simd& operator=(basic_simd&&) =
       default;
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd(U&& value) noexcept
       : m_value(value) {}
-  template <class U, std::enable_if_t<std::is_convertible_v<U, value_type>,
-                                      bool> = false>
+  template <class U>
+    requires std::convertible_to<U, value_type>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(static_cast<U>(other)) {}
-  template <class G,
-            std::enable_if_t<
-                // basically, can you do { value_type r =
-                // gen(std::integral_constant<std::size_t, i>()); }
-                std::is_invocable_r_v<value_type, G,
-                                      std::integral_constant<std::size_t, 0>>,
-                bool> = false>
+  template <class G>
+    requires Impl::InvocableWithReturnType<
+        G, value_type, std::integral_constant<std::size_t, 0>>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
       : m_value(gen(0)) {}
   template <typename FlagType>
@@ -255,7 +249,8 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value + rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  template <typename U>
+    requires Impl::Arithmetic<U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value + basic_simd(rhs);
@@ -264,7 +259,8 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value - rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  template <typename U>
+    requires Impl::Arithmetic<U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value - basic_simd(rhs);
@@ -273,7 +269,8 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value * rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  template <typename U>
+    requires Impl::Arithmetic<U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value * basic_simd(rhs);
@@ -282,7 +279,8 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value / rhs.m_value);
   }
-  template <typename U, std::enable_if_t<std::is_arithmetic_v<U>, bool> = false>
+  template <typename U>
+    requires Impl::Arithmetic<U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value / basic_simd(rhs);
@@ -441,10 +439,8 @@ copysign(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type, simd_abi::scalar>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires Impl::ScalarAbi<typename SimdType::abi_type>
 KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_unchecked_load(
     const typename SimdType::value_type* ptr,
     simd_flags<Flags...> flag = simd_flag_default) {
@@ -459,10 +455,8 @@ simd_unchecked_load(const T* ptr,
   return basic_simd<T, simd_abi::scalar>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type, simd_abi::scalar>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires Impl::ScalarAbi<typename SimdType::abi_type>
 KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_unchecked_load(
     const typename SimdType::value_type* ptr,
     typename SimdType::mask_type const& mask,
@@ -478,10 +472,8 @@ simd_partial_load(const T* ptr,
   return basic_simd<T, simd_abi::scalar>(ptr, mask, flag);
 }
 
-template <typename SimdType, typename... Flags,
-          std::enable_if_t<
-              std::is_same_v<typename SimdType::abi_type, simd_abi::scalar>,
-              bool> = false>
+template <typename SimdType, typename... Flags>
+  requires Impl::ScalarAbi<typename SimdType::abi_type>
 KOKKOS_FORCEINLINE_FUNCTION constexpr SimdType simd_partial_load(
     const typename SimdType::value_type* ptr,
     typename SimdType::mask_type const& mask,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -249,8 +249,7 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value + rhs.m_value);
   }
-  template <typename U>
-    requires Impl::Arithmetic<U>
+  template <Impl::Arithmetic U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value + basic_simd(rhs);
@@ -259,8 +258,7 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value - rhs.m_value);
   }
-  template <typename U>
-    requires Impl::Arithmetic<U>
+  template <Impl::Arithmetic U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator-(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value - basic_simd(rhs);
@@ -269,8 +267,7 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value * rhs.m_value);
   }
-  template <typename U>
-    requires Impl::Arithmetic<U>
+  template <Impl::Arithmetic U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator*(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value * basic_simd(rhs);
@@ -279,8 +276,7 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value / rhs.m_value);
   }
-  template <typename U>
-    requires Impl::Arithmetic<U>
+  template <Impl::Arithmetic U>
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/(
       basic_simd const& lhs, U rhs) {
     return lhs.m_value / basic_simd(rhs);

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -60,6 +60,7 @@ class basic_simd_mask<T, simd_abi::scalar> {
   template <class G>
     requires Impl::InvocableWithReturnType<G, value_type,
                                            std::integral_constant<bool, false>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
       : m_value(gen(0)) {}
@@ -186,6 +187,7 @@ class basic_simd<T, simd_abi::scalar> {
       default;
   template <class U>
     requires std::convertible_to<U, value_type>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd(U&& value) noexcept
       : m_value(value) {}
   template <class U>
@@ -197,6 +199,7 @@ class basic_simd<T, simd_abi::scalar> {
   template <class G>
     requires Impl::InvocableWithReturnType<
         G, value_type, std::integral_constant<std::size_t, 0>>
+  // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
       : m_value(gen(0)) {}
   template <typename FlagType>


### PR DESCRIPTION
Follow up from https://github.com/kokkos/kokkos/pull/7960#pullrequestreview-3258056705

Replaced basic SFINAE usages with concepts for checking ABIs and generator constructor invocability.