### PR TITLE
Minimal changes to support NVCC with GNU 10 as host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,13 @@ if(Kokkos_ENABLE_CUDA)
   # -std then the underlying host compiler by itself). Setting this variable
   # forces CMake to always add the -std flag even if it thinks it doesn't need it
   global_set(CMAKE_CXX_STANDARD_DEFAULT 98)
+
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+      set(CMAKE_CXX20_STANDARD_COMPILE_OPTION -std=c++20)
+    endif()
+  endif()
 endif()
 
 # These are the variables we will append to as we go

--- a/core/unit_test/TestSpaceAwareAccessor.hpp
+++ b/core/unit_test/TestSpaceAwareAccessor.hpp
@@ -87,9 +87,10 @@ void test_space_aware_accessor() {
             std::is_same_v<typename acc_t::nested_accessor_type, FunkyAcc<T>>);
         static_assert(std::copyable<acc_t>);
 // Windows and nvcc >= 13 (separately) )don't treat no-unique-address correctly
-#if !defined(_WIN32) &&                                               \
-    !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_NVCC) && \
-      (KOKKOS_COMPILER_NVCC >= 1300))
+#if !defined(_WIN32) &&                                                     \
+    !(defined(KOKKOS_ENABLE_CUDA) &&                                        \
+      ((defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1300)) || \
+       (defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 1100)))
         static_assert(std::is_empty_v<acc_t>);
 #endif
       },


### PR DESCRIPTION
Two issues: cmake tries to use -std=c++2a which nvcc doesn't support. No-unique-address doesn't fully work apparently.