### PR TITLE
Cuda,HIP: Launch work graph on the specified instance

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_WorkGraphPolicy.hpp
@@ -70,7 +70,8 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     const int shared = 0;
 
     Kokkos::Impl::CudaParallelLaunch<Self>(
-        *this, grid, block, shared, Cuda().impl_internal_space_instance());
+        *this, grid, block, shared,
+        m_policy.space().impl_internal_space_instance());
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -54,7 +54,8 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>, HIP> {
     const int shared = 0;
 
     HIPParallelLaunch<Self>(*this, grid, block, shared,
-                            HIP().impl_internal_space_instance(), false);
+                            m_policy.space().impl_internal_space_instance(),
+                            false);
   }
 
   inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)


### PR DESCRIPTION
I expect that these were meant to be enqueued onto the exec space instance that is stored in the exec policy.