### PR TITLE
Disable CUDA-12.2-NVCC-RDC

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -223,6 +223,7 @@ pipeline {
                               export CMAKE_PREFIX_PATH=${PWD}/../install && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
+                                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DCMAKE_CXX_FLAGS="-Werror --Werror=all-warnings -Xcudafe --diag_suppress=940" \
                                 -DCMAKE_EXE_LINKER_FLAGS="-Xnvlink -suppress-stack-size-warning" \
@@ -254,7 +255,6 @@ pipeline {
                     post {
                         always {
                             sh 'ccache --show-stats'
-                            xunit([CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build-tests/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)])
                         }
                     }
                 }

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -222,7 +222,6 @@ pipeline {
                               export CMAKE_PREFIX_PATH=${PWD}/../install && \
                               cmake \
                                 -DCMAKE_BUILD_TYPE=Release \
-                                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                                 -DCMAKE_CXX_COMPILER=$WORKSPACE/bin/nvcc_wrapper \
                                 -DCMAKE_CXX_FLAGS="-Werror --Werror=all-warnings -Xcudafe --diag_suppress=940" \
                                 -DCMAKE_EXE_LINKER_FLAGS="-Xnvlink -suppress-stack-size-warning" \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -173,6 +173,7 @@ pipeline {
                         }
                     }
                 }
+/*
                 stage('CUDA-12.2-NVCC-RDC') {
                     agent {
                         dockerfile {
@@ -257,6 +258,7 @@ pipeline {
                         }
                     }
                 }
+*/
             }
         }
         stage('Build-2') {


### PR DESCRIPTION
CUDA-12.2-NVCC-RDC started failing a while ago with errors such as
```
CUDA-12.2-NVCC-RDC] nvlink fatal   : Could not open input file '/usr/lib/x86_64-linux-gnu/libcuda.so'
```
This pull request suggest to disable the test until we have figured out an actual fix for the issue.