### PR TITLE
jenkins: Let stage-1 host builds use nvidia runners

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -41,7 +41,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.modules'
                             dir 'scripts/docker'
-                            label 'docker'
+                            label 'nvidia-docker || docker'
                             args '--env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
@@ -86,7 +86,7 @@ pipeline {
                          dockerfile {
                              filename 'Dockerfile.gcc'
                              dir 'scripts/docker'
-                             label 'docker'
+                             label 'nvidia-docker || docker'
                              args '--env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                          }
                      }


### PR DESCRIPTION
We are often bottlenecked on the CPU steps in stage-1 in jenkins CI while we have many NVIDIA runners available. We are already allowing `clang-format` to run on those runners as well and this pull requests proposes that we do the same for those host builds.