### PR TITLE
Fix missing typename keyword in View::operator() declaration

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -528,7 +528,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
           Kokkos::Impl::IsLayoutRightPadded<
               typename base_t::layout_type>::value ||
           std::is_same_v<typename base_t::layout_type, Kokkos::layout_stride>))
-  KOKKOS_FUNCTION constexpr base_t::reference operator()(
+  KOKKOS_FUNCTION constexpr reference_type operator()(
       OtherIndexTypes... indices) const {
     KOKKOS_IMPL_BASICVIEW_OPERATOR_VERIFY(indices...);
     return m_acc.access(m_ptr,


### PR DESCRIPTION
Seen in on ORNL Jenkins CI
```
[CUDA-11.8-Clang-15] /var/jenkins/workspace/Kokkos_PR-8558/core/src/Kokkos_View.hpp:531:29: error: missing 'typename' prior to dependent type name 'base_t::reference' [clang-diagnostic-error]
[CUDA-11.8-Clang-15]   KOKKOS_FUNCTION constexpr base_t::reference operator()(
[CUDA-11.8-Clang-15]                             ^~~~~~~~~~~~~~~~~
[CUDA-11.8-Clang-15]                             typename 
```

Fixup for https://github.com/kokkos/kokkos/pull/8476/files#r2439525035