### PR TITLE
Remove (unused) `Threads::impl_instance()`

### DIFF
--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -91,8 +91,6 @@ class Threads {
 
   static int impl_is_initialized();
 
-  static Threads& impl_instance(int = 0);
-
   //----------------------------------------
 
   static int impl_thread_pool_size(int depth = 0);

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -676,11 +676,6 @@ void Threads::fence(const std::string &name) const {
   Impl::ThreadsInternal::fence(name);
 }
 
-Threads &Threads::impl_instance(int) {
-  static Threads t;
-  return t;
-}
-
 int Threads::impl_thread_pool_rank_host() {
   const std::thread::id pid = std::this_thread::get_id();
   int i                     = 0;


### PR DESCRIPTION
This member function is unused and prefixed with impl_* so removing it without deprecation is fair game.