### PR TITLE
Make one more View ctor explicit

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -643,7 +643,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     requires(!std::is_null_pointer_v<P> &&
              std::is_constructible_v<typename base_t::data_handle_type, P> &&
              sizeof...(Args) != rank() + 1)
-  KOKKOS_FUNCTION View(P ptr_, Args... args)
+  KOKKOS_FUNCTION explicit View(P ptr_, Args... args)
       : View(Kokkos::view_wrap(static_cast<pointer_type>(ptr_)), args...) {}
 
   // Special function to be preferred over the above for string literals


### PR DESCRIPTION
Caused ambiguous overload in one Tpetra test when I did some more testing. However I wasn't successful in producing a reproducer yet. The original test failure looked like this:

```
/ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/test/Comm/idot.cpp: In function ‘void {anonymous}::testIdot(bool&, std::ostream&, const Teuchos::RCP<const Teuchos::Comm<int> >&)’:
/ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/test/Comm/idot.cpp:78:28: error: call of overloaded ‘idot({anonymous}::SC*, {anonymous}::vec_type&, {anonymous}::vec_type&)’ is ambiguous
   78 |     auto req = Tpetra::idot(&result, x, y);
      |                ~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from /ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/test/Comm/idot.cpp:10:
/ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/src/Tpetra_idot.hpp:241:1: note: candidate: ‘std::shared_ptr<Tpetra::Details::CommRequest> Tpetra::idot(typename Tpetra::MultiVector<DS, DL, DG, DN>::dot_type*, const Tpetra::MultiVector<DS, DL, DG, DN>&, const Tpetra::MultiVector<DS, DL, DG, DN>&) [with SC = double; LO = int; GO = long long int; NT = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP>; typename Tpetra::MultiVector<DS, DL, DG, DN>::dot_type = double]’
  241 | idot(typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* resultRaw,
      | ^~~~
/ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/src/Tpetra_idot.hpp:317:1: note: candidate: ‘std::shared_ptr<Tpetra::Details::CommRequest> Tpetra::idot(const Kokkos::View<typename Tpetra::MultiVector<DS, DL, DG, DN>::dot_type*, typename Tpetra::MultiVector<DS, DL, DG, DN>::device_type>&, const Tpetra::MultiVector<DS, DL, DG, DN>&, const Tpetra::MultiVector<DS, DL, DG, DN>&) [with SC = double; LO = int; GO = long long int; NT = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP>; typename Tpetra::MultiVector<DS, DL, DG, DN>::device_type = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>; typename Tpetra::MultiVector<DS, DL, DG, DN>::dot_type = double]’
  317 | idot(const Kokkos::View<typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type*,
      | ^~~~
/ascldap/users/crtrott/Software/trilinos/packages/tpetra/core/src/Tpetra_idot.hpp:367:1: note: candidate: ‘std::shared_ptr<Tpetra::Details::CommRequest> Tpetra::idot(const Kokkos::View<typename Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dot_type, typename Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_type>&, const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&, const Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) [with SC = double; LO = int; GO = long long int; NT = Tpetra::KokkosCompat::KokkosDeviceWrapperNode<Kokkos::OpenMP>; typename Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_type = Kokkos::Device<Kokkos::OpenMP, Kokkos::HostSpace>; typename Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dot_type = double]’
  367 | idot(const Kokkos::View<typename ::Tpetra::Vector<SC, LO, GO, NT>::dot_type,
      | ^~~~
[ 67%] Built target TpetraCore_extractMpiCommFromTeuchos
```

Here is the idot file: https://github.com/trilinos/Trilinos/blob/master/packages/tpetra/core/src/Tpetra_idot.hpp

My attempt to reproduce was this:

```c++
template<class T>
struct Foo {
  using type = T;
  Foo(T) {}
};

template<class T>
void foo(typename Foo<T>::type*, const Foo<T>&) {
  printf("ptr\n");
}
template<class T>
void foo(const Kokkos::View<typename Foo<T>::type>&, const Foo<T>&) {
  printf("View-0D\n");
}
template<class T>
void foo(const Kokkos::View<typename Foo<T>::type*>&, const Foo<T>&) {
  printf("View-1D\n");
}

TEST(defaultdevicetype, development_test) {
  int a;
  Foo b(0);
  Foo<int>& c = b;
  foo(&a,c);
}
```

But it didn't trigger a problem. 