### PR TITLE
simd: Fix a bug in the deduction of the default vector width

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -8,6 +8,7 @@
 #include <Kokkos_SIMD_Scalar.hpp>
 #include <Kokkos_Macros.hpp>
 
+#include <climits>
 #include <cstdint>
 
 // FIXME_OPENMPTARGET The device pass disables all compiler macros checked
@@ -76,7 +77,7 @@ template <class T>
 using host_fixed_native = avx512_fixed_size<8>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, avx512_fixed_size<512 / (8 * sizeof(T))>,
+    std::conditional_t<N == 0, avx512_fixed_size<512 / (CHAR_BIT * sizeof(T))>,
                        avx512_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_AVX2)
@@ -84,13 +85,13 @@ template <class T>
 using host_fixed_native = avx2_fixed_size<4>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, avx2_fixed_size<256 / (8 * sizeof(T))>,
+    std::conditional_t<N == 0, avx2_fixed_size<256 / (CHAR_BIT * sizeof(T))>,
                        avx2_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_ARM_SVE)
 template <class T>
 using host_fixed_native =
-    sve_fixed_size<(__ARM_FEATURE_SVE_BITS / (8 * sizeof(T)))>;
+    sve_fixed_size<(__ARM_FEATURE_SVE_BITS / (CHAR_BIT * sizeof(T)))>;
 template <typename T, int N>
 using host_native_abi =
     std::conditional_t<N == 0, host_fixed_native<T>, sve_fixed_size<N>>;
@@ -100,7 +101,7 @@ template <class T>
 using host_fixed_native = neon_fixed_size<2>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, neon_fixed_size<128 / (8 * sizeof(T))>,
+    std::conditional_t<N == 0, neon_fixed_size<128 / (CHAR_BIT * sizeof(T))>,
                        neon_fixed_size<N>>;
 
 #else

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -295,8 +295,8 @@ using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>,
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #else
-using host_abi_set  = abi_set<simd_abi::scalar>;
-using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
+using host_abi_set    = abi_set<simd_abi::scalar>;
+using data_type_set   = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #endif
 

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -76,7 +76,7 @@ template <class T>
 using host_fixed_native = avx512_fixed_size<8>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, avx512_fixed_size<512 / sizeof(T)>,
+    std::conditional_t<N == 0, avx512_fixed_size<512 / (8 * sizeof(T))>,
                        avx512_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_AVX2)
@@ -84,7 +84,7 @@ template <class T>
 using host_fixed_native = avx2_fixed_size<4>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, avx2_fixed_size<256 / sizeof(T)>,
+    std::conditional_t<N == 0, avx2_fixed_size<256 / (8 * sizeof(T))>,
                        avx2_fixed_size<N>>;
 
 #elif defined(KOKKOS_ARCH_ARM_SVE)
@@ -100,7 +100,7 @@ template <class T>
 using host_fixed_native = neon_fixed_size<2>;
 template <typename T, int N>
 using host_native_abi =
-    std::conditional_t<N == 0, neon_fixed_size<128 / sizeof(T)>,
+    std::conditional_t<N == 0, neon_fixed_size<128 / (8 * sizeof(T))>,
                        neon_fixed_size<N>>;
 
 #else
@@ -295,8 +295,8 @@ using host_abi_set = abi_set<simd_abi::scalar, simd_abi::neon_fixed_size<2>,
 using data_type_set =
     data_types<std::int32_t, std::int64_t, std::uint64_t, double, float>;
 #else
-using host_abi_set    = abi_set<simd_abi::scalar>;
-using data_type_set   = data_types<std::int32_t, std::uint32_t, std::int64_t,
+using host_abi_set  = abi_set<simd_abi::scalar>;
+using data_type_set = data_types<std::int32_t, std::uint32_t, std::int64_t,
                                  std::uint64_t, double, float>;
 #endif
 

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -12,6 +12,8 @@ import kokkos.simd;
 #endif
 #include <SIMDTesting_Utilities.hpp>
 
+#include <climits>
+
 using Kokkos::Experimental::all_of;
 
 template <typename Abi, typename DataType>
@@ -89,13 +91,14 @@ inline void host_test_simd_default_abi() {
     defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
   constexpr int expected_size = 1;
 #elif defined(KOKKOS_ARCH_AVX512XEON)
-  constexpr int expected_size = 512 / (8 * sizeof(DataType));
+  constexpr int expected_size = 512 / (CHAR_BIT * sizeof(DataType));
 #elif defined(KOKKOS_ARCH_AVX2)
-  constexpr int expected_size = 256 / (8 * sizeof(DataType));
+  constexpr int expected_size = 256 / (CHAR_BIT * sizeof(DataType));
 #elif defined(KOKKOS_ARCH_ARM_SVE)
-  constexpr int expected_size = __ARM_FEATURE_SVE_BITS / (8 * sizeof(DataType));
+  constexpr int expected_size =
+      __ARM_FEATURE_SVE_BITS / (CHAR_BIT * sizeof(DataType));
 #elif defined(KOKKOS_ARCH_ARM_NEON)
-  constexpr int expected_size = 128 / (8 * sizeof(DataType));
+  constexpr int expected_size = 128 / (CHAR_BIT * sizeof(DataType));
 #else
   constexpr int expected_size = 1;
 #endif

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -83,11 +83,33 @@ inline void host_test_simd_alias() {
 }
 
 template <typename Abi, typename DataType>
+inline void host_test_simd_default_abi() {
+#if defined(KOKKOS_ARCH_AVX512XEON)
+  constexpr int expected_size = 512 / (8 * sizeof(DataType));
+#elif defined(KOKKOS_ARCH_AVX2)
+  constexpr int expected_size = 256 / (8 * sizeof(DataType));
+#elif defined(KOKKOS_ARCH_ARM_SVE)
+  constexpr int expected_size = __ARM_FEATURE_SVE_BITS / (8 * sizeof(DataType));
+#elif defined(KOKKOS_ARCH_ARM_NEON)
+  constexpr int expected_size = 128 / (8 * sizeof(DataType));
+#else
+  constexpr int expected_size = 1;
+#endif
+
+  using simd_type      = Kokkos::Experimental::simd<DataType>;
+  using simd_mask_type = typename simd_type::mask_type;
+
+  static_assert(simd_type::size() == expected_size);
+  static_assert(simd_mask_type::size() == expected_size);
+}
+
+template <typename Abi, typename DataType>
 inline void host_check_construction() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     host_test_simd_traits<Abi, DataType>();
     host_test_mask_traits<Abi, DataType>();
     host_test_simd_alias<Abi, DataType>();
+    host_test_simd_default_abi<Abi, DataType>();
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -82,7 +82,7 @@ inline void host_test_simd_alias() {
   }
 }
 
-template <typename Abi, typename DataType>
+template <typename /*Abi*/, typename DataType>
 inline void host_test_simd_default_abi() {
 #if defined(KOKKOS_ENABLE_HPX) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
     defined(KOKKOS_ENABLE_OPENACC) || defined(KOKKOS_ENABLE_CUDA) ||     \

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -84,7 +84,11 @@ inline void host_test_simd_alias() {
 
 template <typename Abi, typename DataType>
 inline void host_test_simd_default_abi() {
-#if defined(KOKKOS_ARCH_AVX512XEON)
+#if defined(KOKKOS_ENABLE_HPX) || defined(KOKKOS_ENABLE_OPENMPTARGET) || \
+    defined(KOKKOS_ENABLE_OPENACC) || defined(KOKKOS_ENABLE_CUDA) ||     \
+    defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
+  constexpr int expected_size = 1;
+#elif defined(KOKKOS_ARCH_AVX512XEON)
   constexpr int expected_size = 512 / (8 * sizeof(DataType));
 #elif defined(KOKKOS_ARCH_AVX2)
   constexpr int expected_size = 256 / (8 * sizeof(DataType));


### PR DESCRIPTION
This fixes a bug when creating a simd object using the `simd<T>` alias without specifying the size would fail to compile on anything other than the scalar abi because the default width was deduced to an invalid size (we were doing `width = hw_width / sizeof(T)` instead of `width = hw_width / (8 * sizeof(T))`.
I also added a test for this