### PR TITLE
CUDA: Use __grid_constant__ kernel argument launch  mode if available

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -24,6 +24,11 @@ extern "C" void kokkos_impl_cuda_set_serial_execution(bool);
 extern "C" bool kokkos_impl_cuda_use_serial_execution();
 #endif
 
+#if defined(KOKKOS_COMPILER_NVCC) && !defined(KOKKOS_ARCH_MAXWELL) && \
+    !defined(KOKKOS_ARCH_PASCAL)
+#define KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
+#endif
+
 namespace Kokkos {
 namespace Impl {
 
@@ -39,7 +44,11 @@ struct CudaTraits {
   static constexpr CudaSpace::size_type ConstantMemoryCache =
       0x002000; /*  8k bytes */
   static constexpr CudaSpace::size_type KernelArgumentLimit =
+#ifdef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
+      0x008000; /* 32k bytes */
+#else
       0x001000; /*  4k bytes */
+#endif
   static constexpr CudaSpace::size_type MaxHierarchicalParallelism =
       1024; /* team_size * vector_length */
   using ConstantGlobalBufferType =

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -22,6 +22,14 @@
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
+// If KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT is used we leverage implicit constant
+// cache use via an argument attribute in the "local launch" mechanism. At that
+// point we only need local and global launch - the latter for functors that
+// exceed the kernel argument limit which is now 32kB. Local launch is always
+// strictly better than global launch - which means the light weight/heavy
+// weight property can be ignored - the only thing that matters is the size of
+// the functor.
+#ifndef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 /** \brief  Access to constant memory on the device */
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
 
@@ -34,6 +42,7 @@ __device__ __constant__ unsigned long kokkos_impl_cuda_constant_memory_buffer
     [Kokkos::Impl::CudaTraits::ConstantMemoryUsage / sizeof(unsigned long)];
 
 #endif
+#endif  // !KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 
 template <typename T>
 inline __device__ T* kokkos_impl_cuda_shared_memory() {
@@ -51,6 +60,7 @@ namespace Impl {
 // function qualifier which could be used to improve performance.
 //----------------------------------------------------------------------------
 
+#ifndef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 template <class DriverType>
 __global__ static void cuda_parallel_launch_constant_memory() {
   const DriverType& driver =
@@ -81,6 +91,22 @@ __global__ __launch_bounds__(
                                                                  driver) {
   driver();
 }
+#else
+template <class DriverType>
+__global__ static void cuda_parallel_launch_local_memory(
+    const __grid_constant__ DriverType driver) {
+  driver();
+}
+
+template <class DriverType, unsigned int maxTperB, unsigned int minBperSM>
+__global__ __launch_bounds__(
+    maxTperB,
+    minBperSM) static void cuda_parallel_launch_local_memory(const __grid_constant__
+                                                                 DriverType
+                                                                     driver) {
+  driver();
+}
+#endif  // KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 
 template <class DriverType>
 __global__ static void cuda_parallel_launch_global_memory(
@@ -241,31 +267,51 @@ struct DeduceCudaLaunchMechanism {
       (sizeof(DriverType) < CudaTraits::KernelArgumentLimit
            ? CudaLaunchMechanism::LocalMemory
            : CudaLaunchMechanism::Default) |
+#ifndef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
       (sizeof(DriverType) < CudaTraits::ConstantMemoryUsage
            ? CudaLaunchMechanism::ConstantMemory
            : CudaLaunchMechanism::Default) |
+#endif
       CudaLaunchMechanism::GlobalMemory;
 
   static constexpr CudaLaunchMechanism requested_launch_mechanism =
+#ifdef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
+      CudaLaunchMechanism::LocalMemory |
+#else
       (((property & light_weight) == light_weight)
            ? CudaLaunchMechanism::LocalMemory
            : CudaLaunchMechanism::ConstantMemory) |
+#endif
       CudaLaunchMechanism::GlobalMemory;
 
   static constexpr CudaLaunchMechanism default_launch_mechanism =
+#ifdef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
+      (sizeof(DriverType) < CudaTraits::KernelArgumentLimit)
+          ? CudaLaunchMechanism::LocalMemory
+          : CudaLaunchMechanism::GlobalMemory;
+#else
       // BuildValidMask
       (sizeof(DriverType) < CudaTraits::ConstantMemoryUseThreshold)
           ? CudaLaunchMechanism::LocalMemory
           : ((sizeof(DriverType) < CudaTraits::ConstantMemoryUsage)
                  ? CudaLaunchMechanism::ConstantMemory
                  : CudaLaunchMechanism::GlobalMemory);
+#endif
 
-  //              None                LightWeight    HeavyWeight
-  // F<UseT       LCG LCG L  L        LCG  LG L  L    LCG  CG L  C
-  // UseT<F<KAL   LCG LCG C  C        LCG  LG C  L    LCG  CG C  C
-  // Kal<F<CMU     CG LCG C  C         CG  LG C  G     CG  CG C  C
-  // CMU<F          G LCG G  G          G  LG G  G      G  CG G  G
   static constexpr CudaLaunchMechanism launch_mechanism =
+#ifdef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
+      default_launch_mechanism;
+#else
+      // Logic mask for choosing launch mechanism by functor size (F) and
+      // Kernel Property. First column is restriction by size (local L,
+      // constant C, global G), second is restriction by property, third is
+      // default based on size, and last is actual mode.
+      //
+      //              None                LightWeight    HeavyWeight
+      // F<UseT       LCG LCG L  L        LCG  LG L  L    LCG  CG L  C
+      // UseT<F<KAL   LCG LCG C  C        LCG  LG C  L    LCG  CG C  C
+      // Kal<F<CMU     CG LCG C  C         CG  LG C  G     CG  CG C  C
+      // CMU<F          G LCG G  G          G  LG G  G      G  CG G  G
       ((property & light_weight) == light_weight)
           ? (sizeof(DriverType) < CudaTraits::KernelArgumentLimit
                  ? CudaLaunchMechanism::LocalMemory
@@ -275,6 +321,7 @@ struct DeduceCudaLaunchMechanism {
                         ? CudaLaunchMechanism::ConstantMemory
                         : CudaLaunchMechanism::GlobalMemory)
                  : (default_launch_mechanism));
+#endif  // KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 };
 
 // </editor-fold> end DeduceCudaLaunchMechanism }}}2
@@ -515,7 +562,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
 //------------------------------------------------------------------------------
 // <editor-fold desc="Constant Memory"> {{{2
-
+#ifndef KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 template <class DriverType, unsigned int MaxThreadsPerBlock,
           unsigned int MinBlocksPerSM>
 struct CudaParallelLaunchKernelFunc<
@@ -606,6 +653,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
         driver, grid, block, shmem, cuda_instance);
   }
 };
+#endif  // !KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT
 
 // </editor-fold> end Constant Memory }}}2
 //------------------------------------------------------------------------------


### PR DESCRIPTION
We now can use up to 32kB of size for parameters for global function, and can have the compiler manage the use of constant cache for that argument, through the `__grid_constant__` parameter. Only available for CC 7.0 or later and since CUDA 12.2 with NVCC (not clang as CUDA compiler).

If `KOKKOS_IMPL_CUDA_USE_GRID_CONSTANT` is used we leverage implicit constant cache use via an argument attribute in the "local launch" mechanism. At that point we only need local and global launch - the latter for functors
that exceed the kernel argument limit which is now 32kB.
Local launch is always strictly better than global launch - which means the light weight/heavy weight property can be ignored - the only thing that matters is the size of the functor.

I did some testing with the following code:

```c++
template<size_t N>
struct functor {
  Kokkos::View<int***> a,b,c;
  float data[N];

  functor(Kokkos::View<int***> a_, Kokkos::View<int***> b_, Kokkos::View<int***> c_, float* data_):a(a_),b(b_),c(c_) {
    for(int i = 0; i<N; i++) data[i] = data_[i];
  }

  KOKKOS_FUNCTION
  void operator()(int i) const {
    for(int j=0; j<a.extent(1); j++)
      for(int k=0; k<a.extent(2); k++)
        a(i,j,k) += b(i,j,k) + c(i,j,k) + data[k % N];
  }
};

template<size_t K>
void foo(int N, int M, int KK, int R) {
  Kokkos::View<int***> a("A", N, M, KK);
  Kokkos::View<int***> b("A", N, M, KK);
  Kokkos::View<int***> c("A", N, M, KK);

  float data[K];
  for(int k=0; k<K; k++) data[k] = k;
  Kokkos::deep_copy(b,2);
  Kokkos::deep_copy(c,3);

  functor<K> f(a,b,c,data);

  Kokkos::parallel_for(N, f);

  Kokkos::Timer timer;
  for(int r = 0; r<R; r++) Kokkos::parallel_for(N, f);
  Kokkos::fence();
  double time = timer.seconds();

  size_t errors;
  Kokkos::parallel_reduce(N, KOKKOS_LAMBDA(int i, size_t& lsum) {
    for(int j=0; j<a.extent(1); j++)
      for(int k=0; k<a.extent(2); k++)
        if(a(i,j,k) != (R+1)*(2 + 3 + k%K)) lsum++;
  }, errors);
  printf("N=%i M=%i K=%lu KK=%i R=%i Time: %lf us Errors: %lu\n",N,M,K,KK,R,time * 1.e6/ R, errors);
}
```

New:
```
N=1 M=1 K=1 KK=1 R=20 Time: 3.780050 us Errors: 0
N=1 M=1 K=4000 KK=1 R=20 Time: 9.266150 us Errors: 0
N=1 M=1 K=40000 KK=1 R=20 Time: 41.734450 us Errors: 0

N=1 M=2 K=1 KK=1000 R=20 Time: 180.949000 us Errors: 0
N=1 M=2 K=4000 KK=1000 R=20 Time: 186.581900 us Errors: 0
N=1 M=2 K=40000 KK=1000 R=20 Time: 478.332450 us Errors: 0

N=200000 M=1 K=1 KK=1 R=20 Time: 5.617950 us Errors: 0
N=200000 M=1 K=4000 KK=1 R=20 Time: 9.809200 us Errors: 0
N=200000 M=1 K=40000 KK=1 R=20 Time: 41.711850 us Errors: 0

N=200000 M=2 K=1 KK=100 R=20 Time: 876.692750 us Errors: 0
N=200000 M=2 K=4000 KK=100 R=20 Time: 913.998600 us Errors: 0
N=200000 M=2 K=40000 KK=100 R=20 Time: 1083.674100 us Errors: 0
```

Old:
```
N=1 M=1 K=1 KK=1 R=20 Time: 3.788900 us Errors: 0
N=1 M=1 K=4000 KK=1 R=20 Time: 15.624350 us Errors: 0
N=1 M=1 K=40000 KK=1 R=20 Time: 42.278350 us Errors: 0

N=1 M=2 K=1 KK=1000 R=20 Time: 180.940250 us Errors: 0
N=1 M=2 K=4000 KK=1000 R=20 Time: 199.479100 us Errors: 0
N=1 M=2 K=40000 KK=1000 R=20 Time: 478.678350 us Errors: 0

N=200000 M=1 K=1 KK=1 R=20 Time: 5.784100 us Errors: 0
N=200000 M=1 K=4000 KK=1 R=20 Time: 18.831600 us Errors: 0
N=200000 M=1 K=40000 KK=1 R=20 Time: 42.156050 us Errors: 0

N=200000 M=2 K=1 KK=100 R=20 Time: 874.896100 us Errors: 0
N=200000 M=2 K=4000 KK=100 R=20 Time: 924.781400 us Errors: 0
N=200000 M=2 K=40000 KK=100 R=20 Time: 1083.891950 us Errors: 0
```

As you can see the difference is there for the mid-size functors. The smallest doesn't see a difference, and the biggest doesn't (the K parameter is essentially the size of a stored array in the functor). 
But for the midsize functor (16kB) the minimum latency goes from 15us to 9us and the runtime for 200k iterations goes from 18.8us to 9.8us. So quite a bit of improvement.  