### PR TITLE
Enforce ExecutionSpace::size_type is an unsigned integral type

### DIFF
--- a/core/src/impl/Kokkos_ExecSpaceManager.hpp
+++ b/core/src/impl/Kokkos_ExecSpaceManager.hpp
@@ -8,6 +8,7 @@
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_Concepts.hpp>
 
+#include <concepts>
 #include <iosfwd>
 #include <map>
 #include <string>
@@ -21,7 +22,7 @@ using public_member_types_t = std::enable_if_t<
     Kokkos::is_memory_space_v<typename T::memory_space> &&
     Kokkos::is_device_v<typename T::device_type> &&
     Kokkos::is_array_layout_v<typename T::array_layout> &&
-    std::is_integral_v<typename T::size_type> &&
+    std::unsigned_integral<typename T::size_type> &&
     Kokkos::is_memory_space_v<typename T::scratch_memory_space>>;
 
 template <class T>


### PR DESCRIPTION
Following up on #8542 and checking at compile-time that ExecutionSpace::size_type is indeed unsigned.