### PR TITLE
Fix COPYRIGHT notice

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -16,8 +16,8 @@ Date Range: present -- 2025-08-11
 
 ### Sandia National Laboratories (SNL)
 
-Under the terms of Contract DE-NA0003525 with NTESS,
-the U.S. Government retains certain rights in this software.
+    Under the terms of Contract DE-NA0003525 with NTESS,
+    the U.S. Government retains certain rights in this software.
 
 - Christian Trott; SNL; crtrott@sandia.gov
 - Nathan Ellingwood; SNL; ndellin@sandia.gov

--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -19,34 +19,34 @@ Date Range: present -- 2025-08-11
 Under the terms of Contract DE-NA0003525 with NTESS,
 the U.S. Government retains certain rights in this software.
 
-Christian Trott; SNL; crtrott@sandia.gov
-Nathan Ellingwood; SNL; ndellin@sandia.gov
-Dong Hun Lee; SNL; donlee@sandia.gov
-Nicolas Morales; SNL; nmmoral@sandia.gov
-Conrad Clevenger ; SNL; tccleve@sandia.gov
-Carl Pearson; SNL; cwpears@sandia.gov
-Jan Ciesko; SNL; jan.ciesko@gmail.com
+- Christian Trott; SNL; crtrott@sandia.gov
+- Nathan Ellingwood; SNL; ndellin@sandia.gov
+- Dong Hun Lee; SNL; donlee@sandia.gov
+- Nicolas Morales; SNL; nmmoral@sandia.gov
+- Conrad Clevenger ; SNL; tccleve@sandia.gov
+- Carl Pearson; SNL; cwpears@sandia.gov
+- Jan Ciesko; SNL; jan.ciesko@gmail.com
 
 ### Oak Ridge National Laboratories (ORNL)
 
-Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
-Daniel Arndt; ORNL; arndtd@ornl.gov
-Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
-Jakob Bludau; ORNL; bludauj@ornl.gov
-Seyong Lee; ORNL; lees2@ornl.gov
+- Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
+- Daniel Arndt; ORNL; arndtd@ornl.gov
+- Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+- Jakob Bludau; ORNL; bludauj@ornl.gov
+- Seyong Lee; ORNL; lees2@ornl.gov
 
 ### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
 
-Paul Zehner; CEA; paul.zehner@cea.fr
-Trévis Morvany; CEA; trevis.morvany@cea.fr
-Paul Gannay; CEA; paul.gannay@cea.fr
-Thomas Padioleau; CEA; thomas.padioleau@cea.fr
-Cédric Chevalier; CEA; cedric.chevalier@cea.fr
+- Paul Zehner; CEA; paul.zehner@cea.fr
+- Trévis Morvany; CEA; trevis.morvany@cea.fr
+- Paul Gannay; CEA; paul.gannay@cea.fr
+- Thomas Padioleau; CEA; thomas.padioleau@cea.fr
+- Cédric Chevalier; CEA; cedric.chevalier@cea.fr
 
 ### Individual Contributors (OTHER)
 
-Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
-Maarten Arnst; OTHER; maarten.arnst@uliege.be
+- Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
+- Maarten Arnst; OTHER; maarten.arnst@uliege.be
 
 ## Kokkos 4
 
@@ -58,48 +58,48 @@ Date Range: 2025-08-11 -- 2022-09-20
       Copyright (2022) National Technology & Engineering
               Solutions of Sandia, LLC (NTESS).
 
-Under the terms of Contract DE-NA0003525 with NTESS,
-the U.S. Government retains certain rights in this software.
+    Under the terms of Contract DE-NA0003525 with NTESS,
+    the U.S. Government retains certain rights in this software.
 
-Christian Trott; SNL; crtrott@sandia.gov
-Francesco Rizzi; SNL; fnrizzi@sandia.gov
-Nathan Ellingwood; SNL; ndellin@sandia.gov
-Dong Hun Lee; SNL; donlee@sandia.gov
-Nicolas Morales; SNL; nmmoral@sandia.gov
-Conrad Clevenger ; SNL; tccleve@sandia.gov
-Carl Pearson; SNL; cwpears@sandia.gov
-Jan Ciesko; SNL; jan.ciesko@gmail.com
-Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
-Arkadiusz Szczepkowicz; SNL; arek.szczepkowicz@ng-analytics.com
-Dan Ibanez; SNL; daibane@sandia.gov
-Evan Harvey; SNL; eharvey@sandia.gov
+- Christian Trott; SNL; crtrott@sandia.gov
+- Francesco Rizzi; SNL; fnrizzi@sandia.gov
+- Nathan Ellingwood; SNL; ndellin@sandia.gov
+- Dong Hun Lee; SNL; donlee@sandia.gov
+- Nicolas Morales; SNL; nmmoral@sandia.gov
+- Conrad Clevenger ; SNL; tccleve@sandia.gov
+- Carl Pearson; SNL; cwpears@sandia.gov
+- Jan Ciesko; SNL; jan.ciesko@gmail.com
+- Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
+- Arkadiusz Szczepkowicz; SNL; arek.szczepkowicz@ng-analytics.com
+- Dan Ibanez; SNL; daibane@sandia.gov
+- Evan Harvey; SNL; eharvey@sandia.gov
 
 ### Oak Ridge National Laboratories (ORNL)
 
-Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
-Daniel Arndt; ORNL; arndtd@ornl.gov
-Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
-Jakob Bludau; ORNL; bludauj@ornl.gov
-Seyong Lee; ORNL; lees2@ornl.gov
-Andrey Prokopenko; ORNL; prokopenkoav@ornl.gov
+- Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
+- Daniel Arndt; ORNL; arndtd@ornl.gov
+- Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+- Jakob Bludau; ORNL; bludauj@ornl.gov
+- Seyong Lee; ORNL; lees2@ornl.gov
+- Andrey Prokopenko; ORNL; prokopenkoav@ornl.gov
 
 ### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
 
-Paul Zehner; CEA; paul.zehner@cea.fr
-Thomas Padioleau; CEA; thomas.padioleau@cea.fr
-Trévis Morvany; CEA; trevis.morvany@cea.fr
-Cédric Chevalier; CEA; cedric.chevalier@cea.fr
-Paul Gannay; CEA; paul.gannay@cea.fr
+- Paul Zehner; CEA; paul.zehner@cea.fr
+- Thomas Padioleau; CEA; thomas.padioleau@cea.fr
+- Trévis Morvany; CEA; trevis.morvany@cea.fr
+- Cédric Chevalier; CEA; cedric.chevalier@cea.fr
+- Paul Gannay; CEA; paul.gannay@cea.fr
 
 ### Individual Contributors (OTHER)
 
-Rahulkumar Gayatri; OTHER; rahulgayatri84@gmail.com rgayatri@lbl.gov rahulkgayatri@gmail.com
-Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
-Mikael Simberg; OTHER; mikael.simberg@iki.fi
-Nevin ":-)" Liber; OTHER; nliber+github@gmail.com nliber@anl.gov
-Maarten Arnst; OTHER; maarten.arnst@uliege.be
-Christoph Junghans; OTHER; junghans@votca.org
-Timo Heister; OTHER; timo.heister@gmail.com
+- Rahulkumar Gayatri; OTHER; rahulgayatri84@gmail.com rgayatri@lbl.gov rahulkgayatri@gmail.com
+- Romin Tomasetti; OTHER; romin.tomasetti@gmail.com
+- Mikael Simberg; OTHER; mikael.simberg@iki.fi
+- Nevin ":-)" Liber; OTHER; nliber+github@gmail.com nliber@anl.gov
+- Maarten Arnst; OTHER; maarten.arnst@uliege.be
+- Christoph Junghans; OTHER; junghans@votca.org
+- Timo Heister; OTHER; timo.heister@gmail.com
 
 ## Kokkos 3
 
@@ -111,51 +111,51 @@ Date Range: 2022-09-20 -- 2019-06-24
       Copyright (2020) National Technology & Engineering
               Solutions of Sandia, LLC (NTESS).
 
-Under the terms of Contract DE-NA0003525 with NTESS,
-the U.S. Government retains certain rights in this software.
+    Under the terms of Contract DE-NA0003525 with NTESS,
+    the U.S. Government retains certain rights in this software.
 
-Christian Trott; SNL; crtrott@sandia.gov
-D. S. Hollman; SNL; dshollm@sandia.gov
-David Poliakoff; SNL; david.poliakoff@gmail.com
-Nathan Ellingwood; SNL; ndellin@sandia.gov
-Dan Ibanez; SNL; daibane@sandia.gov
-Francesco Rizzi; SNL; fnrizzi@sandia.gov
-Dong Hun Lee; SNL; donlee@sandia.gov
-Evan Harvey; SNL; eharvey@sandia.gov
-Phil Miller; SNL; pbmille@sandia.gov
-Jeff Miles; SNL; jsmiles@sandia.gov
-Nicolas Morales; SNL; nmmoral@sandia.gov
-Jeremiah Wilke; SNL; jjwilke@sandia.gov
-Jan Ciesko; SNL; jan.ciesko@gmail.com
-Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
-Brian Kelley; SNL; bmkelle@sandia.gov
-Jonathan Lifflander; SNL; jliffla@sandia.gov
-Vinh Dang; SNL; vqdang@sandia.gov
-CA Lewis; SNL; canlewi@sandia.gov
-Amy Powell; SNL; ajpowel@sandia.gov
-Eric Phipps; SNL; etphipp@sandia.gov
-Samuel Browne; SNL; sebrown@sandia.gov
-Si Hammond; SNL; sdhammo@compton1.(none)
+- Christian Trott; SNL; crtrott@sandia.gov
+- D. S. Hollman; SNL; dshollm@sandia.gov
+- David Poliakoff; SNL; david.poliakoff@gmail.com
+- Nathan Ellingwood; SNL; ndellin@sandia.gov
+- Dan Ibanez; SNL; daibane@sandia.gov
+- Francesco Rizzi; SNL; fnrizzi@sandia.gov
+- Dong Hun Lee; SNL; donlee@sandia.gov
+- Evan Harvey; SNL; eharvey@sandia.gov
+- Phil Miller; SNL; pbmille@sandia.gov
+- Jeff Miles; SNL; jsmiles@sandia.gov
+- Nicolas Morales; SNL; nmmoral@sandia.gov
+- Jeremiah Wilke; SNL; jjwilke@sandia.gov
+- Jan Ciesko; SNL; jan.ciesko@gmail.com
+- Cezary Skrzyński; SNL; cezary.skrzynski@ng-analytics.com
+- Brian Kelley; SNL; bmkelle@sandia.gov
+- Jonathan Lifflander; SNL; jliffla@sandia.gov
+- Vinh Dang; SNL; vqdang@sandia.gov
+- CA Lewis; SNL; canlewi@sandia.gov
+- Amy Powell; SNL; ajpowel@sandia.gov
+- Eric Phipps; SNL; etphipp@sandia.gov
+- Samuel Browne; SNL; sebrown@sandia.gov
+- Si Hammond; SNL; sdhammo@compton1.(none)
 
 ### Oak Ridge National Laboratories (ORNL)
 
-Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
-Daniel Arndt; ORNL; arndtd@ornl.gov
-Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
-Seyong Lee; ORNL; lees2@ornl.gov
+- Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
+- Daniel Arndt; ORNL; arndtd@ornl.gov
+- Bruno Turcksin; ORNL; bruno.turcksin@gmail.com
+- Seyong Lee; ORNL; lees2@ornl.gov
 
 ### Individual Contributors (OTHER)
 
-Rahul Gayatri; OTHER; rgayatri@lbl.gov rahulgayatri84@gmail.com
-Nick Curtis; OTHER; nicholas.curtis@amd.com nicurtis@amd.com
-Jonathan R. Madsen; OTHER; jonathanrmadsen@gmail.com
-Christoph Junghans; OTHER; junghans@votca.org
-Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
-J Todd; OTHER; joeatodd@gmail.com
-Jakob Bludau; OTHER; jakob.bludau@tum.de
-Matt Stack; OTHER; 36867242+matt-stack@users.noreply.github.com
-Jeff Hammond; OTHER; jeff.r.hammond@intel.com
-Cameron Smith; OTHER; smithc11@rpi.edu
+- Rahul Gayatri; OTHER; rgayatri@lbl.gov rahulgayatri84@gmail.com
+- Nick Curtis; OTHER; nicholas.curtis@amd.com nicurtis@amd.com
+- Jonathan R. Madsen; OTHER; jonathanrmadsen@gmail.com
+- Christoph Junghans; OTHER; junghans@votca.org
+- Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
+- J Todd; OTHER; joeatodd@gmail.com
+- Jakob Bludau; OTHER; jakob.bludau@tum.de
+- Matt Stack; OTHER; 36867242+matt-stack@users.noreply.github.com
+- Jeff Hammond; OTHER; jeff.r.hammond@intel.com
+- Cameron Smith; OTHER; smithc11@rpi.edu
 
 ## Kokkos 2
 
@@ -164,43 +164,43 @@ Cameron Smith; OTHER; smithc11@rpi.edu
                        Kokkos v. 2.0
              Copyright (2014) Sandia Corporation
 
-Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-the U.S. Government retains certain rights in this software.
+    Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+    the U.S. Government retains certain rights in this software.
 
-Christian Trott; SNL; crtrott@sandia.gov
-Carter Edwards; SNL; hcedwar@sandia.gov
-Dan Ibanez; SNL; daibane@sandia.gov
-Nathan Ellingwood; SNL; ndellin@sandia.gov
-David Hollman; SNL; dshollm@sandia.gov
-Dan Sunderland; SNL; dsunder@sandia.gov
-James Foucar; SNL; jgfouca@sandia.gov
-Steve Bova; SNL; swbova@sandia.gov
-Vinh Dang; SNL; vqdang@sandia.gov
-Greg Mackey; SNL; gemacke@sandia.gov
-Si Hammond; SNL; sdhammo@sandia.gov
-James David Stevens; SNL; jdsteve@kokkos-dev.sandia.gov
-Mark Hoemmen; SNL; mhoemme@sandia.gov
-Jeremiah Wilke; SNL; jjwilke@sandia.gov
-Jeff Miles; SNL; jsmiles@sandia.gov
-Stan Moore; SNL; stamoor@sandia.gov
-James Elliott; SNL; jjellio@sandia.gov
-Eric Phipps; SNL; etphipp@sandia.gov
-Kyungjoo Kim; SNL; kyukim@sandia.gov
-Steven W. Bova; SNL; swbova@kokkos-dev.sandia.gov
+- Christian Trott; SNL; crtrott@sandia.gov
+- Carter Edwards; SNL; hcedwar@sandia.gov
+- Dan Ibanez; SNL; daibane@sandia.gov
+- Nathan Ellingwood; SNL; ndellin@sandia.gov
+- David Hollman; SNL; dshollm@sandia.gov
+- Dan Sunderland; SNL; dsunder@sandia.gov
+- James Foucar; SNL; jgfouca@sandia.gov
+- Steve Bova; SNL; swbova@sandia.gov
+- Vinh Dang; SNL; vqdang@sandia.gov
+- Greg Mackey; SNL; gemacke@sandia.gov
+- Si Hammond; SNL; sdhammo@sandia.gov
+- James David Stevens; SNL; jdsteve@kokkos-dev.sandia.gov
+- Mark Hoemmen; SNL; mhoemme@sandia.gov
+- Jeremiah Wilke; SNL; jjwilke@sandia.gov
+- Jeff Miles; SNL; jsmiles@sandia.gov
+- Stan Moore; SNL; stamoor@sandia.gov
+- James Elliott; SNL; jjellio@sandia.gov
+- Eric Phipps; SNL; etphipp@sandia.gov
+- Kyungjoo Kim; SNL; kyukim@sandia.gov
+- Steven W. Bova; SNL; swbova@kokkos-dev.sandia.gov
 
 ### Oak Ridge National Laboratories (ORNL)
 
-Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
+- Damien Lebrun-Grandie; ORNL; dalg24@gmail.com
 
 ### Commissariat à l’Energie Atomique et aux Energies Alternatives (CEA)
 
-Pierre Kestener; CEA; pierre.kestener@cea.fr
+- Pierre Kestener; CEA; pierre.kestener@cea.fr
 
 ### Individual Contributors (OTHER)
 
-Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
-Chip Freitag; OTHER; chip.freitag@amd.com
-Scott Kruger; OTHER; scott.e.kruger@gmail.com
-Christoph Junghans; OTHER; junghans@votca.org
-Daniel Holladay; OTHER; dholladay00@lanl.gov
+- Mikael Simberg; OTHER; simberg@cscs.ch mikael.simberg@iki.fi
+- Chip Freitag; OTHER; chip.freitag@amd.com
+- Scott Kruger; OTHER; scott.e.kruger@gmail.com
+- Christoph Junghans; OTHER; junghans@votca.org
+- Daniel Holladay; OTHER; dholladay00@lanl.gov
 

--- a/Copyright.txt
+++ b/Copyright.txt
@@ -1,8 +1,0 @@
-************************************************************************
-
-                       Kokkos v. 4.0
-      Copyright (2022) National Technology & Engineering
-              Solutions of Sandia, LLC (NTESS).
-
-Under the terms of Contract DE-NA0003525 with NTESS,
-the U.S. Government retains certain rights in this software.


### PR DESCRIPTION
- Removes old copyright file
- fixes linebreaks in the new file
- removed the md file format check to not complain about double spaces which indicate line break. 

Markdown apparently has various syntax expressing things with spaces
- double space at end is line break
- four spaces at beginning are copyable block
  - four spaces and nothing else on a line are an empty line in the copyable block

So maybe we just shouldn't bother checking for white space stuff in MD.  