### PR TITLE
Fixup SIMD tests missing fences after parallel fors

### DIFF
--- a/simd/unit_tests/include/TestSIMD_Condition.hpp
+++ b/simd/unit_tests/include/TestSIMD_Condition.hpp
@@ -95,8 +95,8 @@ TEST(simd, host_condition) {
 }
 
 TEST(simd, device_condition) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_condition_functor());
+  Kokkos::parallel_for(1, simd_device_condition_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -199,8 +199,8 @@ TEST(simd, host_construction) {
 }
 
 TEST(simd, device_construction) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_construction_functor());
+  Kokkos::parallel_for(1, simd_device_construction_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_Conversions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Conversions.hpp
@@ -129,8 +129,8 @@ TEST(simd, host_conversions) {
 }
 
 TEST(simd, device_conversions) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_conversions_functor());
+  Kokkos::parallel_for(1, simd_device_conversions_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
+++ b/simd/unit_tests/include/TestSIMD_GeneratorCtors.hpp
@@ -137,6 +137,7 @@ TEST(simd, host_gen_ctors) {
 
 TEST(simd, device_gen_ctors) {
   Kokkos::parallel_for(1, simd_device_gen_ctor_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_LoadStore.hpp
+++ b/simd/unit_tests/include/TestSIMD_LoadStore.hpp
@@ -229,8 +229,8 @@ TEST(simd, host_loadstore) {
 }
 
 TEST(simd, device_loadstore) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_loadstore_functor());
+  Kokkos::parallel_for(1, simd_device_loadstore_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_MaskOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MaskOps.hpp
@@ -106,8 +106,8 @@ TEST(simd, host_mask_ops) {
 }
 
 TEST(simd, device_mask_ops) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_mask_ops_functor());
+  Kokkos::parallel_for(1, simd_device_mask_ops_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_MathOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_MathOps.hpp
@@ -556,6 +556,7 @@ TEST(simd, device_math_ops) {
          "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
   Kokkos::parallel_for(1, simd_device_math_ops_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -238,6 +238,7 @@ TEST(simd, device_reductions) {
          "cuStreamSynchronize: an illegal memory access was encountered";
 #endif
   Kokkos::parallel_for(1, simd_device_reduction_functor());
+  Kokkos::fence();
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ShiftOps.hpp
@@ -292,8 +292,8 @@ TEST(simd, host_shift_ops) {
 }
 
 TEST(simd, device_shift_ops) {
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::IndexType<int>>(0, 1),
-                       simd_device_shift_ops_functor());
+  Kokkos::parallel_for(1, simd_device_shift_ops_functor());
+  Kokkos::fence();
 }
 
 #endif


### PR DESCRIPTION
The SIMD device-side tests are missing fences.
It led to errors with HPX in #8546

Drive-by change: using terse syntax for the parallel_for to simplify the code.