### PR TITLE
Remove flang workarounds

### DIFF
--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -121,16 +121,6 @@ jobs:
           path: ~/.cache/ccache
           key: kokkos-${{ matrix.arch }}-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.stdcxx }}-${{ matrix.cmake_build_type }}-${{ matrix.backend }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.arch }}${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.stdcxx }}-${{ matrix.cmake_build_type }}-${{ matrix.backend }}-${{ github.ref }}
-      - name: maybe_use_flang_new
-        if: ${{ matrix.cxx == 'clang++' }}
-        run: |
-          if type flang; then
-            echo "flang found"
-            echo "FC=flang" >> $GITHUB_ENV
-          elif type flang-new; then
-            echo "flang-new found"
-            echo "FC=flang-new" >> $GITHUB_ENV
-          fi
       - name: Configure Kokkos
         run: |
           cmake -B builddir \

--- a/.github/workflows/continuous-integration-linux.yml
+++ b/.github/workflows/continuous-integration-linux.yml
@@ -121,6 +121,13 @@ jobs:
           path: ~/.cache/ccache
           key: kokkos-${{ matrix.arch }}-${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.stdcxx }}-${{ matrix.cmake_build_type }}-${{ matrix.backend }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: kokkos-${{ matrix.arch }}${{ matrix.distro }}-${{ matrix.cxx }}-${{ matrix.stdcxx }}-${{ matrix.cmake_build_type }}-${{ matrix.backend }}-${{ github.ref }}
+      - name: maybe_use_flang
+        if: ${{ matrix.cxx == 'clang++' }}
+        run: |
+          if type flang; then
+            echo "flang found"
+            echo "FC=flang" >> $GITHUB_ENV
+          fi
       - name: Configure Kokkos
         run: |
           cmake -B builddir \

--- a/example/build_cmake_installed/CMakeLists.txt
+++ b/example/build_cmake_installed/CMakeLists.txt
@@ -10,12 +10,6 @@ project(Example CXX Fortran)
 find_package(Kokkos REQUIRED)
 
 add_executable(example cmake_example.cpp foo.f)
-if(CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
-  set_target_properties(example PROPERTIES LINKER_LANGUAGE Fortran)
-  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 19)
-    target_link_options(example PRIVATE -fno-fortran-main)
-  endif()
-endif()
 
 # This is the only thing required to set up compiler/linker flags
 target_link_libraries(example Kokkos::kokkos)

--- a/example/build_cmake_installed/foo.f
+++ b/example/build_cmake_installed/foo.f
@@ -1,4 +1,4 @@
-        FUNCTION print_fortran()
+        SUBROUTINE print_fortran()
           PRINT *, 'Hello World from Fortran'
           RETURN
-        END
+        END SUBROUTINE


### PR DESCRIPTION
Split from https://github.com/kokkos/kokkos/pull/8628. We ran into
```
/__w/kokkos/kokkos/example/build_cmake_installed/foo.f:1:18: warning: Function result is never defined [-Wundefined-function-result]
          FUNCTION print_fortran()
                   ^^^^^^^^^^^^^
```
and
```
1/1 Test #1: KokkosInTree_Verify ..............***Failed    0.00 sec
/__w/kokkos/kokkos/example/build_cmake_installed/builddir_buildtree/example: error while loading shared libraries: libflang_rt.runtime.so: cannot open shared object file: No such file or directory
```
after updates to `flang` and decided to just drop testing for it given the trouble it has given us in the past.