### PR TITLE
Don't identify gcc on MacOS X as AppleClang

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -128,7 +128,7 @@
 // CRAY compiler for host code
 #define KOKKOS_COMPILER_CRAYC _CRAYC
 
-#elif defined(__APPLE_CC__)
+#elif defined(__APPLE_CC__) && defined(__clang__)
 #define KOKKOS_COMPILER_APPLECC __APPLE_CC__
 
 #elif defined(__NVCOMPILER)


### PR DESCRIPTION
Related to #8586 this is a minimal solution for distinguishing gcc (installed via `homebrew`) and AppleClang on MacOS X. `gcc` now identifies as `KOKKOS_COMPILER_GNU`.