### PR TITLE
[ci skip] Update the tag pattern in the realease workflow to align with semver

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    tags: '[0-9]+.[0-9]+.[0-9][0-9]'
+    tags: '[0-9]+.[0-9]+.[0-9]+'
   
 
 permissions: read-all


### PR DESCRIPTION
Since we are using semver starting from 5.0, the tag pattern in the releases.yml workflow should match `5.0.0` and not `5.0.00`