### PR TITLE
Make size_type unsigned across all backends

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -19,7 +19,7 @@ namespace Impl {
 
 class SYCLInternal {
  public:
-  using size_type = int;
+  using size_type = unsigned int;
 
   SYCLInternal() = default;
   ~SYCLInternal();

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -40,8 +40,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   const Policy m_policy;
   const pointer_type m_result_ptr;
   const bool m_result_ptr_device_accessible;
-  size_type m_shmem_begin;
-  size_type m_shmem_size;
+  int m_shmem_begin;
+  int m_shmem_size;
   size_t m_scratch_size[2];
   const size_type m_league_size;
   int m_team_size;
@@ -456,7 +456,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     const Kokkos::Impl::SYCLInternal& instance =
         *m_policy.space().impl_internal_space_instance();
-    if (static_cast<size_type>(instance.m_maxShmemPerBlock) <
+    if (static_cast<int>(instance.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {
       std::stringstream out;
       out << "Kokkos::Impl::ParallelFor<SYCL> insufficient shared memory! "

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -185,8 +185,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                                   ReducerType>) {
                   reference_type update =
                       reducer.init(&local_mem[local_id * value_count]);
-                  for (int league_rank = group_id; league_rank < league_size;
-                       league_rank += n_wgroups) {
+                  for (size_type league_rank = group_id;
+                       league_rank < league_size; league_rank += n_wgroups) {
                     const member_type team_member(
                         team_scratch_memory_L0
                             .get_multi_ptr<sycl::access::decorated::yes>(),
@@ -456,7 +456,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
 
     const Kokkos::Impl::SYCLInternal& instance =
         *m_policy.space().impl_internal_space_instance();
-    if (static_cast<int>(instance.m_maxShmemPerBlock) <
+    if (static_cast<size_type>(instance.m_maxShmemPerBlock) <
         m_shmem_size - m_shmem_begin) {
       std::stringstream out;
       out << "Kokkos::Impl::ParallelFor<SYCL> insufficient shared memory! "


### PR DESCRIPTION
`SYCL` was the only backend with a signed `size_type`. Note that we want to basically replace all uses of `size_type` with a signed `index_type` in https://github.com/kokkos/kokkos/pull/7441.