### PR TITLE
core: modernization of `partition_space`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -10,7 +10,7 @@
 #include <cuda_runtime_api.h>
 #include "Kokkos_CudaSpace.hpp"
 
-#include <algorithms>
+#include <algorithm>
 #include <atomic>
 #include <iterator>
 #include <map>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -4,7 +4,6 @@
 #ifndef KOKKOS_CUDA_INSTANCE_HPP_
 #define KOKKOS_CUDA_INSTANCE_HPP_
 
-#include <algorithm>
 #include <impl/Kokkos_Tools.hpp>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <cuda_runtime_api.h>

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -366,20 +366,15 @@ class CudaInternal {
 namespace Experimental::Impl {
 // For each space in partition, create new cudaStream_t on the same device as
 // base_instance, ignoring weights
-template <class T>
-std::vector<Cuda> impl_partition_space(const Cuda& base_instance,
-                                       const std::vector<T>& weights) {
-  std::vector<Cuda> instances;
-  instances.reserve(weights.size());
-  std::generate_n(
-      std::back_inserter(instances), weights.size(), [&base_instance]() {
-        cudaStream_t stream;
-        KOKKOS_IMPL_CUDA_SAFE_CALL(base_instance.impl_internal_space_instance()
-                                       ->cuda_stream_create_wrapper(&stream));
-        return Cuda(stream, Kokkos::Impl::ManageStream::yes);
-      });
-
-  return instances;
+template <std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const Cuda& base_instance, const Weights& weights,
+                          OutIter instances) {
+  std::ranges::transform(weights, instances, [&base_instance](const auto) {
+    cudaStream_t stream;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(base_instance.impl_internal_space_instance()
+                                   ->cuda_stream_create_wrapper(&stream));
+    return Cuda(stream, Kokkos::Impl::ManageStream::yes);
+  });
 }
 }  // namespace Experimental::Impl
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -4,15 +4,18 @@
 #ifndef KOKKOS_CUDA_INSTANCE_HPP_
 #define KOKKOS_CUDA_INSTANCE_HPP_
 
-#include <vector>
+#include <algorithm>
 #include <impl/Kokkos_Tools.hpp>
-#include <atomic>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
 #include <cuda_runtime_api.h>
 #include "Kokkos_CudaSpace.hpp"
 
-#include <set>
+#include <algorithms>
+#include <atomic>
+#include <iterator>
 #include <map>
+#include <set>
+#include <ranges>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -366,10 +369,10 @@ class CudaInternal {
 namespace Experimental::Impl {
 // For each space in partition, create new cudaStream_t on the same device as
 // base_instance, ignoring weights
-template <std::ranges::input_range Weights, class OutIter>
+template <std::ranges::input_range Weights, std::output_iterator<Cuda> OutIter>
 void impl_partition_space(const Cuda& base_instance, const Weights& weights,
-                          OutIter instances) {
-  std::ranges::transform(weights, instances, [&base_instance](const auto) {
+                          OutIter out) {
+  std::ranges::generate_n(out, std::ranges::size(weights), [&base_instance] {
     cudaStream_t stream;
     KOKKOS_IMPL_CUDA_SAFE_CALL(base_instance.impl_internal_space_instance()
                                    ->cuda_stream_create_wrapper(&stream));

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -11,9 +11,12 @@
 
 #include <hip/hip_runtime_api.h>
 
+#include <algorithm>
 #include <atomic>
+#include <iterator>
 #include <map>
 #include <mutex>
+#include <ranges>
 #include <set>
 
 namespace Kokkos {
@@ -343,10 +346,10 @@ class HIPInternal {
 namespace Experimental::Impl {
 // For each space in partition, create new hipStream_t on the same device as
 // base_instance, ignoring weights
-template <std::ranges::input_range Weights, class OutIer>
+template <std::ranges::input_range Weights, std::output_iterator<HIP> OutIter>
 void impl_partition_space(const HIP &base_instance, const Weights &weights,
-                          OutIter instances) {
-  std::ranges::transform(weights, instances, [&base_instance](const auto) {
+                          OutIter out) {
+  std::ranges::generate_n(out, std::ranges::size(weights), [&base_instance] {
     hipStream_t stream;
     KOKKOS_IMPL_HIP_SAFE_CALL(
         base_instance.impl_internal_space_instance()->hip_stream_create_wrapper(

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -343,20 +343,16 @@ class HIPInternal {
 namespace Experimental::Impl {
 // For each space in partition, create new hipStream_t on the same device as
 // base_instance, ignoring weights
-template <class T>
-std::vector<HIP> impl_partition_space(const HIP &base_instance,
-                                      const std::vector<T> &weights) {
-  std::vector<HIP> instances;
-  instances.reserve(weights.size());
-  std::generate_n(
-      std::back_inserter(instances), weights.size(), [&base_instance]() {
-        hipStream_t stream;
-        KOKKOS_IMPL_HIP_SAFE_CALL(base_instance.impl_internal_space_instance()
-                                      ->hip_stream_create_wrapper(&stream));
-        return HIP(stream, Kokkos::Impl::ManageStream::yes);
-      });
-
-  return instances;
+template <std::ranges::input_range Weights, class OutIer>
+void impl_partition_space(const HIP &base_instance, const Weights &weights,
+                          OutIter instances) {
+  std::ranges::transform(weights, instances, [&base_instance](const auto) {
+    hipStream_t stream;
+    KOKKOS_IMPL_HIP_SAFE_CALL(
+        base_instance.impl_internal_space_instance()->hip_stream_create_wrapper(
+            &stream));
+    return HIP(stream, Kokkos::Impl::ManageStream::yes);
+  });
 }
 }  // namespace Experimental::Impl
 }  // namespace Kokkos

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -446,15 +446,12 @@ class HPX {
 namespace Impl {
 // Create new, independent instance of HPX execution space for each partition,
 // ignoring weights
-template <class T>
-std::vector<HPX> impl_partition_space(const HPX &,
-                                      const std::vector<T> &weights) {
-  std::vector<HPX> instances;
-  instances.reserve(weights.size());
-  std::generate_n(std::back_inserter(instances), weights.size(),
-                  []() { return HPX(HPX::instance_mode::independent); });
-
-  return instances;
+template <std::ranges::input_range Weights, class OutIer>
+void impl_partition_space(const HPX &, const Weights &weights,
+                          OutIer instances) {
+  std::ranges::transform(weights, instances, [](const auto) {
+    return HPX(HPX::instance_mode::independent);
+  });
 }
 }  // namespace Impl
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -37,12 +37,14 @@ static_assert(false,
 
 #include <Kokkos_UniqueToken.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <iosfwd>
+#include <iterator>
 #include <functional>
 #include <memory>
+#include <ranges>
 #include <type_traits>
-#include <vector>
 
 namespace Kokkos {
 namespace Impl {
@@ -449,9 +451,8 @@ namespace Impl {
 template <std::ranges::input_range Weights, class OutIer>
 void impl_partition_space(const HPX &, const Weights &weights,
                           OutIer instances) {
-  std::ranges::transform(weights, instances, [](const auto) {
-    return HPX(HPX::instance_mode::independent);
-  });
+  std::ranges::generate_n(instances, std::ranges::size(weights),
+                          [] { return HPX(HPX::instance_mode::independent); });
 }
 }  // namespace Impl
 

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -59,7 +59,6 @@ void impl_partition_space(const OpenACC& base_instance, const Weights& weights,
     return OpenACC(OpenACCInternal::m_next_async +
                    KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN);
   });
-  return instances;
 }
 
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -8,8 +8,11 @@
 
 #include <openacc.h>
 
+#include <algorithms>
 #include <cstdint>
 #include <iosfwd>
+#include <iterator>
+#include <ranges>
 #include <string>
 
 namespace Kokkos::Experimental::Impl {
@@ -44,12 +47,13 @@ class OpenACCInternal {
 };
 
 // For each space in partition, assign a new async ID, ignoring weights
-template <std::ranges::input_range Weights, class OutIter>
+template <std::ranges::input_range Weights,
+          std::output_iterator<OpenACC> OutIter>
 void impl_partition_space(const OpenACC& base_instance, const Weights& weights,
-                          OutIter instances) {
+                          OutIter out) {
   constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN  = 64;
   constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH = 128;
-  std::ranges::transform(weights, instances, [](const auto) {
+  std::ranges::generate_n(out, std::ranges::size(weights), [] {
     OpenACCInternal::m_next_async = (OpenACCInternal::m_next_async + 1) %
                                     KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH;
     return OpenACC(OpenACCInternal::m_next_async +

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -8,7 +8,7 @@
 
 #include <openacc.h>
 
-#include <algorithms>
+#include <algorithm>
 #include <cstdint>
 #include <iosfwd>
 #include <iterator>

--- a/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Instance.hpp
@@ -44,15 +44,12 @@ class OpenACCInternal {
 };
 
 // For each space in partition, assign a new async ID, ignoring weights
-template <class T>
-std::vector<OpenACC> impl_partition_space(const OpenACC& base_instance,
-                                          const std::vector<T>& weights) {
+template <std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const OpenACC& base_instance, const Weights& weights,
+                          OutIter instances) {
   constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_BEGIN  = 64;
   constexpr int KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH = 128;
-  std::vector<OpenACC> instances;
-  auto const n = weights.size();
-  instances.reserve(n);
-  std::generate_n(std::back_inserter(instances), n, [] {
+  std::ranges::transform(weights, instances, [](const auto) {
     OpenACCInternal::m_next_async = (OpenACCInternal::m_next_async + 1) %
                                     KOKKOS_IMPL_ACC_ASYNC_RANGE_LENGTH;
     return OpenACC(OpenACCInternal::m_next_async +

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -22,7 +22,7 @@
 
 #include <omp.h>
 
-#include <algorithms>
+#include <algorithm>
 #include <iterator>
 #include <mutex>
 #include <numeric>

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -135,11 +135,11 @@ inline bool execute_in_serial(OpenMP const& space = OpenMP()) {
 
 namespace Experimental::Impl {
 // Calculate pool sizes for partitioned OpenMP spaces
-template <typename T>
-inline std::vector<int> calculate_omp_pool_sizes(
-    OpenMP const& main_instance, std::vector<T> const& weights) {
+template <std::ranges::input_range Weights>
+inline std::vector<int> calculate_omp_pool_sizes(OpenMP const& main_instance,
+                                                 const Weights& weights) {
   static_assert(
-      std::is_arithmetic_v<T>,
+      std::is_arithmetic_v<typename Weights::value_type>,
       "Kokkos Error: partitioning arguments must be integers or floats");
   if (weights.size() == 0) {
     Kokkos::abort("Kokkos::abort: Partition weights vector is empty.");
@@ -161,9 +161,9 @@ inline std::vector<int> calculate_omp_pool_sizes(
 }
 
 // Create new OpenMP instances with pool sizes relative to input weights
-template <class T>
-std::vector<OpenMP> impl_partition_space(const OpenMP& base_instance,
-                                         const std::vector<T>& weights) {
+template <std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const OpenMP& base_instance, const Weights& weights,
+                          OutIter instances) {
 #if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
     _OPENMP >= 201511
   bool has_nested = omp_get_max_active_levels() > 1;
@@ -171,18 +171,14 @@ std::vector<OpenMP> impl_partition_space(const OpenMP& base_instance,
   bool has_nested = static_cast<bool>(omp_get_nested());
 #endif
   if (!has_nested || omp_get_level() != 0) {
-    return std::vector<OpenMP>(weights.size());
+    std::ranges::generate_n(instances, std::ranges::size(weights),
+                            [] { return Kokkos::OpenMP{}; });
   } else {
     const auto pool_sizes =
         Impl::calculate_omp_pool_sizes(base_instance, weights);
 
-    std::vector<OpenMP> instances;
-    instances.reserve(pool_sizes.size());
-    for (size_t i = 0; i < pool_sizes.size(); ++i) {
-      instances.emplace_back(OpenMP(pool_sizes[i]));
-    }
-
-    return instances;
+    std::ranges::transform(pool_sizes, instances,
+                           [](const auto size) { return OpenMP(size); });
   }
 }
 }  // namespace Experimental::Impl

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.hpp
@@ -22,8 +22,11 @@
 
 #include <omp.h>
 
+#include <algorithms>
+#include <iterator>
 #include <mutex>
 #include <numeric>
+#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -161,9 +164,10 @@ inline std::vector<int> calculate_omp_pool_sizes(OpenMP const& main_instance,
 }
 
 // Create new OpenMP instances with pool sizes relative to input weights
-template <std::ranges::input_range Weights, class OutIter>
+template <std::ranges::input_range Weights,
+          std::output_iterator<OpenMP> OutIter>
 void impl_partition_space(const OpenMP& base_instance, const Weights& weights,
-                          OutIter instances) {
+                          OutIter out) {
 #if (!defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1110) && \
     _OPENMP >= 201511
   bool has_nested = omp_get_max_active_levels() > 1;
@@ -171,13 +175,13 @@ void impl_partition_space(const OpenMP& base_instance, const Weights& weights,
   bool has_nested = static_cast<bool>(omp_get_nested());
 #endif
   if (!has_nested || omp_get_level() != 0) {
-    std::ranges::generate_n(instances, std::ranges::size(weights),
+    std::ranges::generate_n(out, std::ranges::size(weights),
                             [] { return Kokkos::OpenMP{}; });
   } else {
     const auto pool_sizes =
         Impl::calculate_omp_pool_sizes(base_instance, weights);
 
-    std::ranges::transform(pool_sizes, instances,
+    std::ranges::transform(pool_sizes, out,
                            [](const auto size) { return OpenMP(size); });
   }
 }

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -25,7 +25,7 @@ static_assert(false,
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 
-#include <algorithms>
+#include <algorithm>
 #include <iterator>
 #include <ranges>
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -25,6 +25,10 @@ static_assert(false,
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
 
+#include <algorithms>
+#include <iterator>
+#include <ranges>
+
 namespace Kokkos {
 namespace Impl {
 class SYCLInternal;
@@ -133,13 +137,13 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 namespace Experimental::Impl {
 // For each space in partition, create new queue on the same device as
 // base_instance, ignoring weights
-template <std::ranges::input_range Weights, class OutIter>
+template <std::ranges::input_range Weights, std::output_iterator<SYCL> OutIter>
 void impl_partition_space(const SYCL& base_instance, const Weights& weights,
-                          OutIter instances) {
+                          OutIter out) {
   sycl::context context = base_instance.sycl_queue().get_context();
   sycl::device device   = base_instance.sycl_queue().get_device();
 
-  std::ranges::transform(weights, instances, [&context, &device]() {
+  std::ranges::generate_n(out, std::ranges::size(weights), [&context, &device] {
     return SYCL(sycl::queue(context, device
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
                             ,

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -133,25 +133,20 @@ struct DeviceTypeTraits<Kokkos::SYCL> {
 namespace Experimental::Impl {
 // For each space in partition, create new queue on the same device as
 // base_instance, ignoring weights
-template <class T>
-std::vector<SYCL> impl_partition_space(const SYCL& base_instance,
-                                       const std::vector<T>& weights) {
+template <std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const SYCL& base_instance, const Weights& weights,
+                          OutIter instances) {
   sycl::context context = base_instance.sycl_queue().get_context();
   sycl::device device   = base_instance.sycl_queue().get_device();
 
-  std::vector<SYCL> instances;
-  instances.reserve(weights.size());
-  std::generate_n(std::back_inserter(instances), weights.size(),
-                  [&context, &device]() {
-                    return SYCL(sycl::queue(context, device
+  std::ranges::transform(weights, instances, [&context, &device]() {
+    return SYCL(sycl::queue(context, device
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-                                            ,
-                                            sycl::property::queue::in_order()
+                            ,
+                            sycl::property::queue::in_order()
 #endif
-                                                ));
-                  });
-
-  return instances;
+                                ));
+  });
 }
 }  // namespace Experimental::Impl
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -260,15 +260,11 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 namespace Kokkos::Experimental::Impl {
 // Create new instance of Serial execution space for each partition, ignoring
 // weights
-template <class T>
-std::vector<Serial> impl_partition_space(const Serial&,
-                                         const std::vector<T>& weights) {
-  std::vector<Serial> instances;
-  instances.reserve(weights.size());
-  std::generate_n(std::back_inserter(instances), weights.size(),
-                  []() { return Serial(NewInstance{}); });
-
-  return instances;
+template <std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const Serial&, const Weights& weights,
+                          OutIter instances) {
+  std::ranges::transform(weights, instances,
+                         [](const auto) { return Serial(NewInstance{}); });
 }
 }  // namespace Kokkos::Experimental::Impl
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -15,10 +15,12 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_SERIAL)
 
+#include <algorithms>
 #include <cstddef>
 #include <iosfwd>
 #include <iterator>
 #include <mutex>
+#include <ranges>
 #include <thread>
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Layout.hpp>
@@ -260,11 +262,11 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
 namespace Kokkos::Experimental::Impl {
 // Create new instance of Serial execution space for each partition, ignoring
 // weights
-template <std::ranges::input_range Weights, class OutIter>
-void impl_partition_space(const Serial&, const Weights& weights,
-                          OutIter instances) {
-  std::ranges::transform(weights, instances,
-                         [](const auto) { return Serial(NewInstance{}); });
+template <std::ranges::input_range Weights,
+          std::output_iterator<Serial> OutIter>
+void impl_partition_space(const Serial&, const Weights& weights, OutIter out) {
+  std::ranges::transform(out, std::ranges::size(weights),
+                         [] { return Serial(NewInstance{}); });
 }
 }  // namespace Kokkos::Experimental::Impl
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -15,7 +15,7 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_SERIAL)
 
-#include <algorithms>
+#include <algorithm>
 #include <cstddef>
 #include <iosfwd>
 #include <iterator>

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -265,8 +265,8 @@ namespace Kokkos::Experimental::Impl {
 template <std::ranges::input_range Weights,
           std::output_iterator<Serial> OutIter>
 void impl_partition_space(const Serial&, const Weights& weights, OutIter out) {
-  std::ranges::transform(out, std::ranges::size(weights),
-                         [] { return Serial(NewInstance{}); });
+  std::ranges::generate_n(out, std::ranges::size(weights),
+                          [] { return Serial(NewInstance{}); });
 }
 }  // namespace Kokkos::Experimental::Impl
 

--- a/core/src/impl/Kokkos_PartitionSpace.hpp
+++ b/core/src/impl/Kokkos_PartitionSpace.hpp
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 #include <array>
+#include <iterator>
+#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -20,12 +22,13 @@ namespace Kokkos::Experimental::Impl {
 
 // Customization point for backends. Default behavior is to return the passed
 // in instance, ignoring weights
-template <class ExecSpace, std::ranges::input_range Weights, class OutIter>
+template <class ExecSpace, std::ranges::input_range Weights,
+          std::output_iterator<ExecSpace> OutIter>
+  requires(is_execution_space_v<ExecSpace>)
 void impl_partition_space(const ExecSpace& base_instance,
-                          const Weights& weights, OutIter instances) {
-  std::ranges::transform(weights, instances, [&base_instance](const auto) {
-    return base_instance;
-  });
+                          const Weights& weights, OutIter out) {
+  std::ranges::generate_n(out, std::ranges::size(weights),
+                          [&base_instance] { return base_instance; });
 }
 
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/impl/Kokkos_PartitionSpace.hpp
+++ b/core/src/impl/Kokkos_PartitionSpace.hpp
@@ -20,15 +20,12 @@ namespace Kokkos::Experimental::Impl {
 
 // Customization point for backends. Default behavior is to return the passed
 // in instance, ignoring weights
-template <class ExecSpace, class T>
-std::vector<ExecSpace> impl_partition_space(const ExecSpace& base_instance,
-                                            const std::vector<T>& weights) {
-  std::vector<ExecSpace> instances;
-  instances.reserve(weights.size());
-  std::generate_n(std::back_inserter(instances), weights.size(),
-                  [&base_instance]() { return base_instance; });
-
-  return instances;
+template <class ExecSpace, std::ranges::input_range Weights, class OutIter>
+void impl_partition_space(const ExecSpace& base_instance,
+                          const Weights& weights, OutIter instances) {
+  std::ranges::transform(weights, instances, [&base_instance](const auto) {
+    return base_instance;
+  });
 }
 
 }  // namespace Kokkos::Experimental::Impl
@@ -43,37 +40,28 @@ namespace Kokkos::Experimental {
 // Ouput:
 //   - Array (or vector) of execution spaces partitioned based on weights
 template <class ExecSpace, class... Args>
+  requires(is_execution_space_v<ExecSpace> &&
+           (std::is_arithmetic_v<Args> && ...))
 std::array<ExecSpace, sizeof...(Args)> partition_space(
     ExecSpace const& base_instance, Args... args) {
-  static_assert(is_execution_space<ExecSpace>::value,
-                "Kokkos Error: partition_space expects an Execution Space as "
-                "first argument");
-  static_assert(
-      (... && std::is_arithmetic_v<Args>),
-      "Kokkos Error: partitioning arguments must be integers or floats");
+  using weight_type  = std::common_type_t<Args...>;
+  constexpr size_t N = sizeof...(Args);
 
-  // Get vector of instances from backend specific impl
-  std::vector<std::common_type_t<Args...>> weights = {args...};
-  auto instances_vec = Impl::impl_partition_space(base_instance, weights);
-
-  // Convert to std::array and return
-  std::array<ExecSpace, sizeof...(Args)> instances;
-  std::copy(instances_vec.begin(), instances_vec.end(), instances.begin());
+  std::array<ExecSpace, N> instances;
+  Impl::impl_partition_space(base_instance, std::array<weight_type, N>{args...},
+                             instances.begin());
   return instances;
 }
 
 template <class ExecSpace, class T>
+  requires(is_execution_space_v<ExecSpace> && std::is_arithmetic_v<T>)
 std::vector<ExecSpace> partition_space(ExecSpace const& base_instance,
                                        std::vector<T> const& weights) {
-  static_assert(is_execution_space<ExecSpace>::value,
-                "Kokkos Error: partition_space expects an Execution Space as "
-                "first argument");
-  static_assert(
-      std::is_arithmetic_v<T>,
-      "Kokkos Error: partitioning arguments must be integers or floats");
-
-  // Return vector of instances from backend specific impl
-  return Impl::impl_partition_space(base_instance, weights);
+  std::vector<ExecSpace> instances;
+  instances.reserve(weights.size());
+  Impl::impl_partition_space(base_instance, weights,
+                             std::back_inserter(instances));
+  return instances;
 }
 
 }  // namespace Kokkos::Experimental

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -177,6 +177,13 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings_1) {
+  // FIXME_OPENMP
+  // https://github.com/kokkos/kokkos/pull/8556#issuecomment-3407533379
+#if defined(KOKKOS_ENABLE_OPENMP)
+  if constexpr (std::same_as<TEST_EXECSPACE, Kokkos::OpenMP>) {
+    GTEST_SKIP() << "OpenMP partitioning with one weight won't pass the tests.";
+  }
+#endif
   TEST_EXECSPACE exec{};
   auto [instance] = Kokkos::Experimental::partition_space(exec, 1);
   test_partitioning(exec, instance);

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -177,8 +177,9 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
 }
 
 TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings_1) {
-  [[maybe_unused]] const auto [instance] =
-      Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1);
+  TEST_EXECSPACE exec{};
+  auto [instance] = Kokkos::Experimental::partition_space(exec, 1);
+  test_partitioning(exec, instance);
 }
 
 TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings_1_1) {

--- a/core/unit_test/TestExecSpacePartitioning.hpp
+++ b/core/unit_test/TestExecSpacePartitioning.hpp
@@ -176,7 +176,12 @@ TEST(TEST_CATEGORY, partitioning_by_args) {
   test_partitioning(instances[0], instances[1]);
 }
 
-TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings) {
+TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings_1) {
+  [[maybe_unused]] const auto [instance] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1);
+}
+
+TEST(TEST_CATEGORY, partitioning_by_args_with_structured_bindings_1_1) {
   auto [instance0, instance1] =
       Kokkos::Experimental::partition_space(TEST_EXECSPACE(), 1, 1);
   test_partitioning(instance0, instance1);


### PR DESCRIPTION
This PR modernizes the `partition_space` thingy.

More specifically, the backends now implement a "container agnostic" way of filling the instances.

This allows the user-facing `partition_space` to avoid allocating `std::vector` when it is not required.