### PR TITLE
Print host name and stage name in jenkins CI

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -28,7 +28,10 @@ pipeline {
                 }
             }
             steps {
-                sh 'echo "Hostname: ${NODE_NAME}" && ./scripts/docker/check_format_cpp.sh'
+                sh '''#!/bin/bash
+                      exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                      echo "Hostname: ${NODE_NAME}" && \
+                      ./scripts/docker/check_format_cpp.sh'''
             }
         }
         stage('Build-1') {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -258,7 +258,8 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -298,7 +299,8 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -332,7 +334,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -380,7 +383,8 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -422,7 +426,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -459,7 +464,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -496,7 +502,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -535,7 +542,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -575,7 +583,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -43,8 +43,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sh label: "C++20-Modules-Clang-19", script:
-                           '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
                                 -B build \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -44,7 +44,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
@@ -86,7 +85,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -44,7 +44,7 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
@@ -86,7 +86,7 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -123,7 +123,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -181,7 +181,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -260,7 +260,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -300,7 +300,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -334,7 +334,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -382,7 +382,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -424,7 +424,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -461,7 +461,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -498,7 +498,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -537,7 +537,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -577,7 +577,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -28,7 +28,7 @@ pipeline {
                 }
             }
             steps {
-                sh './scripts/docker/check_format_cpp.sh'
+                sh 'echo "Hostname: $(hostname)" && ./scripts/docker/check_format_cpp.sh'
             }
         }
         stage('Build-1') {
@@ -42,7 +42,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sh '''rm -rf build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && \
                               cmake \
                                 -B build \
                                 -GNinja \
@@ -80,7 +81,8 @@ pipeline {
                         OMP_PROC_BIND = 'true'
                     }
                     steps {
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_STANDARD=20 \
@@ -115,7 +117,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -171,7 +174,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf install && mkdir -p install && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -249,7 +253,8 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
                                 -DCMAKE_CXX_STANDARD=20 \
@@ -288,7 +293,8 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -321,7 +327,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -368,7 +375,8 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
                                 -DCMAKE_CXX_COMPILER=hipcc \
@@ -409,7 +417,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -445,7 +454,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER=clang++ \
@@ -481,7 +491,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -519,7 +530,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -558,7 +570,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''rm -rf build && mkdir -p build && cd build && \
+                        sh '''echo "Hostname: $(hostname)" && \
+                              rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
                                 -DCMAKE_BUILD_TYPE=Debug \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -24,7 +24,7 @@ pipeline {
                     filename 'Dockerfile.clang'
                     dir 'scripts/docker'
                     label 'nvidia-docker || docker'
-                    args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME}'
+                    args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                 }
             }
             steps {
@@ -39,12 +39,12 @@ pipeline {
                             filename 'Dockerfile.modules'
                             dir 'scripts/docker'
                             label 'docker'
-                            args '-v --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
@@ -75,7 +75,7 @@ pipeline {
                              filename 'Dockerfile.gcc'
                              dir 'scripts/docker'
                              label 'docker'
-                             args '-v --env NODE_NAME=${env.NODE_NAME}'
+                             args '-v --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                          }
                      }
                     environment {
@@ -86,7 +86,7 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -117,13 +117,13 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.2.4-complete@sha256:6604a97283a218fc62ab59e23c54ec34ad634be9201b001435844a59ba1b8eb5'
                             label 'rocm-docker'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -166,7 +166,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:12.2.2-devel-ubuntu22.04@sha256:5f603101462baa721ff6ddc44af82f6e9ba7cbd92a424c9f9f348e6e9d6d64c3 --build-arg ADDITIONAL_PACKAGES="gfortran clang" --build-arg CMAKE_VERSION=3.25.3'
                             label 'nvidia-docker && (volta || ampere)'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     environment {
@@ -181,7 +181,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                              exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -253,14 +253,14 @@ pipeline {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta && large_images'
-                            args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     environment {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -287,7 +287,7 @@ pipeline {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && large_images && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     environment {
@@ -300,7 +300,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -329,12 +329,12 @@ pipeline {
                             filename 'Dockerfile.sycl'
                             dir 'scripts/docker'
                             label 'nvidia-docker && ampere'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -370,7 +370,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.4-complete@sha256:76e99e263ef6ce69ba5d32905623c801fff3f85a6108e931820f6eb1d13eac67'
                             label 'rocm-docker '
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     environment {
@@ -382,7 +382,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -415,7 +415,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.2-complete@sha256:c7049ac3ae8516c7b230deec6dc6dd678a0b3f7215d5a7f7fe2f2b71880b62f8 --build-arg ADDITIONAL_PACKAGES="clang-tidy"'
                             label 'rocm-docker'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     environment {
@@ -424,7 +424,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -456,12 +456,12 @@ pipeline {
                             filename 'Dockerfile.openmptarget'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -492,13 +492,13 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu22.04 --build-arg ADDITIONAL_PACKAGES="clang-15 clang-tidy-15"'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -531,13 +531,13 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:12.5.1-devel-ubuntu24.04 --build-arg ADDITIONAL_PACKAGES="clang-17 clang-tidy-17"'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -572,12 +572,12 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04@sha256:435220c0fef35cbf712e11999f8670a83835ef3cdd18564e5e8122f83078c88c --build-arg CMAKE_VERSION=3.22.6'
                             label 'nvidia-docker && ampere && cuda-13-driver'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''exec > >(awk '{ print "[${STAGE_NAME}]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -43,7 +43,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
@@ -84,7 +85,8 @@ pipeline {
                         OMP_PROC_BIND = 'true'
                     }
                     steps {
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -120,7 +122,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -177,7 +180,8 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
+                        sh '''#!/bin/bash
+                              exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -84,7 +84,7 @@ pipeline {
                         OMP_PROC_BIND = 'true'
                     }
                     steps {
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -120,7 +120,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -177,7 +177,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -256,7 +256,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -296,7 +296,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -330,7 +330,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -378,7 +378,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -420,7 +420,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -457,7 +457,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -494,7 +494,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -533,7 +533,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -573,7 +573,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh '''exec > >(awk '{ print "[C++20-Modules-Clang-19]", $0 }') 2>&1 && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -39,11 +39,12 @@ pipeline {
                             filename 'Dockerfile.modules'
                             dir 'scripts/docker'
                             label 'docker'
-                            args '-v --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
+                            args '--env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
                     steps {
                         sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
                               echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
@@ -74,7 +75,7 @@ pipeline {
                              filename 'Dockerfile.gcc'
                              dir 'scripts/docker'
                              label 'docker'
-                             args '-v --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
+                             args '--env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                          }
                      }
                     environment {
@@ -85,6 +86,8 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
+                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -122,6 +125,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -180,6 +184,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -260,6 +265,7 @@ pipeline {
                     steps {
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -301,6 +307,7 @@ pipeline {
                     steps {
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -336,6 +343,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -385,6 +393,7 @@ pipeline {
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -428,6 +437,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -466,6 +476,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -504,6 +515,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -544,6 +556,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -585,6 +598,7 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
                               exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
+                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -43,7 +43,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sh '''echo "Hostname: ${NODE_NAME}" && \
+                        sh label: "C++20-Modules-Clang-19", script:
+                           '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
                                 -B build \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -28,7 +28,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'echo "Hostname: $(hostname)" && ./scripts/docker/check_format_cpp.sh'
+                sh 'echo "Hostname: ${env.NODE_NAME}" && ./scripts/docker/check_format_cpp.sh'
             }
         }
         stage('Build-1') {
@@ -42,7 +42,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
                                 -B build \
@@ -81,7 +81,7 @@ pipeline {
                         OMP_PROC_BIND = 'true'
                     }
                     steps {
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -117,7 +117,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -174,7 +174,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -253,7 +253,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -293,7 +293,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -327,7 +327,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -375,7 +375,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -417,7 +417,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -454,7 +454,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -491,7 +491,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -530,7 +530,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -570,7 +570,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: $(hostname)" && \
+                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -24,11 +24,11 @@ pipeline {
                     filename 'Dockerfile.clang'
                     dir 'scripts/docker'
                     label 'nvidia-docker || docker'
-                    args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                    args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME}'
                 }
             }
             steps {
-                sh 'echo "Hostname: ${env.NODE_NAME}" && ./scripts/docker/check_format_cpp.sh'
+                sh 'echo "Hostname: ${NODE_NAME}" && ./scripts/docker/check_format_cpp.sh'
             }
         }
         stage('Build-1') {
@@ -39,10 +39,11 @@ pipeline {
                             filename 'Dockerfile.modules'
                             dir 'scripts/docker'
                             label 'docker'
+                            args '-v --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     steps {
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               cmake \
                                 -B build \
@@ -72,6 +73,7 @@ pipeline {
                              filename 'Dockerfile.gcc'
                              dir 'scripts/docker'
                              label 'docker'
+                             args '-v --env NODE_NAME=${env.NODE_NAME}'
                          }
                      }
                     environment {
@@ -81,7 +83,7 @@ pipeline {
                         OMP_PROC_BIND = 'true'
                     }
                     steps {
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -112,12 +114,12 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-22.04:6.2.4-complete@sha256:6604a97283a218fc62ab59e23c54ec34ad634be9201b001435844a59ba1b8eb5'
                             label 'rocm-docker'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -160,7 +162,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:12.2.2-devel-ubuntu22.04@sha256:5f603101462baa721ff6ddc44af82f6e9ba7cbd92a424c9f9f348e6e9d6d64c3 --build-arg ADDITIONAL_PACKAGES="gfortran clang" --build-arg CMAKE_VERSION=3.25.3'
                             label 'nvidia-docker && (volta || ampere)'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     environment {
@@ -174,7 +176,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
@@ -246,14 +248,14 @@ pipeline {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta && large_images'
-                            args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     environment {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_CXX_COMPILER=nvc++ \
@@ -280,7 +282,7 @@ pipeline {
                             filename 'Dockerfile.nvhpc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && large_images && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     environment {
@@ -293,7 +295,7 @@ pipeline {
                         NVHPC_CUDA_HOME = '/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2'
                     }
                     steps {
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               /opt/cmake/bin/cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -322,12 +324,12 @@ pipeline {
                             filename 'Dockerfile.sycl'
                             dir 'scripts/docker'
                             label 'nvidia-docker && ampere'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
@@ -363,7 +365,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.3.4-complete@sha256:76e99e263ef6ce69ba5d32905623c801fff3f85a6108e931820f6eb1d13eac67'
                             label 'rocm-docker '
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     environment {
@@ -375,7 +377,7 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Debug \
@@ -408,7 +410,7 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:6.2-complete@sha256:c7049ac3ae8516c7b230deec6dc6dd678a0b3f7215d5a7f7fe2f2b71880b62f8 --build-arg ADDITIONAL_PACKAGES="clang-tidy"'
                             label 'rocm-docker'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     environment {
@@ -417,7 +419,7 @@ pipeline {
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \
@@ -449,12 +451,12 @@ pipeline {
                             filename 'Dockerfile.openmptarget'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -485,13 +487,13 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:11.8.0-devel-ubuntu22.04 --build-arg ADDITIONAL_PACKAGES="clang-15 clang-tidy-15"'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -524,13 +526,13 @@ pipeline {
                             filename 'Dockerfile.nvcc'
                             dir 'scripts/docker'
                             label 'nvidia-docker && volta'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:12.5.1-devel-ubuntu24.04 --build-arg ADDITIONAL_PACKAGES="clang-17 clang-tidy-17"'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -565,12 +567,12 @@ pipeline {
                             dir 'scripts/docker'
                             additionalBuildArgs '--build-arg BASE=nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04@sha256:435220c0fef35cbf712e11999f8670a83835ef3cdd18564e5e8122f83078c88c --build-arg CMAKE_VERSION=3.22.6'
                             label 'nvidia-docker && ampere && cuda-13-driver'
-                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+                            args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME}'
                         }
                     }
                     steps {
                         sh 'ccache --zero-stats'
-                        sh '''echo "Hostname: ${env.NODE_NAME}" && \
+                        sh '''echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               cmake \
                                 -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
This pull request prefixes all output for a stage with the stage name and prints the runner's name so that we can associate any errors found in the generic output (e.g., https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8553/14/consoleText) with a particular machine and CI build.