### PR TITLE
HIP: get multi processor count from the instance device prop

### DIFF
--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -165,7 +165,7 @@ unsigned get_preferred_blocksize_for_range(HIPInternal const *hip_instance,
                                   LaunchMechanism>::default_launchbounds()) {
     if (requested_parallelism &&
         requested_parallelism < size_t(hip_instance->concurrency())) {
-      const unsigned eus            = hip_internal_multiprocessor_count();
+      const unsigned eus = hip_instance->m_deviceProp.multiProcessorCount;
       const unsigned requestedPerEU = (requested_parallelism + eus - 1) / eus;
       // round up to power of 2
       unsigned threadsPerEU = Kokkos::bit_ceil(requestedPerEU);

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -415,10 +415,6 @@ std::map<int, SharedResourceLock> HIPInternal::constantMemReusable = {};
 
 //----------------------------------------------------------------------------
 
-Kokkos::HIP::size_type hip_internal_multiprocessor_count() {
-  return HIPInternal::singleton().m_deviceProp.multiProcessorCount;
-}
-
 Kokkos::HIP::size_type *hip_internal_scratch_space(const HIP &instance,
                                                    const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -46,8 +46,6 @@ struct HIPTraits {
 
 //----------------------------------------------------------------------------
 
-HIP::size_type hip_internal_multiprocessor_count();
-
 HIP::size_type *hip_internal_scratch_space(const HIP &instance,
                                            const std::size_t size);
 HIP::size_type *hip_internal_scratch_flags(const HIP &instance,

--- a/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
+++ b/core/src/HIP/Kokkos_HIP_WorkGraphPolicy.hpp
@@ -49,7 +49,9 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>, HIP> {
 
   inline void execute() {
     const int warps_per_block = 4;
-    const dim3 grid(hip_internal_multiprocessor_count(), 1, 1);
+    const int multiProcessorCount =
+        m_policy.space().hip_device_prop().multiProcessorCount;
+    const dim3 grid(multiProcessorCount, 1, 1);
     const dim3 block(1, HIPTraits::WarpSize, warps_per_block);
     const int shared = 0;
 


### PR DESCRIPTION
For multi-gpu compatiblity and in preparation of an upcoming refactor (droping singleton and reworking backend initialization)