### PR TITLE
HIP: improve non-team block size deduction during limited parallelism

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -76,6 +76,7 @@ set(BENCHMARK_SOURCES
     PerfTestGramSchmidt.cpp
     PerfTest_CustomReduction.cpp
     PerfTest_ExecSpacePartitioning.cpp
+    PerfTest_Gemv.cpp
     PerfTestHexGrad.cpp
     PerfTest_MallocFree.cpp
     PerfTest_ViewAllocate.cpp

--- a/core/perf_test/PerfTest_Gemv.cpp
+++ b/core/perf_test/PerfTest_Gemv.cpp
@@ -1,18 +1,5 @@
-//@HEADER
-// ************************************************************************
-//
-//                        Kokkos v. 4.0
-//       Copyright (2022) National Technology & Engineering
-//               Solutions of Sandia, LLC (NTESS).
-//
-// Under the terms of Contract DE-NA0003525 with NTESS,
-// the U.S. Government retains certain rights in this software.
-//
-// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
-// See https://kokkos.org/LICENSE for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//@HEADER
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 /**
  * @file PerfTest_Gemv.cpp

--- a/core/perf_test/PerfTest_Gemv.cpp
+++ b/core/perf_test/PerfTest_Gemv.cpp
@@ -1,0 +1,137 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+/**
+ * @file PerfTest_Gemv.cpp
+ *
+ * This file implements a performance test of a naive GEMV implementation.
+ * This was created to reproduce a performance problem observed on MI300A using
+ * the HIP backend. With a relatively small number of rows (4000), the HIP
+ * backend was choosing large block sizes, which led to very few active EUs on
+ * the GPU.
+ */
+
+#include <Kokkos_Core.hpp>
+#include <benchmark/benchmark.h>
+#include "Benchmark_Context.hpp"
+
+namespace Benchmark {
+
+template <typename P, typename L>
+void impl(benchmark::State& state) {
+  const size_t M = state.range(0);
+  const size_t N = state.range(1);
+
+  Kokkos::View<int**, L> A("A", M, N);
+  Kokkos::View<int*> y("y", M);
+  Kokkos::View<int*> x("x", N);
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    Kokkos::parallel_for(
+        P(0, y.extent(0)), KOKKOS_LAMBDA(const int i) {
+          int sum = 0;
+          for (int j = 0; j < x.extent_int(0); j++) {
+            sum += A(i, j) * x(j);
+          }
+          y(i) = sum;
+        });
+    Kokkos::fence();
+    state.SetIterationTime(timer.seconds());
+  }
+}
+
+#if defined(KOKKOS_ENABLE_HIP)
+template <class T>
+__global__ void gemv_hip(const T lambda, int M) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < M) lambda(i);
+}
+
+template <int BS, typename L>
+void impl_hip(benchmark::State& state) {
+  const size_t M = state.range(0);
+  const size_t N = state.range(1);
+
+  Kokkos::View<int**, L> A("A", M, N);
+  Kokkos::View<int*> y("y", M);
+  Kokkos::View<int*> x("x", N);
+
+  auto lambda = KOKKOS_LAMBDA(const int i) {
+    int sum = 0;
+    for (int j = 0; j < x.extent_int(0); j++) {
+      sum += A(i, j) * x(j);
+    }
+    y(i) = sum;
+  };
+
+  for (auto _ : state) {
+    Kokkos::Timer timer;
+    gemv_hip<<<(y.extent(0) + BS - 1) / BS, BS>>>(lambda, y.extent_int(0));
+    Kokkos::fence();
+    state.SetIterationTime(timer.seconds());
+  }
+}
+
+template <int BS, typename L>
+static void GemvHip(benchmark::State& state) {
+  impl_hip<BS, L>(state);
+}
+#endif  // defined(KOKKOS_ENABLE_HIP)
+
+template <typename L>
+static void GemvDefault(benchmark::State& state) {
+  using P = Kokkos::RangePolicy<>;
+  impl<P, L>(state);
+}
+
+template <int BS, typename L>
+static void Gemv(benchmark::State& state) {
+  using P = Kokkos::RangePolicy<Kokkos::LaunchBounds<BS, 1>>;
+  impl<P, L>(state);
+}
+
+#define COMMON_ARGS()                 \
+  ArgNames({"M", "N"})                \
+      ->UseManualTime()               \
+      ->Unit(benchmark::kMicrosecond) \
+      ->Args({4'000, 10'000})         \
+      ->Args({400'000, 100})
+
+BENCHMARK(GemvDefault<Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvDefault<Kokkos::LayoutRight>)->COMMON_ARGS();
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+BENCHMARK(Gemv<64, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<64, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(Gemv<256, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<256, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(Gemv<1024, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(Gemv<1024, Kokkos::LayoutRight>)->COMMON_ARGS();
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+BENCHMARK(GemvHip<64, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<64, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(GemvHip<256, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<256, Kokkos::LayoutRight>)->COMMON_ARGS();
+BENCHMARK(GemvHip<1024, Kokkos::LayoutLeft>)->COMMON_ARGS();
+BENCHMARK(GemvHip<1024, Kokkos::LayoutRight>)->COMMON_ARGS();
+#endif
+
+#undef COMMON_ARGS
+
+}  // namespace Benchmark

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -165,16 +165,15 @@ unsigned get_preferred_blocksize_range(HIPInternal const *hip_instance,
                                   LaunchMechanism>::default_launchbounds()) {
     if (requested_parallelism &&
         requested_parallelism < size_t(hip_instance->concurrency())) {
-      const unsigned pes            = hip_internal_multiprocessor_count();
-      const unsigned requestedPerPE = (requested_parallelism + pes - 1) / pes;
+      const unsigned eus            = hip_internal_multiprocessor_count();
+      const unsigned requestedPerEU = (requested_parallelism + eus - 1) / eus;
       // round up to power of 2
-      unsigned threadsPerPE = Kokkos::bit_ceil(requestedPerPE);
-      // make sure it's at least as big as the "conservative" block size
-      threadsPerPE = std::max(threadsPerPE,
-                              unsigned(HIPTraits::ConservativeThreadsPerBlock));
-      threadsPerPE =
-          std::min(threadsPerPE, unsigned(HIPTraits::MaxThreadsPerBlock));
-      return threadsPerPE;
+      unsigned threadsPerEU = Kokkos::bit_ceil(requestedPerEU);
+      threadsPerEU          = std::max(threadsPerEU,
+                                       unsigned(HIPTraits::ConservativeThreadsPerBlock));
+      threadsPerEU =
+          std::min(threadsPerEU, unsigned(HIPTraits::MaxThreadsPerBlock));
+      return threadsPerEU;
     }
   }
   const int hip_device = hip_instance->m_hipDev;

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -151,8 +151,8 @@ unsigned hip_get_preferred_blocksize(const int hip_device) {
 template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
           HIPLaunchMechanism LaunchMechanism =
               DeduceHIPLaunchMechanism<DriverType>::launch_mechanism>
-unsigned get_preferred_blocksize_range(HIPInternal const *hip_instance,
-                                       size_t requested_parallelism) {
+unsigned get_preferred_blocksize_for_range(HIPInternal const *hip_instance,
+                                           size_t requested_parallelism) {
   /* General approach, if the user did not make a launch bounds request
   - If the requested parallelism is less than the available concurrency, get the
   largest block size that would result in at least 1 block per PE, while also:

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_BitManipulation.hpp>
 
 #if defined(__HIPCC__)
 
@@ -146,6 +147,40 @@ unsigned hip_get_preferred_blocksize(const int hip_device) {
   return get_preferred_blocksize_impl<DriverType, LaunchBounds>(hip_device);
 }
 
+// Heuristic to compute the block size for non-team parallelism
+template <typename DriverType, typename LaunchBounds = Kokkos::LaunchBounds<>,
+          HIPLaunchMechanism LaunchMechanism =
+              DeduceHIPLaunchMechanism<DriverType>::launch_mechanism>
+unsigned get_preferred_blocksize_range(HIPInternal const *hip_instance,
+                                       size_t requested_parallelism) {
+  /* General approach, if the user did not make a launch bounds request
+  - If the requested parallelism is less than the available concurrency, get the
+  largest block size that would result in at least 1 block per PE, while also:
+    - at least 256
+    - power of 2
+    - no more than 1024
+  */
+
+  if constexpr (HIPParallelLaunch<DriverType, LaunchBounds,
+                                  LaunchMechanism>::default_launchbounds()) {
+    if (requested_parallelism &&
+        requested_parallelism < size_t(hip_instance->concurrency())) {
+      const unsigned pes            = hip_internal_multiprocessor_count();
+      const unsigned requestedPerPE = (requested_parallelism + pes - 1) / pes;
+      // round up to power of 2
+      unsigned threadsPerPE = Kokkos::bit_ceil(requestedPerPE);
+      // make sure it's at least as big as the "conservative" block size
+      threadsPerPE = std::max(threadsPerPE,
+                              unsigned(HIPTraits::ConservativeThreadsPerBlock));
+      threadsPerPE =
+          std::min(threadsPerPE, unsigned(HIPTraits::MaxThreadsPerBlock));
+      return threadsPerPE;
+    }
+  }
+  const int hip_device = hip_instance->m_hipDev;
+  return get_preferred_blocksize_impl<DriverType, LaunchBounds>(hip_device);
+}
+
 // Standardized blocksize deduction for parallel constructs with no LDS usage
 // Returns the max blocksize as dictated by register usage
 //
@@ -162,6 +197,9 @@ unsigned hip_get_max_blocksize() {
 //
 // The ShmemFunctor takes a single argument of the current blocksize under
 // consideration, and returns the LDS usage
+//
+// requested_parallelism is a hint about how much parallelism was requested
+// in the parallel construct
 //
 // Note: a returned block_size of zero indicates that the algorithm could not
 //       find a valid block size.  The caller is responsible for error handling.

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -63,7 +63,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
 
     using DriverType = ParallelFor<FunctorType, Policy, Kokkos::HIP>;
     const int block_size =
-        Kokkos::Impl::get_preferred_blocksize_range<DriverType, LaunchBounds>(
+        Kokkos::Impl::get_preferred_blocksize_for_range<DriverType,
+                                                        LaunchBounds>(
             m_policy.space().impl_internal_space_instance(), nwork);
 
     if (block_size == 0) {

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -63,8 +63,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
 
     using DriverType = ParallelFor<FunctorType, Policy, Kokkos::HIP>;
     const int block_size =
-        Kokkos::Impl::hip_get_preferred_blocksize<DriverType, LaunchBounds>(
-            m_policy.space().hip_device());
+        Kokkos::Impl::get_preferred_blocksize_range<DriverType, LaunchBounds>(
+            m_policy.space().impl_internal_space_instance(), nwork);
 
     if (block_size == 0) {
       Kokkos::Impl::throw_runtime_exception(


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8506

Adds a new blocksize deduction function that is aware of the requested parallelism for non-team policies. It obeys the same logic as the previous heuristic, except when the requested parallelism is less than the execution space concurrency, it tries to find the largest block size that will put at least one block on each PE while making sure the block size is a power of 2 and at least `HIPTraits::ConservativeThreadsPerBlock` and not more than `HIPTraits::MaxThreadsPerBlock`.

Adds a naive gemv perf test that uses limited parallelism and various launch bounds, and also whatever the heuristic chooses by default.