### PR TITLE
Enable ScatterView contribute into a View that is a rvalue

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -1561,7 +1561,8 @@ namespace Experimental {
 template <typename DT1, typename DT2, typename LY, typename ES, typename OP,
           typename CT, typename DP, typename... VP>
 void contribute(
-    typename ES::execution_space const& exec_space, View<DT1, VP...>& dest,
+    typename ES::execution_space const& exec_space,
+    View<DT1, VP...> const& dest,
     Kokkos::Experimental::ScatterView<DT2, LY, ES, OP, CT, DP> const& src) {
   src.contribute_into(exec_space, dest);
 }
@@ -1569,7 +1570,7 @@ void contribute(
 template <typename DT1, typename DT2, typename LY, typename ES, typename OP,
           typename CT, typename DP, typename... VP>
 void contribute(
-    View<DT1, VP...>& dest,
+    View<DT1, VP...> const& dest,
     Kokkos::Experimental::ScatterView<DT2, LY, ES, OP, CT, DP> const& src) {
   using execution_space = typename ES::execution_space;
   contribute(execution_space{}, dest, src);

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -469,7 +469,12 @@ struct test_default_scatter_sub_view {
 
       scatter_view_test_impl.run_parallel(original_sub_view.extent(0));
 
-      Kokkos::Experimental::contribute(original_sub_view, scatter_view);
+      // purposefully using a rvalue below
+      // see https://github.com/kokkos/kokkos/issues/8588
+      Kokkos::Experimental::contribute(/*original_sub_view=*/
+                                       Kokkos::subview(original_view, rangeDim0,
+                                                       rangeDim1),
+                                       scatter_view);
       Kokkos::fence();
 
       scatter_view_test_impl.validateResultsForSubview(original_view, rangeDim0,


### PR DESCRIPTION
Fix #8588 
Per the original report taking the destination view by non-const reference forces the user to pass a lvalue as argument.
There is no good reason for it.  This PR follows @dslyon-lanl's  suggestion and add a const-qualifier to relax that accidental restriction.