### PR TITLE
Fix abort for ROCm 7.0 with code dump disabled

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Error.cpp
+++ b/core/src/HIP/Kokkos_HIP_Error.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#define KOKKOS_IMPL_PUBLIC_INCLUDE
+#endif
+
+#include <impl/Kokkos_Error.hpp>
+
+#include <sstream>
+
+namespace Kokkos {
+namespace Impl {
+void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
+                              const int line) {
+  std::ostringstream out;
+  out << name << " error( " << hipGetErrorName(e)
+      << "): " << hipGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  throw_runtime_exception(out.str());
+}
+
+void hip_internal_error_abort(hipError_t e, const char *name, const char *file,
+                              const int line) {
+  std::ostringstream out;
+  out << name << " error( " << hipGetErrorName(e)
+      << "): " << hipGetErrorString(e);
+  if (file) {
+    out << " " << file << ":" << line;
+  }
+  host_abort(out.str().c_str());
+}
+}  // namespace Impl
+}  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Error.hpp
+++ b/core/src/HIP/Kokkos_HIP_Error.hpp
@@ -15,11 +15,51 @@ namespace Impl {
 void hip_internal_error_throw(hipError_t e, const char* name,
                               const char* file = nullptr, const int line = 0);
 
+void hip_internal_error_abort(hipError_t e, const char* name,
+                              const char* file = nullptr, const int line = 0);
+
 inline void hip_internal_safe_call(hipError_t e, const char* name,
                                    const char* file = nullptr,
                                    const int line   = 0) {
-  if (hipSuccess != e) {
-    hip_internal_error_throw(e, name, file, line);
+  // 1. Success -> normal continuation.
+  // 2. Error codes for which, to continue using HIP, the process must be
+  //    terminated and relaunched -> call abort on the host-side.
+  // 3. Any other error code -> throw a runtime error.
+  switch (e) {
+    case hipSuccess: break;
+    case hipErrorInvalidValue:
+    case hipErrorOutOfMemory:
+#if (HIP_VERSION_MAJOR >= 7)
+    case hipErrorMemoryAllocation:
+#endif
+    case hipErrorInitializationError:
+    case hipErrorDeinitialized:
+    case hipErrorInvalidConfiguration:
+    case hipErrorInvalidSymbol:
+    case hipErrorInvalidDevicePointer:
+    case hipErrorInvalidMemcpyDirection:
+    case hipErrorInsufficientDriver:
+    case hipErrorMissingConfiguration:
+    case hipErrorPriorLaunchFailure:
+    case hipErrorInvalidDeviceFunction:
+    case hipErrorNoDevice:
+    case hipErrorInvalidDevice:
+    case hipErrorInvalidContext:
+    case hipErrorNoBinaryForGpu:
+    case hipErrorInvalidSource:
+    case hipErrorIllegalState:
+    case hipErrorNotFound:
+    case hipErrorIllegalAddress:
+    case hipErrorLaunchOutOfResources:
+    case hipErrorLaunchTimeOut:
+    case hipErrorAssert:
+    case hipErrorLaunchFailure:
+    case hipErrorNotSupported:
+    case hipErrorStreamCaptureUnsupported:
+    case hipErrorCapturedEvent:
+    case hipErrorGraphExecUpdateFailure:
+    case hipErrorUnknown: hip_internal_error_abort(e, name, file, line); break;
+    default: hip_internal_error_throw(e, name, file, line);
   }
 }
 

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -16,7 +16,6 @@
 #include <HIP/Kokkos_HIP_IsXnack.hpp>
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>
-#include <impl/Kokkos_Error.hpp>
 
 /*--------------------------------------------------------------------------*/
 /* Standard 'C' libraries */
@@ -24,7 +23,6 @@
 
 /* Standard 'C++' libraries */
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -426,23 +424,6 @@ Kokkos::HIP::size_type *hip_internal_scratch_flags(const HIP &instance,
   return instance.impl_internal_space_instance()->scratch_flags(size);
 }
 
-}  // namespace Impl
-}  // namespace Kokkos
-
-//----------------------------------------------------------------------------
-
-namespace Kokkos {
-namespace Impl {
-void hip_internal_error_throw(hipError_t e, const char *name, const char *file,
-                              const int line) {
-  std::ostringstream out;
-  out << name << " error( " << hipGetErrorName(e)
-      << "): " << hipGetErrorString(e);
-  if (file) {
-    out << " " << file << ":" << line;
-  }
-  throw_runtime_exception(out.str());
-}
 }  // namespace Impl
 }  // namespace Kokkos
 


### PR DESCRIPTION
ROCm 7.0 changed the way `abort` works when core dump is disabled, the kernel returns an error code and keeps going. This was done to match CUDA's behavior. This PR changes the implementation `KOKKOS_IMPL_HIP_SAFE_CALL` to match the CUDA's implementation. 