### PR TITLE
fix is_in_bounds missing device annotation

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -494,14 +494,37 @@ class BasicView {
 
   template <class T>
   KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const std::pair<T, T> arg) {
+                                                  const std::pair<T, T> arg)
+    requires(std::is_signed_v<T>)
+  {
     return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
            arg.first <= arg.second;
   }
 
   template <class T>
-  static bool is_in_bounds(size_t extent, const Kokkos::pair<T, T> arg) {
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const std::pair<T, T> arg)
+    requires(!std::is_signed_v<T>)
+  {
+    return static_cast<std::size_t>(arg.second) <= extent &&
+           arg.first <= arg.second;
+  }
+
+  template <class T>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const Kokkos::pair<T, T> arg)
+    requires(std::is_signed_v<T>)
+  {
     return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+           arg.first <= arg.second;
+  }
+
+  template <class T>
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
+                                                  const Kokkos::pair<T, T> arg)
+    requires(!std::is_signed_v<T>)
+  {
+    return static_cast<std::size_t>(arg.second) <= extent &&
            arg.first <= arg.second;
   }
 

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -494,38 +494,26 @@ class BasicView {
 
   template <class T>
   KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const std::pair<T, T> arg)
-    requires(std::is_signed_v<T>)
-  {
-    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
-           arg.first <= arg.second;
+                                                  const std::pair<T, T> arg) {
+    if constexpr (std::is_signed_v<T>) {
+      return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+             arg.first <= arg.second;
+    } else {
+      return static_cast<std::size_t>(arg.second) <= extent &&
+             arg.first <= arg.second;
+    }
   }
 
   template <class T>
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const std::pair<T, T> arg)
-    requires(!std::is_signed_v<T>)
-  {
-    return static_cast<std::size_t>(arg.second) <= extent &&
-           arg.first <= arg.second;
-  }
-
-  template <class T>
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const Kokkos::pair<T, T> arg)
-    requires(std::is_signed_v<T>)
-  {
-    return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
-           arg.first <= arg.second;
-  }
-
-  template <class T>
-  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t extent,
-                                                  const Kokkos::pair<T, T> arg)
-    requires(!std::is_signed_v<T>)
-  {
-    return static_cast<std::size_t>(arg.second) <= extent &&
-           arg.first <= arg.second;
+  KOKKOS_INLINE_FUNCTION static bool is_in_bounds(
+      size_t extent, const Kokkos::pair<T, T> arg) {
+    if constexpr (std::is_signed_v<T>) {
+      return static_cast<std::size_t>(arg.second) <= extent && arg.first >= 0 &&
+             arg.first <= arg.second;
+    } else {
+      return static_cast<std::size_t>(arg.second) <= extent &&
+             arg.first <= arg.second;
+    }
   }
 
   KOKKOS_INLINE_FUNCTION static bool is_in_bounds(size_t /*extent*/,


### PR DESCRIPTION
Shows up on some nvcc builds. Also split the functions in signed vs unsigned to get rid of annoying nvcc "pointless comparison with unsigned and zero" warning; I can use constexpr if instead if ppl prefer that.