### PR TITLE
Use C++20 modules in example/build_cmake_installed_modules

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -64,7 +64,7 @@ pipeline {
                                 -B build \
                                 -GNinja \
                                 -DCMAKE_CXX_COMPILER=clang++-19 \
-                                -DCMAKE_CXX_FLAGS=-Werror && \
+                                -DCMAKE_CXX_FLAGS="-stdlib=libc++ -Werror" && \
                               cmake --build build -j 8 && \
                               ctest --test-dir build --verbose'''
                     }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -64,7 +64,7 @@ pipeline {
                                 -B build \
                                 -GNinja \
                                 -DCMAKE_CXX_COMPILER=clang++-19 \
-                                -DCMAKE_CXX_FLAGS="-stdlib=libc++ -Werror" && \
+                                -DCMAKE_CXX_FLAGS="-Werror" && \
                               cmake --build build -j 8 && \
                               ctest --test-dir build --verbose'''
                     }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -57,7 +57,16 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_SERIAL=ON && \
                               cmake --build build --target install -j 8 && \
-                              ctest --test-dir build --no-compress-output -T Test --verbose'''
+                              ctest --test-dir build --no-compress-output -T Test --verbose && \
+                              cd example/build_cmake_installed_modules && \
+                              rm -rf build && \
+                              cmake \
+                                -B build \
+                                -GNinja \
+                                -DCMAKE_CXX_COMPILER=clang++-19 \
+                                -DCMAKE_CXX_FLAGS=-Werror && \
+                              cmake --build build -j 8 && \
+                              ctest --test-dir build --verbose'''
                     }
                     post {
                         always {

--- a/example/build_cmake_installed_modules/CMakeLists.txt
+++ b/example/build_cmake_installed_modules/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.28.2)
+
+project(Example CXX)
+
+# Look for an installed Kokkos
+find_package(Kokkos REQUIRED)
+
+add_executable(example cmake_example.cpp)
+
+# This is the only thing required to set up compiler/linker flags
+# FIXME_MODULES We should be able to link against Kokkos::kokkos
+target_link_libraries(example Kokkos::kokkoscore)
+
+enable_testing()
+add_test(NAME KokkosInTree_Verify COMMAND example 10)

--- a/example/build_cmake_installed_modules/cmake_example.cpp
+++ b/example/build_cmake_installed_modules/cmake_example.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+import kokkos.core;
+
+#include <cstdio>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+  Kokkos::initialize(argc, argv);
+  Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s [<kokkos_options>] <size>\n", argv[0]);
+    Kokkos::finalize();
+    exit(1);
+  }
+
+  const long n = strtol(argv[1], nullptr, 10);
+
+  printf("Number of even integers from 0 to %ld\n", n - 1);
+
+  Kokkos::Timer timer;
+  timer.reset();
+
+  // Compute the number of even integers from 0 to n-1, in parallel.
+  long count = 0;
+  Kokkos::parallel_reduce(
+      n, KOKKOS_LAMBDA(const long i, long& lcount) { lcount += (i % 2) == 0; },
+      count);
+
+  double count_time = timer.seconds();
+  printf("  Parallel: %ld    %10.6f\n", count, count_time);
+
+  timer.reset();
+
+  // Compare to a sequential loop.
+  long seq_count = 0;
+  for (long i = 0; i < n; ++i) {
+    seq_count += (i % 2) == 0;
+  }
+
+  count_time = timer.seconds();
+  printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
+
+  Kokkos::finalize();
+
+  return (count == seq_count) ? 0 : -1;
+}

--- a/example/build_cmake_installed_modules/cmake_example.cpp
+++ b/example/build_cmake_installed_modules/cmake_example.cpp
@@ -9,25 +9,24 @@ import kokkos.core;
 // example, we need it for KOKKOS_LAMBDA in particular.
 #include <Kokkos_Macros.hpp>
 
-#include <cstdio>
 #include <iostream>
+#include <format>
 
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
 
   if (argc < 2) {
-    fprintf(stderr, "Usage: %s [<kokkos_options>] <size>\n", argv[0]);
+    std::cerr << std::format("Usage: {} [<kokkos_options>] <size>\n", argv[0]);
     Kokkos::finalize();
     exit(1);
   }
 
   const long n = strtol(argv[1], nullptr, 10);
 
-  printf("Number of even integers from 0 to %ld\n", n - 1);
+  std::cout << std::format("Number of even integers from 0 to %ld\n", n - 1);
 
   Kokkos::Timer timer;
-  timer.reset();
 
   // Compute the number of even integers from 0 to n-1, in parallel.
   long count = 0;
@@ -36,7 +35,7 @@ int main(int argc, char* argv[]) {
       count);
 
   double count_time = timer.seconds();
-  printf("  Parallel: %ld    %10.6f\n", count, count_time);
+  std::cout << std::format("  Parallel: %ld    %10.6f\n", count, count_time);
 
   timer.reset();
 
@@ -47,7 +46,8 @@ int main(int argc, char* argv[]) {
   }
 
   count_time = timer.seconds();
-  printf("Sequential: %ld    %10.6f\n", seq_count, count_time);
+  std::cout << std::format("Sequential: %ld    %10.6f\n", seq_count,
+                           count_time);
 
   Kokkos::finalize();
 

--- a/example/build_cmake_installed_modules/cmake_example.cpp
+++ b/example/build_cmake_installed_modules/cmake_example.cpp
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include <Kokkos_Macros.hpp>
+// Replaces the usual #include <Kokkos_Core.hpp>
 import kokkos.core;
+// We don't get any transitive includes or macro definitions when importing
+// C++20 modules. Since pretty much every Kokkos-based code needs configuration
+// macros, it's recommended to always include Kokkos_Macros.hpp. In this
+// example, we need it for KOKKOS_LAMBDA in particular.
+#include <Kokkos_Macros.hpp>
 
 #include <cstdio>
 #include <iostream>

--- a/example/build_cmake_installed_modules/cmake_example.cpp
+++ b/example/build_cmake_installed_modules/cmake_example.cpp
@@ -10,21 +10,20 @@ import kokkos.core;
 #include <Kokkos_Macros.hpp>
 
 #include <iostream>
-#include <format>
 
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
 
   if (argc < 2) {
-    std::cerr << std::format("Usage: {} [<kokkos_options>] <size>\n", argv[0]);
+    std::cerr << "Usage: " << argv[0] << " [<kokkos_options>] <size>\n";
     Kokkos::finalize();
     exit(1);
   }
 
   const long n = strtol(argv[1], nullptr, 10);
 
-  std::cout << std::format("Number of even integers from 0 to %ld\n", n - 1);
+  std::cout << "Number of even integers from 0 to " << n - 1 << '\n';
 
   Kokkos::Timer timer;
 
@@ -35,7 +34,7 @@ int main(int argc, char* argv[]) {
       count);
 
   double count_time = timer.seconds();
-  std::cout << std::format("  Parallel: %ld    %10.6f\n", count, count_time);
+  std::cout << "  Parallel: " << count << "    " << count_time << '\n';
 
   timer.reset();
 
@@ -46,8 +45,7 @@ int main(int argc, char* argv[]) {
   }
 
   count_time = timer.seconds();
-  std::cout << std::format("Sequential: %ld    %10.6f\n", seq_count,
-                           count_time);
+  std::cout << "Sequential: " << seq_count << "    " << count_time << '\n';
 
   Kokkos::finalize();
 


### PR DESCRIPTION
This is the last piece for C++20 modules support for testing against an installation and demonstrate use.
We are running into https://gitlab.kitware.com/cmake/cmake/-/issues/26813 and so have to link against `Kokkos::kokkoscore` instead of `Kokkos::kokkos`.