### PR TITLE
Add missing `<new>` header

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -41,6 +41,7 @@ static_assert(false,
 #include <iosfwd>
 #include <functional>
 #include <memory>
+#include <new>
 #include <type_traits>
 #include <vector>
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -21,6 +21,7 @@ import kokkos.core;
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <new>
 #include <sstream>
 #include <thread>
 

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -7,6 +7,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <cstdio>
+#include <new>
 
 #include <utility>
 #include <impl/Kokkos_HostThreadTeam.hpp>

--- a/core/src/View/Kokkos_ViewAlloc.hpp
+++ b/core/src/View/Kokkos_ViewAlloc.hpp
@@ -11,6 +11,7 @@ static_assert(false,
 #define KOKKOS_VIEW_ALLOC_HPP
 
 #include <cstring>
+#include <new>
 #include <type_traits>
 #include <string>
 #include <optional>

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_FUNCTORANALYSIS_HPP
 
 #include <cstddef>
+#include <new>
 #include <Kokkos_Core_fwd.hpp>
 #include <impl/Kokkos_Traits.hpp>
 

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>
+#include <new>
 
 #include <iostream>
 #include <sstream>

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -10,6 +10,7 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <new>
 #include <gtest/gtest.h>
 
 using Kokkos::Impl::HostSharedPtr;

--- a/core/unit_test/TestViewOfViews.hpp
+++ b/core/unit_test/TestViewOfViews.hpp
@@ -10,6 +10,8 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <new>
+
 namespace {
 
 // User-defined types with a View data member

--- a/example/virtual_functions/main.cpp
+++ b/example/virtual_functions/main.cpp
@@ -3,6 +3,8 @@
 
 #include <classes.hpp>
 
+#include <new>
+
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
 


### PR DESCRIPTION
This PR fixes the missing header `<new>` in files using:
- non-throwing allocation functions
  - `core/src/impl/Kokkos_HostSpace.cpp`
- non-allocating placement allocation functions
  - `core/src/HPX/Kokkos_HPX.hpp`
  - `core/src/OpenMP/Kokkos_OpenMP_Instance.cpp`
  - `core/src/Threads/Kokkos_Threads_Team.hpp`
  - `core/src/View/Kokkos_ViewAlloc.hpp`
  - `core/src/impl/Kokkos_FunctorAnalysis.hpp`
  - `core/unit_test/TestHostSharedPtrAccessOnDevice.hpp`
  - `core/unit_test/TestViewOfViews.hpp`
  - `example/virtual_functions/main.cpp`

This missing header triggers an IWYU warning in downstream projects. It is optional only in other few cases citing [cppreference](https://en.cppreference.com/w/cpp/memory/new/operator_new.html):
> Overloads ([1-4](https://en.cppreference.com/w/cpp/memory/new/operator_new.html#Version_1)) are implicitly declared in each translation unit even if the [<new>](https://en.cppreference.com/w/cpp/header/new.html) header is not included.