### PR TITLE
Produce a diff when comparing kokkos/mdspan or desul/atomics

### DIFF
--- a/.github/workflows/desul-version-check.yml
+++ b/.github/workflows/desul-version-check.yml
@@ -27,4 +27,4 @@ jobs:
         rm desul-atomics/atomics/CMakeLists.txt
         rm desul-atomics/atomics/desul_atomicsConfig.cmake.in
         rm desul-atomics/atomics/src/common.cpp
-        diff --brief --recursive tpls/desul desul-atomics/atomics
+        diff --unified 3 --recursive tpls/desul desul-atomics/atomics

--- a/.github/workflows/desul-version-check.yml
+++ b/.github/workflows/desul-version-check.yml
@@ -27,4 +27,4 @@ jobs:
         rm desul-atomics/atomics/CMakeLists.txt
         rm desul-atomics/atomics/desul_atomicsConfig.cmake.in
         rm desul-atomics/atomics/src/common.cpp
-        diff --unified 3 --recursive tpls/desul desul-atomics/atomics
+        diff --unified=3 --recursive tpls/desul desul-atomics/atomics

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -23,4 +23,4 @@ jobs:
     - run: |
         rm kokkos-mdspan/include/experimental/mdarray
         rm kokkos-mdspan/include/experimental/mdspan
-        diff --brief --recursive tpls/mdspan/include kokkos-mdspan/include
+        diff --unified 3 --recursive tpls/mdspan/include kokkos-mdspan/include

--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -23,4 +23,4 @@ jobs:
     - run: |
         rm kokkos-mdspan/include/experimental/mdarray
         rm kokkos-mdspan/include/experimental/mdspan
-        diff --unified 3 --recursive tpls/mdspan/include kokkos-mdspan/include
+        diff --unified=3 --recursive tpls/mdspan/include kokkos-mdspan/include


### PR DESCRIPTION
In https://github.com/kokkos/kokkos/actions/runs/18650866410/job/53168295770 the GitHub action log just says "Files A and B differ". I think that it might be worth spitting out the actual diff at the risk of printing more volume.  In the case of
https://github.com/kokkos/kokkos/pull/8562 it would have been usefu for me to understand what was going on.

Thoughts?