### PR TITLE
Add Gemv performance test

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -76,6 +76,7 @@ set(BENCHMARK_SOURCES
     PerfTestGramSchmidt.cpp
     PerfTest_CustomReduction.cpp
     PerfTest_ExecSpacePartitioning.cpp
+    PerfTest_Gemv.cpp
     PerfTestHexGrad.cpp
     PerfTest_MallocFree.cpp
     PerfTest_ViewAllocate.cpp

--- a/core/perf_test/PerfTest_Gemv.cpp
+++ b/core/perf_test/PerfTest_Gemv.cpp
@@ -1,0 +1,137 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/**
+ * @file PerfTest_Gemv.cpp
+ *
+ * This file implements a performance test of a naive GEMV implementation.
+ * This was created to reproduce a performance problem observed on MI300A using
+ * the HIP backend. With a relatively small number of rows (4000), the HIP
+ * backend was choosing large block sizes, which led to very few active EUs on
+ * the GPU.
+ */
+
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+#include "Benchmark_Context.hpp"
+
+namespace Benchmark {
+
+template <typename P, typename L>
+void impl(benchmark::State& state) {
+  const size_t M = state.range(0);
+  const size_t N = state.range(1);
+
+  Kokkos::View<int**, L> A("A", M, N);
+  Kokkos::View<int*> y("y", M);
+  Kokkos::View<int*> x("x", N);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    Kokkos::parallel_for(
+        P(0, y.extent(0)), KOKKOS_LAMBDA(const int i) {
+          int sum = 0;
+          for (int j = 0; j < x.extent_int(0); j++) {
+            sum += A(i, j) * x(j);
+          }
+          y(i) = sum;
+        });
+    Kokkos::fence();
+    state.SetIterationTime(timer.seconds());
+  }
+}
+
+#if defined(KOKKOS_ENABLE_HIP)
+template <class T>
+__global__ void gemv_hip(const T lambda, int M) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M) lambda(i);
+}
+
+template <int BS, typename L>
+void impl_hip(benchmark::State& state) {
+  const size_t M = state.range(0);
+  const size_t N = state.range(1);
+
+  Kokkos::View<int**, L> A("A", M, N);
+  Kokkos::View<int*> y("y", M);
+  Kokkos::View<int*> x("x", N);
+
+  auto lambda = KOKKOS_LAMBDA(const int i) {
+    int sum = 0;
+    for (int j = 0; j < x.extent_int(0); j++) {
+      sum += A(i, j) * x(j);
+    }
+    y(i) = sum;
+  };
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    gemv_hip<<<(y.extent(0) + BS - 1) / BS, BS>>>(lambda, y.extent_int(0));
+    Kokkos::fence();
+    state.SetIterationTime(timer.seconds());
+  }
+}
+
+template <int BS, typename L>
+static void GemvHip(benchmark::State& state) {
+  impl_hip<BS, L>(state);
+}
+#endif  // defined(KOKKOS_ENABLE_HIP)
+
+template <typename L>
+static void GemvDefault(benchmark::State& state) {
+  using P = Kokkos::RangePolicy<>;
+  impl<P, L>(state);
+}
+
+template <int BS, typename L>
+static void Gemv(benchmark::State& state) {
+  using P = Kokkos::RangePolicy<Kokkos::LaunchBounds<BS, 1>>;
+  impl<P, L>(state);
+}
+
+#define COMMON_ARGS()                 \
+  ArgNames({"M", "N"})                \
+      ->UseManualTime()               \
+      ->Unit(benchmark::kMicrosecond) \
+      ->Args({4'000, 10'000})         \
+      ->Args({400'000, 100})
+
+BENCHMARK(GemvDefault<Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvDefault<Kokkos::LayoutRight>)->COMMON_ARGS();
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+BENCHMARK(Gemv<64, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<64, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(Gemv<256, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<256, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(Gemv<1024, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<1024, Kokkos::LayoutRight>)->COMMON_ARGS();
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+BENCHMARK(GemvHip<64, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<64, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(GemvHip<256, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<256, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(GemvHip<1024, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<1024, Kokkos::LayoutRight>)->COMMON_ARGS();
+#endif
+
+#undef COMMON_ARGS
+
+}  // namespace Benchmark


### PR DESCRIPTION
Produced the data in https://github.com/kokkos/kokkos/issues/8506

```
--------------------------------------------------------------------------------------------------------
Benchmark                                                              Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------
GemvDefault<Kokkos::LayoutLeft>/M:4000/N:10000/manual_time          2629 us         2610 us          266
GemvDefault<Kokkos::LayoutLeft>/M:400000/N:100/manual_time          59.5 us         58.1 us        11882
GemvDefault<Kokkos::LayoutRight>/M:4000/N:10000/manual_time         3413 us         3383 us          205
GemvDefault<Kokkos::LayoutRight>/M:400000/N:100/manual_time          396 us          391 us         1911
Gemv<64, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time             2345 us         2321 us          298
Gemv<64, Kokkos::LayoutLeft>/M:400000/N:100/manual_time             63.1 us         61.2 us        11185
Gemv<64, Kokkos::LayoutRight>/M:4000/N:10000/manual_time             640 us          632 us         1093
Gemv<64, Kokkos::LayoutRight>/M:400000/N:100/manual_time             364 us          361 us         1878
Gemv<256, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time            2513 us         2493 us          279
Gemv<256, Kokkos::LayoutLeft>/M:400000/N:100/manual_time            50.7 us         50.3 us        13777
Gemv<256, Kokkos::LayoutRight>/M:4000/N:10000/manual_time            856 us          848 us          820
Gemv<256, Kokkos::LayoutRight>/M:400000/N:100/manual_time            354 us          350 us         1992
Gemv<1024, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time           2616 us         2592 us          267
Gemv<1024, Kokkos::LayoutLeft>/M:400000/N:100/manual_time           51.0 us         50.7 us        13655
Gemv<1024, Kokkos::LayoutRight>/M:4000/N:10000/manual_time          3402 us         3379 us          206
Gemv<1024, Kokkos::LayoutRight>/M:400000/N:100/manual_time           384 us          382 us         1974
GemvHip<64, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time          2312 us         2296 us          302
GemvHip<64, Kokkos::LayoutLeft>/M:400000/N:100/manual_time          51.2 us         50.9 us        13678
GemvHip<64, Kokkos::LayoutRight>/M:4000/N:10000/manual_time          598 us          593 us         1165
GemvHip<64, Kokkos::LayoutRight>/M:400000/N:100/manual_time          535 us          532 us         1306
GemvHip<256, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time         2289 us         2272 us          306
GemvHip<256, Kokkos::LayoutLeft>/M:400000/N:100/manual_time         50.6 us         50.3 us        13806
GemvHip<256, Kokkos::LayoutRight>/M:4000/N:10000/manual_time         593 us          589 us         1175
GemvHip<256, Kokkos::LayoutRight>/M:400000/N:100/manual_time         543 us          539 us         1290
GemvHip<1024, Kokkos::LayoutLeft>/M:4000/N:10000/manual_time        2524 us         2506 us          277
GemvHip<1024, Kokkos::LayoutLeft>/M:400000/N:100/manual_time        50.4 us         50.1 us        13815
GemvHip<1024, Kokkos::LayoutRight>/M:4000/N:10000/manual_time       2737 us         2716 us          256
GemvHip<1024, Kokkos::LayoutRight>/M:400000/N:100/manual_time        483 us          479 us         1439
```