### PR TITLE
[Fix] Incompatible comparison types in static batch size implementation

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -74,8 +74,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 #endif
       for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
                          i < work_end - iwork;
-           i = (i < (work_end - work_stride - iwork)) ? i + work_stride
-                                                      : work_end - iwork) {
+           i = (i < static_cast<Member>(work_end - work_stride - iwork))
+                   ? i + work_stride
+                   : work_end - iwork) {
         this->template exec_range<WorkTag>(iwork + i);
       }
     }


### PR DESCRIPTION
This PR fixes compilation issues with incompatible type comparison (mentioned [here](https://github.com/kokkos/kokkos/pull/8164#issuecomment-3386185339))

