### PR TITLE
Kokkos::Array: added noexcept to data(), empty(), size(), max_size()

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -111,10 +111,10 @@ struct Array {
     return m_internal_implementation_private_member_data[i];
   }
 
-  KOKKOS_INLINE_FUNCTION constexpr pointer data() {
+  KOKKOS_INLINE_FUNCTION constexpr pointer data() noexcept {
     return &m_internal_implementation_private_member_data[0];
   }
-  KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const {
+  KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const noexcept {
     return &m_internal_implementation_private_member_data[0];
   }
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -90,9 +90,15 @@ struct Array {
   using pointer         = T*;
   using const_pointer   = std::add_const_t<T>*;
 
-  KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return N; }
-  KOKKOS_INLINE_FUNCTION static constexpr bool empty() { return false; }
-  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return N; }
+  KOKKOS_INLINE_FUNCTION static constexpr size_type size() noexcept {
+    return N;
+  }
+  KOKKOS_INLINE_FUNCTION static constexpr bool empty() noexcept {
+    return false;
+  }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const noexcept {
+    return N;
+  }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr reference operator[](const iType& i) {
@@ -178,9 +184,13 @@ struct Array<T, 0> {
   using pointer         = T*;
   using const_pointer   = std::add_const_t<T>*;
 
-  KOKKOS_INLINE_FUNCTION static constexpr size_type size() { return 0; }
-  KOKKOS_INLINE_FUNCTION static constexpr bool empty() { return true; }
-  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const { return 0; }
+  KOKKOS_INLINE_FUNCTION static constexpr size_type size() noexcept {
+    return 0;
+  }
+  KOKKOS_INLINE_FUNCTION static constexpr bool empty() noexcept { return true; }
+  KOKKOS_INLINE_FUNCTION constexpr size_type max_size() const noexcept {
+    return 0;
+  }
 
   template <typename iType>
   KOKKOS_INLINE_FUNCTION reference operator[](const iType&) {
@@ -198,8 +208,8 @@ struct Array<T, 0> {
     return *reinterpret_cast<const_pointer>(-1);
   }
 
-  KOKKOS_INLINE_FUNCTION constexpr pointer data() { return nullptr; }
-  KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const {
+  KOKKOS_INLINE_FUNCTION constexpr pointer data() noexcept { return nullptr; }
+  KOKKOS_INLINE_FUNCTION constexpr const_pointer data() const noexcept {
     return nullptr;
   }
 

--- a/core/unit_test/TestArrayOps.hpp
+++ b/core/unit_test/TestArrayOps.hpp
@@ -16,8 +16,13 @@ TEST(TEST_CATEGORY, array_capacity) {
   using A = Kokkos::Array<int, 2>;
   A a{{3, 5}};
 
+  static_assert(noexcept(a.empty()));
   ASSERT_FALSE(a.empty());
+
+  static_assert(noexcept(a.size()));
   ASSERT_EQ(a.size(), 2u);
+
+  static_assert(noexcept(a.max_size()));
   ASSERT_EQ(a.max_size(), 2u);
 }
 
@@ -80,7 +85,10 @@ TEST(TEST_CATEGORY, array_element_access) {
   ASSERT_EQ(a[es], a[index]);
   ASSERT_EQ(ca[es], a[index]);
 
+  static_assert(noexcept(a.data()));
   ASSERT_EQ(a.data()[index], a[index]);
+
+  static_assert(noexcept(ca.data()));
   ASSERT_EQ(ca.data()[index], a[index]);
 }
 
@@ -113,8 +121,13 @@ TEST(TEST_CATEGORY, array_zero_capacity) {
   using A = Kokkos::Array<int, 0>;
   A e;
 
+  static_assert(noexcept(e.empty()));
   ASSERT_TRUE(e.empty());
+
+  static_assert(noexcept(e.size()));
   ASSERT_EQ(e.size(), 0u);
+
+  static_assert(noexcept(e.max_size()));
   ASSERT_EQ(e.max_size(), 0u);
 }
 
@@ -122,9 +135,11 @@ TEST(TEST_CATEGORY, array_zero_data_nullptr) {
   using A = Kokkos::Array<int, 0>;
 
   A e;
+  static_assert(noexcept(e.data()));
   ASSERT_EQ(e.data(), nullptr);
 
   const A& ce = e;
+  static_assert(noexcept(ce.data()));
   ASSERT_EQ(ce.data(), nullptr);
 }
 


### PR DESCRIPTION
In `Kokkos::Array`, added `noexcept` to `data()`, `empty()`, `size()`, `max_size()` to make it consistent with `std::array`.