### PR TITLE
Simplify num_threads selection in Python test

### DIFF
--- a/core/unit_test/TestDeviceAndThreads.py
+++ b/core/unit_test/TestDeviceAndThreads.py
@@ -18,22 +18,7 @@ def GetFlag(flag, *extra_args):
     return int(p.stdout)
 
 def GetNumThreads(max_threads):
-    args = []
-    name = platform.system()
-    if name == 'Darwin':
-        args = ['sysctl', '-n', 'hw.physicalcpu_max']
-    elif name == 'Linux':
-        args = ['nproc', '--all']
-    else:
-        args = ['wmic', 'cpu', 'get', 'NumberOfCores']
-
-    result = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    output = result.stdout.decode('utf-8')
-    phys_cores_count = int(output)
-    looplist = [1] + [i*phys_cores_count for i in [1,2,3,4,5,6,7]] \
-        if GetFlag("hwloc_enabled") else [1,2,3,4,5]
-
-    for x in looplist:
+    for x in [1, 2] if GetFlag("hwloc_enabled") else [1, 2, 3, 4, 5]:
         if x >= max_threads:
             break
         yield x


### PR DESCRIPTION
Getting rid of logic introduced in #6604 on the grounds that it is IMO too complex.
Prompted by a discussion on #8431 where determining the number of hardware cores becomes yet more convoluted.