### PR TITLE
Add missing symbols to fix CI

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -185,6 +185,7 @@ export {
   using ::Kokkos::Experimental::partition_space;
   using ::Kokkos::Experimental::prefer;
   using ::Kokkos::Experimental::require;
+  using ::Kokkos::Experimental::StaticBatchSize;
   using ::Kokkos::Experimental::WorkItemProperty;
   }  // namespace Experimental
 


### PR DESCRIPTION
Fixes
```
var/jenkins/workspace/Kokkos_PR-8534/core/unit_test/TestRange.hpp:427:37: error: missing '#include'; 'StaticBatchSize' must be declared before it is used

  427 |   ASSERT_TRUE(Kokkos::Experimental::StaticBatchSize<1>::batch_size == 1);
```
after merging https://github.com/kokkos/kokkos/pull/8164 and https://github.com/kokkos/kokkos/pull/8263 simultaneously.