### PR TITLE
Add traits for Kokkos::Array

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -67,7 +67,7 @@ template <class>
 struct is_array : public std::false_type {};
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-template <class T = void, size_t N = KOKKOS_INVALID_INDEX, class Proxy = void>
+template <class T, size_t N, class Proxy>
 struct Array;
 
 template <class T, size_t N, class Proxy>

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -63,6 +63,32 @@ struct ArrayBoundsCheck<Integral, false> {
 
 #endif  // !defined( KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK )
 
+template <class>
+struct is_array : public std::false_type {};
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+template <class T = void, size_t N = KOKKOS_INVALID_INDEX, class Proxy = void>
+struct Array;
+
+template <class T, size_t N, class Proxy>
+struct is_array<Kokkos::Array<T, N, Proxy>> : public std::true_type {};
+
+template <class T, size_t N, class Proxy>
+struct is_array<const Kokkos::Array<T, N, Proxy>> : public std::true_type {};
+#else
+template <class T, size_t N>
+struct Array;
+
+template <class T, size_t N>
+struct is_array<Kokkos::Array<T, N>> : public std::true_type {};
+
+template <class T, size_t N>
+struct is_array<const Kokkos::Array<T, N>> : public std::true_type {};
+#endif
+
+template <class T>
+inline constexpr bool is_array_v = is_array<T>::value;
+
 /**\brief  Derived from the C++17 'std::array'.
  *         Dropping the iterator interface.
  */

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <array>
 #include <Kokkos_Array.hpp>
 #include <Kokkos_DetectionIdiom.hpp>
 
@@ -312,5 +313,29 @@ constexpr bool test_array_equality_comparable() {
 }
 
 static_assert(test_array_equality_comparable());
+
+constexpr bool test_array_traits() {
+  using C0      = Kokkos::Array<char, 0>;
+  using C2      = Kokkos::Array<char, 2>;
+  using constC3 = const Kokkos::Array<char, 2>;
+  using I0      = Kokkos::Array<int, 0>;
+  using I2      = Kokkos::Array<int, 2>;
+  using constI3 = const Kokkos::Array<int, 2>;
+  using c0      = std::array<char, 0>;
+  using i0      = std::array<int, 0>;
+
+  static_assert(Kokkos::is_array_v<C0>);
+  static_assert(Kokkos::is_array_v<C2>);
+  static_assert(Kokkos::is_array_v<constC3>);
+  static_assert(Kokkos::is_array_v<I0>);
+  static_assert(Kokkos::is_array_v<I2>);
+  static_assert(Kokkos::is_array_v<constI3>);
+  static_assert(!Kokkos::is_array_v<c0>);
+  static_assert(!Kokkos::is_array_v<i0>);
+
+  return true;
+}
+
+static_assert(test_array_traits());
 
 }  // namespace

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -317,19 +317,19 @@ static_assert(test_array_equality_comparable());
 constexpr bool test_array_traits() {
   using C0      = Kokkos::Array<char, 0>;
   using C2      = Kokkos::Array<char, 2>;
-  using constC3 = const Kokkos::Array<char, 2>;
+  using constC2 = const Kokkos::Array<char, 2>;
   using I0      = Kokkos::Array<int, 0>;
   using I2      = Kokkos::Array<int, 2>;
-  using constI3 = const Kokkos::Array<int, 2>;
+  using constI2 = const Kokkos::Array<int, 2>;
   using c0      = std::array<char, 0>;
   using i0      = std::array<int, 0>;
 
   static_assert(Kokkos::is_array_v<C0>);
   static_assert(Kokkos::is_array_v<C2>);
-  static_assert(Kokkos::is_array_v<constC3>);
+  static_assert(Kokkos::is_array_v<constC2>);
   static_assert(Kokkos::is_array_v<I0>);
   static_assert(Kokkos::is_array_v<I2>);
-  static_assert(Kokkos::is_array_v<constI3>);
+  static_assert(Kokkos::is_array_v<constI2>);
   static_assert(!Kokkos::is_array_v<c0>);
   static_assert(!Kokkos::is_array_v<i0>);
 


### PR DESCRIPTION
This PR adds `Kokkos::is_array_v`, which can be used as concepts by #8494