### PR TITLE
Use CTEST_OUTPUT_ON_FAILURE with cmake --target test

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -166,6 +166,7 @@ jobs:
         run: |
           cmake -B builddir_buildtree -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_CXX_STANDARD=${{ matrix.stdcxx }} -DKokkos_ROOT=../../builddir
           cmake --build builddir_buildtree
+          export CTEST_OUTPUT_ON_FAILURE=1
           cmake --build builddir_buildtree --target test
       - name: Test DESTDIR Install
         run: DESTDIR=${PWD}/install cmake --build builddir --target install && rm -rf ${PWD}/install/usr && rmdir ${PWD}/install
@@ -177,4 +178,5 @@ jobs:
         run: |
           cmake -B builddir -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DCMAKE_CXX_STANDARD=${{ matrix.stdcxx }}
           cmake --build builddir
+          export CTEST_OUTPUT_ON_FAILURE=1
           cmake --build builddir --target test

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -185,6 +185,7 @@ pipeline {
                         }
                     }
                     environment {
+                        CTEST_OUTPUT_ON_FAILURE = 1
                         OMP_NUM_THREADS = 8
                         // Nested OpenMP does not work for this configuration,
                         // so disabling it
@@ -250,7 +251,6 @@ pipeline {
                               cd ../.. && \
                               cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=20 build_cmake_installed_different_compiler && \
                               cmake --build build_cmake_installed_different_compiler/build --target all && \
-                              export CTEST_OUTPUT_ON_FAILURE=1 && \
                               cmake --build build_cmake_installed_different_compiler/build --target test'''
                     }
                     post {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -250,6 +250,7 @@ pipeline {
                               cd ../.. && \
                               cmake -B build_cmake_installed_different_compiler/build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror -DCMAKE_CXX_STANDARD=20 build_cmake_installed_different_compiler && \
                               cmake --build build_cmake_installed_different_compiler/build --target all && \
+                              export CTEST_OUTPUT_ON_FAILURE=1 && \
                               cmake --build build_cmake_installed_different_compiler/build --target test'''
                     }
                     post {


### PR DESCRIPTION
Split from https://github.com/kokkos/kokkos/pull/8628 where we noticed missing failure information. 