### PR TITLE
Improve error message when constructing views before initialize or after finalize

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -163,9 +163,6 @@ class Cuda {
   //! Free any resources being consumed by the device.
   static void impl_finalize();
 
-  //! Has been initialized
-  static int impl_is_initialized();
-
   //! Initialize, telling the CUDA run-time library which device to use.
   static void impl_initialize(InitializationSettings const&);
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -530,10 +530,6 @@ int Cuda::concurrency() const {
   return Impl::CudaInternal::concurrency();
 }
 
-int Cuda::impl_is_initialized() {
-  return Impl::CudaInternal::singleton().is_initialized();
-}
-
 void Cuda::impl_initialize(InitializationSettings const &settings) {
   const std::vector<int> &visible_devices = Impl::get_visible_devices();
   const int cuda_device_id =

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -32,10 +32,6 @@ int HIP::concurrency() const {
   return Impl::HIPInternal::concurrency();
 }
 
-int HIP::impl_is_initialized() {
-  return Impl::HIPInternal::singleton().is_initialized();
-}
-
 void HIP::impl_initialize(InitializationSettings const& settings) {
   const std::vector<int>& visible_devices = Impl::get_visible_devices();
   const int hip_device_id =

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -92,8 +92,6 @@ class HIP {
 
   static void impl_initialize(InitializationSettings const&);
 
-  static int impl_is_initialized();
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   KOKKOS_DEPRECATED static size_type detect_device_count() {
     int count;

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -215,11 +215,6 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
   }
 }
 
-bool HPX::impl_is_initialized() noexcept {
-  hpx::runtime *rt = hpx::get_runtime_ptr();
-  return rt != nullptr;
-}
-
 void HPX::impl_finalize() {
   if (m_hpx_initialized) {
     hpx::runtime *rt = hpx::get_runtime_ptr();

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -261,7 +261,6 @@ class HPX {
   int concurrency() const;
 #endif
   static void impl_initialize(InitializationSettings const &);
-  static bool impl_is_initialized() noexcept;
   static void impl_finalize();
   static int impl_thread_pool_size() noexcept;
   static int impl_thread_pool_rank() noexcept;

--- a/core/src/OpenACC/Kokkos_OpenACC.cpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.cpp
@@ -108,10 +108,6 @@ void Kokkos::Experimental::OpenACC::impl_finalize() {
   Impl::OpenACCInternal::singleton().finalize();
 }
 
-bool Kokkos::Experimental::OpenACC::impl_is_initialized() {
-  return Impl::OpenACCInternal::singleton().is_initialized();
-}
-
 void Kokkos::Experimental::OpenACC::print_configuration(std::ostream& os,
                                                         bool verbose) const {
   os << "Device Execution Space:\n";

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -68,7 +68,6 @@ class OpenACC {
 
   static void impl_initialize(InitializationSettings const& settings);
   static void impl_finalize();
-  static bool impl_is_initialized();
 
   void print_configuration(std::ostream& os, bool verbose = false) const;
 

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -83,10 +83,6 @@ void OpenMP::fence(const std::string &name) const {
       });
 }
 
-bool OpenMP::impl_is_initialized() noexcept {
-  return Impl::OpenMPInternal::singleton().is_initialized();
-}
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_DEPRECATED bool OpenMP::in_parallel(OpenMP const &exec_space) noexcept {
   return exec_space.impl_internal_space_instance()->m_level < omp_get_level();

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -98,10 +98,6 @@ class OpenMP {
 
   static void impl_initialize(InitializationSettings const&);
 
-  /// \brief is the default execution space initialized for current 'master'
-  /// thread
-  static bool impl_is_initialized() noexcept;
-
   /// \brief Free any resources being consumed by the default execution space
   static void impl_finalize();
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -77,9 +77,6 @@ class OpenMPTarget {
   //! Free any resources being consumed by the device.
   static void impl_finalize();
 
-  //! Has been initialized
-  static int impl_is_initialized();
-
   //! Initialize, telling the CUDA run-time library which device to use.
   static void impl_initialize(InitializationSettings const&);
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget_Instance.cpp
@@ -227,9 +227,6 @@ void OpenMPTarget::impl_initialize(InitializationSettings const& settings) {
 void OpenMPTarget::impl_finalize() {
   Impl::OpenMPTargetInternal::impl_singleton()->impl_finalize();
 }
-int OpenMPTarget::impl_is_initialized() {
-  return Impl::OpenMPTargetInternal::impl_singleton()->impl_is_initialized();
-}
 }  // Namespace Experimental
 
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -69,10 +69,6 @@ int SYCL::concurrency() const { return m_space_instance->m_maxConcurrency; }
 
 const char* SYCL::name() { return "SYCL"; }
 
-bool SYCL::impl_is_initialized() {
-  return Impl::SYCLInternal::singleton().is_initialized();
-}
-
 void SYCL::impl_finalize() { Impl::SYCLInternal::singleton().finalize(); }
 
 void SYCL::print_configuration(std::ostream& os, bool verbose) const {

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -93,8 +93,6 @@ class SYCL {
 
   static void impl_initialize(InitializationSettings const&);
 
-  static bool impl_is_initialized();
-
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   static int concurrency();
 #else

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -168,10 +168,6 @@ void Serial::print_configuration(std::ostream& os, bool /*verbose*/) const {
   os << "\nSerial Runtime Configuration:\n";
 }
 
-bool Serial::impl_is_initialized() {
-  return Impl::SerialInternal::singleton().is_initialized();
-}
-
 void Serial::impl_initialize(InitializationSettings const&) {
   Impl::SerialInternal::singleton().initialize();
 }

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -192,8 +192,6 @@ class Serial {
 
   static void impl_initialize(InitializationSettings const&);
 
-  static bool impl_is_initialized();
-
   //! Free any resources being consumed by the device.
   static void impl_finalize();
 

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -89,7 +89,6 @@ class Threads {
 
   static void impl_initialize(InitializationSettings const&);
 
-
   //----------------------------------------
 
   static int impl_thread_pool_size(int depth = 0);

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -89,8 +89,6 @@ class Threads {
 
   static void impl_initialize(InitializationSettings const&);
 
-  static int impl_is_initialized();
-
   static Threads& impl_instance(int = 0);
 
   //----------------------------------------

--- a/core/src/Threads/Kokkos_Threads_Instance.hpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.hpp
@@ -539,10 +539,6 @@ KOKKOS_DEPRECATED inline int Threads::in_parallel() {
 }
 #endif
 
-inline int Threads::impl_is_initialized() {
-  return Impl::ThreadsInternal::is_initialized();
-}
-
 inline void Threads::impl_initialize(InitializationSettings const &settings) {
   Impl::ThreadsInternal::initialize(
       settings.has_num_threads() ? settings.get_num_threads() : -1);

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -403,9 +403,8 @@ class BasicView {
   // Ctors to pull out AccessorArg_t
   // Need also the other ones to keep the overload set consistent and all the
   // constraints mutually exclusive. Delegate to private ctors
-  // We need to explicitly distinguish between the has_pointer and
-  // !has_pointer versions since only the ones with a pointer can be marked
-  // host/device
+  // We need to explicitly distinguish between the has_pointer and !has_pointer
+  // versions since only the ones with a pointer can be marked host/device
   template <class... P>
   explicit BasicView(
       const Impl::ViewCtorProp<P...> &arg_prop,

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -345,6 +345,16 @@ class BasicView {
       const Impl::ViewCtorProp<P...> &arg_prop,
       const typename mdspan_type::mapping_type &arg_mapping,
       const typename mdspan_type::accessor_type &arg_accessor) {
+    if (is_finalized()) {
+      abort(
+          "Kokkos ERROR: View is being constructed after finalize() has been "
+          "called");
+    }
+    if (!is_initialized()) {
+      abort(
+          "Kokkos ERROR: View is being constructed before initialize() has "
+          "been called");
+    }
     using storage_value_type = typename data_handle_type::value_type;
     constexpr bool has_exec  = Impl::ViewCtorProp<P...>::has_execution_space;
     // Copy the input allocation properties with possibly defaulted properties

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -351,7 +351,7 @@ class BasicView {
       std::stringstream ss;
       ss << "Kokkos ERROR: View ";
       constexpr bool has_label = Impl::ViewCtorProp<P...>::has_label;
-      if (has_label) {
+      if constexpr (has_label) {
         auto const &lbl = Impl::get_property<Impl::LabelTag>(arg_prop);
         ss << "(label=\"" << lbl << "\") ";
       }

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -654,9 +654,9 @@ class BasicView {
 
   KOKKOS_FUNCTION void assign_data(element_type *ptr) { m_ptr = ptr; }
 
-// ========================= mdspan =================================
+  // ========================= mdspan =================================
 
-// [mdspan.mdspan.members], members
+  // [mdspan.mdspan.members], members
 
 // Introducing the C++20 and C++23 variants of the operators already
 #ifndef KOKKOS_ENABLE_CXX20

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -346,15 +346,24 @@ class BasicView {
       const Impl::ViewCtorProp<P...> &arg_prop,
       const typename mdspan_type::mapping_type &arg_mapping,
       const typename mdspan_type::accessor_type &arg_accessor) {
-    if (is_finalized()) {
-      abort(
-          "Kokkos ERROR: View is being constructed after finalize() has been "
-          "called");
-    }
-    if (!is_initialized()) {
-      abort(
-          "Kokkos ERROR: View is being constructed before initialize() has "
-          "been called");
+    if (bool was_finalized = is_finalized();
+        was_finalized || !is_initialized()) {
+      std::stringstream ss;
+      ss << "Kokkos ERROR: View ";
+      constexpr bool has_label = Impl::ViewCtorProp<P...>::has_label;
+      if (has_label) {
+        auto const &lbl = Impl::get_property<Impl::LabelTag>(arg_prop);
+        ss << "(label=\"" << lbl << "\") ";
+      }
+      ss << "is being constructed ";
+      if (was_finalized) {
+        ss << "after finalize() ";
+      } else {
+        ss << "before initialize() ";
+      }
+      ss << "has been called";
+      auto const err = ss.str();
+      abort(err.c_str());
     }
     using storage_value_type = typename data_handle_type::value_type;
     constexpr bool has_exec  = Impl::ViewCtorProp<P...>::has_execution_space;
@@ -394,8 +403,9 @@ class BasicView {
   // Ctors to pull out AccessorArg_t
   // Need also the other ones to keep the overload set consistent and all the
   // constraints mutually exclusive. Delegate to private ctors
-  // We need to explicitly distinguish between the has_pointer and !has_pointer
-  // versions since only the ones with a pointer can be marked host/device
+  // We need to explicitly distinguish between the has_pointer and
+  // !has_pointer versions since only the ones with a pointer can be marked
+  // host/device
   template <class... P>
   explicit BasicView(
       const Impl::ViewCtorProp<P...> &arg_prop,
@@ -645,9 +655,9 @@ class BasicView {
 
   KOKKOS_FUNCTION void assign_data(element_type *ptr) { m_ptr = ptr; }
 
-  // ========================= mdspan =================================
+// ========================= mdspan =================================
 
-  // [mdspan.mdspan.members], members
+// [mdspan.mdspan.members], members
 
 // Introducing the C++20 and C++23 variants of the operators already
 #ifndef KOKKOS_ENABLE_CXX20

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -9,6 +9,7 @@ static_assert(false,
 #ifndef KOKKOS_BASIC_VIEW_HPP
 #define KOKKOS_BASIC_VIEW_HPP
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_InitializeFinalize.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 #include <impl/Kokkos_SharedAlloc.hpp>
 #include <View/Kokkos_ViewAlloc.hpp>

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -365,15 +365,6 @@ class BasicView {
         prop_copy_tmp, memory_space{}, execution_space{});
     using alloc_prop = decltype(prop_copy);
 
-    if (alloc_prop::initialize &&
-        !alloc_prop::execution_space::impl_is_initialized()) {
-      // If initializing view data then
-      // the execution space must be initialized.
-      Kokkos::abort(
-          "Constructing View and initializing data with uninitialized "
-          "execution space");
-    }
-
     // get allocation size: may be different from
     // arg_mapping.required_span_size()
     size_t allocation_size =

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -993,7 +993,6 @@ class View : public ViewTraits<DataType, Properties...> {
     auto prop_copy = Impl::with_properties_if_unset(
         prop_copy_tmp, typename traits::device_type::memory_space{},
         typename traits::device_type::execution_space{});
-    using alloc_prop = decltype(prop_copy);
 
     static_assert(!traits::memory_traits::is_unmanaged,
                   "View allocation constructor requires managed memory");

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -20,6 +20,7 @@ static_assert(false,
 #include <Kokkos_ExecPolicy.hpp>
 #include <View/Hooks/Kokkos_ViewHooks.hpp>
 
+#include <impl/Kokkos_InitializeFinalize.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -976,6 +976,16 @@ class View : public ViewTraits<DataType, Properties...> {
       std::enable_if_t<!Impl::ViewCtorProp<P...>::has_pointer,
                        typename traits::array_layout> const& arg_layout)
       : m_track(), m_map() {
+    if (is_finalized()) {
+      abort(
+          "Kokkos ERROR: View is being constructed after finalize() has been "
+          "called");
+    }
+    if (!is_initialized()) {
+      abort(
+          "Kokkos ERROR: View is being constructed before initialize() has "
+          "been called");
+    }
     // Copy the input allocation properties with possibly defaulted properties
     // We need to split it in two to avoid MSVC compiler errors
     auto prop_copy_tmp =

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -981,7 +981,7 @@ class View : public ViewTraits<DataType, Properties...> {
       std::stringstream ss;
       ss << "Kokkos ERROR: View ";
       constexpr bool has_label = Impl::ViewCtorProp<P...>::has_label;
-      if (has_label) {
+      if constexpr (has_label) {
         auto const& lbl = Impl::get_property<Impl::LabelTag>(arg_prop);
         ss << "(label=\"" << lbl << "\") ";
       }

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -998,15 +998,6 @@ class View : public ViewTraits<DataType, Properties...> {
     static_assert(!traits::memory_traits::is_unmanaged,
                   "View allocation constructor requires managed memory");
 
-    if (alloc_prop::initialize &&
-        !alloc_prop::execution_space::impl_is_initialized()) {
-      // If initializing view data then
-      // the execution space must be initialized.
-      Kokkos::abort(
-          "Constructing View and initializing data with uninitialized "
-          "execution space");
-    }
-
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
     if constexpr (std::is_same_v<typename traits::array_layout,
                                  Kokkos::LayoutLeft> ||

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -976,15 +976,24 @@ class View : public ViewTraits<DataType, Properties...> {
       std::enable_if_t<!Impl::ViewCtorProp<P...>::has_pointer,
                        typename traits::array_layout> const& arg_layout)
       : m_track(), m_map() {
-    if (is_finalized()) {
-      abort(
-          "Kokkos ERROR: View is being constructed after finalize() has been "
-          "called");
-    }
-    if (!is_initialized()) {
-      abort(
-          "Kokkos ERROR: View is being constructed before initialize() has "
-          "been called");
+    if (bool was_finalized = is_finalized();
+        was_finalized || !is_initialized()) {
+      std::stringstream ss;
+      ss << "Kokkos ERROR: View ";
+      constexpr bool has_label = Impl::ViewCtorProp<P...>::has_label;
+      if (has_label) {
+        auto const& lbl = Impl::get_property<Impl::LabelTag>(arg_prop);
+        ss << "(label=\"" << lbl << "\") ";
+      }
+      ss << "is being constructed ";
+      if (was_finalized) {
+        ss << "after finalize() ";
+      } else {
+        ss << "before initialize() ";
+      }
+      ss << "has been called";
+      auto const err = ss.str();
+      abort(err.c_str());
     }
     // Copy the input allocation properties with possibly defaulted properties
     // We need to split it in two to avoid MSVC compiler errors

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -99,28 +99,15 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
-    defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
-  std::string matcher = std::string("Kokkos::") +
-#ifdef KOKKOS_ENABLE_OPENACC
-                        "Experimental::" +
-#endif
-                        Kokkos::DefaultExecutionSpace::name() +
-                        "::" + Kokkos::DefaultExecutionSpace::name() +
-                        " instance constructor : ERROR device not initialized";
-#else
-  std::string matcher =
-      "Constructing View and initializing data with uninitialized execution "
-      "space";
-#endif
-  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); }, matcher);
+  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); },
+               "View is being constructed before initialize");
   EXPECT_DEATH(
       {
         Kokkos::initialize();
         Kokkos::finalize();
         Kokkos::View<int*> v("v", 0);
       },
-      matcher);
+      "View is being constructed after finalize");
 }
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -99,15 +99,16 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
       "Kokkos allocation \"v\" is being deallocated after Kokkos::finalize was "
       "called");
 
-  EXPECT_DEATH({ Kokkos::View<int*> v("v", 0); },
-               "View is being constructed before initialize");
+  EXPECT_DEATH(
+      { Kokkos::View<int*> v("v", 0); },
+      "View \\(label=\\\"v\\\"\\) is being constructed before initialize");
   EXPECT_DEATH(
       {
         Kokkos::initialize();
         Kokkos::finalize();
         Kokkos::View<int*> v("v", 0);
       },
-      "View is being constructed after finalize");
+      "View \\(label=\\\"v\\\"\\) is being constructed after finalize");
 }
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,


### PR DESCRIPTION
* Increase quality of the error message
* Drop (now unused) ExecutionSpace::imp_is_initialized() member function in all backends