### PR TITLE
Disable mdspan-based View optimization for Cuda+Clang and clang-17/18

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -412,13 +412,13 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // ROCM: The below code segfaults the compiler with ROCM 6.3 and ROCM 6.2
   // We will simply avoid the performance optimization code path for those.
   // SYCL: The below code segfaults the compiler with Intel OneAPI 2024
-  // Cuda+Clang segfaults before clang-18
+  // Cuda+Clang segfaults for clang-17 andt clang-18
 #if !(defined(HIP_VERSION) && HIP_VERSION_MAJOR == 6 &&                     \
       HIP_VERSION_MINOR <= 3) &&                                            \
     !(defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
       KOKKOS_COMPILER_INTEL_LLVM < 20250000) &&                             \
     !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_CLANG) &&      \
-      KOKKOS_COMPILER_CLANG < 1800)
+      KOKKOS_COMPILER_CLANG >= 1700 && KOKKOS_COMPILER_CLANG < 1900)
   // Rank 0
   KOKKOS_FUNCTION constexpr auto compute_offset(std::index_sequence<>) const {
     return 0;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -409,13 +409,16 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // directly, since BasicView anyway requires you to be explicit about the
   // desired index_type
 
-  // The below code segfaults in LLVM 17 & 18 when offloading, which
-  // affects ROCM 6.2 and 6.3 as well as Intel OneAPI 2024, and Clang-Cuda
-  // builds.
-#if (!defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_SYCL) && \
-     !defined(KOKKOS_ENABLE_HIP)) ||                                 \
-    !defined(__clang_major__) || (__clang_major__ < 17) ||           \
-    (__clang_major__ > 18)
+  // ROCM: The below code segfaults the compiler with ROCM 6.3 and ROCM 6.2
+  // We will simply avoid the performance optimization code path for those.
+  // SYCL: The below code segfaults the compiler with Intel OneAPI 2024
+  // Cuda+Clang segfaults for clang-17 andt clang-18
+#if !(defined(HIP_VERSION) && HIP_VERSION_MAJOR == 6 &&                     \
+      HIP_VERSION_MINOR <= 3) &&                                            \
+    !(defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
+      KOKKOS_COMPILER_INTEL_LLVM < 20250000) &&                             \
+    !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_CLANG) &&      \
+      KOKKOS_COMPILER_CLANG >= 1700 && KOKKOS_COMPILER_CLANG < 1900)
   // Rank 0
   KOKKOS_FUNCTION constexpr auto compute_offset(std::index_sequence<>) const {
     return 0;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -412,10 +412,13 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // ROCM: The below code segfaults the compiler with ROCM 6.3 and ROCM 6.2
   // We will simply avoid the performance optimization code path for those.
   // SYCL: The below code segfaults the compiler with Intel OneAPI 2024
+  // Cuda+Clang segfaults before clang-18
 #if !(defined(HIP_VERSION) && HIP_VERSION_MAJOR == 6 &&                     \
       HIP_VERSION_MINOR <= 3) &&                                            \
     !(defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-      KOKKOS_COMPILER_INTEL_LLVM < 20250000)
+      KOKKOS_COMPILER_INTEL_LLVM < 20250000) &&                             \
+    !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_CLANG) &&      \
+      KOKKOS_COMPILER_CLANG < 1800)
   // Rank 0
   KOKKOS_FUNCTION constexpr auto compute_offset(std::index_sequence<>) const {
     return 0;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -409,16 +409,13 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   // directly, since BasicView anyway requires you to be explicit about the
   // desired index_type
 
-  // ROCM: The below code segfaults the compiler with ROCM 6.3 and ROCM 6.2
-  // We will simply avoid the performance optimization code path for those.
-  // SYCL: The below code segfaults the compiler with Intel OneAPI 2024
-  // Cuda+Clang segfaults for clang-17 andt clang-18
-#if !(defined(HIP_VERSION) && HIP_VERSION_MAJOR == 6 &&                     \
-      HIP_VERSION_MINOR <= 3) &&                                            \
-    !(defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-      KOKKOS_COMPILER_INTEL_LLVM < 20250000) &&                             \
-    !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_CLANG) &&      \
-      KOKKOS_COMPILER_CLANG >= 1700 && KOKKOS_COMPILER_CLANG < 1900)
+  // The below code segfaults in LLVM 17 & 18 when offloading, which
+  // affects ROCM 6.2 and 6.3 as well as Intel OneAPI 2024, and Clang-Cuda
+  // builds.
+#if (!defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_SYCL) && \
+     !defined(KOKKOS_ENABLE_HIP)) ||                                 \
+    !defined(__clang_major__) || (__clang_major__ < 17) ||           \
+    (__clang_major__ > 18)
   // Rank 0
   KOKKOS_FUNCTION constexpr auto compute_offset(std::index_sequence<>) const {
     return 0;


### PR DESCRIPTION
Fixes the Clang+Cuda+RDC build that is failing with segmentation faults after #8476.