### PR TITLE
simd: add bitwise operators

### DIFF
--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -75,6 +75,13 @@ export {
   using ::Kokkos::Experimental::operator*;
   using ::Kokkos::Experimental::operator-;
   using ::Kokkos::Experimental::operator/;
+  using ::Kokkos::Experimental::operator~;
+  using ::Kokkos::Experimental::operator&=;
+  using ::Kokkos::Experimental::operator|=;
+  using ::Kokkos::Experimental::operator^=;
+  using ::Kokkos::Experimental::operator&;
+  using ::Kokkos::Experimental::operator|;
+  using ::Kokkos::Experimental::operator^;
   using ::Kokkos::Experimental::operator>>=;
   using ::Kokkos::Experimental::operator<<=;
 

--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -75,13 +75,9 @@ export {
   using ::Kokkos::Experimental::operator*;
   using ::Kokkos::Experimental::operator-;
   using ::Kokkos::Experimental::operator/;
-  using ::Kokkos::Experimental::operator~;
   using ::Kokkos::Experimental::operator&=;
   using ::Kokkos::Experimental::operator|=;
   using ::Kokkos::Experimental::operator^=;
-  using ::Kokkos::Experimental::operator&;
-  using ::Kokkos::Experimental::operator|;
-  using ::Kokkos::Experimental::operator^;
   using ::Kokkos::Experimental::operator>>=;
   using ::Kokkos::Experimental::operator<<=;
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -81,8 +81,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m256d>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_pd(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
@@ -90,13 +89,31 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_pd(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_xor_pd(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -156,8 +173,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m128>(basic_simd_mask(true));
-    return basic_simd_mask(_mm_andnot_ps(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
@@ -165,13 +181,31 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm_andnot_ps(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_xor_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -234,8 +268,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m256>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_ps(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
@@ -243,13 +276,31 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_ps(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_xor_ps(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -309,8 +360,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m128i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm_andnot_si128(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
@@ -318,13 +368,31 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm_andnot_si128(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm_xor_si128(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -388,8 +456,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -397,13 +464,31 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -468,8 +553,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -477,13 +561,31 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -548,8 +650,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    auto const true_value = static_cast<__m256i>(basic_simd_mask(true));
-    return basic_simd_mask(_mm256_andnot_si256(m_value, true_value));
+    return operator~();
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
@@ -557,13 +658,31 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs & rhs;
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -1921,6 +2040,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm_andnot_si128(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   operator[](std::size_t i) const {
     switch (i) {
@@ -1951,6 +2075,21 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm_and_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm_or_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm_xor_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2266,6 +2405,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2280,6 +2424,21 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2600,6 +2759,11 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
@@ -2620,6 +2784,21 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2946,6 +3125,11 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2964,13 +3148,18 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_and_si256(static_cast<__m256i>(lhs),
-                            static_cast<__m256i>(rhs));
+    return basic_simd(
+        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_or_si256(static_cast<__m256i>(lhs),
-                           static_cast<__m256i>(rhs));
+    return basic_simd(
+        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -90,9 +90,12 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    static const __mmask8 true_value(
-        static_cast<__mmask8>(basic_simd_mask(true)));
-    return basic_simd_mask(_kxor_mask8(true_value, m_value));
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(_knot_mask8(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask8()
@@ -102,11 +105,24 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<8>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kand_mask8(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kand_mask8(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_kor_mask8(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kxor_mask8(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -212,9 +228,12 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
   operator!() const noexcept {
-    static const __mmask16 true_value(
-        static_cast<__mmask16>(basic_simd_mask(true)));
-    return basic_simd_mask(_kxor_mask16(true_value, m_value));
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  operator~() const noexcept {
+    return basic_simd_mask(_knot_mask16(m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __mmask16()
@@ -222,13 +241,26 @@ class basic_simd_mask<T, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs & rhs;
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
+      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
+    return basic_simd_mask(_kand_mask16(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
     return basic_simd_mask(_kor_mask16(lhs.m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_kand_mask16(lhs.m_value, rhs.m_value));
+    return basic_simd_mask(_kxor_mask16(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
@@ -1601,6 +1633,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(_mm256_sub_epi32(_mm256_set1_epi32(0), m_value));
   }
@@ -1619,6 +1656,21 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1962,6 +2014,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm512_andnot_epi32(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>(
@@ -1976,6 +2033,21 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_and_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_or_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_xor_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2321,6 +2393,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2335,6 +2412,21 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
                                          static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2672,6 +2764,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm512_andnot_epi32(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -2686,6 +2783,21 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi32(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_and_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_or_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_xor_epi32(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -3027,6 +3139,11 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm512_andnot_epi64(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -3041,6 +3158,21 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(_mm512_mullo_epi64(static_cast<__m512i>(lhs),
                                          static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_and_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_or_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_xor_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) {
@@ -3369,6 +3501,11 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
     return m_value;
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(
+        _mm512_andnot_epi64(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
@@ -3386,13 +3523,18 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm512_and_epi64(static_cast<__m512i>(lhs),
-                            static_cast<__m512i>(rhs));
+    return basic_simd(
+        _mm512_and_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm512_or_epi64(static_cast<__m512i>(lhs),
-                           static_cast<__m512i>(rhs));
+    return basic_simd(
+        _mm512_or_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        _mm512_xor_epi64(static_cast<__m512i>(lhs), static_cast<__m512i>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
       basic_simd const& lhs, int rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -363,6 +363,48 @@ operator/=(where_expression<M, T>& lhs, U&& rhs) {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator&=(
+    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+  lhs = lhs & rhs;
+  return lhs;
+}
+
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator|=(
+    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator^=(
+    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+  lhs = lhs ^ rhs;
+  return lhs;
+}
+
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator&=(
+    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+  lhs = lhs & rhs;
+  return lhs;
+}
+
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator|=(
+    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+  lhs = lhs | rhs;
+  return lhs;
+}
+
+template <class T, Impl::NonScalarAbi Abi>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator^=(
+    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+  lhs = lhs ^ rhs;
+  return lhs;
+}
+
 template <class T, class U, Impl::NonScalarAbi Abi>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
     basic_simd<T, Abi>& lhs, U&& rhs) {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -92,8 +92,11 @@ class neon_mask<Derived, 64, 2> {
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const noexcept {
-    auto const true_value = static_cast<uint64x2_t>(neon_mask(true));
-    return Derived(veorq_u64(m_value, true_value));
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator~() const noexcept {
+    return Derived(veorq_u64(m_value, neon_mask(true).m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
@@ -103,11 +106,23 @@ class neon_mask<Derived, 64, 2> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
-    return Derived(vandq_u64(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator||(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(vandq_u64(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator|(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
     return Derived(vorrq_u64(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator^(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(veorq_u64(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator==(
@@ -181,8 +196,11 @@ class neon_mask<Derived, 32, 2> {
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const noexcept {
-    auto const true_value = static_cast<uint32x2_t>(neon_mask(true));
-    return Derived(veor_u32(m_value, true_value));
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator~() const noexcept {
+    return Derived(veor_u32(m_value, neon_mask(true).m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x2_t()
@@ -192,11 +210,23 @@ class neon_mask<Derived, 32, 2> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
-    return Derived(vand_u32(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator||(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(vand_u32(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator|(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
     return Derived(vorr_u32(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator^(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(veor_u32(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator==(
@@ -272,8 +302,11 @@ class neon_mask<Derived, 32, 4> {
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const noexcept {
-    auto const true_value = static_cast<uint32x4_t>(neon_mask(true));
-    return Derived(veorq_u32(m_value, true_value));
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator~() const noexcept {
+    return Derived(veorq_u32(m_value, neon_mask(true).m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint32x4_t()
@@ -283,11 +316,23 @@ class neon_mask<Derived, 32, 4> {
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
-    return Derived(vandq_u32(lhs.m_value, rhs.m_value));
+    return lhs & rhs;
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator||(
       neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(vandq_u32(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator|(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
     return Derived(vorrq_u32(lhs.m_value, rhs.m_value));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator^(
+      neon_mask const& lhs, neon_mask const& rhs) noexcept {
+    return Derived(veorq_u32(lhs.m_value, rhs.m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator==(
@@ -1519,6 +1564,10 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     return basic_simd(vneg_s32(m_value));
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(veor_s32(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x2_t()
       const noexcept {
     return m_value;
@@ -1538,6 +1587,21 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vmul_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vand_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vorr_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        veor_s32(static_cast<int32x2_t>(lhs), static_cast<int32x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1833,6 +1897,10 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     return basic_simd(vnegq_s32(m_value));
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(veorq_s32(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int32x4_t()
       const noexcept {
     return m_value;
@@ -1852,6 +1920,21 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vmulq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vandq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vorrq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        veorq_s32(static_cast<int32x4_t>(lhs), static_cast<int32x4_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2149,6 +2232,10 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     return basic_simd(vnegq_s64(m_value));
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(veorq_s64(m_value, basic_simd(~value_type(0)).m_value));
+  }
+
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator int64x2_t()
       const noexcept {
     return m_value;
@@ -2167,6 +2254,21 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd([&](std::size_t i) { return lhs[i] * rhs[i]; });
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vandq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vorrq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        veorq_s64(static_cast<int64x2_t>(lhs), static_cast<int64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2456,10 +2558,8 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(veorq_u64(m_value, basic_simd(~value_type(0)).m_value));
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator uint64x2_t()
@@ -2471,6 +2571,11 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vaddq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        vsubq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2485,6 +2590,11 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(
         vorrq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(
+        veorq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -180,19 +180,36 @@ class sve_mask<Derived, 64> {
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const noexcept {
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator~() const noexcept {
     return Derived(
         static_cast<implementation_type>(svnot_z(svptrue_b64(), m_value)));
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return lhs & rhs;
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator||(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return Derived(static_cast<implementation_type>(
+        svand_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator|(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
     return Derived(static_cast<implementation_type>(
         svorr_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator^(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
     return Derived(static_cast<implementation_type>(
-        svand_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
+        sveor_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator!=(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
@@ -295,19 +312,36 @@ class sve_mask<Derived, 32> {
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator!() const noexcept {
+    return operator~();
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Derived operator~() const noexcept {
     return Derived(
         static_cast<implementation_type>(svnot_z(svptrue_b32(), m_value)));
   }
 
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return lhs & rhs;
+  }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator||(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return lhs | rhs;
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&(
+      sve_mask const& lhs, sve_mask const& rhs) noexcept {
+    return Derived(static_cast<implementation_type>(
+        svand_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator|(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
     return Derived(static_cast<implementation_type>(
         svorr_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator&&(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator^(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
     return Derived(static_cast<implementation_type>(
-        svand_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
+        sveor_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend Derived operator!=(
       sve_mask const& lhs, sve_mask const& rhs) noexcept {
@@ -1328,6 +1362,10 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
     return basic_simd(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b32(), m_value)));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svnot_m(m_value, svptrue_b32(), m_value)));
+  }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1352,6 +1390,25 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(static_cast<implementation_type>(
         svsub_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
+                static_cast<vls_int32_t>(rhs))));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svand_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
+                static_cast<vls_int32_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svorr_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
+                static_cast<vls_int32_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        sveor_m(svptrue_b32(), static_cast<vls_int32_t>(lhs),
                 static_cast<vls_int32_t>(rhs))));
   }
 
@@ -1786,6 +1843,10 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(static_cast<implementation_type>(svundef_u32()));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svnot_m(m_value, svptrue_b32(), m_value)));
+  }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -1810,6 +1871,25 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(static_cast<implementation_type>(
         svsub_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
+                static_cast<vls_uint32_t>(rhs))));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svand_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
+                static_cast<vls_uint32_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svorr_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
+                static_cast<vls_uint32_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        sveor_m(svptrue_b32(), static_cast<vls_uint32_t>(lhs),
                 static_cast<vls_uint32_t>(rhs))));
   }
 
@@ -2228,6 +2308,10 @@ class basic_simd<std::int64_t,
     return basic_simd(static_cast<implementation_type>(
         svneg_m(m_value, svptrue_b64(), m_value)));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svnot_m(m_value, svptrue_b64(), m_value)));
+  }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2252,6 +2336,25 @@ class basic_simd<std::int64_t,
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(static_cast<implementation_type>(
         svsub_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
+                static_cast<vls_int64_t>(rhs))));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svand_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
+                static_cast<vls_int64_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svorr_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
+                static_cast<vls_int64_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        sveor_m(svptrue_b64(), static_cast<vls_int64_t>(lhs),
                 static_cast<vls_int64_t>(rhs))));
   }
 
@@ -2691,6 +2794,10 @@ class basic_simd<std::uint64_t,
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
     return basic_simd(static_cast<implementation_type>(svundef_u64()));
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svnot_m(m_value, svptrue_b64(), m_value)));
+  }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -2715,6 +2822,25 @@ class basic_simd<std::uint64_t,
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(static_cast<implementation_type>(
         svsub_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
+                static_cast<vls_uint64_t>(rhs))));
+  }
+
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svand_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
+                static_cast<vls_uint64_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        svorr_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
+                static_cast<vls_uint64_t>(rhs))));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return basic_simd(static_cast<implementation_type>(
+        sveor_m(svptrue_b64(), static_cast<vls_uint64_t>(lhs),
                 static_cast<vls_uint64_t>(rhs))));
   }
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -62,6 +62,11 @@ class basic_simd_mask<T, simd_abi::scalar> {
     return basic_simd_mask(!m_value);
   }
 
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd_mask operator~()
+      const noexcept {
+    return basic_simd_mask(~m_value);
+  }
+
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool()
       const noexcept {
     return m_value;
@@ -235,6 +240,10 @@ class basic_simd<T, simd_abi::scalar> {
     return basic_simd(-m_value);
   }
 
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd operator~() const noexcept {
+    return basic_simd(~m_value);
+  }
+
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator+(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return basic_simd(lhs.m_value + rhs.m_value);
@@ -279,6 +288,10 @@ class basic_simd<T, simd_abi::scalar> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return lhs.m_value | rhs.m_value;
   }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator^(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return lhs.m_value ^ rhs.m_value;
+  }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<(
       basic_simd const& lhs, int rhs) noexcept {
     return basic_simd(lhs.m_value << rhs);
@@ -314,6 +327,21 @@ class basic_simd<T, simd_abi::scalar> {
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator/=(
       basic_simd& lhs, basic_simd const& rhs) noexcept {
     lhs = lhs / rhs;
+    return lhs;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd& operator&=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
+    lhs = lhs & rhs;
+    return lhs;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd& operator|=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
+    lhs = lhs | rhs;
+    return lhs;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd& operator^=(
+      basic_simd& lhs, basic_simd const& rhs) noexcept {
+    lhs = lhs ^ rhs;
     return lhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd operator<<=(
@@ -587,8 +615,9 @@ max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <class T>
-class KOKKOS_DEPRECATED const_where_expression<
-    basic_simd_mask<T, simd_abi::scalar>, basic_simd<T, simd_abi::scalar>> {
+class KOKKOS_DEPRECATED
+    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
+                           basic_simd<T, simd_abi::scalar>> {
  public:
   using abi_type   = simd_abi::scalar;
   using value_type = basic_simd<T, abi_type>;

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -84,15 +84,15 @@ class basic_simd_mask<T, simd_abi::scalar> {
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator&(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) & static_cast<bool>(rhs));
+    return lhs && rhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator|(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) | static_cast<bool>(rhs));
+    return lhs || rhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask operator^(
       basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(static_cast<bool>(lhs) ^ static_cast<bool>(rhs));
+    return (lhs && !rhs) || (!lhs && rhs);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator&=(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -97,17 +97,17 @@ class basic_simd_mask<T, simd_abi::scalar> {
 
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator&=(
       basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
-    lhs &= rhs;
+    lhs = lhs & rhs;
     return lhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator|=(
       basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
-    lhs |= rhs;
+    lhs = lhs | rhs;
     return lhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr basic_simd_mask& operator^=(
       basic_simd_mask& lhs, basic_simd_mask const& rhs) noexcept {
-    lhs ^= rhs;
+    lhs = lhs ^ rhs;
     return lhs;
   }
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -64,7 +64,9 @@ class basic_simd_mask<T, simd_abi::scalar> {
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd_mask operator~()
       const noexcept {
-    return basic_simd_mask(~m_value);
+    // We don't use ~m_value here as it will give the wrong result when m_value
+    // is true (~1 == 0b111...1110 which still converts to true).
+    return basic_simd_mask(!m_value);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator bool()

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -617,9 +617,8 @@ max(Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& a,
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
 template <class T>
-class KOKKOS_DEPRECATED
-    const_where_expression<basic_simd_mask<T, simd_abi::scalar>,
-                           basic_simd<T, simd_abi::scalar>> {
+class KOKKOS_DEPRECATED const_where_expression<
+    basic_simd_mask<T, simd_abi::scalar>, basic_simd<T, simd_abi::scalar>> {
  public:
   using abi_type   = simd_abi::scalar;
   using value_type = basic_simd<T, abi_type>;

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -5,6 +5,7 @@
 #include <TestSIMD_MaskOps.hpp>
 #include <TestSIMD_Conversions.hpp>
 #include <TestSIMD_ShiftOps.hpp>
+#include <TestSIMD_BitwiseOps.hpp>
 #include <TestSIMD_Condition.hpp>
 #include <TestSIMD_GeneratorCtors.hpp>
 #include <TestSIMD_Reductions.hpp>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -283,6 +283,90 @@ class shift_left_eq {
   }
 };
 
+class bitwise_not {
+ public:
+  template <typename T>
+  auto on_host(T const& a) const {
+    return ~a;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a) const {
+    return ~a;
+  }
+};
+
+class bitwise_and {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a & b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a & b;
+  }
+};
+
+class bitwise_and_eq {
+ public:
+  template <typename T>
+  auto on_host(T& a, T const& b) const {
+    return a &= b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T& a, T const& b) const {
+    return a &= b;
+  }
+};
+
+class bitwise_or {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a | b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a | b;
+  }
+};
+
+class bitwise_or_eq {
+ public:
+  template <typename T>
+  auto on_host(T& a, T const& b) const {
+    return a |= b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T& a, T const& b) const {
+    return a |= b;
+  }
+};
+
+class bitwise_xor {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a ^ b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a ^ b;
+  }
+};
+
+class bitwise_xor_eq {
+ public:
+  template <typename T>
+  auto on_host(T& a, T const& b) const {
+    return a ^= b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T& a, T const& b) const {
+    return a ^= b;
+  }
+};
+
 class minimum {
  public:
   template <typename T>

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -89,7 +89,8 @@ template <class T, class Abi>
 inline void host_check_mask_equality(
     Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
     Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
-    std::size_t nlanes) {
+    std::size_t nlanes =
+        Kokkos::Experimental::basic_simd_mask<T, Abi>::size()) {
   gtest_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
@@ -100,23 +101,12 @@ template <class T, class Abi>
 KOKKOS_INLINE_FUNCTION void device_check_mask_equality(
     Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
     Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
-    std::size_t nlanes) {
+    std::size_t nlanes =
+        Kokkos::Experimental::basic_simd_mask<T, Abi>::size()) {
   kokkos_checker checker;
   for (std::size_t i = 0; i < nlanes; ++i) {
     checker.equality(expected_result[i], computed_result[i]);
   }
-}
-
-template <typename T, typename Abi>
-KOKKOS_INLINE_FUNCTION void check_mask_equality(
-    Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
-    Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
-    std::size_t nlanes =
-        Kokkos::Experimental::basic_simd_mask<T, Abi>::size()) {
-  KOKKOS_IF_ON_HOST(
-      (host_check_mask_equality(expected_result, computed_result, nlanes);))
-  KOKKOS_IF_ON_DEVICE(
-      (device_check_mask_equality(expected_result, computed_result, nlanes);))
 }
 
 class load_element_aligned {

--- a/simd/unit_tests/include/SIMDTesting_Utilities.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Utilities.hpp
@@ -85,6 +85,40 @@ KOKKOS_INLINE_FUNCTION void check_equality(
       (device_check_equality(expected_result, computed_result, nlanes);))
 }
 
+template <class T, class Abi>
+inline void host_check_mask_equality(
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
+    std::size_t nlanes) {
+  gtest_checker checker;
+  for (std::size_t i = 0; i < nlanes; ++i) {
+    checker.equality(expected_result[i], computed_result[i]);
+  }
+}
+
+template <class T, class Abi>
+KOKKOS_INLINE_FUNCTION void device_check_mask_equality(
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
+    std::size_t nlanes) {
+  kokkos_checker checker;
+  for (std::size_t i = 0; i < nlanes; ++i) {
+    checker.equality(expected_result[i], computed_result[i]);
+  }
+}
+
+template <typename T, typename Abi>
+KOKKOS_INLINE_FUNCTION void check_mask_equality(
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& expected_result,
+    Kokkos::Experimental::basic_simd_mask<T, Abi> const& computed_result,
+    std::size_t nlanes =
+        Kokkos::Experimental::basic_simd_mask<T, Abi>::size()) {
+  KOKKOS_IF_ON_HOST(
+      (host_check_mask_equality(expected_result, computed_result, nlanes);))
+  KOKKOS_IF_ON_DEVICE(
+      (device_check_mask_equality(expected_result, computed_result, nlanes);))
+}
+
 class load_element_aligned {
  public:
   template <class T, class Abi>

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_SIMD_BITWISE_OPS_HPP
+#define KOKKOS_TEST_SIMD_BITWISE_OPS_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
+#include <Kokkos_SIMD.hpp>
+#endif
+#include <SIMDTesting_Utilities.hpp>
+
+template <class Abi, class Loader, bool is_compound_op, class BinaryOp, class T>
+void host_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
+                                      T const* first_args,
+                                      T const* second_args) {
+  Loader loader;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    if ((std::is_same_v<BinaryOp, divides> ||
+         std::is_same_v<BinaryOp, divides_eq>) &&
+        nremaining < width)
+      continue;
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.host_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.host_load(second_args + i, nlanes, second_arg);
+    if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    T expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      T tmp              = first_arg[lane];
+      expected_val[lane] = binary_op.on_host(tmp, T(second_arg[lane]));
+    }
+
+    simd_type expected_result =
+        Kokkos::Experimental::simd_unchecked_load<simd_type>(
+            expected_val, Kokkos::Experimental::simd_flag_default);
+    simd_type const computed_result = binary_op.on_host(first_arg, second_arg);
+    host_check_equality(expected_result, computed_result, nlanes);
+    if constexpr (is_compound_op) {
+      host_check_equality(first_arg, expected_result, nlanes);
+    }
+  }
+}
+
+template <class Abi, class Loader, bool, class UnaryOp, class T>
+void host_check_bitwise_op_one_loader(UnaryOp unary_op, std::size_t n,
+                                      T const* args) {
+  Loader loader;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    simd_type arg;
+    bool const loaded_arg = loader.host_load(args + i, nlanes, arg);
+    if (!loaded_arg) continue;
+
+    auto unary_op_result   = unary_op.on_host(arg);
+    using result_simd_type = decltype(unary_op_result);
+
+    typename result_simd_type::value_type expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      expected_val[lane] = unary_op.on_host(T(arg[lane]));
+    }
+
+    result_simd_type expected_result =
+        Kokkos::Experimental::simd_unchecked_load<result_simd_type>(
+            expected_val, Kokkos::Experimental::simd_flag_default);
+    auto computed_result = unary_op.on_host(arg);
+    host_check_equality(expected_result, computed_result, nlanes);
+  }
+}
+
+template <class Abi, bool is_compound_op, class Op, class... T>
+inline void host_check_bitwise_op_all_loaders(Op op, std::size_t n,
+                                              T const*... args) {
+  host_check_bitwise_op_one_loader<Abi, load_element_aligned, is_compound_op>(
+      op, n, args...);
+  host_check_bitwise_op_one_loader<Abi, load_masked, is_compound_op>(op, n,
+                                                                     args...);
+  host_check_bitwise_op_one_loader<Abi, load_as_scalars, is_compound_op>(
+      op, n, args...);
+  host_check_bitwise_op_one_loader<Abi, load_vector_aligned, is_compound_op>(
+      op, n, args...);
+}
+
+template <typename Abi, typename DataType, size_t n>
+inline void host_check_all_bitwise_ops(const DataType (&first_args)[n],
+                                       const DataType (&second_args)[n]) {
+  host_check_bitwise_op_all_loaders<Abi, false>(bitwise_not(), n, first_args);
+  host_check_bitwise_op_all_loaders<Abi, false>(bitwise_and(), n, first_args,
+                                                second_args);
+  host_check_bitwise_op_all_loaders<Abi, false>(bitwise_or(), n, first_args,
+                                                second_args);
+  host_check_bitwise_op_all_loaders<Abi, false>(bitwise_xor(), n, first_args,
+                                                second_args);
+  host_check_bitwise_op_all_loaders<Abi, true>(bitwise_and_eq(), n, first_args,
+                                               second_args);
+  host_check_bitwise_op_all_loaders<Abi, true>(bitwise_or_eq(), n, first_args,
+                                               second_args);
+  host_check_bitwise_op_all_loaders<Abi, true>(bitwise_xor_eq(), n, first_args,
+                                               second_args);
+}
+
+template <typename Abi, typename DataType>
+inline void host_check_bitwise_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi> &&
+                std::is_integral_v<DataType>) {
+    constexpr size_t alignment =
+        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        sizeof(DataType);
+
+    constexpr int half_shift   = (CHAR_BIT * sizeof(DataType)) / 2;
+    constexpr DataType zero    = static_cast<DataType>(0);
+    constexpr DataType all_set = ~zero;
+    constexpr DataType hi_set  = all_set << half_shift;
+    constexpr DataType lo_set  = ~hi_set;
+
+    alignas(alignment) DataType const first_args[] = {
+        0,         0,          1,        all_set,  all_set,   all_set,
+        all_set,   lo_set,     hi_set,   0,        704475968, 1845076239,
+        432747131, 1285171335, 17011965, 139561533};
+    alignas(alignment) DataType const second_args[] = {
+        0,         1,          1,          0,         all_set,    hi_set,
+        lo_set,    lo_set,     hi_set,     hi_set,    1841853988, 747428271,
+        357605498, 1412297337, 1663131103, 2062867687};
+    host_check_all_bitwise_ops<Abi>(first_args, second_args);
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_bitwise_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_bitwise_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_bitwise_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_bitwise_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+template <class Abi, class Loader, bool is_compound_op, class BinaryOp, class T>
+void device_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
+                                        T const* first_args,
+                                        T const* second_args) {
+  Loader loader;
+  using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    if ((std::is_same_v<BinaryOp, divides> ||
+         std::is_same_v<BinaryOp, divides_eq>) &&
+        nremaining < width)
+      continue;
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.device_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.device_load(second_args + i, nlanes, second_arg);
+    if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    T expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      T tmp              = first_arg[lane];
+      expected_val[lane] = binary_op.on_device(tmp, T(second_arg[lane]));
+    }
+
+    simd_type expected_result =
+        Kokkos::Experimental::simd_unchecked_load<simd_type>(
+            expected_val, Kokkos::Experimental::simd_flag_default);
+    simd_type const computed_result =
+        binary_op.on_device(first_arg, second_arg);
+    device_check_equality(expected_result, computed_result, nlanes);
+    if constexpr (is_compound_op) {
+      device_check_equality(first_arg, expected_result, nlanes);
+    }
+  }
+}
+
+template <class Abi, class Loader, bool, class UnaryOp, class T>
+void device_check_bitwise_op_one_loader(UnaryOp unary_op, std::size_t n,
+                                        T const* args) {
+  Loader loader;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+
+  constexpr std::size_t width = simd_type::size();
+  for (std::size_t i = 0; i < n; i += width) {
+    std::size_t const nremaining = n - i;
+    std::size_t const nlanes     = Kokkos::min(nremaining, width);
+    simd_type arg;
+    bool const loaded_arg = loader.device_load(args + i, nlanes, arg);
+    if (!loaded_arg) continue;
+
+    auto unary_op_result   = unary_op.on_device(arg);
+    using result_simd_type = decltype(unary_op_result);
+
+    typename result_simd_type::value_type expected_val[width];
+    for (std::size_t lane = 0; lane < width; ++lane) {
+      expected_val[lane] = unary_op.on_device(T(arg[lane]));
+    }
+
+    result_simd_type expected_result =
+        Kokkos::Experimental::simd_unchecked_load<result_simd_type>(
+            expected_val, Kokkos::Experimental::simd_flag_default);
+    auto computed_result = unary_op.on_device(arg);
+    device_check_equality(expected_result, computed_result, nlanes);
+  }
+}
+
+template <class Abi, bool is_compound_op, class Op, class... T>
+inline void device_check_bitwise_op_all_loaders(Op op, std::size_t n,
+                                                T const*... args) {
+  device_check_bitwise_op_one_loader<Abi, load_element_aligned, is_compound_op>(
+      op, n, args...);
+  device_check_bitwise_op_one_loader<Abi, load_masked, is_compound_op>(op, n,
+                                                                       args...);
+  device_check_bitwise_op_one_loader<Abi, load_as_scalars, is_compound_op>(
+      op, n, args...);
+  device_check_bitwise_op_one_loader<Abi, load_vector_aligned, is_compound_op>(
+      op, n, args...);
+}
+
+template <typename Abi, typename DataType, size_t n>
+inline void device_check_all_bitwise_ops(const DataType (&first_args)[n],
+                                         const DataType (&second_args)[n]) {
+  device_check_bitwise_op_all_loaders<Abi, false>(bitwise_not(), n, first_args);
+  device_check_bitwise_op_all_loaders<Abi, false>(bitwise_and(), n, first_args,
+                                                  second_args);
+  device_check_bitwise_op_all_loaders<Abi, false>(bitwise_or(), n, first_args,
+                                                  second_args);
+  device_check_bitwise_op_all_loaders<Abi, false>(bitwise_xor(), n, first_args,
+                                                  second_args);
+  device_check_bitwise_op_all_loaders<Abi, true>(bitwise_and_eq(), n,
+                                                 first_args, second_args);
+  device_check_bitwise_op_all_loaders<Abi, true>(bitwise_or_eq(), n, first_args,
+                                                 second_args);
+  device_check_bitwise_op_all_loaders<Abi, true>(bitwise_xor_eq(), n,
+                                                 first_args, second_args);
+}
+
+template <typename Abi, typename DataType>
+inline void device_check_bitwise_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi> &&
+                std::is_integral_v<DataType>) {
+    constexpr size_t alignment =
+        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        sizeof(DataType);
+
+    constexpr int half_shift   = (CHAR_BIT * sizeof(DataType)) / 2;
+    constexpr DataType zero    = static_cast<DataType>(0);
+    constexpr DataType all_set = ~zero;
+    constexpr DataType hi_set  = all_set << half_shift;
+    constexpr DataType lo_set  = ~hi_set;
+
+    alignas(alignment) DataType const first_args[] = {
+        0,         0,          1,        all_set,  all_set,   all_set,
+        all_set,   lo_set,     hi_set,   0,        704475968, 1845076239,
+        432747131, 1285171335, 17011965, 139561533};
+    alignas(alignment) DataType const second_args[] = {
+        0,         1,          1,          0,         all_set,    hi_set,
+        lo_set,    lo_set,     hi_set,     hi_set,    1841853988, 747428271,
+        357605498, 1412297337, 1663131103, 2062867687};
+    device_check_all_bitwise_ops<Abi>(first_args, second_args);
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void device_check_bitwise_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_bitwise_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void device_check_bitwise_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_bitwise_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_bitwise_ops_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_bitwise_ops_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set());
+  }
+};
+
+TEST(simd, host_bitwise_ops) {
+  host_check_bitwise_ops_all_abis(Kokkos::Experimental::Impl::host_abi_set());
+}
+
+TEST(simd, device_bitwise_ops) {
+  Kokkos::parallel_for(1, simd_device_bitwise_ops_functor());
+}
+
+#endif

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -523,10 +523,12 @@ TEST(simd, host_mask_bitwise_ops) {
 
 TEST(simd, device_bitwise_ops) {
   Kokkos::parallel_for(1, simd_device_bitwise_ops_functor());
+  Kokkos::fence();
 }
 
 TEST(simd, device_mask_bitwise_ops) {
   Kokkos::parallel_for(1, simd_device_mask_bitwise_ops_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -23,7 +23,8 @@ void host_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
     if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
+         std::is_same_v<BinaryOp, divides_eq>) &&
+        nremaining < width)
       continue;
     simd_type first_arg;
     bool const loaded_first_arg =
@@ -161,7 +162,8 @@ KOKKOS_INLINE_FUNCTION void device_check_bitwise_op_one_loader(
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
     if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
+         std::is_same_v<BinaryOp, divides_eq>) &&
+        nremaining < width)
       continue;
     simd_type first_arg;
     bool const loaded_first_arg =
@@ -299,125 +301,132 @@ class simd_device_bitwise_ops_functor {
 };
 
 template <typename Abi, typename DataType>
-KOKKOS_INLINE_FUNCTION void check_mask_bitwise_ops() {
+inline void host_check_mask_bitwise_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
     constexpr std::size_t width = mask_type::size();
 
     mask_type const all(true);
     mask_type const none(false);
-    mask_type const hi(
-        KOKKOS_LAMBDA(std::size_t const i) { return i >= width / 2; });
-    mask_type const lo(
-        KOKKOS_LAMBDA(std::size_t const i) { return i < width / 2; });
-    mask_type const even(
-        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 0; });
-    mask_type const odd(
-        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 1; });
 
     check_mask_equality(~all, none);
     check_mask_equality(~none, all);
-    check_mask_equality(~hi, lo);
-    check_mask_equality(~lo, hi);
-    check_mask_equality(~even, odd);
-    check_mask_equality(~odd, even);
 
     check_mask_equality(all & all, all);
     check_mask_equality(all & none, none);
     check_mask_equality(none & none, none);
-    check_mask_equality(all & hi, hi);
-    check_mask_equality(hi & hi, hi);
-    check_mask_equality(lo & lo, lo);
-    check_mask_equality(hi & lo, none);
-    check_mask_equality(even & even, even);
-    check_mask_equality(even & odd, none);
 
     check_mask_equality(all | all, all);
     check_mask_equality(all | none, all);
-    check_mask_equality(all | hi, all);
     check_mask_equality(none | none, none);
-    check_mask_equality(none | hi, hi);
-    check_mask_equality(hi | hi, hi);
-    check_mask_equality(hi | lo, all);
-    check_mask_equality(even | even, even);
-    check_mask_equality(even | odd, all);
 
     check_mask_equality(all ^ all, none);
     check_mask_equality(all ^ none, all);
-    check_mask_equality(all ^ hi, lo);
     check_mask_equality(none ^ none, none);
-    check_mask_equality(none ^ hi, hi);
-    check_mask_equality(hi ^ hi, none);
-    check_mask_equality(hi ^ lo, all);
-    check_mask_equality(even ^ even, none);
-    check_mask_equality(even ^ odd, all);
+
+    if constexpr (!std::is_same_v<Abi,
+                                  Kokkos::Experimental::simd_abi::scalar>) {
+      mask_type const hi([=](std::size_t const i) { return i >= width / 2; });
+      mask_type const lo([=](std::size_t const i) { return i < width / 2; });
+      mask_type const even([=](std::size_t const i) { return i % 2 == 0; });
+      mask_type const odd([=](std::size_t const i) { return i % 2 == 1; });
+
+      check_mask_equality(~hi, lo);
+      check_mask_equality(~lo, hi);
+      check_mask_equality(~even, odd);
+      check_mask_equality(~odd, even);
+
+      check_mask_equality(all & hi, hi);
+      check_mask_equality(hi & hi, hi);
+      check_mask_equality(lo & lo, lo);
+      check_mask_equality(hi & lo, none);
+      check_mask_equality(even & even, even);
+      check_mask_equality(even & odd, none);
+
+      check_mask_equality(all | hi, all);
+      check_mask_equality(none | hi, hi);
+      check_mask_equality(hi | hi, hi);
+      check_mask_equality(hi | lo, all);
+      check_mask_equality(even | even, even);
+      check_mask_equality(even | odd, all);
+
+      check_mask_equality(all ^ hi, lo);
+      check_mask_equality(none ^ hi, hi);
+      check_mask_equality(hi ^ hi, none);
+      check_mask_equality(hi ^ lo, all);
+      check_mask_equality(even ^ even, none);
+      check_mask_equality(even ^ odd, all);
+    }
   }
 }
 
 template <typename Abi, typename DataType, typename Op>
-KOKKOS_INLINE_FUNCTION void check_mask_bitwise_assignment_op(
+inline void host_check_mask_bitwise_assignment_op(
     Op op, Kokkos::Experimental::basic_simd_mask<Abi, DataType> lhs,
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& rhs,
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& expected) {
-  auto const res = op.on_device(lhs, rhs);
+  auto const res = op.on_host(lhs, rhs);
   check_mask_equality(res, expected);
   check_mask_equality(lhs, expected);
 }
 
 template <typename Abi, typename DataType>
-KOKKOS_INLINE_FUNCTION void check_mask_bitwise_assignment_ops() {
+inline void host_check_mask_bitwise_assignment_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
     constexpr std::size_t width = mask_type::size();
 
     mask_type const all(true);
     mask_type const none(false);
-    mask_type const hi(
-        KOKKOS_LAMBDA(std::size_t const i) { return i >= width / 2; });
-    mask_type const lo(
-        KOKKOS_LAMBDA(std::size_t const i) { return i < width / 2; });
-    mask_type const even(
-        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 0; });
-    mask_type const odd(
-        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 1; });
 
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, all, all);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, none, none);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), none, none, none);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, hi, hi);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, hi, hi);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), lo, lo, lo);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, lo, none);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), even, even, even);
-    check_mask_bitwise_assignment_op(bitwise_and_eq(), even, odd, none);
+    host_check_mask_bitwise_assignment_op(bitwise_and_eq(), all, all, all);
+    host_check_mask_bitwise_assignment_op(bitwise_and_eq(), all, none, none);
+    host_check_mask_bitwise_assignment_op(bitwise_and_eq(), none, none, none);
 
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, all, all);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, none, all);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, hi, all);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), none, none, none);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), none, hi, hi);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, hi, hi);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, lo, all);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), even, even, even);
-    check_mask_bitwise_assignment_op(bitwise_or_eq(), even, odd, all);
+    host_check_mask_bitwise_assignment_op(bitwise_or_eq(), all, all, all);
+    host_check_mask_bitwise_assignment_op(bitwise_or_eq(), all, none, all);
+    host_check_mask_bitwise_assignment_op(bitwise_or_eq(), none, none, none);
 
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, all, none);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, none, all);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, hi, lo);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, none, none);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, hi, hi);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, hi, none);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, lo, all);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, even, none);
-    check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, odd, all);
+    host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, all, none);
+    host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, none, all);
+    host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, none, none);
+
+    if constexpr (!std::is_same_v<Abi,
+                                  Kokkos::Experimental::simd_abi::scalar>) {
+      mask_type const hi([=](std::size_t const i) { return i >= width / 2; });
+      mask_type const lo([=](std::size_t const i) { return i < width / 2; });
+      mask_type const even([=](std::size_t const i) { return i % 2 == 0; });
+      mask_type const odd([=](std::size_t const i) { return i % 2 == 1; });
+
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), all, hi, hi);
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, hi, hi);
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), lo, lo, lo);
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, lo, none);
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), even, even, even);
+      host_check_mask_bitwise_assignment_op(bitwise_and_eq(), even, odd, none);
+
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), all, hi, all);
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), none, hi, hi);
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, hi, hi);
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, lo, all);
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), even, even, even);
+      host_check_mask_bitwise_assignment_op(bitwise_or_eq(), even, odd, all);
+
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, hi, lo);
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, hi, hi);
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, hi, none);
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, lo, all);
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, even, none);
+      host_check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, odd, all);
+    }
   }
 }
 
 template <typename Abi, typename... DataTypes>
 inline void host_check_mask_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
-  (check_mask_bitwise_ops<Abi, DataTypes>(), ...);
-  (check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
+  (host_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
+  (host_check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
@@ -427,11 +436,67 @@ inline void host_check_mask_bitwise_ops_all_abis(
   (host_check_mask_bitwise_ops_all_types<Abis>(DataTypes()), ...);
 }
 
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+
+    mask_type const all(true);
+    mask_type const none(false);
+
+    check_mask_equality(~all, none);
+    check_mask_equality(~none, all);
+
+    check_mask_equality(all & all, all);
+    check_mask_equality(all & none, none);
+    check_mask_equality(none & none, none);
+
+    check_mask_equality(all | all, all);
+    check_mask_equality(all | none, all);
+    check_mask_equality(none | none, none);
+
+    check_mask_equality(all ^ all, none);
+    check_mask_equality(all ^ none, all);
+    check_mask_equality(none ^ none, none);
+  }
+}
+
+template <typename Abi, typename DataType, typename Op>
+KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_assignment_op(
+    Op op, Kokkos::Experimental::basic_simd_mask<Abi, DataType> lhs,
+    Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& rhs,
+    Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& expected) {
+  auto const res = op.on_device(lhs, rhs);
+  check_mask_equality(res, expected);
+  check_mask_equality(lhs, expected);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_assignment_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+
+    mask_type const all(true);
+    mask_type const none(false);
+
+    device_check_mask_bitwise_assignment_op(bitwise_and_eq(), all, all, all);
+    device_check_mask_bitwise_assignment_op(bitwise_and_eq(), all, none, none);
+    device_check_mask_bitwise_assignment_op(bitwise_and_eq(), none, none, none);
+
+    device_check_mask_bitwise_assignment_op(bitwise_or_eq(), all, all, all);
+    device_check_mask_bitwise_assignment_op(bitwise_or_eq(), all, none, all);
+    device_check_mask_bitwise_assignment_op(bitwise_or_eq(), none, none, none);
+
+    device_check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, all, none);
+    device_check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, none, all);
+    device_check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, none, none);
+  }
+}
 template <typename Abi, typename... DataTypes>
 KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
-  (check_mask_bitwise_ops<Abi, DataTypes>(), ...);
-  (check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
+  (device_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
+  (device_check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -23,8 +23,7 @@ void host_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
     if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>) &&
-        nremaining < width)
+         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
       continue;
     simd_type first_arg;
     bool const loaded_first_arg =
@@ -162,8 +161,7 @@ KOKKOS_INLINE_FUNCTION void device_check_bitwise_op_one_loader(
     std::size_t const nremaining = n - i;
     std::size_t const nlanes     = Kokkos::min(nremaining, width);
     if ((std::is_same_v<BinaryOp, divides> ||
-         std::is_same_v<BinaryOp, divides_eq>) &&
-        nremaining < width)
+         std::is_same_v<BinaryOp, divides_eq>)&&nremaining < width)
       continue;
     simd_type first_arg;
     bool const loaded_first_arg =

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -138,10 +138,63 @@ inline void host_check_bitwise_ops() {
   }
 }
 
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void host_device_check_mask_bitwise_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+    constexpr size_t width = mask_type::size();
+
+    mask_type const all(true);
+    mask_type const none(false);
+    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
+    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
+    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
+    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
+
+    check_mask_equality(~all, none);
+    check_mask_equality(~none, all);
+    check_mask_equality(~hi, lo);
+    check_mask_equality(~lo, hi);
+    check_mask_equality(~even, odd);
+    check_mask_equality(~odd, even);
+
+    check_mask_equality(all & all, all);
+    check_mask_equality(all & none, none);
+    check_mask_equality(none & none, none);
+    check_mask_equality(all & hi, hi);
+    check_mask_equality(hi & hi, hi);
+    check_mask_equality(lo & lo, lo);
+    check_mask_equality(hi & lo, none);
+    check_mask_equality(even & even, even);
+    check_mask_equality(even & odd, none);
+
+    check_mask_equality(all | all, all);
+    check_mask_equality(all | none, all);
+    check_mask_equality(all | hi, all);
+    check_mask_equality(none | none, none);
+    check_mask_equality(none | hi, hi);
+    check_mask_equality(hi | hi, hi);
+    check_mask_equality(hi | lo, all);
+    check_mask_equality(even | even, even);
+    check_mask_equality(even | odd, all);
+
+    check_mask_equality(all ^ all, none);
+    check_mask_equality(all ^ none, all);
+    check_mask_equality(all ^ hi, lo);
+    check_mask_equality(none ^ none, none);
+    check_mask_equality(none ^ hi, hi);
+    check_mask_equality(hi ^ hi, none);
+    check_mask_equality(hi ^ lo, all);
+    check_mask_equality(even ^ even, none);
+    check_mask_equality(even ^ odd, all);
+  }
+}
+
 template <typename Abi, typename... DataTypes>
 inline void host_check_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
   (host_check_bitwise_ops<Abi, DataTypes>(), ...);
+  (host_device_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
@@ -152,9 +205,9 @@ inline void host_check_bitwise_ops_all_abis(
 }
 
 template <class Abi, class Loader, bool is_compound_op, class BinaryOp, class T>
-void device_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
-                                        T const* first_args,
-                                        T const* second_args) {
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_op_one_loader(
+    BinaryOp binary_op, std::size_t n, T const* first_args,
+    T const* second_args) {
   Loader loader;
   using simd_type             = Kokkos::Experimental::basic_simd<T, Abi>;
   constexpr std::size_t width = simd_type::size();
@@ -192,8 +245,9 @@ void device_check_bitwise_op_one_loader(BinaryOp binary_op, std::size_t n,
 }
 
 template <class Abi, class Loader, bool, class UnaryOp, class T>
-void device_check_bitwise_op_one_loader(UnaryOp unary_op, std::size_t n,
-                                        T const* args) {
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_op_one_loader(UnaryOp unary_op,
+                                                               std::size_t n,
+                                                               T const* args) {
   Loader loader;
   using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
 
@@ -222,8 +276,8 @@ void device_check_bitwise_op_one_loader(UnaryOp unary_op, std::size_t n,
 }
 
 template <class Abi, bool is_compound_op, class Op, class... T>
-inline void device_check_bitwise_op_all_loaders(Op op, std::size_t n,
-                                                T const*... args) {
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_op_all_loaders(
+    Op op, std::size_t n, T const*... args) {
   device_check_bitwise_op_one_loader<Abi, load_element_aligned, is_compound_op>(
       op, n, args...);
   device_check_bitwise_op_one_loader<Abi, load_masked, is_compound_op>(op, n,
@@ -235,8 +289,8 @@ inline void device_check_bitwise_op_all_loaders(Op op, std::size_t n,
 }
 
 template <typename Abi, typename DataType, size_t n>
-inline void device_check_all_bitwise_ops(const DataType (&first_args)[n],
-                                         const DataType (&second_args)[n]) {
+KOKKOS_INLINE_FUNCTION void device_check_all_bitwise_ops(
+    const DataType (&first_args)[n], const DataType (&second_args)[n]) {
   device_check_bitwise_op_all_loaders<Abi, false>(bitwise_not(), n, first_args);
   device_check_bitwise_op_all_loaders<Abi, false>(bitwise_and(), n, first_args,
                                                   second_args);
@@ -253,7 +307,7 @@ inline void device_check_all_bitwise_ops(const DataType (&first_args)[n],
 }
 
 template <typename Abi, typename DataType>
-inline void device_check_bitwise_ops() {
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi> &&
                 std::is_integral_v<DataType>) {
     constexpr size_t alignment =
@@ -279,13 +333,14 @@ inline void device_check_bitwise_ops() {
 }
 
 template <typename Abi, typename... DataTypes>
-inline void device_check_bitwise_ops_all_types(
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
   (device_check_bitwise_ops<Abi, DataTypes>(), ...);
+  (host_device_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
-inline void device_check_bitwise_ops_all_abis(
+KOKKOS_INLINE_FUNCTION void device_check_bitwise_ops_all_abis(
     Kokkos::Experimental::Impl::abi_set<Abis...>) {
   using DataTypes = Kokkos::Experimental::Impl::data_type_set;
   (device_check_bitwise_ops_all_types<Abis>(DataTypes()), ...);

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -307,20 +307,20 @@ inline void host_check_mask_bitwise_ops() {
     mask_type const all(true);
     mask_type const none(false);
 
-    check_mask_equality(~all, none);
-    check_mask_equality(~none, all);
+    host_check_mask_equality(~all, none);
+    host_check_mask_equality(~none, all);
 
-    check_mask_equality(all & all, all);
-    check_mask_equality(all & none, none);
-    check_mask_equality(none & none, none);
+    host_check_mask_equality(all & all, all);
+    host_check_mask_equality(all & none, none);
+    host_check_mask_equality(none & none, none);
 
-    check_mask_equality(all | all, all);
-    check_mask_equality(all | none, all);
-    check_mask_equality(none | none, none);
+    host_check_mask_equality(all | all, all);
+    host_check_mask_equality(all | none, all);
+    host_check_mask_equality(none | none, none);
 
-    check_mask_equality(all ^ all, none);
-    check_mask_equality(all ^ none, all);
-    check_mask_equality(none ^ none, none);
+    host_check_mask_equality(all ^ all, none);
+    host_check_mask_equality(all ^ none, all);
+    host_check_mask_equality(none ^ none, none);
 
     if constexpr (!std::is_same_v<Abi,
                                   Kokkos::Experimental::simd_abi::scalar>) {
@@ -329,31 +329,31 @@ inline void host_check_mask_bitwise_ops() {
       mask_type const even([=](std::size_t const i) { return i % 2 == 0; });
       mask_type const odd([=](std::size_t const i) { return i % 2 == 1; });
 
-      check_mask_equality(~hi, lo);
-      check_mask_equality(~lo, hi);
-      check_mask_equality(~even, odd);
-      check_mask_equality(~odd, even);
+      host_check_mask_equality(~hi, lo);
+      host_check_mask_equality(~lo, hi);
+      host_check_mask_equality(~even, odd);
+      host_check_mask_equality(~odd, even);
 
-      check_mask_equality(all & hi, hi);
-      check_mask_equality(hi & hi, hi);
-      check_mask_equality(lo & lo, lo);
-      check_mask_equality(hi & lo, none);
-      check_mask_equality(even & even, even);
-      check_mask_equality(even & odd, none);
+      host_check_mask_equality(all & hi, hi);
+      host_check_mask_equality(hi & hi, hi);
+      host_check_mask_equality(lo & lo, lo);
+      host_check_mask_equality(hi & lo, none);
+      host_check_mask_equality(even & even, even);
+      host_check_mask_equality(even & odd, none);
 
-      check_mask_equality(all | hi, all);
-      check_mask_equality(none | hi, hi);
-      check_mask_equality(hi | hi, hi);
-      check_mask_equality(hi | lo, all);
-      check_mask_equality(even | even, even);
-      check_mask_equality(even | odd, all);
+      host_check_mask_equality(all | hi, all);
+      host_check_mask_equality(none | hi, hi);
+      host_check_mask_equality(hi | hi, hi);
+      host_check_mask_equality(hi | lo, all);
+      host_check_mask_equality(even | even, even);
+      host_check_mask_equality(even | odd, all);
 
-      check_mask_equality(all ^ hi, lo);
-      check_mask_equality(none ^ hi, hi);
-      check_mask_equality(hi ^ hi, none);
-      check_mask_equality(hi ^ lo, all);
-      check_mask_equality(even ^ even, none);
-      check_mask_equality(even ^ odd, all);
+      host_check_mask_equality(all ^ hi, lo);
+      host_check_mask_equality(none ^ hi, hi);
+      host_check_mask_equality(hi ^ hi, none);
+      host_check_mask_equality(hi ^ lo, all);
+      host_check_mask_equality(even ^ even, none);
+      host_check_mask_equality(even ^ odd, all);
     }
   }
 }
@@ -364,8 +364,8 @@ inline void host_check_mask_bitwise_assignment_op(
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& rhs,
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& expected) {
   auto const res = op.on_host(lhs, rhs);
-  check_mask_equality(res, expected);
-  check_mask_equality(lhs, expected);
+  host_check_mask_equality(res, expected);
+  host_check_mask_equality(lhs, expected);
 }
 
 template <typename Abi, typename DataType>
@@ -442,20 +442,20 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_ops() {
     mask_type const all(true);
     mask_type const none(false);
 
-    check_mask_equality(~all, none);
-    check_mask_equality(~none, all);
+    device_check_mask_equality(~all, none);
+    device_check_mask_equality(~none, all);
 
-    check_mask_equality(all & all, all);
-    check_mask_equality(all & none, none);
-    check_mask_equality(none & none, none);
+    device_check_mask_equality(all & all, all);
+    device_check_mask_equality(all & none, none);
+    device_check_mask_equality(none & none, none);
 
-    check_mask_equality(all | all, all);
-    check_mask_equality(all | none, all);
-    check_mask_equality(none | none, none);
+    device_check_mask_equality(all | all, all);
+    device_check_mask_equality(all | none, all);
+    device_check_mask_equality(none | none, none);
 
-    check_mask_equality(all ^ all, none);
-    check_mask_equality(all ^ none, all);
-    check_mask_equality(none ^ none, none);
+    device_check_mask_equality(all ^ all, none);
+    device_check_mask_equality(all ^ none, all);
+    device_check_mask_equality(none ^ none, none);
   }
 }
 
@@ -465,8 +465,8 @@ KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_assignment_op(
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& rhs,
     Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& expected) {
   auto const res = op.on_device(lhs, rhs);
-  check_mask_equality(res, expected);
-  check_mask_equality(lhs, expected);
+  device_check_mask_equality(res, expected);
+  device_check_mask_equality(lhs, expected);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -302,14 +302,18 @@ template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void check_mask_bitwise_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
-    constexpr size_t width = mask_type::size();
+    constexpr std::size_t width = mask_type::size();
 
     mask_type const all(true);
     mask_type const none(false);
-    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
-    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
-    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
-    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
+    mask_type const hi(
+        KOKKOS_LAMBDA(std::size_t const i) { return i >= width / 2; });
+    mask_type const lo(
+        KOKKOS_LAMBDA(std::size_t const i) { return i < width / 2; });
+    mask_type const even(
+        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 0; });
+    mask_type const odd(
+        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 1; });
 
     check_mask_equality(~all, none);
     check_mask_equality(~none, all);
@@ -364,14 +368,18 @@ template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void check_mask_bitwise_assignment_ops() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
-    constexpr size_t width = mask_type::size();
+    constexpr std::size_t width = mask_type::size();
 
     mask_type const all(true);
     mask_type const none(false);
-    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
-    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
-    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
-    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
+    mask_type const hi(
+        KOKKOS_LAMBDA(std::size_t const i) { return i >= width / 2; });
+    mask_type const lo(
+        KOKKOS_LAMBDA(std::size_t const i) { return i < width / 2; });
+    mask_type const even(
+        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 0; });
+    mask_type const odd(
+        KOKKOS_LAMBDA(std::size_t const i) { return i % 2 == 1; });
 
     check_mask_bitwise_assignment_op(bitwise_and_eq(), all, all, all);
     check_mask_bitwise_assignment_op(bitwise_and_eq(), all, none, none);

--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -138,63 +138,10 @@ inline void host_check_bitwise_ops() {
   }
 }
 
-template <typename Abi, typename DataType>
-KOKKOS_INLINE_FUNCTION void host_device_check_mask_bitwise_ops() {
-  if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
-    constexpr size_t width = mask_type::size();
-
-    mask_type const all(true);
-    mask_type const none(false);
-    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
-    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
-    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
-    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
-
-    check_mask_equality(~all, none);
-    check_mask_equality(~none, all);
-    check_mask_equality(~hi, lo);
-    check_mask_equality(~lo, hi);
-    check_mask_equality(~even, odd);
-    check_mask_equality(~odd, even);
-
-    check_mask_equality(all & all, all);
-    check_mask_equality(all & none, none);
-    check_mask_equality(none & none, none);
-    check_mask_equality(all & hi, hi);
-    check_mask_equality(hi & hi, hi);
-    check_mask_equality(lo & lo, lo);
-    check_mask_equality(hi & lo, none);
-    check_mask_equality(even & even, even);
-    check_mask_equality(even & odd, none);
-
-    check_mask_equality(all | all, all);
-    check_mask_equality(all | none, all);
-    check_mask_equality(all | hi, all);
-    check_mask_equality(none | none, none);
-    check_mask_equality(none | hi, hi);
-    check_mask_equality(hi | hi, hi);
-    check_mask_equality(hi | lo, all);
-    check_mask_equality(even | even, even);
-    check_mask_equality(even | odd, all);
-
-    check_mask_equality(all ^ all, none);
-    check_mask_equality(all ^ none, all);
-    check_mask_equality(all ^ hi, lo);
-    check_mask_equality(none ^ none, none);
-    check_mask_equality(none ^ hi, hi);
-    check_mask_equality(hi ^ hi, none);
-    check_mask_equality(hi ^ lo, all);
-    check_mask_equality(even ^ even, none);
-    check_mask_equality(even ^ odd, all);
-  }
-}
-
 template <typename Abi, typename... DataTypes>
 inline void host_check_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
   (host_check_bitwise_ops<Abi, DataTypes>(), ...);
-  (host_device_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
@@ -336,7 +283,6 @@ template <typename Abi, typename... DataTypes>
 KOKKOS_INLINE_FUNCTION void device_check_bitwise_ops_all_types(
     Kokkos::Experimental::Impl::data_types<DataTypes...>) {
   (device_check_bitwise_ops<Abi, DataTypes>(), ...);
-  (host_device_check_mask_bitwise_ops<Abi, DataTypes>(), ...);
 }
 
 template <typename... Abis>
@@ -354,12 +300,164 @@ class simd_device_bitwise_ops_functor {
   }
 };
 
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void check_mask_bitwise_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+    constexpr size_t width = mask_type::size();
+
+    mask_type const all(true);
+    mask_type const none(false);
+    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
+    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
+    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
+    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
+
+    check_mask_equality(~all, none);
+    check_mask_equality(~none, all);
+    check_mask_equality(~hi, lo);
+    check_mask_equality(~lo, hi);
+    check_mask_equality(~even, odd);
+    check_mask_equality(~odd, even);
+
+    check_mask_equality(all & all, all);
+    check_mask_equality(all & none, none);
+    check_mask_equality(none & none, none);
+    check_mask_equality(all & hi, hi);
+    check_mask_equality(hi & hi, hi);
+    check_mask_equality(lo & lo, lo);
+    check_mask_equality(hi & lo, none);
+    check_mask_equality(even & even, even);
+    check_mask_equality(even & odd, none);
+
+    check_mask_equality(all | all, all);
+    check_mask_equality(all | none, all);
+    check_mask_equality(all | hi, all);
+    check_mask_equality(none | none, none);
+    check_mask_equality(none | hi, hi);
+    check_mask_equality(hi | hi, hi);
+    check_mask_equality(hi | lo, all);
+    check_mask_equality(even | even, even);
+    check_mask_equality(even | odd, all);
+
+    check_mask_equality(all ^ all, none);
+    check_mask_equality(all ^ none, all);
+    check_mask_equality(all ^ hi, lo);
+    check_mask_equality(none ^ none, none);
+    check_mask_equality(none ^ hi, hi);
+    check_mask_equality(hi ^ hi, none);
+    check_mask_equality(hi ^ lo, all);
+    check_mask_equality(even ^ even, none);
+    check_mask_equality(even ^ odd, all);
+  }
+}
+
+template <typename Abi, typename DataType, typename Op>
+KOKKOS_INLINE_FUNCTION void check_mask_bitwise_assignment_op(
+    Op op, Kokkos::Experimental::basic_simd_mask<Abi, DataType> lhs,
+    Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& rhs,
+    Kokkos::Experimental::basic_simd_mask<Abi, DataType> const& expected) {
+  auto const res = op.on_device(lhs, rhs);
+  check_mask_equality(res, expected);
+  check_mask_equality(lhs, expected);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void check_mask_bitwise_assignment_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+    constexpr size_t width = mask_type::size();
+
+    mask_type const all(true);
+    mask_type const none(false);
+    mask_type const hi(KOKKOS_LAMBDA(auto const i) { return i >= width / 2; });
+    mask_type const lo(KOKKOS_LAMBDA(auto const i) { return i < width / 2; });
+    mask_type const even(KOKKOS_LAMBDA(auto const i) { return i % 2 == 0; });
+    mask_type const odd(KOKKOS_LAMBDA(auto const i) { return i % 2 == 1; });
+
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, all, all);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, none, none);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), none, none, none);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), all, hi, hi);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, hi, hi);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), lo, lo, lo);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), hi, lo, none);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), even, even, even);
+    check_mask_bitwise_assignment_op(bitwise_and_eq(), even, odd, none);
+
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, all, all);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, none, all);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), all, hi, all);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), none, none, none);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), none, hi, hi);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, hi, hi);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), hi, lo, all);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), even, even, even);
+    check_mask_bitwise_assignment_op(bitwise_or_eq(), even, odd, all);
+
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, all, none);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, none, all);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), all, hi, lo);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, none, none);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), none, hi, hi);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, hi, none);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), hi, lo, all);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, even, none);
+    check_mask_bitwise_assignment_op(bitwise_xor_eq(), even, odd, all);
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_mask_bitwise_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (check_mask_bitwise_ops<Abi, DataTypes>(), ...);
+  (check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_mask_bitwise_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_mask_bitwise_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (check_mask_bitwise_ops<Abi, DataTypes>(), ...);
+  (check_mask_bitwise_assignment_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void device_check_mask_bitwise_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_mask_bitwise_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_mask_bitwise_ops_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_mask_bitwise_ops_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set());
+  }
+};
+
 TEST(simd, host_bitwise_ops) {
   host_check_bitwise_ops_all_abis(Kokkos::Experimental::Impl::host_abi_set());
 }
 
+TEST(simd, host_mask_bitwise_ops) {
+  host_check_mask_bitwise_ops_all_abis(
+      Kokkos::Experimental::Impl::host_abi_set());
+}
+
 TEST(simd, device_bitwise_ops) {
   Kokkos::parallel_for(1, simd_device_bitwise_ops_functor());
+}
+
+TEST(simd, device_mask_bitwise_ops) {
+  Kokkos::parallel_for(1, simd_device_mask_bitwise_ops_functor());
 }
 
 #endif


### PR DESCRIPTION
This PR adds bitwise operators (`~, &, |, ^, &=, |=, ^=`) to simd vectors of integral types and simd masks.

A user notified me that he couldn't do bitwise operations on Kokkos::simd types. There was indeed for some reason a very sparse support for this, basically only the scalar abi and `simd<int64_t>` on some abis had some of these operators defined, and it was undocumented anyways. This PR implements all the operators for all abis.

Associated doc PR: https://github.com/kokkos/kokkos-core-wiki/pull/743