### PR TITLE
Pin SLSA GitHub Generator

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -43,7 +43,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release


### PR DESCRIPTION
Attempting to resolve the following "Pinned-Dependencies" report on our OpenSSF [Scorecard Report](https://securityscorecards.dev/viewer/?uri=github.com/kokkos/kokkos)
```
Warn: third-party GitHubAction not pinned by hash: .github/workflows/releases.yml:46: update your workflow
```