### PR TITLE
Do not install google benchmark when installing kokkos

### DIFF
--- a/core/perf_test/CMakeLists.txt
+++ b/core/perf_test/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
   message(STATUS "No installed google benchmark found, fetching from GitHub")
   include(FetchContent)
   set(BENCHMARK_ENABLE_TESTING OFF)
+  set(BENCHMARK_ENABLE_INSTALL OFF)
 
   list(APPEND CMAKE_MESSAGE_INDENT "[benchmark] ")
   FetchContent_Declare(


### PR DESCRIPTION
This PR sets `BENCHMARK_ENABLE_INSTALL` to `OFF` to prevent google benchmark to be installed when installing kokkos