### PR TITLE
Drop Cuda "deep copy" exec space

### DIFF
--- a/containers/src/Kokkos_DualView.hpp
+++ b/containers/src/Kokkos_DualView.hpp
@@ -67,15 +67,17 @@ namespace Impl {
 
 #ifdef KOKKOS_ENABLE_CUDA
 
-inline const Kokkos::Cuda& get_cuda_space(const Kokkos::Cuda& in) { return in; }
+inline cudaStream_t get_cuda_stream(const Kokkos::Cuda& in) {
+  return in.cuda_stream();
+}
 
-inline const Kokkos::Cuda& get_cuda_space() {
-  return *Kokkos::Impl::cuda_get_deep_copy_space();
+inline cudaStream_t get_cuda_stream() {
+  return Kokkos::Impl::cuda_get_deep_copy_stream();
 }
 
 template <typename NonCudaExecSpace>
-inline const Kokkos::Cuda& get_cuda_space(const NonCudaExecSpace&) {
-  return get_cuda_space();
+inline cudaStream_t get_cuda_stream(const NonCudaExecSpace&) {
+  return get_cuda_stream();
 }
 
 #endif  // KOKKOS_ENABLE_CUDA
@@ -552,7 +554,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
                          Kokkos::CudaUVMSpace>::value) {
           if (d_view.data() == h_view.data())
             Kokkos::Impl::cuda_prefetch_pointer(
-                Impl::get_cuda_space(args...), d_view.data(),
+                Impl::get_cuda_stream(args...), d_view.data(),
                 sizeof(typename t_dev::value_type) * d_view.span(), true);
         }
 #endif
@@ -569,7 +571,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
                          Kokkos::CudaUVMSpace>::value) {
           if (d_view.data() == h_view.data())
             Kokkos::Impl::cuda_prefetch_pointer(
-                Impl::get_cuda_space(args...), d_view.data(),
+                Impl::get_cuda_stream(args...), d_view.data(),
                 sizeof(typename t_dev::value_type) * d_view.span(), false);
         }
 #endif
@@ -652,7 +654,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
                        Kokkos::CudaUVMSpace>::value) {
         if (d_view.data() == h_view.data())
           Kokkos::Impl::cuda_prefetch_pointer(
-              Impl::get_cuda_space(args...), d_view.data(),
+              Impl::get_cuda_stream(args...), d_view.data(),
               sizeof(typename t_dev::value_type) * d_view.span(), false);
       }
 #endif
@@ -695,7 +697,7 @@ class DualView : public ViewTraits<DataType, Properties...> {
                        Kokkos::CudaUVMSpace>::value) {
         if (d_view.data() == h_view.data())
           Kokkos::Impl::cuda_prefetch_pointer(
-              Impl::get_cuda_space(args...), d_view.data(),
+              Impl::get_cuda_stream(args...), d_view.data(),
               sizeof(typename t_dev::value_type) * d_view.span(), true);
       }
 #endif

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -434,23 +434,28 @@ void CudaHostPinnedSpace::impl_deallocate(
 namespace Kokkos {
 namespace Impl {
 
-void cuda_prefetch_pointer(const Cuda &space, const void *ptr, size_t bytes,
+void cuda_prefetch_pointer(cudaStream_t stream, const void *ptr, size_t bytes,
                            bool to_device) {
   if ((ptr == nullptr) || (bytes == 0)) return;
   cudaPointerAttributes attr;
-  KOKKOS_IMPL_CUDA_SAFE_CALL((
-      space.impl_internal_space_instance()->cuda_pointer_get_attributes_wrapper(
-          &attr, ptr)));
+  KOKKOS_IMPL_CUDA_SAFE_CALL((cudaPointerGetAttributes(&attr, ptr)));
   // I measured this and it turns out prefetching towards the host slows
   // DualView syncs down. Probably because the latency is not too bad in the
-  // first place for the pull down. If we want to change that provde
+  // first place for the pull down. If we want to change that provide
   // cudaCpuDeviceId as the device if to_device is false
   bool is_managed = attr.type == cudaMemoryTypeManaged;
+  Cuda default_instance;
   if (to_device && is_managed &&
-      space.cuda_device_prop().concurrentManagedAccess) {
+      default_instance.cuda_device_prop().concurrentManagedAccess) {
+    const int dstDevice = default_instance.cuda_device();
+#if CUDART_VERSION >= 13000
+    cudaMemLocation loc = {cudaMemLocationTypeDevice, dstDevice};
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (space.impl_internal_space_instance()->cuda_mem_prefetch_async_wrapper(
-            ptr, bytes, space.cuda_device())));
+        (cudaMemPrefetchAsync(ptr, bytes, loc, /*flags=*/0, stream)));
+#else
+    KOKKOS_IMPL_CUDA_SAFE_CALL(
+        (cudaMemPrefetchAsync(ptr, bytes, dstDevice, stream)));
+#endif
   }
 }
 

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -39,14 +39,6 @@ cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   return s;
 }
 
-const std::unique_ptr<Kokkos::Cuda> &Kokkos::Impl::cuda_get_deep_copy_space(
-    bool initialize) {
-  static std::unique_ptr<Cuda> space = nullptr;
-  if (!space && initialize)
-    space = std::make_unique<Cuda>(Kokkos::Impl::cuda_get_deep_copy_stream());
-  return space;
-}
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -321,9 +321,6 @@ namespace Impl {
 
 cudaStream_t cuda_get_deep_copy_stream();
 
-const std::unique_ptr<Kokkos::Cuda>& cuda_get_deep_copy_space(
-    bool initialize = true);
-
 static_assert(Kokkos::Impl::MemorySpaceAccess<Kokkos::CudaSpace,
                                               Kokkos::CudaSpace>::assignable);
 static_assert(Kokkos::Impl::MemorySpaceAccess<

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -644,9 +644,6 @@ void Cuda::impl_finalize() {
         Kokkos::Impl::CudaInternal::constantMemReusablePerDevice[cuda_device]));
   }
 
-  auto &deep_copy_space = Impl::cuda_get_deep_copy_space(/*initialize*/ false);
-  if (deep_copy_space)
-    deep_copy_space->impl_internal_space_instance()->finalize();
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaStreamDestroy(Impl::cuda_get_deep_copy_stream()));
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -275,17 +275,6 @@ class CudaInternal {
     return cudaMallocHost(ptr, size);
   }
 
-  cudaError_t cuda_mem_prefetch_async_wrapper(const void* devPtr, size_t count,
-                                              int dstDevice) const {
-    set_cuda_device();
-#if CUDART_VERSION >= 13000
-    cudaMemLocation loc = {cudaMemLocationTypeDevice, dstDevice};
-    return cudaMemPrefetchAsync(devPtr, count, loc, 0, m_stream);
-#else
-    return cudaMemPrefetchAsync(devPtr, count, dstDevice, m_stream);
-#endif
-  }
-
   cudaError_t cuda_memcpy_wrapper(void* dst, const void* src, size_t count,
                                   cudaMemcpyKind kind) const {
     set_cuda_device();
@@ -316,12 +305,6 @@ class CudaInternal {
                                         size_t count) const {
     set_cuda_device();
     return cudaMemsetAsync(devPtr, value, count, m_stream);
-  }
-
-  cudaError_t cuda_pointer_get_attributes_wrapper(
-      cudaPointerAttributes* attributes, const void* ptr) const {
-    set_cuda_device();
-    return cudaPointerGetAttributes(attributes, ptr);
   }
 
   cudaError_t cuda_stream_create_wrapper(cudaStream_t* pStream) const {

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -100,9 +100,9 @@ struct ViewValueFunctor {
     }
 
 #ifdef KOKKOS_ENABLE_CUDA
-    if (std::is_same<ExecSpace, Kokkos::Cuda>::value) {
-      Kokkos::Impl::cuda_prefetch_pointer(space, ptr, sizeof(ValueType) * n,
-                                          true);
+    if constexpr (std::is_same<ExecSpace, Kokkos::Cuda>::value) {
+      Kokkos::Impl::cuda_prefetch_pointer(space.cuda_stream(), ptr,
+                                          sizeof(ValueType) * n, true);
     }
 #endif
     const Kokkos::Impl::ParallelFor<ViewValueFunctor, PolicyType> closure(


### PR DESCRIPTION
One motivation for this refactor was that lifetime issues with that special Cuda exec space instance (see #8546)
Instead coming up with elaborated ways to manage that "deep copy" exec space that is used by DualView, this PR proposes to get rid of it.

Along the way we get rid of `Impl::CudaInternal::cuda_{mem_prefetch_async,pointer_get_attributes}_wrapper`
