### PR TITLE
Make SYCL size_type unsigned

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -19,7 +19,7 @@ namespace Impl {
 
 class SYCLInternal {
  public:
-  using size_type = int;
+  using size_type = unsigned int;
 
   SYCLInternal() = default;
   ~SYCLInternal();


### PR DESCRIPTION
Makes the type alias `size_type` in SYCL consistent with other executions spaces.

**Notes:**
- Occurrences where we actually use this type alias are listed in [1].
- `./src/Kokkos_HostSpace.hpp:  using size_type    = size_t;`, seems like HostSpace is using `size_t` which might be an inconsistancy.

[1]
```
./src/View/Kokkos_ViewTraits.hpp:  using size_type = typename MemorySpace::size_type;
./src/Kokkos_GraphNode.hpp:  typename execution_space::size_type idx_end,
./src/Kokkos_GraphNode.hpp:  auto then_parallel_reduce(typename execution_space::size_type idx_end,
```
