### PR TITLE
Fix 'hipErrorOutOfMemory' and 'hipErrorMemoryAllocation' both equal '2'

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Error.hpp
+++ b/core/src/HIP/Kokkos_HIP_Error.hpp
@@ -28,11 +28,7 @@ inline void hip_internal_safe_call(hipError_t e, const char* name,
   switch (e) {
     case hipSuccess: break;
     case hipErrorInvalidValue:
-#if (HIP_VERSION_MAJOR >= 7)
-    case hipErrorMemoryAllocation:
-#else
     case hipErrorOutOfMemory:
-#endif
     case hipErrorInitializationError:
     case hipErrorDeinitialized:
     case hipErrorInvalidConfiguration:

--- a/core/src/HIP/Kokkos_HIP_Error.hpp
+++ b/core/src/HIP/Kokkos_HIP_Error.hpp
@@ -28,9 +28,10 @@ inline void hip_internal_safe_call(hipError_t e, const char* name,
   switch (e) {
     case hipSuccess: break;
     case hipErrorInvalidValue:
-    case hipErrorOutOfMemory:
 #if (HIP_VERSION_MAJOR >= 7)
     case hipErrorMemoryAllocation:
+#else
+    case hipErrorOutOfMemory:
 #endif
     case hipErrorInitializationError:
     case hipErrorDeinitialized:


### PR DESCRIPTION
Fixes https://my.cdash.org/viewBuildError.php?buildid=3125997. Also see https://rocm.docs.amd.com/projects/HIP/en/docs-5.2.1/doxygen/html/hip__runtime__api_8h.html#a05eeeb24bcbaf9bce1e70c96406e11d3.