### PR TITLE
Remov cmake print for enabling "experimental" mdspan

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -132,7 +132,7 @@ if(Kokkos_ENABLE_EXPERIMENTAL_CXX20_MODULES)
   endif()
 endif()
 
-kokkos_enable_option(IMPL_MDSPAN ON "Whether to enable experimental mdspan support")
+kokkos_enable_option(IMPL_MDSPAN ON "Whether to enable mdspan support (internal use only)")
 kokkos_enable_option(MDSPAN_EXTERNAL OFF "Whether to use an external version of mdspan")
 kokkos_enable_option(
   IMPL_CHECK_POSSIBLY_BREAKING_LAYOUTS

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -153,8 +153,6 @@ if(NOT desul_FOUND)
 endif()
 
 if(Kokkos_ENABLE_IMPL_MDSPAN)
-  message(STATUS "Experimental mdspan support is enabled")
-
   if(Kokkos_ENABLE_MDSPAN_EXTERNAL)
     global_set(KOKKOS_MDSPAN_VERSION "unknown")
     message(STATUS "Using external mdspan")


### PR DESCRIPTION
It should always be enabled, not experimental anymore