### PR TITLE
Refactor DeviceIterateTile for `MDRangePolicy` on Device

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -60,40 +60,47 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   using functor_type = FunctorType;
 
  private:
-  using RP               = Policy;
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
   using LaunchBounds     = typename Policy::launch_bounds;
   using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
-  const Policy m_rp;
+  const Policy m_policy;
   const MaxGridSize m_max_grid_size;
+
+  array_type m_lower;
+  array_type m_upper;
+  array_type m_max_threads;
 
  public:
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy& pol, const Functor&) {
     return max_tile_size_product_helper<ParallelFor>(pol, LaunchBounds{});
   }
-  Policy const& get_policy() const { return m_rp; }
+
+  Policy const& get_policy() const { return m_policy; }
+
   inline __device__ void operator()() const {
-    Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
-                                    MaxGridSize, typename Policy::work_tag>(
-        m_rp, m_functor, m_max_grid_size)
+    Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
+                                FunctorType, Policy::inner_direction,
+                                typename Policy::work_tag>(
+        m_lower, m_upper, m_max_threads, m_functor)
         .exec_range();
   }
 
   inline void execute() const {
-    if (m_rp.m_num_tiles == 0) return;
+    if (m_policy.m_num_tiles == 0) return;
 
     // maximum number of threads in each dimension of the block as fetched by
     // the API
     [[maybe_unused]] const auto max_threads_dim =
-        m_rp.space().cuda_device_prop().maxThreadsDim;
+        m_policy.space().cuda_device_prop().maxThreadsDim;
 
     // maximum total number of threads per block as fetched by the API
     [[maybe_unused]] const auto max_threads_per_block =
-        m_rp.space().cuda_device_prop().maxThreadsPerBlock;
+        m_policy.space().cuda_device_prop().maxThreadsPerBlock;
 
     // make sure the block dimensions don't exceed the max number of threads
     // allowed
@@ -121,114 +128,127 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
     dim3 grid(1, 1, 1);
     dim3 block(1, 1, 1);
-    if constexpr (RP::rank == 2) {
-      const array_index_type block_0 = m_rp.m_tile[0];
-      const array_index_type block_1 = m_rp.m_tile[1];
 
-      const array_index_type grid_0 =
-          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
-      const array_index_type grid_1 =
-          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
-
-      if constexpr (RP::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y
-        block = dim3(block_0, block_1, 1);
-        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]), 1);
+    if constexpr (Policy::rank == 2) {
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        block.x = m_policy.m_tile[0];
+        block.y = m_policy.m_tile[1];
+        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[0],
+                                            m_max_grid_size[0]);
+        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[1],
+                                            m_max_grid_size[1]);
       } else {
-        // Iterate::Right, map id1->x, id0->y
-        block = dim3(block_1, block_0, 1);
-        grid  = dim3(std::min<array_index_type>(grid_1, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_0, m_max_grid_size[1]), 1);
+        block.x = m_policy.m_tile[1];
+        block.y = m_policy.m_tile[0];
+        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[1],
+                                            m_max_grid_size[0]);
+        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[0],
+                                            m_max_grid_size[1]);
       }
-    } else if constexpr (RP::rank == 3) {
-      const array_index_type block_0 = m_rp.m_tile[0];
-      const array_index_type block_1 = m_rp.m_tile[1];
-      const array_index_type block_2 = m_rp.m_tile[2];
+    } else if constexpr (Policy::rank >= 3) {
+      array_index_type grid_0 = 1;
+      array_index_type grid_1 = 1;
+      array_index_type grid_2 = 1;
 
-      const array_index_type grid_0 =
-          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
-      const array_index_type grid_1 =
-          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
-      const array_index_type grid_2 =
-          (m_rp.m_upper[2] - m_rp.m_lower[2] + block_2 - 1) / block_2;
-
-      if constexpr (RP::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y, id2->z
-        block = dim3(block_0, block_1, block_2);
-        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                     std::min<array_index_type>(grid_2, m_max_grid_size[2]));
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        if constexpr (Policy::rank == 3) {
+          block.x = m_policy.m_tile[0];
+          block.y = m_policy.m_tile[1];
+          block.z = m_policy.m_tile[2];
+          grid_0  = m_policy.m_tile_end[0];
+          grid_1  = m_policy.m_tile_end[1];
+          grid_2  = m_policy.m_tile_end[2];
+        } else if constexpr (Policy::rank >= 4) {
+          block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
+          block.y = m_policy.m_tile[2];
+          block.z = m_policy.m_tile[3];
+          grid_0  = m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
+          grid_1  = m_policy.m_tile_end[2];
+          grid_2  = m_policy.m_tile_end[3];
+        }
+        if constexpr (Policy::rank >= 5) {
+          block.y = m_policy.m_tile[2] * m_policy.m_tile[3];
+          block.z = m_policy.m_tile[4];
+          grid_1  = m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
+          grid_2  = m_policy.m_tile_end[4];
+        }
+        if constexpr (Policy::rank >= 6) {
+          block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
+          grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
+        }
       } else {
-        // Iterate::Right, map id2->x, id1->y, id0->z
-        block = dim3(block_2, block_1, block_0);
-        grid  = dim3(std::min<array_index_type>(grid_2, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                     std::min<array_index_type>(grid_0, m_max_grid_size[2]));
+        if constexpr (Policy::rank == 3) {
+          block.x = m_policy.m_tile[2];
+          block.y = m_policy.m_tile[1];
+          block.z = m_policy.m_tile[0];
+          grid_0  = m_policy.m_tile_end[2];
+          grid_1  = m_policy.m_tile_end[1];
+          grid_2  = m_policy.m_tile_end[0];
+        } else if constexpr (Policy::rank >= 4) {
+          block.x = m_policy.m_tile[Policy::rank - 1] *
+                    m_policy.m_tile[Policy::rank - 2];
+          block.y = m_policy.m_tile[Policy::rank - 3];
+          block.z = m_policy.m_tile[Policy::rank - 4];
+          grid_0  = m_policy.m_tile_end[Policy::rank - 1] *
+                   m_policy.m_tile_end[Policy::rank - 2];
+          grid_1 = m_policy.m_tile_end[Policy::rank - 3];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 4];
+        }
+        if constexpr (Policy::rank >= 5) {
+          block.y = m_policy.m_tile[Policy::rank - 3] *
+                    m_policy.m_tile[Policy::rank - 4];
+          block.z = m_policy.m_tile[Policy::rank - 5];
+          grid_1  = m_policy.m_tile_end[Policy::rank - 3] *
+                   m_policy.m_tile_end[Policy::rank - 4];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 5];
+        }
+        if constexpr (Policy::rank >= 6) {
+          block.z = m_policy.m_tile[Policy::rank - 5] *
+                    m_policy.m_tile[Policy::rank - 6];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 5] *
+                   m_policy.m_tile_end[Policy::rank - 6];
+        }
       }
-    } else if constexpr (RP::rank == 4) {
-      // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
-      // threadIdx.z
-      block =
-          dim3(m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2], m_rp.m_tile[3]);
-      grid =
-          dim3(std::min<array_index_type>(
-                   m_rp.m_tile_end[0] * m_rp.m_tile_end[1], m_max_grid_size[0]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[2] - m_rp.m_lower[2] + block.y - 1) / block.y,
-                   m_max_grid_size[1]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[3] - m_rp.m_lower[3] + block.z - 1) / block.z,
-                   m_max_grid_size[2]));
-    } else if constexpr (RP::rank == 5) {
-      // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4 to
-      // threadIdx.z
-      block = dim3(m_rp.m_tile[0] * m_rp.m_tile[1],
-                   m_rp.m_tile[2] * m_rp.m_tile[3], m_rp.m_tile[4]);
-      grid =
-          dim3(std::min<array_index_type>(
-                   m_rp.m_tile_end[0] * m_rp.m_tile_end[1], m_max_grid_size[0]),
-               std::min<array_index_type>(
-                   m_rp.m_tile_end[2] * m_rp.m_tile_end[3], m_max_grid_size[1]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[4] - m_rp.m_lower[4] + block.z - 1) / block.z,
-                   m_max_grid_size[2]));
-    } else if constexpr (RP::rank == 6) {
-      // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4,id5 to
-      // threadIdx.z
-      block =
-          dim3(m_rp.m_tile[0] * m_rp.m_tile[1], m_rp.m_tile[2] * m_rp.m_tile[3],
-               m_rp.m_tile[4] * m_rp.m_tile[5]);
-      grid = dim3(
-          std::min<array_index_type>(m_rp.m_tile_end[0] * m_rp.m_tile_end[1],
-                                     m_max_grid_size[0]),
-          std::min<array_index_type>(m_rp.m_tile_end[2] * m_rp.m_tile_end[3],
-                                     m_max_grid_size[1]),
-          std::min<array_index_type>(m_rp.m_tile_end[4] * m_rp.m_tile_end[5],
-                                     m_max_grid_size[2]));
-    } else {
-      Kokkos::abort("Kokkos::MDRange Error: Exceeded rank bounds with Cuda\n");
+      grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                  std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                  std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     }
+
     // ensure we don't exceed the capability of the device
     check_grid_sizes(grid);
     check_block_sizes(block);
     // launch the kernel
     CudaParallelLaunch<ParallelFor, LaunchBounds>(
-        *this, grid, block, 0, m_rp.space().impl_internal_space_instance());
+        *this, grid, block, 0, m_policy.space().impl_internal_space_instance());
   }  // end execute
 
   //  inline
   ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
       : m_functor(arg_functor),
-        m_rp(arg_policy),
+        m_policy(arg_policy),
         m_max_grid_size({
             static_cast<index_type>(
-                m_rp.space().cuda_device_prop().maxGridSize[0]),
+                m_policy.space().cuda_device_prop().maxGridSize[0]),
             static_cast<index_type>(
-                m_rp.space().cuda_device_prop().maxGridSize[1]),
+                m_policy.space().cuda_device_prop().maxGridSize[1]),
             static_cast<index_type>(
-                m_rp.space().cuda_device_prop().maxGridSize[2]),
-        }) {}
+                m_policy.space().cuda_device_prop().maxGridSize[2]),
+        }) {
+    // Initialize begins and ends based on layout
+    // Swap the fastest indexes to x dimension
+    for (array_index_type i = 0; i < Policy::rank; ++i) {
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        m_lower[i]       = m_policy.m_lower[i];
+        m_upper[i]       = m_policy.m_upper[i];
+        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+      } else {
+        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
+        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                           m_policy.m_tile_end[Policy::rank - 1 - i];
+      }
+    }
+  }
 };
 
 template <class CombinedFunctorReducerType, class... Traits>

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -122,29 +122,50 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     dim3 grid(1, 1, 1);
     dim3 block(1, 1, 1);
     if constexpr (RP::rank == 2) {
-      // id0 to threadIdx.x; id1 to threadIdx.y
-      block = dim3(m_rp.m_tile[0], m_rp.m_tile[1], 1);
-      grid =
-          dim3(std::min<array_index_type>(
-                   (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
-                   m_max_grid_size[0]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) / block.y,
-                   m_max_grid_size[1]),
-               1);
+      const array_index_type block_0 = m_rp.m_tile[0];
+      const array_index_type block_1 = m_rp.m_tile[1];
+
+      const array_index_type grid_0 =
+          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
+      const array_index_type grid_1 =
+          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
+
+      if constexpr (RP::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y
+        block = dim3(block_0, block_1, 1);
+        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]), 1);
+      } else {
+        // Iterate::Right, map id1->x, id0->y
+        block = dim3(block_1, block_0, 1);
+        grid  = dim3(std::min<array_index_type>(grid_1, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_0, m_max_grid_size[1]), 1);
+      }
     } else if constexpr (RP::rank == 3) {
-      // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
-      block = dim3(m_rp.m_tile[0], m_rp.m_tile[1], m_rp.m_tile[2]);
-      grid =
-          dim3(std::min<array_index_type>(
-                   (m_rp.m_upper[0] - m_rp.m_lower[0] + block.x - 1) / block.x,
-                   m_max_grid_size[0]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[1] - m_rp.m_lower[1] + block.y - 1) / block.y,
-                   m_max_grid_size[1]),
-               std::min<array_index_type>(
-                   (m_rp.m_upper[2] - m_rp.m_lower[2] + block.z - 1) / block.z,
-                   m_max_grid_size[2]));
+      const array_index_type block_0 = m_rp.m_tile[0];
+      const array_index_type block_1 = m_rp.m_tile[1];
+      const array_index_type block_2 = m_rp.m_tile[2];
+
+      const array_index_type grid_0 =
+          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
+      const array_index_type grid_1 =
+          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
+      const array_index_type grid_2 =
+          (m_rp.m_upper[2] - m_rp.m_lower[2] + block_2 - 1) / block_2;
+
+      if constexpr (RP::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y, id2->z
+        block = dim3(block_0, block_1, block_2);
+        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                     std::min<array_index_type>(grid_2, m_max_grid_size[2]));
+      } else {
+        // Iterate::Right, map id2->x, id1->y, id0->z
+        block = dim3(block_2, block_1, block_0);
+        grid  = dim3(std::min<array_index_type>(grid_2, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                     std::min<array_index_type>(grid_0, m_max_grid_size[2]));
+      }
     } else if constexpr (RP::rank == 4) {
       // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
       // threadIdx.z

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -72,7 +72,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   array_type m_lower;
   array_type m_upper;
-  array_type m_max_threads;
+  array_type m_extent;
 
  public:
   template <typename Policy, typename Functor>
@@ -85,8 +85,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
                                 FunctorType, Policy::inner_direction,
-                                typename Policy::work_tag>(
-        m_lower, m_upper, m_max_threads, m_functor)
+                                typename Policy::work_tag>(m_lower, m_upper,
+                                                           m_extent, m_functor)
         .exec_range();
   }
 
@@ -126,90 +126,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
                     grid.z <= static_cast<unsigned int>(m_max_grid_size[2]));
     };
 
-    dim3 grid(1, 1, 1);
-    dim3 block(1, 1, 1);
+    const auto [grid, block] =
+        Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
 
-    array_index_type grid_0 = 1;
-    array_index_type grid_1 = 1;
-    array_index_type grid_2 = 1;
-    if constexpr (Policy::rank == 2) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        block.x = m_policy.m_tile[0];
-        block.y = m_policy.m_tile[1];
-        grid_0  = m_policy.m_tile_end[0];
-        grid_1  = m_policy.m_tile_end[1];
-      } else {
-        block.x = m_policy.m_tile[1];
-        block.y = m_policy.m_tile[0];
-        grid_0  = m_policy.m_tile_end[1];
-        grid_1  = m_policy.m_tile_end[0];
-      }
-    } else if constexpr (Policy::rank == 3) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        block.x = m_policy.m_tile[0];
-        block.y = m_policy.m_tile[1];
-        block.z = m_policy.m_tile[2];
-        grid_0  = m_policy.m_tile_end[0];
-        grid_1  = m_policy.m_tile_end[1];
-        grid_2  = m_policy.m_tile_end[2];
-      } else {
-        block.x = m_policy.m_tile[2];
-        block.y = m_policy.m_tile[1];
-        block.z = m_policy.m_tile[0];
-        grid_0  = m_policy.m_tile_end[2];
-        grid_1  = m_policy.m_tile_end[1];
-        grid_2  = m_policy.m_tile_end[0];
-      }
-    } else {  // rank > 3
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank >= 4) {
-          block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
-          block.y = m_policy.m_tile[2];
-          block.z = m_policy.m_tile[3];
-          grid_0  = m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
-          grid_1  = m_policy.m_tile_end[2];
-          grid_2  = m_policy.m_tile_end[3];
-        }
-        if constexpr (Policy::rank >= 5) {
-          block.y = m_policy.m_tile[2] * m_policy.m_tile[3];
-          block.z = m_policy.m_tile[4];
-          grid_1  = m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
-          grid_2  = m_policy.m_tile_end[4];
-        }
-        if constexpr (Policy::rank >= 6) {
-          block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
-          grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
-        }
-      } else {  // InnerDirection == Right
-        if constexpr (Policy::rank >= 4) {
-          block.x = m_policy.m_tile[Policy::rank - 1] *
-                    m_policy.m_tile[Policy::rank - 2];
-          block.y = m_policy.m_tile[Policy::rank - 3];
-          block.z = m_policy.m_tile[Policy::rank - 4];
-          grid_0  = m_policy.m_tile_end[Policy::rank - 1] *
-                   m_policy.m_tile_end[Policy::rank - 2];
-          grid_1 = m_policy.m_tile_end[Policy::rank - 3];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 4];
-        }
-        if constexpr (Policy::rank >= 5) {
-          block.y = m_policy.m_tile[Policy::rank - 3] *
-                    m_policy.m_tile[Policy::rank - 4];
-          block.z = m_policy.m_tile[Policy::rank - 5];
-          grid_1  = m_policy.m_tile_end[Policy::rank - 3] *
-                   m_policy.m_tile_end[Policy::rank - 4];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 5];
-        }
-        if constexpr (Policy::rank >= 6) {
-          block.z = m_policy.m_tile[Policy::rank - 5] *
-                    m_policy.m_tile[Policy::rank - 6];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 5] *
-                   m_policy.m_tile_end[Policy::rank - 6];
-        }
-      }
-    }
-    grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     // ensure we don't exceed the capability of the device
     check_grid_sizes(grid);
     check_block_sizes(block);
@@ -234,14 +153,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     // Swap the fastest indexes to x dimension
     for (array_index_type i = 0; i < Policy::rank; ++i) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        m_lower[i]       = m_policy.m_lower[i];
-        m_upper[i]       = m_policy.m_upper[i];
-        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+        m_lower[i]  = m_policy.m_lower[i];
+        m_upper[i]  = m_policy.m_upper[i];
+        m_extent[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
       } else {
-        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
-        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
-        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
-                           m_policy.m_tile_end[Policy::rank - 1 - i];
+        m_lower[i]  = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]  = m_policy.m_upper[Policy::rank - 1 - i];
+        m_extent[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                      m_policy.m_tile_end[Policy::rank - 1 - i];
       }
     }
   }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -129,36 +129,40 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     dim3 grid(1, 1, 1);
     dim3 block(1, 1, 1);
 
+    array_index_type grid_0 = 1;
+    array_index_type grid_1 = 1;
+    array_index_type grid_2 = 1;
     if constexpr (Policy::rank == 2) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
         block.x = m_policy.m_tile[0];
         block.y = m_policy.m_tile[1];
-        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[0],
-                                            m_max_grid_size[0]);
-        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[1],
-                                            m_max_grid_size[1]);
+        grid_0  = m_policy.m_tile_end[0];
+        grid_1  = m_policy.m_tile_end[1];
       } else {
         block.x = m_policy.m_tile[1];
         block.y = m_policy.m_tile[0];
-        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[1],
-                                            m_max_grid_size[0]);
-        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[0],
-                                            m_max_grid_size[1]);
+        grid_0  = m_policy.m_tile_end[1];
+        grid_1  = m_policy.m_tile_end[0];
       }
-    } else if constexpr (Policy::rank >= 3) {
-      array_index_type grid_0 = 1;
-      array_index_type grid_1 = 1;
-      array_index_type grid_2 = 1;
-
+    } else if constexpr (Policy::rank == 3) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank == 3) {
-          block.x = m_policy.m_tile[0];
-          block.y = m_policy.m_tile[1];
-          block.z = m_policy.m_tile[2];
-          grid_0  = m_policy.m_tile_end[0];
-          grid_1  = m_policy.m_tile_end[1];
-          grid_2  = m_policy.m_tile_end[2];
-        } else if constexpr (Policy::rank >= 4) {
+        block.x = m_policy.m_tile[0];
+        block.y = m_policy.m_tile[1];
+        block.z = m_policy.m_tile[2];
+        grid_0  = m_policy.m_tile_end[0];
+        grid_1  = m_policy.m_tile_end[1];
+        grid_2  = m_policy.m_tile_end[2];
+      } else {
+        block.x = m_policy.m_tile[2];
+        block.y = m_policy.m_tile[1];
+        block.z = m_policy.m_tile[0];
+        grid_0  = m_policy.m_tile_end[2];
+        grid_1  = m_policy.m_tile_end[1];
+        grid_2  = m_policy.m_tile_end[0];
+      }
+    } else {  // rank > 3
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        if constexpr (Policy::rank >= 4) {
           block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
           block.y = m_policy.m_tile[2];
           block.z = m_policy.m_tile[3];
@@ -176,15 +180,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
           block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
           grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
         }
-      } else {
-        if constexpr (Policy::rank == 3) {
-          block.x = m_policy.m_tile[2];
-          block.y = m_policy.m_tile[1];
-          block.z = m_policy.m_tile[0];
-          grid_0  = m_policy.m_tile_end[2];
-          grid_1  = m_policy.m_tile_end[1];
-          grid_2  = m_policy.m_tile_end[0];
-        } else if constexpr (Policy::rank >= 4) {
+      } else {  // InnerDirection == Right
+        if constexpr (Policy::rank >= 4) {
           block.x = m_policy.m_tile[Policy::rank - 1] *
                     m_policy.m_tile[Policy::rank - 2];
           block.y = m_policy.m_tile[Policy::rank - 3];
@@ -209,11 +206,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
                    m_policy.m_tile_end[Policy::rank - 6];
         }
       }
-      grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                  std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                  std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     }
-
+    grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     // ensure we don't exceed the capability of the device
     check_grid_sizes(grid);
     check_block_sizes(block);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -72,7 +72,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   array_type m_lower;
   array_type m_upper;
-  array_type m_extent;
+  array_type m_extent;  // tile_size * num_tiles
 
  public:
   template <typename Policy, typename Functor>

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -26,10 +26,15 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   using index_type       = typename Policy::index_type;
   using LaunchBounds     = typename Policy::launch_bounds;
   using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
   const Policy m_policy;
   const MaxGridSize m_max_grid_size;
+
+  array_type m_lower;
+  array_type m_upper;
+  array_type m_max_threads;
 
  public:
   ParallelFor()                              = delete;
@@ -37,9 +42,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   ParallelFor& operator=(ParallelFor const&) = delete;
 
   inline __device__ void operator()() const {
-    Kokkos::Impl::DeviceIterateTile<Policy::rank, Policy, FunctorType,
-                                    MaxGridSize, typename Policy::work_tag>(
-        m_policy, m_functor, m_max_grid_size)
+    Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
+                                FunctorType, Policy::inner_direction,
+                                typename Policy::work_tag>(
+        m_lower, m_upper, m_max_threads, m_functor)
         .exec_range();
   }
 
@@ -47,129 +53,97 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
 
-    if (Policy::rank == 2) {
-      const array_index_type block_0 = m_policy.m_tile[0];
-      const array_index_type block_1 = m_policy.m_tile[1];
+    dim3 grid(1, 1, 1);
+    dim3 block(1, 1, 1);
 
-      const array_index_type grid_0 =
-          (m_policy.m_upper[0] - m_policy.m_lower[0] + block_0 - 1) / block_0;
-      const array_index_type grid_1 =
-          (m_policy.m_upper[1] - m_policy.m_lower[1] + block_1 - 1) / block_1;
-
-      dim3 grid(1, 1, 1);
-      dim3 block(1, 1, 1);
+    if constexpr (Policy::rank == 2) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y
-        block = dim3(block_0, block_1, 1);
-        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]), 1);
+        block.x = m_policy.m_tile[0];
+        block.y = m_policy.m_tile[1];
+        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[0],
+                                            m_max_grid_size[0]);
+        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[1],
+                                            m_max_grid_size[1]);
       } else {
-        // Iterate::Right, map id1->x, id0->y
-        block = dim3(block_1, block_0, 1);
-        grid  = dim3(std::min<array_index_type>(grid_1, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_0, m_max_grid_size[1]), 1);
+        block.x = m_policy.m_tile[1];
+        block.y = m_policy.m_tile[0];
+        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[1],
+                                            m_max_grid_size[0]);
+        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[0],
+                                            m_max_grid_size[1]);
       }
+    } else if constexpr (Policy::rank >= 3) {
+      array_index_type grid_0 = 1;
+      array_index_type grid_1 = 1;
+      array_index_type grid_2 = 1;
 
-      hip_parallel_launch<ClosureType, LaunchBounds>(
-          *this, grid, block, 0,
-          m_policy.space().impl_internal_space_instance(), false);
-    } else if (Policy::rank == 3) {
-      const array_index_type block_0 = m_policy.m_tile[0];
-      const array_index_type block_1 = m_policy.m_tile[1];
-      const array_index_type block_2 = m_policy.m_tile[2];
-
-      const array_index_type grid_0 =
-          (m_policy.m_upper[0] - m_policy.m_lower[0] + block_0 - 1) / block_0;
-      const array_index_type grid_1 =
-          (m_policy.m_upper[1] - m_policy.m_lower[1] + block_1 - 1) / block_1;
-      const array_index_type grid_2 =
-          (m_policy.m_upper[2] - m_policy.m_lower[2] + block_2 - 1) / block_2;
-      dim3 grid(1, 1, 1);
-      dim3 block(1, 1, 1);
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y, id2->z
-        block = dim3(block_0, block_1, block_2);
-        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                     std::min<array_index_type>(grid_2, m_max_grid_size[2]));
+        if constexpr (Policy::rank == 3) {
+          block.x = m_policy.m_tile[0];
+          block.y = m_policy.m_tile[1];
+          block.z = m_policy.m_tile[2];
+          grid_0  = m_policy.m_tile_end[0];
+          grid_1  = m_policy.m_tile_end[1];
+          grid_2  = m_policy.m_tile_end[2];
+        } else if constexpr (Policy::rank >= 4) {
+          block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
+          block.y = m_policy.m_tile[2];
+          block.z = m_policy.m_tile[3];
+          grid_0  = m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
+          grid_1  = m_policy.m_tile_end[2];
+          grid_2  = m_policy.m_tile_end[3];
+        }
+        if constexpr (Policy::rank >= 5) {
+          block.y = m_policy.m_tile[2] * m_policy.m_tile[3];
+          block.z = m_policy.m_tile[4];
+          grid_1  = m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
+          grid_2  = m_policy.m_tile_end[4];
+        }
+        if constexpr (Policy::rank >= 6) {
+          block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
+          grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
+        }
       } else {
-        // Iterate::Right, map id2->x, id1->y, id0->z
-        block = dim3(block_2, block_1, block_0);
-        grid  = dim3(std::min<array_index_type>(grid_2, m_max_grid_size[0]),
-                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                     std::min<array_index_type>(grid_0, m_max_grid_size[2]));
+        if constexpr (Policy::rank == 3) {
+          block.x = m_policy.m_tile[2];
+          block.y = m_policy.m_tile[1];
+          block.z = m_policy.m_tile[0];
+          grid_0  = m_policy.m_tile_end[2];
+          grid_1  = m_policy.m_tile_end[1];
+          grid_2  = m_policy.m_tile_end[0];
+        } else if constexpr (Policy::rank >= 4) {
+          block.x = m_policy.m_tile[Policy::rank - 1] *
+                    m_policy.m_tile[Policy::rank - 2];
+          block.y = m_policy.m_tile[Policy::rank - 3];
+          block.z = m_policy.m_tile[Policy::rank - 4];
+          grid_0  = m_policy.m_tile_end[Policy::rank - 1] *
+                   m_policy.m_tile_end[Policy::rank - 2];
+          grid_1 = m_policy.m_tile_end[Policy::rank - 3];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 4];
+        }
+        if constexpr (Policy::rank >= 5) {
+          block.y = m_policy.m_tile[Policy::rank - 3] *
+                    m_policy.m_tile[Policy::rank - 4];
+          block.z = m_policy.m_tile[Policy::rank - 5];
+          grid_1  = m_policy.m_tile_end[Policy::rank - 3] *
+                   m_policy.m_tile_end[Policy::rank - 4];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 5];
+        }
+        if constexpr (Policy::rank >= 6) {
+          block.z = m_policy.m_tile[Policy::rank - 5] *
+                    m_policy.m_tile[Policy::rank - 6];
+          grid_2 = m_policy.m_tile_end[Policy::rank - 5] *
+                   m_policy.m_tile_end[Policy::rank - 6];
+        }
       }
-
-      hip_parallel_launch<ClosureType, LaunchBounds>(
-          *this, grid, block, 0,
-          m_policy.space().impl_internal_space_instance(), false);
-    } else if (Policy::rank == 4) {
-      // id0,id1 encoded within threadIdx.x; id2 to threadIdx.y; id3 to
-      // threadIdx.z
-      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
-                       m_policy.m_tile[2], m_policy.m_tile[3]);
-
-      dim3 const grid(
-          std::min<array_index_type>(
-              m_policy.m_tile_end[0] * m_policy.m_tile_end[1],
-              m_max_grid_size[0]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[2] - m_policy.m_lower[2] + block.y - 1) /
-                  block.y,
-              m_max_grid_size[1]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[3] - m_policy.m_lower[3] + block.z - 1) /
-                  block.z,
-              m_max_grid_size[2]));
-
-      hip_parallel_launch<ClosureType, LaunchBounds>(
-          *this, grid, block, 0,
-          m_policy.space().impl_internal_space_instance(), false);
-    } else if (Policy::rank == 5) {
-      // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y; id4
-      // to threadIdx.z
-      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
-                       m_policy.m_tile[2] * m_policy.m_tile[3],
-                       m_policy.m_tile[4]);
-
-      dim3 const grid(
-          std::min<array_index_type>(
-              m_policy.m_tile_end[0] * m_policy.m_tile_end[1],
-              m_max_grid_size[0]),
-          std::min<array_index_type>(
-              m_policy.m_tile_end[2] * m_policy.m_tile_end[3],
-              m_max_grid_size[1]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[4] - m_policy.m_lower[4] + block.z - 1) /
-                  block.z,
-              m_max_grid_size[2]));
-
-      hip_parallel_launch<ClosureType, LaunchBounds>(
-          *this, grid, block, 0,
-          m_policy.space().impl_internal_space_instance(), false);
-    } else if (Policy::rank == 6) {
-      // id0,id1 encoded within threadIdx.x; id2,id3 to threadIdx.y;
-      // id4,id5 to threadIdx.z
-      dim3 const block(m_policy.m_tile[0] * m_policy.m_tile[1],
-                       m_policy.m_tile[2] * m_policy.m_tile[3],
-                       m_policy.m_tile[4] * m_policy.m_tile[5]);
-
-      dim3 const grid(std::min<array_index_type>(
-                          m_policy.m_tile_end[0] * m_policy.m_tile_end[1],
-                          m_max_grid_size[0]),
-                      std::min<array_index_type>(
-                          m_policy.m_tile_end[2] * m_policy.m_tile_end[3],
-                          m_max_grid_size[1]),
-                      std::min<array_index_type>(
-                          m_policy.m_tile_end[4] * m_policy.m_tile_end[5],
-                          m_max_grid_size[2]));
-
-      hip_parallel_launch<ClosureType, LaunchBounds>(
-          *this, grid, block, 0,
-          m_policy.space().impl_internal_space_instance(), false);
-    } else {
-      Kokkos::abort("Kokkos::MDRange Error: Exceeded rank bounds with HIP\n");
+      grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                  std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                  std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     }
+
+    hip_parallel_launch<ClosureType, LaunchBounds>(
+        *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
+        false);
 
   }  // end execute
 
@@ -183,7 +157,22 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
                 m_policy.space().hip_device_prop().maxGridSize[1]),
             static_cast<index_type>(
                 m_policy.space().hip_device_prop().maxGridSize[2]),
-        }) {}
+        }) {
+    // Initialize begins and ends based on layout
+    // Swap the fastest indexes to x dimension
+    for (array_index_type i = 0; i < Policy::rank; ++i) {
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        m_lower[i]       = m_policy.m_lower[i];
+        m_upper[i]       = m_policy.m_upper[i];
+        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+      } else {
+        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
+        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                           m_policy.m_tile_end[Policy::rank - 1 - i];
+      }
+    }
+  }
 
   template <typename Policy, typename Functor>
   static int max_tile_size_product(const Policy&, const Functor&) {

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -34,7 +34,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
 
   array_type m_lower;
   array_type m_upper;
-  array_type m_max_threads;
+  array_type m_extent;  // tile_size * num_tiles
 
  public:
   ParallelFor()                              = delete;
@@ -44,8 +44,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
                                 FunctorType, Policy::inner_direction,
-                                typename Policy::work_tag>(
-        m_lower, m_upper, m_max_threads, m_functor)
+                                typename Policy::work_tag>(m_lower, m_upper,
+                                                           m_extent, m_functor)
         .exec_range();
   }
 
@@ -53,90 +53,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
 
-    dim3 grid(1, 1, 1);
-    dim3 block(1, 1, 1);
+    const auto [grid, block] =
+        Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
 
-    array_index_type grid_0 = 1;
-    array_index_type grid_1 = 1;
-    array_index_type grid_2 = 1;
-    if constexpr (Policy::rank == 2) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        block.x = m_policy.m_tile[0];
-        block.y = m_policy.m_tile[1];
-        grid_0  = m_policy.m_tile_end[0];
-        grid_1  = m_policy.m_tile_end[1];
-      } else {
-        block.x = m_policy.m_tile[1];
-        block.y = m_policy.m_tile[0];
-        grid_0  = m_policy.m_tile_end[1];
-        grid_1  = m_policy.m_tile_end[0];
-      }
-    } else if constexpr (Policy::rank == 3) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        block.x = m_policy.m_tile[0];
-        block.y = m_policy.m_tile[1];
-        block.z = m_policy.m_tile[2];
-        grid_0  = m_policy.m_tile_end[0];
-        grid_1  = m_policy.m_tile_end[1];
-        grid_2  = m_policy.m_tile_end[2];
-      } else {
-        block.x = m_policy.m_tile[2];
-        block.y = m_policy.m_tile[1];
-        block.z = m_policy.m_tile[0];
-        grid_0  = m_policy.m_tile_end[2];
-        grid_1  = m_policy.m_tile_end[1];
-        grid_2  = m_policy.m_tile_end[0];
-      }
-    } else {  // rank > 3
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank >= 4) {
-          block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
-          block.y = m_policy.m_tile[2];
-          block.z = m_policy.m_tile[3];
-          grid_0  = m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
-          grid_1  = m_policy.m_tile_end[2];
-          grid_2  = m_policy.m_tile_end[3];
-        }
-        if constexpr (Policy::rank >= 5) {
-          block.y = m_policy.m_tile[2] * m_policy.m_tile[3];
-          block.z = m_policy.m_tile[4];
-          grid_1  = m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
-          grid_2  = m_policy.m_tile_end[4];
-        }
-        if constexpr (Policy::rank >= 6) {
-          block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
-          grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
-        }
-      } else {  // InnerDirection == Right
-        if constexpr (Policy::rank >= 4) {
-          block.x = m_policy.m_tile[Policy::rank - 1] *
-                    m_policy.m_tile[Policy::rank - 2];
-          block.y = m_policy.m_tile[Policy::rank - 3];
-          block.z = m_policy.m_tile[Policy::rank - 4];
-          grid_0  = m_policy.m_tile_end[Policy::rank - 1] *
-                   m_policy.m_tile_end[Policy::rank - 2];
-          grid_1 = m_policy.m_tile_end[Policy::rank - 3];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 4];
-        }
-        if constexpr (Policy::rank >= 5) {
-          block.y = m_policy.m_tile[Policy::rank - 3] *
-                    m_policy.m_tile[Policy::rank - 4];
-          block.z = m_policy.m_tile[Policy::rank - 5];
-          grid_1  = m_policy.m_tile_end[Policy::rank - 3] *
-                   m_policy.m_tile_end[Policy::rank - 4];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 5];
-        }
-        if constexpr (Policy::rank >= 6) {
-          block.z = m_policy.m_tile[Policy::rank - 5] *
-                    m_policy.m_tile[Policy::rank - 6];
-          grid_2 = m_policy.m_tile_end[Policy::rank - 5] *
-                   m_policy.m_tile_end[Policy::rank - 6];
-        }
-      }
-    }
-    grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     hip_parallel_launch<ClosureType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
         false);
@@ -157,14 +76,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     // Swap the fastest indexes to x dimension
     for (array_index_type i = 0; i < Policy::rank; ++i) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        m_lower[i]       = m_policy.m_lower[i];
-        m_upper[i]       = m_policy.m_upper[i];
-        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+        m_lower[i]  = m_policy.m_lower[i];
+        m_upper[i]  = m_policy.m_upper[i];
+        m_extent[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
       } else {
-        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
-        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
-        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
-                           m_policy.m_tile_end[Policy::rank - 1 - i];
+        m_lower[i]  = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]  = m_policy.m_upper[Policy::rank - 1 - i];
+        m_extent[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                      m_policy.m_tile_end[Policy::rank - 1 - i];
       }
     }
   }

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -48,41 +48,58 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     if (m_policy.m_num_tiles == 0) return;
 
     if (Policy::rank == 2) {
-      // id0 to threadIdx.x; id1 to threadIdx.y
-      dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1], 1);
+      const array_index_type block_0 = m_policy.m_tile[0];
+      const array_index_type block_1 = m_policy.m_tile[1];
 
-      dim3 const grid(
-          std::min<array_index_type>(
-              (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
-                  block.x,
-              m_max_grid_size[0]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
-                  block.y,
-              m_max_grid_size[1]),
-          1);
+      const array_index_type grid_0 =
+          (m_policy.m_upper[0] - m_policy.m_lower[0] + block_0 - 1) / block_0;
+      const array_index_type grid_1 =
+          (m_policy.m_upper[1] - m_policy.m_lower[1] + block_1 - 1) / block_1;
+
+      dim3 grid(1, 1, 1);
+      dim3 block(1, 1, 1);
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y
+        block = dim3(block_0, block_1, 1);
+        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]), 1);
+      } else {
+        // Iterate::Right, map id1->x, id0->y
+        block = dim3(block_1, block_0, 1);
+        grid  = dim3(std::min<array_index_type>(grid_1, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_0, m_max_grid_size[1]), 1);
+      }
 
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
     } else if (Policy::rank == 3) {
-      // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
-      dim3 const block(m_policy.m_tile[0], m_policy.m_tile[1],
-                       m_policy.m_tile[2]);
+      const array_index_type block_0 = m_rp.m_tile[0];
+      const array_index_type block_1 = m_rp.m_tile[1];
+      const array_index_type block_2 = m_rp.m_tile[2];
 
-      dim3 const grid(
-          std::min<array_index_type>(
-              (m_policy.m_upper[0] - m_policy.m_lower[0] + block.x - 1) /
-                  block.x,
-              m_max_grid_size[0]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[1] - m_policy.m_lower[1] + block.y - 1) /
-                  block.y,
-              m_max_grid_size[1]),
-          std::min<array_index_type>(
-              (m_policy.m_upper[2] - m_policy.m_lower[2] + block.z - 1) /
-                  block.z,
-              m_max_grid_size[2]));
+      const array_index_type grid_0 =
+          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
+      const array_index_type grid_1 =
+          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
+      const array_index_type grid_2 =
+          (m_rp.m_upper[2] - m_rp.m_lower[2] + block_2 - 1) / block_2;
+
+      dim3 grid(1, 1, 1);
+      dim3 block(1, 1, 1);
+      if constexpr (RP::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y, id2->z
+        block = dim3(block_0, block_1, block_2);
+        grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                     std::min<array_index_type>(grid_2, m_max_grid_size[2]));
+      } else {
+        // Iterate::Right, map id2->x, id1->y, id0->z
+        block = dim3(block_2, block_1, block_0);
+        grid  = dim3(std::min<array_index_type>(grid_2, m_max_grid_size[0]),
+                     std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                     std::min<array_index_type>(grid_0, m_max_grid_size[2]));
+      }
 
       hip_parallel_launch<ClosureType, LaunchBounds>(
           *this, grid, block, 0,

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -74,17 +74,16 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
           *this, grid, block, 0,
           m_policy.space().impl_internal_space_instance(), false);
     } else if (Policy::rank == 3) {
-      const array_index_type block_0 = m_rp.m_tile[0];
-      const array_index_type block_1 = m_rp.m_tile[1];
-      const array_index_type block_2 = m_rp.m_tile[2];
+      const array_index_type block_0 = m_policy.m_tile[0];
+      const array_index_type block_1 = m_policy.m_tile[1];
+      const array_index_type block_2 = m_policy.m_tile[2];
 
       const array_index_type grid_0 =
-          (m_rp.m_upper[0] - m_rp.m_lower[0] + block_0 - 1) / block_0;
+          (m_policy.m_upper[0] - m_policy.m_lower[0] + block_0 - 1) / block_0;
       const array_index_type grid_1 =
-          (m_rp.m_upper[1] - m_rp.m_lower[1] + block_1 - 1) / block_1;
+          (m_policy.m_upper[1] - m_policy.m_lower[1] + block_1 - 1) / block_1;
       const array_index_type grid_2 =
-          (m_rp.m_upper[2] - m_rp.m_lower[2] + block_2 - 1) / block_2;
-
+          (m_policy.m_upper[2] - m_policy.m_lower[2] + block_2 - 1) / block_2;
       dim3 grid(1, 1, 1);
       dim3 block(1, 1, 1);
       if constexpr (RP::inner_direction == Iterate::Left) {

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -56,36 +56,40 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     dim3 grid(1, 1, 1);
     dim3 block(1, 1, 1);
 
+    array_index_type grid_0 = 1;
+    array_index_type grid_1 = 1;
+    array_index_type grid_2 = 1;
     if constexpr (Policy::rank == 2) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
         block.x = m_policy.m_tile[0];
         block.y = m_policy.m_tile[1];
-        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[0],
-                                            m_max_grid_size[0]);
-        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[1],
-                                            m_max_grid_size[1]);
+        grid_0  = m_policy.m_tile_end[0];
+        grid_1  = m_policy.m_tile_end[1];
       } else {
         block.x = m_policy.m_tile[1];
         block.y = m_policy.m_tile[0];
-        grid.x  = std::min<array_index_type>(m_policy.m_tile_end[1],
-                                            m_max_grid_size[0]);
-        grid.y  = std::min<array_index_type>(m_policy.m_tile_end[0],
-                                            m_max_grid_size[1]);
+        grid_0  = m_policy.m_tile_end[1];
+        grid_1  = m_policy.m_tile_end[0];
       }
-    } else if constexpr (Policy::rank >= 3) {
-      array_index_type grid_0 = 1;
-      array_index_type grid_1 = 1;
-      array_index_type grid_2 = 1;
-
+    } else if constexpr (Policy::rank == 3) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank == 3) {
-          block.x = m_policy.m_tile[0];
-          block.y = m_policy.m_tile[1];
-          block.z = m_policy.m_tile[2];
-          grid_0  = m_policy.m_tile_end[0];
-          grid_1  = m_policy.m_tile_end[1];
-          grid_2  = m_policy.m_tile_end[2];
-        } else if constexpr (Policy::rank >= 4) {
+        block.x = m_policy.m_tile[0];
+        block.y = m_policy.m_tile[1];
+        block.z = m_policy.m_tile[2];
+        grid_0  = m_policy.m_tile_end[0];
+        grid_1  = m_policy.m_tile_end[1];
+        grid_2  = m_policy.m_tile_end[2];
+      } else {
+        block.x = m_policy.m_tile[2];
+        block.y = m_policy.m_tile[1];
+        block.z = m_policy.m_tile[0];
+        grid_0  = m_policy.m_tile_end[2];
+        grid_1  = m_policy.m_tile_end[1];
+        grid_2  = m_policy.m_tile_end[0];
+      }
+    } else {  // rank > 3
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        if constexpr (Policy::rank >= 4) {
           block.x = m_policy.m_tile[0] * m_policy.m_tile[1];
           block.y = m_policy.m_tile[2];
           block.z = m_policy.m_tile[3];
@@ -103,15 +107,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
           block.z = m_policy.m_tile[4] * m_policy.m_tile[5];
           grid_2  = m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
         }
-      } else {
-        if constexpr (Policy::rank == 3) {
-          block.x = m_policy.m_tile[2];
-          block.y = m_policy.m_tile[1];
-          block.z = m_policy.m_tile[0];
-          grid_0  = m_policy.m_tile_end[2];
-          grid_1  = m_policy.m_tile_end[1];
-          grid_2  = m_policy.m_tile_end[0];
-        } else if constexpr (Policy::rank >= 4) {
+      } else {  // InnerDirection == Right
+        if constexpr (Policy::rank >= 4) {
           block.x = m_policy.m_tile[Policy::rank - 1] *
                     m_policy.m_tile[Policy::rank - 2];
           block.y = m_policy.m_tile[Policy::rank - 3];
@@ -136,15 +133,13 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
                    m_policy.m_tile_end[Policy::rank - 6];
         }
       }
-      grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
-                  std::min<array_index_type>(grid_1, m_max_grid_size[1]),
-                  std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     }
-
+    grid = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),
+                std::min<array_index_type>(grid_1, m_max_grid_size[1]),
+                std::min<array_index_type>(grid_2, m_max_grid_size[2]));
     hip_parallel_launch<ClosureType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
         false);
-
   }  // end execute
 
   ParallelFor(FunctorType const& arg_functor, Policy const& arg_policy)

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -86,7 +86,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
           (m_policy.m_upper[2] - m_policy.m_lower[2] + block_2 - 1) / block_2;
       dim3 grid(1, 1, 1);
       dim3 block(1, 1, 1);
-      if constexpr (RP::inner_direction == Iterate::Left) {
+      if constexpr (Policy::inner_direction == Iterate::Left) {
         // Iterate::Left, map id0->x, id1->y, id2->z
         block = dim3(block_0, block_1, block_2);
         grid  = dim3(std::min<array_index_type>(grid_0, m_max_grid_size[0]),

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -170,6 +170,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         const index_type local_x    = item.get_local_id(2);
         const index_type local_y    = item.get_local_id(1);
         const index_type local_z    = item.get_local_id(0);
+        const index_type n_local_x  = item.get_local_range(2);
+        const index_type n_local_y  = item.get_local_range(1);
+        const index_type n_local_z  = item.get_local_range(0);
         const index_type global_x   = item.get_group(2);
         const index_type global_y   = item.get_group(1);
         const index_type global_z   = item.get_group(0);
@@ -181,7 +184,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                                         MaxGridSize, typename Policy::work_tag>(
             bare_policy, functor_wrapper.get_functor(), max_grid_size,
             {n_global_x, n_global_y, n_global_z},
-            {global_x, global_y, global_z}, {local_x, local_y, local_z})
+            {n_local_x, n_local_y, n_local_z}, {global_x, global_y, global_z},
+            {local_x, local_y, local_z})
             .exec_range();
       });
     };

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -141,9 +141,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     if (m_policy.m_num_tiles == 0) return {};
 
-    const auto lower_bound   = m_lower;
-    const auto upper_bound   = m_upper;
-    const auto m_max_threads = m_max_threads;
+    const auto lower_bound = m_lower;
+    const auto upper_bound = m_upper;
+    const auto max_threads = m_max_threads;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -161,7 +161,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       (void)memcpy_event;
 #endif
       cgh.parallel_for(sycl_swapped_range, [lower_bound, upper_bound,
-                                            max_threads](
+                                            max_threads, functor_wrapper](
                                                sycl::nd_item<3> item) {
         // swap back for correct index calculations in DeviceIterateTile
         const index_type local_x    = item.get_local_id(2);
@@ -180,8 +180,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
                                     FunctorType, Policy::inner_direction,
                                     typename Policy::work_tag>(
-            lower_bound, upper_bound, max_threads, m_functor,
-            {n_global_x, n_global_y, n_global_z},
+            lower_bound, upper_bound, max_threads,
+            functor_wrapper.get_functor(), {n_global_x, n_global_y, n_global_z},
             {n_local_x, n_local_y, n_local_z}, {global_x, global_y, global_z},
             {local_x, local_y, local_z})
             .exec_range();

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -25,146 +25,112 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using index_type       = typename Policy::index_type;
   using WorkTag          = typename Policy::work_tag;
   using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
-  // MDRangePolicy is not trivially copyable. Hence, replicate the data we
-  // really need in DeviceIterateTile in a trivially copyable struct.
-  const struct BarePolicy {
-    using index_type = typename Policy::index_type;
-
-    BarePolicy(const Policy& policy)
-        : m_lower(policy.m_lower),
-          m_upper(policy.m_upper),
-          m_tile(policy.m_tile),
-          m_tile_end(policy.m_tile_end),
-          m_num_tiles(policy.m_num_tiles) {}
-
-    const typename Policy::point_type m_lower;
-    const typename Policy::point_type m_upper;
-    const typename Policy::tile_type m_tile;
-    const typename Policy::point_type m_tile_end;
-    const typename Policy::index_type m_num_tiles;
-    static constexpr Iterate inner_direction = Policy::inner_direction;
-  } m_policy;
+  const Policy m_policy;
   const MaxGridSize m_max_grid_size;
   const Kokkos::SYCL& m_space;
 
+  array_type m_lower;
+  array_type m_upper;
+  array_type m_max_threads;
+
   sycl::nd_range<3> compute_ranges() const {
+    static_assert(Policy::rank > 1 && Policy::rank < 7,
+                  "Kokkos::MDRange Error: Exceeded rank bounds with SYCL\n");
+
     const auto& m_tile     = m_policy.m_tile;
     const auto& m_tile_end = m_policy.m_tile_end;
 
+    sycl::range<3> local_sizes(1, 1, 1);
+    sycl::range<3> global_sizes(1, 1, 1);
+
     if constexpr (Policy::rank == 2) {
-      const array_index_type local_0 = m_tile[0];
-      const array_index_type local_1 = m_tile[1];
-
-      const array_index_type global_0 =
-          (m_policy.m_upper[0] - m_policy.m_lower[0] + local_0 - 1) / local_0;
-      const array_index_type global_1 =
-          (m_policy.m_upper[1] - m_policy.m_lower[1] + local_1 - 1) / local_1;
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        local_sizes[0] = m_tile[0];
+        local_sizes[1] = m_tile[1];
+        global_sizes[0] =
+            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]);
+        global_sizes[1] =
+            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]);
+      } else {
+        local_sizes[0] = m_tile[1];
+        local_sizes[1] = m_tile[0];
+        global_sizes[0] =
+            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[0]);
+        global_sizes[1] =
+            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[1]);
+      }
+    } else if constexpr (Policy::rank >= 3) {
+      array_index_type global_0 = 1;
+      array_index_type global_1 = 1;
+      array_index_type global_2 = 1;
 
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y
-        sycl::range<3> local_sizes(local_0, local_1, 1);
-        sycl::range<3> global_sizes(
-            std::min<array_index_type>(global_0, m_max_grid_size[0]) * local_0,
-            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
-            1);
-        return {global_sizes, local_sizes};
+        if constexpr (Policy::rank == 3) {
+          local_sizes[0] = m_tile[0];
+          local_sizes[1] = m_tile[1];
+          local_sizes[2] = m_tile[2];
+          global_0       = m_tile_end[0];
+          global_1       = m_tile_end[1];
+          global_2       = m_tile_end[2];
+        } else if constexpr (Policy::rank >= 4) {
+          local_sizes[0] = m_tile[0] * m_tile[1];
+          local_sizes[1] = m_tile[2];
+          local_sizes[2] = m_tile[3];
+          global_0       = m_tile_end[0] * m_tile_end[1];
+          global_1       = m_tile_end[2];
+          global_2       = m_tile_end[3];
+        }
+        if constexpr (Policy::rank >= 5) {
+          local_sizes[1] = m_tile[2] * m_tile[3];
+          local_sizes[2] = m_tile[4];
+          global_1       = m_tile_end[2] * m_tile_end[3];
+          global_2       = m_tile_end[4];
+        }
+        if constexpr (Policy::rank >= 6) {
+          local_sizes[2] = m_tile[4] * m_tile[5];
+          global_2       = m_tile_end[4] * m_tile_end[5];
+        }
       } else {
-        // Iterate::Right, map id1->x, id0->y
-        sycl::range<3> local_sizes(local_1, local_0, 1);
-        sycl::range<3> global_sizes(
-            std::min<array_index_type>(global_1, m_max_grid_size[0]) * local_1,
-            std::min<array_index_type>(global_0, m_max_grid_size[1]) * local_0,
-            1);
-        return {global_sizes, local_sizes};
+        if constexpr (Policy::rank == 3) {
+          local_sizes[0] = m_tile[2];
+          local_sizes[1] = m_tile[1];
+          local_sizes[2] = m_tile[0];
+          global_0       = m_tile_end[2];
+          global_1       = m_tile_end[1];
+          global_2       = m_tile_end[0];
+        } else if constexpr (Policy::rank >= 4) {
+          local_sizes[0] = m_tile[Policy::rank - 1] * m_tile[Policy::rank - 2];
+          local_sizes[1] = m_tile[Policy::rank - 3];
+          local_sizes[2] = m_tile[Policy::rank - 4];
+          global_0 =
+              m_tile_end[Policy::rank - 1] * m_tile_end[Policy::rank - 2];
+          global_1 = m_tile_end[Policy::rank - 3];
+          global_2 = m_tile_end[Policy::rank - 4];
+        }
+        if constexpr (Policy::rank >= 5) {
+          local_sizes[1] = m_tile[Policy::rank - 3] * m_tile[Policy::rank - 4];
+          local_sizes[2] = m_tile[Policy::rank - 5];
+          global_1 =
+              m_tile_end[Policy::rank - 3] * m_tile_end[Policy::rank - 4];
+          global_2 = m_tile_end[Policy::rank - 5];
+        }
+        if constexpr (Policy::rank >= 6) {
+          local_sizes[2] = m_tile[Policy::rank - 5] * m_tile[Policy::rank - 6];
+          global_2 =
+              m_tile_end[Policy::rank - 5] * m_tile_end[Policy::rank - 6];
+        }
       }
+      global_sizes[0] =
+          std::min<array_index_type>(global_0, m_max_grid_size[0]);
+      global_sizes[1] =
+          std::min<array_index_type>(global_1, m_max_grid_size[1]);
+      global_sizes[2] =
+          std::min<array_index_type>(global_2, m_max_grid_size[2]);
     }
-    if constexpr (Policy::rank == 3) {
-      const array_index_type local_0 = m_tile[0];
-      const array_index_type local_1 = m_tile[1];
-      const array_index_type local_2 = m_tile[2];
-
-      const array_index_type global_0 =
-          (m_policy.m_upper[0] - m_policy.m_lower[0] + local_0 - 1) / local_0;
-      const array_index_type global_1 =
-          (m_policy.m_upper[1] - m_policy.m_lower[1] + local_1 - 1) / local_1;
-      const array_index_type global_2 =
-          (m_policy.m_upper[2] - m_policy.m_lower[2] + local_2 - 1) / local_2;
-
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        // Iterate::Left, map id0->x, id1->y, id2->z
-        sycl::range<3> local_sizes(local_0, local_1, local_2);
-        sycl::range<3> global_sizes(
-            std::min<array_index_type>(global_0, m_max_grid_size[0]) * local_0,
-            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
-            std::min<array_index_type>(global_2, m_max_grid_size[2]) * local_2);
-        return {global_sizes, local_sizes};
-      } else {
-        // Iterate::Right, map id2->z, id1->y, id0->x
-        sycl::range<3> local_sizes(local_2, local_1, local_0);
-        sycl::range<3> global_sizes(
-            std::min<array_index_type>(global_2, m_max_grid_size[0]) * local_2,
-            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
-            std::min<array_index_type>(global_0, m_max_grid_size[2]) * local_0);
-        return {global_sizes, local_sizes};
-      }
-    }
-    if constexpr (Policy::rank == 4) {
-      // id0,id1 encoded within first index; id2 to second index; id3 to third
-      // index
-      sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2], m_tile[3]);
-
-      sycl::range<3> global_sizes(
-          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
-                                     m_max_grid_size[0]) *
-              m_tile[0] * m_tile[1],
-          std::min<array_index_type>(m_tile_end[2], m_max_grid_size[1]) *
-              m_tile[2],
-          std::min<array_index_type>(m_tile_end[3], m_max_grid_size[2]) *
-              m_tile[3]);
-
-      return {global_sizes, local_sizes};
-    }
-    if constexpr (Policy::rank == 5) {
-      // id0,id1 encoded within first index; id2,id3 to second index; id4 to
-      // third index
-      sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2] * m_tile[3],
-                                 m_tile[4]);
-
-      sycl::range<3> global_sizes(
-          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
-                                     m_max_grid_size[0]) *
-              m_tile[0] * m_tile[1],
-          std::min<array_index_type>(m_tile_end[2] * m_tile_end[3],
-                                     m_max_grid_size[1]) *
-              m_tile[2] * m_tile[3],
-          std::min<array_index_type>(m_tile_end[4], m_max_grid_size[2]) *
-              m_tile[4]);
-
-      return {global_sizes, local_sizes};
-    }
-    if constexpr (Policy::rank == 6) {
-      // id0,id1 encoded within first index; id2,id3 to second index; id4,id5 to
-      // third index
-      sycl::range<3> local_sizes(m_tile[0] * m_tile[1], m_tile[2] * m_tile[3],
-                                 m_tile[4] * m_tile[5]);
-
-      sycl::range<3> global_sizes(
-          std::min<array_index_type>(m_tile_end[0] * m_tile_end[1],
-                                     m_max_grid_size[0]) *
-              m_tile[0] * m_tile[1],
-          std::min<array_index_type>(m_tile_end[2] * m_tile_end[3],
-                                     m_max_grid_size[1]) *
-              m_tile[2] * m_tile[3],
-          std::min<array_index_type>(m_tile_end[4] * m_tile_end[5],
-                                     m_max_grid_size[2]) *
-              m_tile[4] * m_tile[5]);
-
-      return {global_sizes, local_sizes};
-    }
-    static_assert(Policy::rank > 1 && Policy::rank < 7,
-                  "Kokkos::MDRange Error: Exceeded rank bounds with SYCL\n");
+    return {global_sizes, local_sizes};
   }
 
   template <typename FunctorWrapper>
@@ -175,8 +141,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     if (m_policy.m_num_tiles == 0) return {};
 
-    const BarePolicy bare_policy(m_policy);
-    const auto& max_grid_size = m_max_grid_size;
+    const auto lower_bound   = m_lower;
+    const auto upper_bound   = m_upper;
+    const auto m_max_threads = m_max_threads;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -193,8 +160,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 #else
       (void)memcpy_event;
 #endif
-      cgh.parallel_for(sycl_swapped_range, [functor_wrapper, bare_policy,
-                                            max_grid_size](
+      cgh.parallel_for(sycl_swapped_range, [lower_bound, upper_bound,
+                                            max_threads](
                                                sycl::nd_item<3> item) {
         // swap back for correct index calculations in DeviceIterateTile
         const index_type local_x    = item.get_local_id(2);
@@ -210,9 +177,10 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         const index_type n_global_y = item.get_group_range(1);
         const index_type n_global_z = item.get_group_range(0);
 
-        Kokkos::Impl::DeviceIterateTile<Policy::rank, BarePolicy, FunctorType,
-                                        MaxGridSize, typename Policy::work_tag>(
-            bare_policy, functor_wrapper.get_functor(), max_grid_size,
+        Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
+                                    FunctorType, Policy::inner_direction,
+                                    typename Policy::work_tag>(
+            lower_bound, upper_bound, max_threads, m_functor,
             {n_global_x, n_global_y, n_global_z},
             {n_local_x, n_local_y, n_local_z}, {global_x, global_y, global_z},
             {local_x, local_y, local_z})
@@ -287,7 +255,22 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_max_grid_size(get_max_grid_size(arg_policy)),
-        m_space(arg_policy.space()) {}
+        m_space(arg_policy.space()) {
+    // Initialize begins and ends based on layout
+    // Swap the fastest indexes to x dimension
+    for (array_index_type i = 0; i < Policy::rank; ++i) {
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        m_lower[i]       = m_policy.m_lower[i];
+        m_upper[i]       = m_policy.m_upper[i];
+        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+      } else {
+        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
+        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                           m_policy.m_tile_end[Policy::rank - 1 - i];
+      }
+    }
+  }
 };
 
 #endif  // KOKKOS_SYCL_PARALLEL_FOR_MDRANGE_HPP_

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -51,16 +51,20 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         local_sizes[0] = m_tile[0];
         local_sizes[1] = m_tile[1];
         global_sizes[0] =
-            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]);
+            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
+            m_tile[0];
         global_sizes[1] =
-            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]);
+            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
+            m_tile[1];
       } else {
         local_sizes[0] = m_tile[1];
         local_sizes[1] = m_tile[0];
         global_sizes[0] =
-            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[0]);
+            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[0]) *
+            m_tile[1];
         global_sizes[1] =
-            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[1]);
+            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[1]) *
+            m_tile[0];
       }
     } else if constexpr (Policy::rank >= 3) {
       array_index_type global_0 = 1;
@@ -124,11 +128,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         }
       }
       global_sizes[0] =
-          std::min<array_index_type>(global_0, m_max_grid_size[0]);
+          std::min<array_index_type>(global_0, m_max_grid_size[0]) *
+          local_sizes[0];
       global_sizes[1] =
-          std::min<array_index_type>(global_1, m_max_grid_size[1]);
+          std::min<array_index_type>(global_1, m_max_grid_size[1]) *
+          local_sizes[1];
       global_sizes[2] =
-          std::min<array_index_type>(global_2, m_max_grid_size[2]);
+          std::min<array_index_type>(global_2, m_max_grid_size[2]) *
+          local_sizes[2];
     }
     return {global_sizes, local_sizes};
   }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -54,31 +54,61 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     const auto& m_tile_end = m_policy.m_tile_end;
 
     if constexpr (Policy::rank == 2) {
-      // id0 to threadIdx.x; id1 to threadIdx.y
-      sycl::range<3> local_sizes(m_tile[0], m_tile[1], 1);
+      const array_index_type local_0 = m_tile[0];
+      const array_index_type local_1 = m_tile[1];
 
-      sycl::range<3> global_sizes(
-          std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
-              m_tile[0],
-          std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
-              m_tile[1],
-          1);
+      const array_index_type global_0 =
+          (m_policy.m_upper[0] - m_policy.m_lower[0] + local_0 - 1) / local_0;
+      const array_index_type global_1 =
+          (m_policy.m_upper[1] - m_policy.m_lower[1] + local_1 - 1) / local_1;
 
-      return {global_sizes, local_sizes};
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y
+        sycl::range<3> local_sizes(local_0, local_1, 1);
+        sycl::range<3> global_sizes(
+            std::min<array_index_type>(global_0, m_max_grid_size[0]) * local_0,
+            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
+            1);
+        return {global_sizes, local_sizes};
+      } else {
+        // Iterate::Right, map id1->x, id0->y
+        sycl::range<3> local_sizes(local_1, local_0, 1);
+        sycl::range<3> global_sizes(
+            std::min<array_index_type>(global_1, m_max_grid_size[0]) * local_1,
+            std::min<array_index_type>(global_0, m_max_grid_size[1]) * local_0,
+            1);
+        return {global_sizes, local_sizes};
+      }
     }
     if constexpr (Policy::rank == 3) {
-      // id0 to threadIdx.x; id1 to threadIdx.y; id2 to threadIdx.z
-      sycl::range<3> local_sizes(m_tile[0], m_tile[1], m_tile[2]);
+      const array_index_type local_0 = m_tile[0];
+      const array_index_type local_1 = m_tile[1];
+      const array_index_type local_2 = m_tile[2];
 
-      sycl::range<3> global_sizes(
-          std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
-              m_tile[0],
-          std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
-              m_tile[1],
-          std::min<array_index_type>(m_tile_end[2], m_max_grid_size[2]) *
-              m_tile[2]);
+      const array_index_type global_0 =
+          (m_policy.m_upper[0] - m_policy.m_lower[0] + local_0 - 1) / local_0;
+      const array_index_type global_1 =
+          (m_policy.m_upper[1] - m_policy.m_lower[1] + local_1 - 1) / local_1;
+      const array_index_type global_2 =
+          (m_policy.m_upper[2] - m_policy.m_lower[2] + local_2 - 1) / local_2;
 
-      return {global_sizes, local_sizes};
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        // Iterate::Left, map id0->x, id1->y, id2->z
+        sycl::range<3> local_sizes(local_0, local_1, local_2);
+        sycl::range<3> global_sizes(
+            std::min<array_index_type>(global_0, m_max_grid_size[0]) * local_0,
+            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
+            std::min<array_index_type>(global_2, m_max_grid_size[2]) * local_2);
+        return {global_sizes, local_sizes};
+      } else {
+        // Iterate::Right, map id2->z, id1->x, id0->y
+        sycl::range<3> local_sizes(local_2, local_1, local_0);
+        sycl::range<3> global_sizes(
+            std::min<array_index_type>(global_2, m_max_grid_size[0]) * local_2,
+            std::min<array_index_type>(global_1, m_max_grid_size[1]) * local_1,
+            std::min<array_index_type>(global_0, m_max_grid_size[2]) * local_0);
+        return {global_sizes, local_sizes};
+      }
     }
     if constexpr (Policy::rank == 4) {
       // id0,id1 encoded within first index; id2 to second index; id3 to third

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -30,7 +30,6 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   const FunctorType m_functor;
   const Policy m_policy;
   const MaxGridSize m_max_grid_size;
-  const Kokkos::SYCL& m_space;
 
   array_type m_lower;
   array_type m_upper;
@@ -40,7 +39,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   sycl::event sycl_direct_launch(const FunctorWrapper& functor_wrapper,
                                  const sycl::event& memcpy_event) const {
     // Convenience references
-    sycl::queue& q = m_space.sycl_queue();
+    const Kokkos::SYCL& space = m_policy.space();
+    sycl::queue& q            = space.sycl_queue();
 
     if (m_policy.m_num_tiles == 0) return {};
 
@@ -146,8 +146,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   }
 
   void execute() const {
+    auto space_instance = m_policy.space().impl_internal_space_instance();
     Kokkos::Impl::SYCLInternal::IndirectKernelMem& indirectKernelMem =
-        m_space.impl_internal_space_instance()->get_indirect_kernel_mem();
+        space_instance->get_indirect_kernel_mem();
 
     auto functor_wrapper =
         Impl::make_sycl_function_wrapper(m_functor, indirectKernelMem);
@@ -159,8 +160,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
       : m_functor(arg_functor),
         m_policy(arg_policy),
-        m_max_grid_size(get_max_grid_size(arg_policy)),
-        m_space(arg_policy.space()) {
+        m_max_grid_size(get_max_grid_size(arg_policy)) {
     // Initialize begins and ends based on layout
     // Swap the fastest indexes to x dimension
     for (array_index_type i = 0; i < Policy::rank; ++i) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -36,100 +36,6 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   array_type m_upper;
   array_type m_max_threads;
 
-  sycl::nd_range<3> compute_ranges() const {
-    static_assert(Policy::rank > 1 && Policy::rank < 7,
-                  "Kokkos::MDRange Error: Exceeded rank bounds with SYCL\n");
-
-    const auto& m_tile     = m_policy.m_tile;
-    const auto& m_tile_end = m_policy.m_tile_end;
-
-    sycl::range<3> local_sizes(1, 1, 1);
-    sycl::range<3> global_sizes(1, 1, 1);
-
-    array_index_type global_0 = 1;
-    array_index_type global_1 = 1;
-    array_index_type global_2 = 1;
-    if constexpr (Policy::rank == 2) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        local_sizes[0] = m_tile[0];
-        local_sizes[1] = m_tile[1];
-        global_0       = m_tile_end[0];
-        global_1       = m_tile_end[1];
-      } else {
-        local_sizes[0] = m_tile[1];
-        local_sizes[1] = m_tile[0];
-        global_0       = m_tile_end[1];
-        global_1       = m_tile_end[0];
-      }
-    } else if constexpr (Policy::rank == 3) {
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        local_sizes[0] = m_tile[0];
-        local_sizes[1] = m_tile[1];
-        local_sizes[2] = m_tile[2];
-        global_0       = m_tile_end[0];
-        global_1       = m_tile_end[1];
-        global_2       = m_tile_end[2];
-      } else {
-        local_sizes[0] = m_tile[2];
-        local_sizes[1] = m_tile[1];
-        local_sizes[2] = m_tile[0];
-        global_0       = m_tile_end[2];
-        global_1       = m_tile_end[1];
-        global_2       = m_tile_end[0];
-      }
-    } else {  // rank > 3
-      if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank >= 4) {
-          local_sizes[0] = m_tile[0] * m_tile[1];
-          local_sizes[1] = m_tile[2];
-          local_sizes[2] = m_tile[3];
-          global_0       = m_tile_end[0] * m_tile_end[1];
-          global_1       = m_tile_end[2];
-          global_2       = m_tile_end[3];
-        }
-        if constexpr (Policy::rank >= 5) {
-          local_sizes[1] = m_tile[2] * m_tile[3];
-          local_sizes[2] = m_tile[4];
-          global_1       = m_tile_end[2] * m_tile_end[3];
-          global_2       = m_tile_end[4];
-        }
-        if constexpr (Policy::rank >= 6) {
-          local_sizes[2] = m_tile[4] * m_tile[5];
-          global_2       = m_tile_end[4] * m_tile_end[5];
-        }
-      } else {  // InnerDirection == Right
-        if constexpr (Policy::rank >= 4) {
-          local_sizes[0] = m_tile[Policy::rank - 1] * m_tile[Policy::rank - 2];
-          local_sizes[1] = m_tile[Policy::rank - 3];
-          local_sizes[2] = m_tile[Policy::rank - 4];
-          global_0 =
-              m_tile_end[Policy::rank - 1] * m_tile_end[Policy::rank - 2];
-          global_1 = m_tile_end[Policy::rank - 3];
-          global_2 = m_tile_end[Policy::rank - 4];
-        }
-        if constexpr (Policy::rank >= 5) {
-          local_sizes[1] = m_tile[Policy::rank - 3] * m_tile[Policy::rank - 4];
-          local_sizes[2] = m_tile[Policy::rank - 5];
-          global_1 =
-              m_tile_end[Policy::rank - 3] * m_tile_end[Policy::rank - 4];
-          global_2 = m_tile_end[Policy::rank - 5];
-        }
-        if constexpr (Policy::rank >= 6) {
-          local_sizes[2] = m_tile[Policy::rank - 5] * m_tile[Policy::rank - 6];
-          global_2 =
-              m_tile_end[Policy::rank - 5] * m_tile_end[Policy::rank - 6];
-        }
-      }
-    }
-    global_sizes[0] = std::min<array_index_type>(global_0, m_max_grid_size[0]) *
-                      local_sizes[0];
-    global_sizes[1] = std::min<array_index_type>(global_1, m_max_grid_size[1]) *
-                      local_sizes[1];
-    global_sizes[2] = std::min<array_index_type>(global_2, m_max_grid_size[2]) *
-                      local_sizes[2];
-    return {global_sizes, local_sizes};
-  }
-
   template <typename FunctorWrapper>
   sycl::event sycl_direct_launch(const FunctorWrapper& functor_wrapper,
                                  const sycl::event& memcpy_event) const {
@@ -145,7 +51,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     desul::ensure_sycl_lock_arrays_on_device(q);
 
     auto cgh_lambda = [&](sycl::handler& cgh) {
-      const auto range                  = compute_ranges();
+      const auto range =
+          Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
       const sycl::range<3> global_range = range.get_global_range();
       const sycl::range<3> local_range  = range.get_local_range();
       const sycl::nd_range sycl_swapped_range{

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -50,9 +50,10 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
-    auto cgh_lambda = [&](sycl::handler& cgh) {
-      const auto range =
-          Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
+    const auto range =
+        Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
+
+    auto cgh_lambda = [&, range](sycl::handler& cgh) {
       const sycl::range<3> global_range = range.get_global_range();
       const sycl::range<3> local_range  = range.get_local_range();
       const sycl::nd_range sycl_swapped_range{

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -101,7 +101,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
             std::min<array_index_type>(global_2, m_max_grid_size[2]) * local_2);
         return {global_sizes, local_sizes};
       } else {
-        // Iterate::Right, map id2->z, id1->x, id0->y
+        // Iterate::Right, map id2->z, id1->y, id0->x
         sycl::range<3> local_sizes(local_2, local_1, local_0);
         sycl::range<3> global_sizes(
             std::min<array_index_type>(global_2, m_max_grid_size[0]) * local_2,

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -46,40 +46,40 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     sycl::range<3> local_sizes(1, 1, 1);
     sycl::range<3> global_sizes(1, 1, 1);
 
+    array_index_type global_0 = 1;
+    array_index_type global_1 = 1;
+    array_index_type global_2 = 1;
     if constexpr (Policy::rank == 2) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
         local_sizes[0] = m_tile[0];
         local_sizes[1] = m_tile[1];
-        global_sizes[0] =
-            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[0]) *
-            m_tile[0];
-        global_sizes[1] =
-            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[1]) *
-            m_tile[1];
+        global_0       = m_tile_end[0];
+        global_1       = m_tile_end[1];
       } else {
         local_sizes[0] = m_tile[1];
         local_sizes[1] = m_tile[0];
-        global_sizes[0] =
-            std::min<array_index_type>(m_tile_end[1], m_max_grid_size[0]) *
-            m_tile[1];
-        global_sizes[1] =
-            std::min<array_index_type>(m_tile_end[0], m_max_grid_size[1]) *
-            m_tile[0];
+        global_0       = m_tile_end[1];
+        global_1       = m_tile_end[0];
       }
-    } else if constexpr (Policy::rank >= 3) {
-      array_index_type global_0 = 1;
-      array_index_type global_1 = 1;
-      array_index_type global_2 = 1;
-
+    } else if constexpr (Policy::rank == 3) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        if constexpr (Policy::rank == 3) {
-          local_sizes[0] = m_tile[0];
-          local_sizes[1] = m_tile[1];
-          local_sizes[2] = m_tile[2];
-          global_0       = m_tile_end[0];
-          global_1       = m_tile_end[1];
-          global_2       = m_tile_end[2];
-        } else if constexpr (Policy::rank >= 4) {
+        local_sizes[0] = m_tile[0];
+        local_sizes[1] = m_tile[1];
+        local_sizes[2] = m_tile[2];
+        global_0       = m_tile_end[0];
+        global_1       = m_tile_end[1];
+        global_2       = m_tile_end[2];
+      } else {
+        local_sizes[0] = m_tile[2];
+        local_sizes[1] = m_tile[1];
+        local_sizes[2] = m_tile[0];
+        global_0       = m_tile_end[2];
+        global_1       = m_tile_end[1];
+        global_2       = m_tile_end[0];
+      }
+    } else {  // rank > 3
+      if constexpr (Policy::inner_direction == Iterate::Left) {
+        if constexpr (Policy::rank >= 4) {
           local_sizes[0] = m_tile[0] * m_tile[1];
           local_sizes[1] = m_tile[2];
           local_sizes[2] = m_tile[3];
@@ -97,15 +97,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
           local_sizes[2] = m_tile[4] * m_tile[5];
           global_2       = m_tile_end[4] * m_tile_end[5];
         }
-      } else {
-        if constexpr (Policy::rank == 3) {
-          local_sizes[0] = m_tile[2];
-          local_sizes[1] = m_tile[1];
-          local_sizes[2] = m_tile[0];
-          global_0       = m_tile_end[2];
-          global_1       = m_tile_end[1];
-          global_2       = m_tile_end[0];
-        } else if constexpr (Policy::rank >= 4) {
+      } else {  // InnerDirection == Right
+        if constexpr (Policy::rank >= 4) {
           local_sizes[0] = m_tile[Policy::rank - 1] * m_tile[Policy::rank - 2];
           local_sizes[1] = m_tile[Policy::rank - 3];
           local_sizes[2] = m_tile[Policy::rank - 4];
@@ -127,16 +120,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
               m_tile_end[Policy::rank - 5] * m_tile_end[Policy::rank - 6];
         }
       }
-      global_sizes[0] =
-          std::min<array_index_type>(global_0, m_max_grid_size[0]) *
-          local_sizes[0];
-      global_sizes[1] =
-          std::min<array_index_type>(global_1, m_max_grid_size[1]) *
-          local_sizes[1];
-      global_sizes[2] =
-          std::min<array_index_type>(global_2, m_max_grid_size[2]) *
-          local_sizes[2];
     }
+    global_sizes[0] = std::min<array_index_type>(global_0, m_max_grid_size[0]) *
+                      local_sizes[0];
+    global_sizes[1] = std::min<array_index_type>(global_1, m_max_grid_size[1]) *
+                      local_sizes[1];
+    global_sizes[2] = std::min<array_index_type>(global_2, m_max_grid_size[2]) *
+                      local_sizes[2];
     return {global_sizes, local_sizes};
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -34,7 +34,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
   array_type m_lower;
   array_type m_upper;
-  array_type m_max_threads;
+  array_type m_extent;  // tile_size * num_tiles
 
   template <typename FunctorWrapper>
   sycl::event sycl_direct_launch(const FunctorWrapper& functor_wrapper,
@@ -46,7 +46,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     const auto lower_bound = m_lower;
     const auto upper_bound = m_upper;
-    const auto max_threads = m_max_threads;
+    const auto extent      = m_extent;
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
@@ -64,8 +64,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 #else
       (void)memcpy_event;
 #endif
-      cgh.parallel_for(sycl_swapped_range, [lower_bound, upper_bound,
-                                            max_threads, functor_wrapper](
+      cgh.parallel_for(sycl_swapped_range, [lower_bound, upper_bound, extent,
+                                            functor_wrapper](
                                                sycl::nd_item<3> item) {
         // swap back for correct index calculations in DeviceIterateTile
         const index_type local_x    = item.get_local_id(2);
@@ -84,8 +84,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
                                     FunctorType, Policy::inner_direction,
                                     typename Policy::work_tag>(
-            lower_bound, upper_bound, max_threads,
-            functor_wrapper.get_functor(), {n_global_x, n_global_y, n_global_z},
+            lower_bound, upper_bound, extent, functor_wrapper.get_functor(),
+            {n_global_x, n_global_y, n_global_z},
             {n_local_x, n_local_y, n_local_z}, {global_x, global_y, global_z},
             {local_x, local_y, local_z})
             .exec_range();
@@ -164,14 +164,14 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     // Swap the fastest indexes to x dimension
     for (array_index_type i = 0; i < Policy::rank; ++i) {
       if constexpr (Policy::inner_direction == Iterate::Left) {
-        m_lower[i]       = m_policy.m_lower[i];
-        m_upper[i]       = m_policy.m_upper[i];
-        m_max_threads[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
+        m_lower[i]  = m_policy.m_lower[i];
+        m_upper[i]  = m_policy.m_upper[i];
+        m_extent[i] = m_policy.m_tile[i] * m_policy.m_tile_end[i];
       } else {
-        m_lower[i]       = m_policy.m_lower[Policy::rank - 1 - i];
-        m_upper[i]       = m_policy.m_upper[Policy::rank - 1 - i];
-        m_max_threads[i] = m_policy.m_tile[Policy::rank - 1 - i] *
-                           m_policy.m_tile_end[Policy::rank - 1 - i];
+        m_lower[i]  = m_policy.m_lower[Policy::rank - 1 - i];
+        m_upper[i]  = m_policy.m_upper[Policy::rank - 1 - i];
+        m_extent[i] = m_policy.m_tile[Policy::rank - 1 - i] *
+                      m_policy.m_tile_end[Policy::rank - 1 - i];
       }
     }
   }

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -28,13 +28,13 @@ struct EmulateCUDADim3 {
 template <class Tag, class Functor, class... Args>
 KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<std::is_void_v<Tag>>
 _tag_invoke(Functor const& f, Args&&... args) {
-  f(std::forward<Args>(args)...);
+  f((Args&&)args...);
 }
 
 template <class Tag, class Functor, class... Args>
 KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<!std::is_void_v<Tag>>
 _tag_invoke(Functor const& f, Args&&... args) {
-  f(Tag{}, std::forward<Args>(args)...);
+  f(Tag{}, (Args&&)args...);
 }
 
 template <class Tag, class Functor, class T, size_t N, size_t... Idxs,
@@ -42,7 +42,7 @@ template <class Tag, class Functor, class T, size_t N, size_t... Idxs,
 KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array_helper(
     Functor const& f, T (&vals)[N], std::integer_sequence<size_t, Idxs...>,
     Args&&... args) {
-  _tag_invoke<Tag>(f, vals[Idxs]..., std::forward<Args>(args)...);
+  _tag_invoke<Tag>(f, vals[Idxs]..., (Args&&)args...);
 }
 
 template <class Tag, class Functor, class T, size_t N, class... Args>
@@ -50,7 +50,7 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
                                                         T (&vals)[N],
                                                         Args&&... args) {
   _tag_invoke_array_helper<Tag>(f, vals, std::make_index_sequence<N>{},
-                                std::forward<Args>(args)...);
+                                (Args&&)args...);
 }
 
 // ------------------------------------------------------------------ //

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -55,6 +55,16 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
 
 // ------------------------------------------------------------------ //
 // ParallelFor iteration pattern
+// map 2D/3D hardware threads to N-D iteration space
+//
+// For ranks 2-3: Direct mapping of hardware threads to iteration space
+// dimensions For ranks 4-6: Multiple logical indices are packed into single
+// hardware dimensions
+//
+// 1. Start iterating at hardware thread identifier
+// 2. Extend iteration space range with stride loops using grid dimensions
+// 3. Bound checking to ensure we do not exceed upper bounds
+//
 template <int N, typename PolicyType, typename Functor, typename MaxGridSize,
           typename Tag>
 struct DeviceIterateTile;
@@ -97,7 +107,9 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type start_1 =
         blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[1];
 
+    // Iterate::Left, fastest index 0
     if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      // Iterate over dimension 1 and 0 with grid strides
       for (index_type idx_1 = start_1;
            idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
            idx_1 += stride_1) {
@@ -107,7 +119,9 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
           Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
         }
       }
-    } else {
+
+    } else {  // Iterate::Right, fastest index 1
+      // Iterate over dimension 0 and 1 with grid strides
       for (index_type idx_0 = start_0;
            idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
            idx_0 += stride_0) {
@@ -173,7 +187,9 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type start_2 =
         blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[2];
 
+    // Iterate::Left, fastest index 0
     if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      // Iterate over dimension 2, 1 and 0 with grid strides
       for (index_type idx_2 = start_2;
            idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
            idx_2 += stride_2) {
@@ -187,7 +203,9 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
           }
         }
       }
-    } else {  // Iterate::Right
+
+    } else {  // Iterate::Right, fastest index 2
+      // Iterate over dimension 0, 1 and 2 with grid strides
       for (index_type idx_0 = start_0;
            idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
            idx_0 += stride_0) {
@@ -256,22 +274,27 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type start_3 =
         blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
 
+    // Maximum number of "virtual" threads needed to cover dimensions 0 and 1
     const index_type max_threads_0 =
         (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
     const index_type max_threads_1 =
         (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
     const index_type max_threads_01 = max_threads_0 * max_threads_1;
 
+    // Iterate::Left, fastest index 0
     if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      // Iterate over dimension 3, 2 and packed 0 and 1 with grid strides
+
       for (index_type idx_3 = start_3;
            idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
            idx_3 += stride_3) {
         for (index_type idx_2 = start_2;
              idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
              idx_2 += stride_2) {
-          // Unpack thread_id_0 and thread_id_1 from dimension x
+          // Unpack from dimension x into thread_id_0 (fastest) and thread_id_1
           for (index_type thread_id_01 = start_01;
                thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+            // Unpack flat thread_id_01 into 2D indices
             const index_type thread_id_1 = thread_id_01 / max_threads_0;
             const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
@@ -286,11 +309,13 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
         }
       }
 
-    } else {  // Iterate::Right
+    } else {  // Iterate::Right, fastest index 3
+      // Iterate over packed dimension 0 and 1 and over 2, 3 with grid strides
 
-      // Unpack thread_id_0 and thread_id_1 from dimension x
+      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
       for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
            thread_id_01 += stride_01) {
+        // Unpack flat thread_id_01 into 2D indices
         const index_type thread_id_0 = thread_id_01 / max_threads_1;
         const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
@@ -365,6 +390,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type stride_23 = gridDim.y * blockDim.y;
     const index_type stride_4  = gridDim.z * blockDim.z;
 
+    // Maximum number of "virtual" threads needed to cover dimensions 0-3
     const index_type max_threads_0 =
         (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
     const index_type max_threads_1 =
@@ -376,13 +402,18 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type max_threads_01 = max_threads_0 * max_threads_1;
     const index_type max_threads_23 = max_threads_2 * max_threads_3;
 
+    // Iterate::Left, fastest index 0
     if (PolicyType::inner_direction == Iterate::Left) {
+      // Iterate over dimension 4, packed 3 and 2, packed 1 and 0 with grid
+      // strides
+
       for (index_type idx_4 = start_4;
            idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
            idx_4 += stride_4) {
-        // Unpack thread_id_2 and thread_id_3 from dimension y
+        // Unpack from dimension y into thread_id_2 (fastest) and thread_id_3
         for (index_type thread_id_23 = start_23; thread_id_23 < max_threads_23;
              thread_id_23 += stride_23) {
+          // Unpack flat thread_id_23 into 2D indices
           const index_type thread_id_3 = thread_id_23 / max_threads_2;
           const index_type thread_id_2 = thread_id_23 % max_threads_2;
 
@@ -391,9 +422,11 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 
           if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
               idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-            // Unpack thread_id_0 and thread_id_1 from dimension x
+            // Unpack from dimension x into thread_id_0 (fastest) and
+            // thread_id_1
             for (index_type thread_id_01 = start_01;
                  thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+              // Unpack flat thread_id_01 into 2D indices
               const index_type thread_id_1 = thread_id_01 / max_threads_0;
               const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
@@ -410,11 +443,14 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
         }
       }
 
-    } else {  // Iterate::Right
+    } else {  // Iterate::Right, fastest index 4
+      // Iterate over packed dimension 0 and 1, packed 2 and 3, and over 4 with
+      // grid strides
 
-      // Unpack thread_id_0 and thread_id_1 from dimension x
+      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
       for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
            thread_id_01 += stride_01) {
+        // Unpack flat thread_id_01 into 2D indices
         const index_type thread_id_0 = thread_id_01 / max_threads_1;
         const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
@@ -423,9 +459,10 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 
         if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
             idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Unpack thread_id_2 and thread_id_3 from dimension y
+          // Unpack from dimension y into thread_id_2 and thread_id_3 (fastest)
           for (index_type thread_id_23 = start_23;
                thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            // Unpack flat thread_id_23 into 2D indices
             const index_type thread_id_2 = thread_id_23 / max_threads_3;
             const index_type thread_id_3 = thread_id_23 % max_threads_3;
 
@@ -498,6 +535,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type stride_23 = gridDim.y * blockDim.y;
     const index_type stride_45 = gridDim.z * blockDim.z;
 
+    // Maximum number of "virtual" threads needed to cover dimensions 0-5
     const index_type max_threads_0 =
         (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
     const index_type max_threads_1 =
@@ -516,9 +554,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
     const index_type max_threads_45 = max_threads_4 * max_threads_5;
 
     if (PolicyType::inner_direction == Iterate::Left) {
-      // Unpack thread_id_4 and thread_id_5 from dimension z
+      // Iterate over packed 5 and 4, packed 3 and 2, packed 1 and 0 with grid
+      // strides
+
+      // Unpack from dimension z into thread_id_4 (fastest) and thread_id_5
       for (index_type thread_id_45 = start_45; thread_id_45 < max_threads_45;
            thread_id_45 += stride_45) {
+        // Unpack flat thread_id_45 into 2D indices
         const index_type thread_id_5 = thread_id_45 / max_threads_4;
         const index_type thread_id_4 = thread_id_45 % max_threads_4;
 
@@ -527,9 +569,10 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
         if (idx_5 < static_cast<index_type>(m_policy.m_upper[5]) &&
             idx_4 < static_cast<index_type>(m_policy.m_upper[4])) {
-          // Unpack thread_id_2 and thread_id_3 from dimension y
+          // Unpack from dimension y into thread_id_2 (fastest) and thread_id_3
           for (index_type thread_id_23 = start_23;
                thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            // Unpack flat thread_id_23 into 2D indices
             const index_type thread_id_3 = thread_id_23 / max_threads_2;
             const index_type thread_id_2 = thread_id_23 % max_threads_2;
 
@@ -538,9 +581,11 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
             if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
                 idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-              // Unpack thread_id_0 and thread_id_1 from dimension x
+              // Unpack from dimension x into thread_id_0 (fastest) and
+              // thread_id_1
               for (index_type thread_id_01 = start_01;
                    thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+                // Unpack flat thread_id_01 into 2D indices
                 const index_type thread_id_1 = thread_id_01 / max_threads_0;
                 const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
@@ -559,10 +604,13 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
       }
 
     } else {  // Iterate::Right
+      // Iterate over packed dimension 0 and 1, packed 2 and 3, packed 4 and 5
+      // with grid strides
 
-      // Unpack thread_id_0 and thread_id_1 from dimension x
+      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
       for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
            thread_id_01 += stride_01) {
+        // Unpack flat thread_id_01 into 2D indices
         const index_type thread_id_0 = thread_id_01 / max_threads_1;
         const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
@@ -571,9 +619,10 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
         if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
             idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Unpack thread_id_2 and thread_id_3 from dimension y
+          // Unpack from dimension y into thread_id_2 and thread_id_3 (fastest)
           for (index_type thread_id_23 = start_23;
                thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            // Unpack flat thread_id_23 into 2D indices
             const index_type thread_id_2 = thread_id_23 / max_threads_3;
             const index_type thread_id_3 = thread_id_23 % max_threads_3;
 
@@ -582,9 +631,11 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
             if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
                 idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
-              // Unpack thread_id_4 and thread_id_5 from dimension z
+              // Unpack from dimension z into thread_id_4 and thread_id_5
+              // (fastest)
               for (index_type thread_id_45 = start_45;
                    thread_id_45 < max_threads_45; thread_id_45 += stride_45) {
+                // Unpack flat thread_id_45 into 2D indices
                 const index_type thread_id_4 = thread_id_45 / max_threads_5;
                 const index_type thread_id_5 = thread_id_45 % max_threads_5;
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -187,7 +187,7 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
           }
         }
       }
-    } else {
+    } else {  // Iterate::Right
       for (index_type idx_0 = start_0;
            idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
            idx_0 += stride_0) {
@@ -246,37 +246,37 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    const index_type stride_2 = gridDim.y * blockDim.y;
-    const index_type stride_3 = gridDim.z * blockDim.z;
+    const index_type stride_01 = gridDim.x * blockDim.x;
+    const index_type stride_2  = gridDim.y * blockDim.y;
+    const index_type stride_3  = gridDim.z * blockDim.z;
 
+    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
     const index_type start_2 =
         blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[2];
     const index_type start_3 =
         blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
 
-    const index_type max_tiles_01 =
-        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
+    const index_type max_threads_0 =
+        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
+    const index_type max_threads_1 =
+        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
+    const index_type max_threads_01 = max_threads_0 * max_threads_1;
 
     if constexpr (PolicyType::inner_direction == Iterate::Left) {
-      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
-      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
-
       for (index_type idx_3 = start_3;
            idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
            idx_3 += stride_3) {
         for (index_type idx_2 = start_2;
              idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
              idx_2 += stride_2) {
-          // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-          for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-               tile_x += gridDim.x) {
-            const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
-            const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
+          // Unpack thread_id_0 and thread_id_1 from dimension x
+          for (index_type thread_id_01 = start_01;
+               thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+            const index_type thread_id_1 = thread_id_01 / max_threads_0;
+            const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
-            const index_type idx_1 =
-                tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
-            const index_type idx_0 =
-                tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
+            const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
+            const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
 
             if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
                 idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
@@ -288,19 +288,14 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
 
     } else {  // Iterate::Right
 
-      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
-      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
+      // Unpack thread_id_0 and thread_id_1 from dimension x
+      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
+           thread_id_01 += stride_01) {
+        const index_type thread_id_0 = thread_id_01 / max_threads_1;
+        const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
-      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-           tile_x += gridDim.x) {
-        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
-        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
-
-        const index_type idx_0 =
-            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
-        const index_type idx_1 =
-            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
+        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
 
         if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
             idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
@@ -316,6 +311,7 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
         }
       }
     }
+
   }  // end exec_range
 
  private:
@@ -360,48 +356,49 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
+    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
+    const index_type start_23 = blockIdx.y * blockDim.y + threadIdx.y;
     const index_type start_4 =
         blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[4];
-    const index_type stride_4 = gridDim.z * blockDim.z;
 
-    const index_type max_tiles_01 =
-        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
-    const index_type max_tiles_23 =
-        m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
+    const index_type stride_01 = gridDim.x * blockDim.x;
+    const index_type stride_23 = gridDim.y * blockDim.y;
+    const index_type stride_4  = gridDim.z * blockDim.z;
+
+    const index_type max_threads_0 =
+        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
+    const index_type max_threads_1 =
+        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
+    const index_type max_threads_2 =
+        (m_policy.m_tile[2] * m_policy.m_tile_end[2]);
+    const index_type max_threads_3 =
+        (m_policy.m_tile[3] * m_policy.m_tile_end[3]);
+    const index_type max_threads_01 = max_threads_0 * max_threads_1;
+    const index_type max_threads_23 = max_threads_2 * max_threads_3;
 
     if (PolicyType::inner_direction == Iterate::Left) {
-      const index_type thread_id_3 = threadIdx.y / m_policy.m_tile[2];
-      const index_type thread_id_2 = threadIdx.y % m_policy.m_tile[2];
-
-      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
-      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
-
       for (index_type idx_4 = start_4;
            idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
            idx_4 += stride_4) {
-        // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
-        for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
-             tile_y += gridDim.y) {
-          const index_type tile_3 = tile_y / m_policy.m_tile_end[2];
-          const index_type tile_2 = tile_y % m_policy.m_tile_end[2];
+        // Unpack thread_id_2 and thread_id_3 from dimension y
+        for (index_type thread_id_23 = start_23; thread_id_23 < max_threads_23;
+             thread_id_23 += stride_23) {
+          const index_type thread_id_3 = thread_id_23 / max_threads_2;
+          const index_type thread_id_2 = thread_id_23 % max_threads_2;
 
-          const index_type idx_3 =
-              tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
-          const index_type idx_2 =
-              tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
+          const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
+          const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
 
           if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
               idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-            // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-            for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-                 tile_x += gridDim.x) {
-              const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
-              const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
+            // Unpack thread_id_0 and thread_id_1 from dimension x
+            for (index_type thread_id_01 = start_01;
+                 thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+              const index_type thread_id_1 = thread_id_01 / max_threads_0;
+              const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
-              const index_type idx_1 = tile_1 * m_policy.m_tile[1] +
-                                       thread_id_1 + m_policy.m_lower[1];
-              const index_type idx_0 = tile_0 * m_policy.m_tile[0] +
-                                       thread_id_0 + m_policy.m_lower[0];
+              const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
+              const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
 
               if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
                   idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
@@ -415,35 +412,25 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 
     } else {  // Iterate::Right
 
-      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
-      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
+      // Unpack thread_id_0 and thread_id_1 from dimension x
+      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
+           thread_id_01 += stride_01) {
+        const index_type thread_id_0 = thread_id_01 / max_threads_1;
+        const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
-      const index_type thread_id_2 = threadIdx.y / m_policy.m_tile[3];
-      const index_type thread_id_3 = threadIdx.y % m_policy.m_tile[3];
-
-      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-           tile_x += gridDim.x) {
-        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
-        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
-
-        const index_type idx_1 =
-            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
-        const index_type idx_0 =
-            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
 
         if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
             idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
-          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
-               tile_y += gridDim.y) {
-            const index_type tile_2 = tile_y / m_policy.m_tile_end[3];
-            const index_type tile_3 = tile_y % m_policy.m_tile_end[3];
+          // Unpack thread_id_2 and thread_id_3 from dimension y
+          for (index_type thread_id_23 = start_23;
+               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            const index_type thread_id_2 = thread_id_23 / max_threads_3;
+            const index_type thread_id_3 = thread_id_23 % max_threads_3;
 
-            const index_type idx_2 =
-                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
-            const index_type idx_3 =
-                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
+            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
+            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
 
             if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
                 idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
@@ -458,6 +445,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
         }
       }
     }
+
   }  // end exec_range
 
  private:
@@ -502,59 +490,62 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    const index_type max_tiles_01 =
-        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
-    const index_type max_tiles_23 =
-        m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
-    const index_type max_tiles_45 =
-        m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
+    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
+    const index_type start_23 = blockIdx.y * blockDim.y + threadIdx.y;
+    const index_type start_45 = blockIdx.z * blockDim.z + threadIdx.z;
+
+    const index_type stride_01 = gridDim.x * blockDim.x;
+    const index_type stride_23 = gridDim.y * blockDim.y;
+    const index_type stride_45 = gridDim.z * blockDim.z;
+
+    const index_type max_threads_0 =
+        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
+    const index_type max_threads_1 =
+        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
+    const index_type max_threads_2 =
+        (m_policy.m_tile[2] * m_policy.m_tile_end[2]);
+    const index_type max_threads_3 =
+        (m_policy.m_tile[3] * m_policy.m_tile_end[3]);
+    const index_type max_threads_4 =
+        (m_policy.m_tile[4] * m_policy.m_tile_end[4]);
+    const index_type max_threads_5 =
+        (m_policy.m_tile[5] * m_policy.m_tile_end[5]);
+
+    const index_type max_threads_01 = max_threads_0 * max_threads_1;
+    const index_type max_threads_23 = max_threads_2 * max_threads_3;
+    const index_type max_threads_45 = max_threads_4 * max_threads_5;
 
     if (PolicyType::inner_direction == Iterate::Left) {
-      const index_type thread_id_5 = threadIdx.z / m_policy.m_tile[4];
-      const index_type thread_id_4 = threadIdx.z % m_policy.m_tile[4];
+      // Unpack thread_id_4 and thread_id_5 from dimension z
+      for (index_type thread_id_45 = start_45; thread_id_45 < max_threads_45;
+           thread_id_45 += stride_45) {
+        const index_type thread_id_5 = thread_id_45 / max_threads_4;
+        const index_type thread_id_4 = thread_id_45 % max_threads_4;
 
-      const index_type thread_id_3 = threadIdx.y / m_policy.m_tile[2];
-      const index_type thread_id_2 = threadIdx.y % m_policy.m_tile[2];
-
-      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
-      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
-
-      // Reconstruct tile 4 and tile 5 from blockIdx.z and threadIdx.z
-      for (index_type tile_z = blockIdx.z; tile_z < max_tiles_45;
-           tile_z += gridDim.z) {
-        const index_type tile_5 = tile_z / m_policy.m_tile_end[4];
-        const index_type tile_4 = tile_z % m_policy.m_tile_end[4];
-
-        const index_type idx_5 =
-            tile_5 * m_policy.m_tile[5] + thread_id_5 + m_policy.m_lower[5];
-        const index_type idx_4 =
-            tile_4 * m_policy.m_tile[4] + thread_id_4 + m_policy.m_lower[4];
+        const index_type idx_5 = thread_id_5 + m_policy.m_lower[5];
+        const index_type idx_4 = thread_id_4 + m_policy.m_lower[4];
 
         if (idx_5 < static_cast<index_type>(m_policy.m_upper[5]) &&
             idx_4 < static_cast<index_type>(m_policy.m_upper[4])) {
-          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
-          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
-               tile_y += gridDim.y) {
-            const index_type tile_3 = tile_y / m_policy.m_tile_end[2];
-            const index_type tile_2 = tile_y % m_policy.m_tile_end[2];
+          // Unpack thread_id_2 and thread_id_3 from dimension y
+          for (index_type thread_id_23 = start_23;
+               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            const index_type thread_id_3 = thread_id_23 / max_threads_2;
+            const index_type thread_id_2 = thread_id_23 % max_threads_2;
 
-            const index_type idx_3 =
-                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
-            const index_type idx_2 =
-                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
+            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
+            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
 
             if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
                 idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-              // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-              for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-                   tile_x += gridDim.x) {
-                const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
-                const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
+              // Unpack thread_id_0 and thread_id_1 from dimension x
+              for (index_type thread_id_01 = start_01;
+                   thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
+                const index_type thread_id_1 = thread_id_01 / max_threads_0;
+                const index_type thread_id_0 = thread_id_01 % max_threads_0;
 
-                const index_type idx_1 = tile_1 * m_policy.m_tile[1] +
-                                         thread_id_1 + m_policy.m_lower[1];
-                const index_type idx_0 = tile_0 * m_policy.m_tile[0] +
-                                         thread_id_0 + m_policy.m_lower[0];
+                const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
+                const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
 
                 if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
                     idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
@@ -569,51 +560,36 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
     } else {  // Iterate::Right
 
-      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
-      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
+      // Unpack thread_id_0 and thread_id_1 from dimension x
+      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
+           thread_id_01 += stride_01) {
+        const index_type thread_id_0 = thread_id_01 / max_threads_1;
+        const index_type thread_id_1 = thread_id_01 % max_threads_1;
 
-      const index_type thread_id_2 = threadIdx.y / m_policy.m_tile[3];
-      const index_type thread_id_3 = threadIdx.y % m_policy.m_tile[3];
-
-      const index_type thread_id_4 = threadIdx.z / m_policy.m_tile[5];
-      const index_type thread_id_5 = threadIdx.z % m_policy.m_tile[5];
-
-      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
-      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
-           tile_x += gridDim.x) {
-        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
-        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
-
-        const index_type idx_0 =
-            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
-        const index_type idx_1 =
-            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
+        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
 
         if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
             idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
-          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
-               tile_y += gridDim.y) {
-            const index_type tile_2 = tile_y / m_policy.m_tile_end[3];
-            const index_type tile_3 = tile_y % m_policy.m_tile_end[3];
+          // Unpack thread_id_2 and thread_id_3 from dimension y
+          for (index_type thread_id_23 = start_23;
+               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
+            const index_type thread_id_2 = thread_id_23 / max_threads_3;
+            const index_type thread_id_3 = thread_id_23 % max_threads_3;
 
-            const index_type idx_2 =
-                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
-            const index_type idx_3 =
-                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
+            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
+            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
 
             if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
                 idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
-              // Reconstruct tile 4 and tile 5 from blockIdx.z and threadIdx.z
-              for (index_type tile_z = blockIdx.z; tile_z < max_tiles_45;
-                   tile_z += gridDim.z) {
-                const index_type tile_4 = tile_z / m_policy.m_tile_end[5];
-                const index_type tile_5 = tile_z % m_policy.m_tile_end[5];
+              // Unpack thread_id_4 and thread_id_5 from dimension z
+              for (index_type thread_id_45 = start_45;
+                   thread_id_45 < max_threads_45; thread_id_45 += stride_45) {
+                const index_type thread_id_4 = thread_id_45 / max_threads_5;
+                const index_type thread_id_5 = thread_id_45 % max_threads_5;
 
-                const index_type idx_4 = tile_4 * m_policy.m_tile[4] +
-                                         thread_id_4 + m_policy.m_lower[4];
-                const index_type idx_5 = tile_5 * m_policy.m_tile[5] +
-                                         thread_id_5 + m_policy.m_lower[5];
+                const index_type idx_4 = thread_id_4 + m_policy.m_lower[4];
+                const index_type idx_5 = thread_id_5 + m_policy.m_lower[5];
 
                 if (idx_4 < static_cast<index_type>(m_policy.m_upper[4]) &&
                     idx_5 < static_cast<index_type>(m_policy.m_upper[5])) {
@@ -626,6 +602,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
         }
       }
     }
+
   }  // end exec_range
 
  private:

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -28,13 +28,13 @@ struct EmulateCUDADim3 {
 template <class Tag, class Functor, class... Args>
 KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<std::is_void_v<Tag>>
 _tag_invoke(Functor const& f, Args&&... args) {
-  f((Args&&)args...);
+  f(std::forward<Args>(args)...);
 }
 
 template <class Tag, class Functor, class... Args>
 KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<!std::is_void_v<Tag>>
 _tag_invoke(Functor const& f, Args&&... args) {
-  f(Tag{}, (Args&&)args...);
+  f(Tag{}, std::forward<Args>(args)...);
 }
 
 template <class Tag, class Functor, class T, size_t N, size_t... Idxs,
@@ -42,7 +42,7 @@ template <class Tag, class Functor, class T, size_t N, size_t... Idxs,
 KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array_helper(
     Functor const& f, T (&vals)[N], std::integer_sequence<size_t, Idxs...>,
     Args&&... args) {
-  _tag_invoke<Tag>(f, vals[Idxs]..., (Args&&)args...);
+  _tag_invoke<Tag>(f, vals[Idxs]..., std::forward<Args>(args)...);
 }
 
 template <class Tag, class Functor, class T, size_t N, class... Args>
@@ -50,7 +50,7 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
                                                         T (&vals)[N],
                                                         Args&&... args) {
   _tag_invoke_array_helper<Tag>(f, vals, std::make_index_sequence<N>{},
-                                (Args&&)args...);
+                                std::forward<Args>(args)...);
 }
 
 // ------------------------------------------------------------------ //
@@ -70,12 +70,14 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
       const PolicyType& policy_, const Functor& f_,
       const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -87,65 +89,32 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    // LL
-    if (PolicyType::inner_direction == Iterate::Left) {
-      // iterate over y blocks
-      for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
-           tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
-        // compute index for dimension 1
-        const index_type offset_1 =
-            tile_id1 * m_policy.m_tile[1] +
-            static_cast<index_type>(threadIdx.y) +
-            static_cast<index_type>(m_policy.m_lower[1]);
-        // check index for dimension 1 is within range
-        if (offset_1 < m_policy.m_upper[1] &&
-            static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
-          // iterate over x blocks
-          for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
-               tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
-            // compute index for dimension 0
-            const index_type offset_0 =
-                tile_id0 * m_policy.m_tile[0] +
-                static_cast<index_type>(threadIdx.x) +
-                static_cast<index_type>(m_policy.m_lower[0]);
-            // check index for dimension 0 is within range
-            if (offset_0 < m_policy.m_upper[0] &&
-                static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
-              // call kernel with computed indices
-              Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1);
-            }
-          }
+    const index_type stride_0 = gridDim.x * blockDim.x;
+    const index_type stride_1 = gridDim.y * blockDim.y;
+
+    const index_type start_0 =
+        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[0];
+    const index_type start_1 =
+        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[1];
+
+    if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      for (index_type idx_1 = start_1;
+           idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
+           idx_1 += stride_1) {
+        for (index_type idx_0 = start_0;
+             idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
+             idx_0 += stride_0) {
+          Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
         }
       }
-    }
-    // LR
-    else {
-      // iterate over x blocks
-      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
-        // compute index for dimension 0
-        const index_type offset_0 =
-            tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(threadIdx.x) +
-            static_cast<index_type>(m_policy.m_lower[0]);
-        // check index for dimension 0 is within range
-        if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
-          // iterate over y blocks
-          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(threadIdx.y) +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
-              // call kernel with computed indices
-              Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1);
-            }
-          }
+    } else {
+      for (index_type idx_0 = start_0;
+           idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
+           idx_0 += stride_0) {
+        for (index_type idx_1 = start_1;
+             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
+             idx_1 += stride_1) {
+          Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
         }
       }
     }
@@ -157,6 +126,7 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
   const MaxGridSize& m_max_grid_size;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif
@@ -173,12 +143,14 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
       const PolicyType& policy_, const Functor& f_,
       const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -190,90 +162,42 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    // LL
-    if (PolicyType::inner_direction == Iterate::Left) {
-      // iterate over z blocks
-      for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
-           tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
-        // compute index for dimension 2
-        const index_type offset_2 =
-            tile_id2 * m_policy.m_tile[2] +
-            static_cast<index_type>(threadIdx.z) +
-            static_cast<index_type>(m_policy.m_lower[2]);
-        // check index for dimension 2 is within range
-        if (offset_2 < m_policy.m_upper[2] &&
-            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
-          // iterate over y blocks
-          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(threadIdx.y) +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
-              // iterate over x blocks
-              for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
-                   tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
-                // compute index for dimension 0
-                const index_type offset_0 =
-                    tile_id0 * m_policy.m_tile[0] +
-                    static_cast<index_type>(threadIdx.x) +
-                    static_cast<index_type>(m_policy.m_lower[0]);
-                // check index for dimension 0 is within range
-                if (offset_0 < m_policy.m_upper[0] &&
-                    static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
-                  // call kernel with computed indices
-                  Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1, offset_2);
-                }
-              }
-            }
+    const index_type stride_0 = gridDim.x * blockDim.x;
+    const index_type stride_1 = gridDim.y * blockDim.y;
+    const index_type stride_2 = gridDim.z * blockDim.z;
+
+    const index_type start_0 =
+        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[0];
+    const index_type start_1 =
+        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[1];
+    const index_type start_2 =
+        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[2];
+
+    if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      for (index_type idx_2 = start_2;
+           idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
+           idx_2 += stride_2) {
+        for (index_type idx_1 = start_1;
+             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
+             idx_1 += stride_1) {
+          for (index_type idx_0 = start_0;
+               idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
+               idx_0 += stride_0) {
+            Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2);
           }
         }
       }
-    }
-    // LR
-    else {
-      // iterate over x blocks
-      for (index_type tile_id0 = static_cast<index_type>(blockIdx.x);
-           tile_id0 < m_policy.m_tile_end[0]; tile_id0 += gridDim.x) {
-        // compute index for dimension 0
-        const index_type offset_0 =
-            tile_id0 * m_policy.m_tile[0] +
-            static_cast<index_type>(threadIdx.x) +
-            static_cast<index_type>(m_policy.m_lower[0]);
-        // check index for dimension 0 is within range
-        if (offset_0 < m_policy.m_upper[0] &&
-            static_cast<index_type>(threadIdx.x) < m_policy.m_tile[0]) {
-          // iterate over y blocks
-          for (index_type tile_id1 = static_cast<index_type>(blockIdx.y);
-               tile_id1 < m_policy.m_tile_end[1]; tile_id1 += gridDim.y) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                tile_id1 * m_policy.m_tile[1] +
-                static_cast<index_type>(threadIdx.y) +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[1]) {
-              // iterate over z blocks
-              for (index_type tile_id2 = static_cast<index_type>(blockIdx.z);
-                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.z) {
-                // compute index for dimension 2
-                const index_type offset_2 =
-                    tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(threadIdx.z) +
-                    static_cast<index_type>(m_policy.m_lower[2]);
-                // check index for dimension 2 is within range
-                if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(threadIdx.z) < m_policy.m_tile[2]) {
-                  // call kernel with computed indices
-                  Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1, offset_2);
-                }
-              }
-            }
+    } else {
+      for (index_type idx_0 = start_0;
+           idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
+           idx_0 += stride_0) {
+        for (index_type idx_1 = start_1;
+             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
+             idx_1 += stride_1) {
+          for (index_type idx_2 = start_2;
+               idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
+               idx_2 += stride_2) {
+            Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2);
           }
         }
       }
@@ -286,6 +210,7 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
   const MaxGridSize& m_max_grid_size;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif
@@ -302,12 +227,14 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
       const PolicyType& policy_, const Functor& f_,
       const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -319,168 +246,71 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    // LL
-    if (PolicyType::inner_direction == Iterate::Left) {
-      // number of tiles for dimension 0
-      const index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      const index_type temp1 = m_policy.m_tile_end[1];
+    const index_type stride_2 = gridDim.y * blockDim.y;
+    const index_type stride_3 = gridDim.z * blockDim.z;
 
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl0
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[0])));
+    const index_type start_2 =
+        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[2];
+    const index_type start_3 =
+        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+    const index_type max_tiles_01 =
+        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
+    if constexpr (PolicyType::inner_direction == Iterate::Left) {
+      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
+      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
 
-      // iterate over z blocks
-      for (index_type tile_id3 = static_cast<index_type>(blockIdx.z);
-           tile_id3 < m_policy.m_tile_end[3]; tile_id3 += gridDim.z) {
-        // compute index for dimension 3
-        const index_type offset_3 =
-            tile_id3 * m_policy.m_tile[3] +
-            static_cast<index_type>(threadIdx.z) +
-            static_cast<index_type>(m_policy.m_lower[3]);
-        // check index for dimension 3 is within range
-        if (offset_3 < m_policy.m_upper[3] &&
-            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[3]) {
-          // iterate over y blocks
-          for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
-               tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
-            // compute index for dimension 2
-            const index_type offset_2 =
-                tile_id2 * m_policy.m_tile[2] +
-                static_cast<index_type>(threadIdx.y) +
-                static_cast<index_type>(m_policy.m_lower[2]);
-            // check index for dimension 2 is within range
-            if (offset_2 < m_policy.m_upper[2] &&
-                static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
-              // iterate over virtual blocks for dimension 1
-              for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-                   j += numbl1) {
-                // compute index for dimension 1
-                const index_type offset_1 =
-                    j * m_policy.m_tile[1] + thr_id1 +
-                    static_cast<index_type>(m_policy.m_lower[1]);
-                // check index for dimension 1 is within range
-                if (offset_1 < m_policy.m_upper[1] &&
-                    thr_id1 < m_policy.m_tile[1]) {
-                  // iterate over virtual blocks for dimension 0
-                  for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
-                       i += numbl0) {
-                    // compute index for dimension 0
-                    const index_type offset_0 =
-                        i * m_policy.m_tile[0] + thr_id0 +
-                        static_cast<index_type>(m_policy.m_lower[0]);
-                    // check index for dimension 0 is within range
-                    if (offset_0 < m_policy.m_upper[0] &&
-                        thr_id0 < m_policy.m_tile[0]) {
-                      // call kernel with computed indices
-                      Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                             offset_2, offset_3);
-                    }
-                  }
-                }
-              }
+      for (index_type idx_3 = start_3;
+           idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
+           idx_3 += stride_3) {
+        for (index_type idx_2 = start_2;
+             idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
+             idx_2 += stride_2) {
+          // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+          for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+               tile_x += gridDim.x) {
+            const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
+            const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
+
+            const index_type idx_1 =
+                tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
+            const index_type idx_0 =
+                tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
+
+            if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
+                idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
+              Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3);
             }
           }
         }
       }
-    }
-    // LR
-    else {
-      // number of tiles for dimension 0
-      const index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      const index_type temp1 = m_policy.m_tile_end[1];
 
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl1
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[0])));
+    } else {  // Iterate::Right
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
+      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
+      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+           tile_x += gridDim.x) {
+        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
+        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
 
-      // iterate over virtual blocks for dimension 0
-      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
-        // compute index for dimension 0
-        const index_type offset_0 =
-            i * m_policy.m_tile[0] + thr_id0 +
-            static_cast<index_type>(m_policy.m_lower[0]);
-        // check index for dimension 0 is within range
-        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
-          // iterate over virtual blocks for dimension 1
-          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-               j += numbl1) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                j * m_policy.m_tile[1] + thr_id1 +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                thr_id1 < m_policy.m_tile[1]) {
-              // iterate over y blocks
-              for (index_type tile_id2 = static_cast<index_type>(blockIdx.y);
-                   tile_id2 < m_policy.m_tile_end[2]; tile_id2 += gridDim.y) {
-                // compute index for dimension 2
-                const index_type offset_2 =
-                    tile_id2 * m_policy.m_tile[2] +
-                    static_cast<index_type>(threadIdx.y) +
-                    static_cast<index_type>(m_policy.m_lower[2]);
-                // check index for dimension 2 is within range
-                if (offset_2 < m_policy.m_upper[2] &&
-                    static_cast<index_type>(threadIdx.y) < m_policy.m_tile[2]) {
-                  // iterate over z blocks
-                  for (index_type tile_id3 =
-                           static_cast<index_type>(blockIdx.z);
-                       tile_id3 < m_policy.m_tile_end[3];
-                       tile_id3 += gridDim.z) {
-                    // compute index for dimension 3
-                    const index_type offset_3 =
-                        tile_id3 * m_policy.m_tile[3] +
-                        static_cast<index_type>(threadIdx.z) +
-                        static_cast<index_type>(m_policy.m_lower[3]);
-                    // check index for dimension 3 is within range
-                    if (offset_3 < m_policy.m_upper[3] &&
-                        static_cast<index_type>(threadIdx.z) <
-                            m_policy.m_tile[3]) {
-                      // call kernel with computed indices
-                      Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                             offset_2, offset_3);
-                    }
-                  }
-                }
-              }
+        const index_type idx_0 =
+            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_1 =
+            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
+
+        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
+            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
+          for (index_type idx_2 = start_2;
+               idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
+               idx_2 += stride_2) {
+            for (index_type idx_3 = start_3;
+                 idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
+                 idx_3 += stride_3) {
+              Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3);
             }
           }
         }
@@ -494,6 +324,7 @@ struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
   const MaxGridSize& m_max_grid_size;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif
@@ -510,12 +341,14 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
       const PolicyType& policy_, const Functor& f_,
       const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -527,243 +360,98 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    // LL
+    const index_type start_4 =
+        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
+    const index_type stride_4 = gridDim.z * blockDim.z;
+
+    const index_type max_tiles_01 =
+        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
+    const index_type max_tiles_23 =
+        m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
+
     if (PolicyType::inner_direction == Iterate::Left) {
-      // number of tiles for dimension 0
-      index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type thread_id_3 = threadIdx.y / m_policy.m_tile[2];
+      const index_type thread_id_2 = threadIdx.y % m_policy.m_tile[2];
 
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl0
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[0])));
+      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
+      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+      for (index_type idx_4 = start_4;
+           idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
+           idx_4 += stride_4) {
+        // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
+        for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
+             tile_y += gridDim.y) {
+          const index_type tile_3 = tile_y / m_policy.m_tile_end[2];
+          const index_type tile_2 = tile_y % m_policy.m_tile_end[2];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
+          const index_type idx_3 =
+              tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
+          const index_type idx_2 =
+              tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
 
-      // number of tiles for dimension 2
-      temp0 = m_policy.m_tile_end[2];
-      // number of tiles for dimension 3
-      temp1 = m_policy.m_tile_end[3];
+          if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
+              idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
+            // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+            for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+                 tile_x += gridDim.x) {
+              const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
+              const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
 
-      // number of virtual blocks for dimension 2
-      const index_type numbl2 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[1]));
-      // number of virtual blocks for dimension 3
-      const index_type numbl3 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[1])
-               ? static_cast<index_type>(m_max_grid_size[1]) / numbl2
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[1])));
+              const index_type idx_1 = tile_1 * m_policy.m_tile[1] +
+                                       thread_id_1 + m_policy.m_lower[1];
+              const index_type idx_0 = tile_0 * m_policy.m_tile[0] +
+                                       thread_id_0 + m_policy.m_lower[0];
 
-      // first virtual block index for dimension 2
-      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
-      // first virtual block index for dimension 3
-      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
-
-      // virtual thread index for dimension 2
-      const index_type thr_id2 =
-          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
-      // virtual thread index for dimension 3
-      const index_type thr_id3 =
-          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
-
-      // iterate over z blocks
-      for (index_type tile_id4 = static_cast<index_type>(blockIdx.z);
-           tile_id4 < m_policy.m_tile_end[4]; tile_id4 += gridDim.z) {
-        // compute index for dimension 4
-        const index_type offset_4 =
-            tile_id4 * m_policy.m_tile[4] +
-            static_cast<index_type>(threadIdx.z) +
-            static_cast<index_type>(m_policy.m_lower[4]);
-        // check index for dimension 4 is within range
-        if (offset_4 < m_policy.m_upper[4] &&
-            static_cast<index_type>(threadIdx.z) < m_policy.m_tile[4]) {
-          // iterate over virtual blocks for dimension 3
-          for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
-               l += numbl3) {
-            // compute index for dimension 3
-            const index_type offset_3 =
-                l * m_policy.m_tile[3] + thr_id3 +
-                static_cast<index_type>(m_policy.m_lower[3]);
-            // check index for dimension 3 is within range
-            if (offset_3 < m_policy.m_upper[3] &&
-                thr_id3 < m_policy.m_tile[3]) {
-              // iterate over virtual blocks for dimension 2
-              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
-                   k += numbl2) {
-                // compute index for dimension 2
-                const index_type offset_2 =
-                    k * m_policy.m_tile[2] + thr_id2 +
-                    static_cast<index_type>(m_policy.m_lower[2]);
-                // check index for dimension 2 is within range
-                if (offset_2 < m_policy.m_upper[2] &&
-                    thr_id2 < m_policy.m_tile[2]) {
-                  // iterate over virtual blocks for dimension 1
-                  for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-                       j += numbl1) {
-                    // compute index for dimension 1
-                    const index_type offset_1 =
-                        j * m_policy.m_tile[1] + thr_id1 +
-                        static_cast<index_type>(m_policy.m_lower[1]);
-                    // check index for dimension 1 is within range
-                    if (offset_1 < m_policy.m_upper[1] &&
-                        thr_id1 < m_policy.m_tile[1]) {
-                      // iterate over virtual blocks for dimension 0
-                      for (index_type i = tile_id0; i < m_policy.m_tile_end[0];
-                           i += numbl0) {
-                        // compute index for dimension 0
-                        const index_type offset_0 =
-                            i * m_policy.m_tile[0] + thr_id0 +
-                            static_cast<index_type>(m_policy.m_lower[0]);
-                        // check index for dimension 0 is within range
-                        if (offset_0 < m_policy.m_upper[0] &&
-                            thr_id0 < m_policy.m_tile[0]) {
-                          // call kernel with computed indices
-                          Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                                 offset_2, offset_3, offset_4);
-                        }
-                      }
-                    }
-                  }
-                }
+              if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
+                  idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
+                Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
+                                       idx_4);
               }
             }
           }
         }
       }
-    }
-    // LR
-    else {
-      // number of tiles for dimension 0
-      index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      index_type temp1 = m_policy.m_tile_end[1];
 
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl1
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[0])));
+    } else {  // Iterate::Right
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
+      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
+      const index_type thread_id_2 = threadIdx.y / m_policy.m_tile[3];
+      const index_type thread_id_3 = threadIdx.y % m_policy.m_tile[3];
 
-      // number of tiles for dimension 2
-      temp0 = m_policy.m_tile_end[2];
-      // number of tiles for dimension 3
-      temp1 = m_policy.m_tile_end[3];
+      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+           tile_x += gridDim.x) {
+        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
+        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
 
-      // number of virtual blocks for dimension 3
-      const index_type numbl3 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[1]));
-      // number of virtual blocks for dimension 2
-      const index_type numbl2 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[1])
-               ? static_cast<index_type>(m_max_grid_size[1]) / numbl3
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[1])));
+        const index_type idx_1 =
+            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
+        const index_type idx_0 =
+            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
 
-      // first virtual block index for dimension 2
-      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
-      // first virtual block index for dimension 3
-      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
+        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
+            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
+          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
+          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
+               tile_y += gridDim.y) {
+            const index_type tile_2 = tile_y / m_policy.m_tile_end[3];
+            const index_type tile_3 = tile_y % m_policy.m_tile_end[3];
 
-      // virtual thread index for dimension 2
-      const index_type thr_id2 =
-          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
-      // virtual thread index for dimension 3
-      const index_type thr_id3 =
-          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
+            const index_type idx_2 =
+                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
+            const index_type idx_3 =
+                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
 
-      // iterate over virtual blocks for dimension 0
-      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
-        // compute index for dimension 0
-        const index_type offset_0 =
-            i * m_policy.m_tile[0] + thr_id0 +
-            static_cast<index_type>(m_policy.m_lower[0]);
-        // check index for dimension 0 is within range
-        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
-          // iterate over virtual blocks for dimension 1
-          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-               j += numbl1) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                j * m_policy.m_tile[1] + thr_id1 +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                thr_id1 < m_policy.m_tile[1]) {
-              // iterate over virtual blocks for dimension 2
-              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
-                   k += numbl2) {
-                // compute index for dimension 2
-                const index_type offset_2 =
-                    k * m_policy.m_tile[2] + thr_id2 +
-                    static_cast<index_type>(m_policy.m_lower[2]);
-                // check index for dimension 2 is within range
-                if (offset_2 < m_policy.m_upper[2] &&
-                    thr_id2 < m_policy.m_tile[2]) {
-                  // iterate over virtual blocks for dimension 3
-                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
-                       l += numbl3) {
-                    // compute index for dimension 3
-                    const index_type offset_3 =
-                        l * m_policy.m_tile[3] + thr_id3 +
-                        static_cast<index_type>(m_policy.m_lower[3]);
-                    // check index for dimension 3 is within range
-                    if (offset_3 < m_policy.m_upper[3] &&
-                        thr_id3 < m_policy.m_tile[3]) {
-                      // iterate over z blocks
-                      for (index_type tile_id4 =
-                               static_cast<index_type>(blockIdx.z);
-                           tile_id4 < m_policy.m_tile_end[4];
-                           tile_id4 += gridDim.z) {
-                        // compute index for dimension 3
-                        const index_type offset_4 =
-                            tile_id4 * m_policy.m_tile[4] +
-                            static_cast<index_type>(threadIdx.z) +
-                            static_cast<index_type>(m_policy.m_lower[4]);
-                        // check index for dimension 3 is within range
-                        if (offset_4 < m_policy.m_upper[4] &&
-                            static_cast<index_type>(threadIdx.z) <
-                                m_policy.m_tile[4]) {
-                          // call kernel with computed indices
-                          Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                                 offset_2, offset_3, offset_4);
-                        }
-                      }
-                    }
-                  }
-                }
+            if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
+                idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
+              for (index_type idx_4 = start_4;
+                   idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
+                   idx_4 += stride_4) {
+                Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
+                                       idx_4);
               }
             }
           }
@@ -778,6 +466,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
   const MaxGridSize& m_max_grid_size;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif
@@ -794,12 +483,14 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
       const PolicyType& policy_, const Functor& f_,
       const MaxGridSize& max_grid_size_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_max_grid_size(max_grid_size_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -811,315 +502,123 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    // LL
+    const index_type max_tiles_01 =
+        m_policy.m_tile_end[0] * m_policy.m_tile_end[1];
+    const index_type max_tiles_23 =
+        m_policy.m_tile_end[2] * m_policy.m_tile_end[3];
+    const index_type max_tiles_45 =
+        m_policy.m_tile_end[4] * m_policy.m_tile_end[5];
+
     if (PolicyType::inner_direction == Iterate::Left) {
-      // number of tiles for dimension 0
-      index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      index_type temp1 = m_policy.m_tile_end[1];
+      const index_type thread_id_5 = threadIdx.z / m_policy.m_tile[4];
+      const index_type thread_id_4 = threadIdx.z % m_policy.m_tile[4];
 
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl0
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[0])));
+      const index_type thread_id_3 = threadIdx.y / m_policy.m_tile[2];
+      const index_type thread_id_2 = threadIdx.y % m_policy.m_tile[2];
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) % numbl0;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) / numbl0;
+      const index_type thread_id_1 = threadIdx.x / m_policy.m_tile[0];
+      const index_type thread_id_0 = threadIdx.x % m_policy.m_tile[0];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[0];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[0];
+      // Reconstruct tile 4 and tile 5 from blockIdx.z and threadIdx.z
+      for (index_type tile_z = blockIdx.z; tile_z < max_tiles_45;
+           tile_z += gridDim.z) {
+        const index_type tile_5 = tile_z / m_policy.m_tile_end[4];
+        const index_type tile_4 = tile_z % m_policy.m_tile_end[4];
 
-      // number of tiles for dimension 2
-      temp0 = m_policy.m_tile_end[2];
-      // number of tiles for dimension 3
-      temp1 = m_policy.m_tile_end[3];
+        const index_type idx_5 =
+            tile_5 * m_policy.m_tile[5] + thread_id_5 + m_policy.m_lower[5];
+        const index_type idx_4 =
+            tile_4 * m_policy.m_tile[4] + thread_id_4 + m_policy.m_lower[4];
 
-      // number of virtual blocks for dimension 2
-      const index_type numbl2 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[1]));
-      // number of virtual blocks for dimension 3
-      const index_type numbl3 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[1])
-               ? static_cast<index_type>(m_max_grid_size[1]) / numbl2
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[1])));
+        if (idx_5 < static_cast<index_type>(m_policy.m_upper[5]) &&
+            idx_4 < static_cast<index_type>(m_policy.m_upper[4])) {
+          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
+          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
+               tile_y += gridDim.y) {
+            const index_type tile_3 = tile_y / m_policy.m_tile_end[2];
+            const index_type tile_2 = tile_y % m_policy.m_tile_end[2];
 
-      // first virtual block index for dimension 2
-      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) % numbl2;
-      // first virtual block index for dimension 3
-      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) / numbl2;
+            const index_type idx_3 =
+                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
+            const index_type idx_2 =
+                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
 
-      // virtual thread index for dimension 2
-      const index_type thr_id2 =
-          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[2];
-      // virtual thread index for dimension 3
-      const index_type thr_id3 =
-          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[2];
+            if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
+                idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
+              // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+              for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+                   tile_x += gridDim.x) {
+                const index_type tile_1 = tile_x / m_policy.m_tile_end[0];
+                const index_type tile_0 = tile_x % m_policy.m_tile_end[0];
 
-      // number of tiles for dimension 4
-      temp0 = m_policy.m_tile_end[4];
-      // number of tiles for dimension 5
-      temp1 = m_policy.m_tile_end[5];
+                const index_type idx_1 = tile_1 * m_policy.m_tile[1] +
+                                         thread_id_1 + m_policy.m_lower[1];
+                const index_type idx_0 = tile_0 * m_policy.m_tile[0] +
+                                         thread_id_0 + m_policy.m_lower[0];
 
-      // number of virtual blocks for dimension 4
-      const index_type numbl4 =
-          Kokkos::min(temp0, static_cast<index_type>(m_max_grid_size[2]));
-      // number of virtual blocks for dimension 5
-      const index_type numbl5 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[2])
-               ? static_cast<index_type>(m_max_grid_size[2]) / numbl4
-               : Kokkos::min(temp1,
-                             static_cast<index_type>(m_max_grid_size[2])));
-
-      // first virtual block index for dimension 4
-      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) % numbl4;
-      // first virtual block index for dimension 5
-      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) / numbl4;
-
-      // virtual thread index for dimension 4
-      const index_type thr_id4 =
-          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[4];
-      // virtual thread index for dimension 5
-      const index_type thr_id5 =
-          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[4];
-
-      // iterate over virtual blocks for dimension 5
-      for (index_type n = tile_id5; n < m_policy.m_tile_end[5]; n += numbl5) {
-        // compute index for dimension 5
-        const index_type offset_5 =
-            n * m_policy.m_tile[5] + thr_id5 +
-            static_cast<index_type>(m_policy.m_lower[5]);
-        // check index for dimension 5 is within range
-        if (offset_5 < m_policy.m_upper[5] && thr_id5 < m_policy.m_tile[5]) {
-          // iterate over virtual blocks for dimension 4
-          for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
-               m += numbl4) {
-            // compute index for dimension 4
-            const index_type offset_4 =
-                m * m_policy.m_tile[4] + thr_id4 +
-                static_cast<index_type>(m_policy.m_lower[4]);
-            // check index for dimension 4 is within range
-            if (offset_4 < m_policy.m_upper[4] &&
-                thr_id4 < m_policy.m_tile[4]) {
-              // iterate over virtual blocks for dimension 3
-              for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
-                   l += numbl3) {
-                // compute index for dimension 3
-                const index_type offset_3 =
-                    l * m_policy.m_tile[3] + thr_id3 +
-                    static_cast<index_type>(m_policy.m_lower[3]);
-                // check index for dimension 3 is within range
-                if (offset_3 < m_policy.m_upper[3] &&
-                    thr_id3 < m_policy.m_tile[3]) {
-                  // iterate over virtual blocks for dimension 2
-                  for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
-                       k += numbl2) {
-                    // compute index for dimension 2
-                    const index_type offset_2 =
-                        k * m_policy.m_tile[2] + thr_id2 +
-                        static_cast<index_type>(m_policy.m_lower[2]);
-                    // check index for dimension 2 is within range
-                    if (offset_2 < m_policy.m_upper[2] &&
-                        thr_id2 < m_policy.m_tile[2]) {
-                      // iterate over virtual blocks for dimension 1
-                      for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-                           j += numbl1) {
-                        // compute index for dimension 1
-                        const index_type offset_1 =
-                            j * m_policy.m_tile[1] + thr_id1 +
-                            static_cast<index_type>(m_policy.m_lower[1]);
-                        // check index for dimension 1 is within range
-                        if (offset_1 < m_policy.m_upper[1] &&
-                            thr_id1 < m_policy.m_tile[1]) {
-                          // iterate over virtual blocks for dimension 0
-                          for (index_type i = tile_id0;
-                               i < m_policy.m_tile_end[0]; i += numbl0) {
-                            // compute index for dimension 0
-                            const index_type offset_0 =
-                                i * m_policy.m_tile[0] + thr_id0 +
-                                static_cast<index_type>(m_policy.m_lower[0]);
-                            // check index for dimension 0 is within range
-                            if (offset_0 < m_policy.m_upper[0] &&
-                                thr_id0 < m_policy.m_tile[0]) {
-                              // call kernel with computed indices
-                              Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                                     offset_2, offset_3,
-                                                     offset_4, offset_5);
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
+                    idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
+                  Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
+                                         idx_4, idx_5);
                 }
               }
             }
           }
         }
       }
-    }
-    // LR
-    else {
-      // number of tiles for dimension 0
-      index_type temp0 = m_policy.m_tile_end[0];
-      // number of tiles for dimension 1
-      index_type temp1 = m_policy.m_tile_end[1];
 
-      // number of virtual blocks for dimension 1
-      const index_type numbl1 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[0]));
-      // number of virtual blocks for dimension 0
-      const index_type numbl0 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[0])
-               ? static_cast<index_type>(m_max_grid_size[0]) / numbl1
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[0])));
+    } else {  // Iterate::Right
 
-      // first virtual block index for dimension 0
-      const index_type tile_id0 = static_cast<index_type>(blockIdx.x) / numbl1;
-      // first virtual block index for dimension 1
-      const index_type tile_id1 = static_cast<index_type>(blockIdx.x) % numbl1;
+      const index_type thread_id_0 = threadIdx.x / m_policy.m_tile[1];
+      const index_type thread_id_1 = threadIdx.x % m_policy.m_tile[1];
 
-      // virtual thread index for dimension 0
-      const index_type thr_id0 =
-          static_cast<index_type>(threadIdx.x) / m_policy.m_tile[1];
-      // virtual thread index for dimension 1
-      const index_type thr_id1 =
-          static_cast<index_type>(threadIdx.x) % m_policy.m_tile[1];
+      const index_type thread_id_2 = threadIdx.y / m_policy.m_tile[3];
+      const index_type thread_id_3 = threadIdx.y % m_policy.m_tile[3];
 
-      // number of tiles for dimension 2
-      temp0 = m_policy.m_tile_end[2];
-      // number of tiles for dimension 3
-      temp1 = m_policy.m_tile_end[3];
+      const index_type thread_id_4 = threadIdx.z / m_policy.m_tile[5];
+      const index_type thread_id_5 = threadIdx.z % m_policy.m_tile[5];
 
-      // number of virtual blocks for dimension 3
-      const index_type numbl3 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[1]));
-      // number of virtual blocks for dimension 2
-      const index_type numbl2 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[1])
-               ? static_cast<index_type>(m_max_grid_size[1]) / numbl3
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[1])));
+      // Reconstruct tile 0 and tile 1 from blockIdx.x and threadIdx.x
+      for (index_type tile_x = blockIdx.x; tile_x < max_tiles_01;
+           tile_x += gridDim.x) {
+        const index_type tile_0 = tile_x / m_policy.m_tile_end[1];
+        const index_type tile_1 = tile_x % m_policy.m_tile_end[1];
 
-      // first virtual block index for dimension 2
-      const index_type tile_id2 = static_cast<index_type>(blockIdx.y) / numbl3;
-      // first virtual block index for dimension 3
-      const index_type tile_id3 = static_cast<index_type>(blockIdx.y) % numbl3;
+        const index_type idx_0 =
+            tile_0 * m_policy.m_tile[0] + thread_id_0 + m_policy.m_lower[0];
+        const index_type idx_1 =
+            tile_1 * m_policy.m_tile[1] + thread_id_1 + m_policy.m_lower[1];
 
-      // virtual thread index for dimension 2
-      const index_type thr_id2 =
-          static_cast<index_type>(threadIdx.y) / m_policy.m_tile[3];
-      // virtual thread index for dimension 3
-      const index_type thr_id3 =
-          static_cast<index_type>(threadIdx.y) % m_policy.m_tile[3];
+        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
+            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
+          // Reconstruct tile 2 and tile 3 from blockIdx.y and threadIdx.y
+          for (index_type tile_y = blockIdx.y; tile_y < max_tiles_23;
+               tile_y += gridDim.y) {
+            const index_type tile_2 = tile_y / m_policy.m_tile_end[3];
+            const index_type tile_3 = tile_y % m_policy.m_tile_end[3];
 
-      // number of tiles for dimension 4
-      temp0 = m_policy.m_tile_end[4];
-      // number of tiles for dimension 5
-      temp1 = m_policy.m_tile_end[5];
+            const index_type idx_2 =
+                tile_2 * m_policy.m_tile[2] + thread_id_2 + m_policy.m_lower[2];
+            const index_type idx_3 =
+                tile_3 * m_policy.m_tile[3] + thread_id_3 + m_policy.m_lower[3];
 
-      // number of virtual blocks for dimension 5
-      const index_type numbl5 =
-          Kokkos::min(temp1, static_cast<index_type>(m_max_grid_size[2]));
-      // number of virtual blocks for dimension 3
-      const index_type numbl4 =
-          (temp0 * temp1 > static_cast<index_type>(m_max_grid_size[2])
-               ? static_cast<index_type>(m_max_grid_size[2]) / numbl5
-               : Kokkos::min(temp0,
-                             static_cast<index_type>(m_max_grid_size[2])));
+            if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
+                idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
+              // Reconstruct tile 4 and tile 5 from blockIdx.z and threadIdx.z
+              for (index_type tile_z = blockIdx.z; tile_z < max_tiles_45;
+                   tile_z += gridDim.z) {
+                const index_type tile_4 = tile_z / m_policy.m_tile_end[5];
+                const index_type tile_5 = tile_z % m_policy.m_tile_end[5];
 
-      // first virtual block index for dimension 4
-      const index_type tile_id4 = static_cast<index_type>(blockIdx.z) / numbl5;
-      // first virtual block index for dimension 5
-      const index_type tile_id5 = static_cast<index_type>(blockIdx.z) % numbl5;
+                const index_type idx_4 = tile_4 * m_policy.m_tile[4] +
+                                         thread_id_4 + m_policy.m_lower[4];
+                const index_type idx_5 = tile_5 * m_policy.m_tile[5] +
+                                         thread_id_5 + m_policy.m_lower[5];
 
-      // virtual thread index for dimension 4
-      const index_type thr_id4 =
-          static_cast<index_type>(threadIdx.z) / m_policy.m_tile[5];
-      // virtual thread index for dimension 5
-      const index_type thr_id5 =
-          static_cast<index_type>(threadIdx.z) % m_policy.m_tile[5];
-
-      // iterate over virtual blocks for dimension 0
-      for (index_type i = tile_id0; i < m_policy.m_tile_end[0]; i += numbl0) {
-        // compute index for dimension 0
-        const index_type offset_0 =
-            i * m_policy.m_tile[0] + thr_id0 +
-            static_cast<index_type>(m_policy.m_lower[0]);
-        // check index for dimension 0 is within range
-        if (offset_0 < m_policy.m_upper[0] && thr_id0 < m_policy.m_tile[0]) {
-          // iterate over virtual blocks for dimension 1
-          for (index_type j = tile_id1; j < m_policy.m_tile_end[1];
-               j += numbl1) {
-            // compute index for dimension 1
-            const index_type offset_1 =
-                j * m_policy.m_tile[1] + thr_id1 +
-                static_cast<index_type>(m_policy.m_lower[1]);
-            // check index for dimension 1 is within range
-            if (offset_1 < m_policy.m_upper[1] &&
-                thr_id1 < m_policy.m_tile[1]) {
-              // iterate over virtual blocks for dimension 2
-              for (index_type k = tile_id2; k < m_policy.m_tile_end[2];
-                   k += numbl2) {
-                // compute index for dimension 2
-                const index_type offset_2 =
-                    k * m_policy.m_tile[2] + thr_id2 +
-                    static_cast<index_type>(m_policy.m_lower[2]);
-                // check index for dimension 2 is within range
-                if (offset_2 < m_policy.m_upper[2] &&
-                    thr_id2 < m_policy.m_tile[2]) {
-                  // iterate over virtual blocks for dimension 3
-                  for (index_type l = tile_id3; l < m_policy.m_tile_end[3];
-                       l += numbl3) {
-                    // compute index for dimension 3
-                    const index_type offset_3 =
-                        l * m_policy.m_tile[3] + thr_id3 +
-                        static_cast<index_type>(m_policy.m_lower[3]);
-                    // check index for dimension 3 is within range
-                    if (offset_3 < m_policy.m_upper[3] &&
-                        thr_id3 < m_policy.m_tile[3]) {
-                      // iterate over virtual blocks for dimension 4
-                      for (index_type m = tile_id4; m < m_policy.m_tile_end[4];
-                           m += numbl4) {
-                        // compute index for dimension 4
-                        const index_type offset_4 =
-                            m * m_policy.m_tile[4] + thr_id4 +
-                            static_cast<index_type>(m_policy.m_lower[4]);
-                        // check index for dimension 4 is within range
-                        if (offset_4 < m_policy.m_upper[4] &&
-                            thr_id4 < m_policy.m_tile[4]) {
-                          // iterate over virtual blocks for dimension 5
-                          for (index_type n = tile_id5;
-                               n < m_policy.m_tile_end[5]; n += numbl5) {
-                            // compute index for dimension 5
-                            const index_type offset_5 =
-                                n * m_policy.m_tile[5] + thr_id5 +
-                                static_cast<index_type>(m_policy.m_lower[5]);
-                            // check index for dimension 5 is within range
-                            if (offset_5 < m_policy.m_upper[5] &&
-                                thr_id5 < m_policy.m_tile[5]) {
-                              // call kernel with computed indices
-                              Impl::_tag_invoke<Tag>(m_func, offset_0, offset_1,
-                                                     offset_2, offset_3,
-                                                     offset_4, offset_5);
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                if (idx_4 < static_cast<index_type>(m_policy.m_upper[4]) &&
+                    idx_5 < static_cast<index_type>(m_policy.m_upper[5])) {
+                  Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
+                                         idx_4, idx_5);
                 }
               }
             }
@@ -1135,6 +634,7 @@ struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
   const MaxGridSize& m_max_grid_size;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -361,7 +361,7 @@ struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
     const index_type start_4 =
-        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
+        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[4];
     const index_type stride_4 = gridDim.z * blockDim.z;
 
     const index_type max_tiles_01 =

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -66,593 +66,203 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
 // 2. Extend iteration space range with stride loops using grid dimensions
 // 3. Bound checking to ensure we do not exceed upper bounds
 //
-template <int N, typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile;
+template <int Rank, typename array_index_type, typename index_type,
+          typename Functor, Kokkos::Iterate Layout, typename Tag>
+struct DeviceIterate;
 
-// Rank 2
-template <typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
-  using index_type = typename PolicyType::index_type;
+template <int Rank, typename array_index_type, typename index_type,
+          typename Functor, Kokkos::Iterate Layout, typename Tag>
+struct DeviceIterate {
+  using array_type = Kokkos::Array<array_index_type, Rank>;
+
+ private:
+  const array_type m_lower;
+  const array_type m_upper;
+  const array_type m_max_threads;
+  Functor m_functor;
 
 #ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_,
+  const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
+  const EmulateCUDADim3<index_type> blockIdx;
+  const EmulateCUDADim3<index_type> threadIdx;
+#endif
+
+ public:
+#ifdef KOKKOS_ENABLE_SYCL
+  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterate(
+      const array_type& lower, const array_type& upper,
+      const array_type& max_threads, const Functor& functor,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
-      : m_policy(policy_),
-        m_func(f_),
-        m_max_grid_size(max_grid_size_),
+      : m_lower(lower),
+        m_upper(upper),
+        m_max_threads(max_threads),
+        m_functor(functor),
         gridDim(gridDim_),
         blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_)
-      : m_policy(policy_), m_func(f_), m_max_grid_size(max_grid_size_) {}
+
+  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterate(const array_type& lower,
+                                            const array_type& upper,
+                                            const array_type& max_threads,
+                                            const Functor& functor)
+      : m_lower(lower),
+        m_upper(upper),
+        m_max_threads(max_threads),
+        m_functor(functor) {}
 #endif
 
-  KOKKOS_IMPL_DEVICE_FUNCTION
+  KOKKOS_INLINE_FUNCTION
   void exec_range() const {
-    // Map policy dimensions to hardware threads
-    constexpr Kokkos::Array<int, 2> idx =
-        (PolicyType::inner_direction == Iterate::Left)
-            ? Kokkos::Array<int, 2>{0, 1}
-            : Kokkos::Array<int, 2>{1, 0};
+    // Execute nested loops directly without precomputing arrays
+    iterate(std::integral_constant<unsigned, Rank>());
+  }
 
-    const index_type stride_x = gridDim.x * blockDim.x;
-    const index_type stride_y = gridDim.y * blockDim.y;
+ private:
+  // Unpack happen on consecutive ranks
+  template <unsigned R>
+  static consteval __device__ bool is_packed_index() {
+    return ((R == 0 || R == 1) && Rank > 3) ||
+           ((R == 2 || R == 3) && Rank > 4) || ((R == 4 || R == 5) && Rank > 5);
+  }
 
-    const index_type start_0 =
-        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[idx[0]];
-    const index_type start_1 =
-        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[idx[1]];
-
-    // Iterate over dimension 0 and 1 with grid strides
-    for (index_type idx_1 = start_1;
-         idx_1 < static_cast<index_type>(m_policy.m_upper[idx[1]]);
-         idx_1 += stride_y) {
-      for (index_type idx_0 = start_0;
-           idx_0 < static_cast<index_type>(m_policy.m_upper[idx[0]]);
-           idx_0 += stride_x) {
-        if constexpr (PolicyType::inner_direction == Iterate::Left) {
-          Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
+  template <unsigned R>
+  KOKKOS_INLINE_FUNCTION constexpr index_type my_begin() const noexcept {
+    static_assert(R < 6, "R must be smaller than 6");
+    if constexpr (is_packed_index<R>()) {
+      if constexpr (R == 0 || R == 1) {
+        return blockIdx.x * blockDim.x + threadIdx.x;
+      } else if constexpr (R == 2 || R == 3) {
+        return blockIdx.y * blockDim.y + threadIdx.y;
+      } else if constexpr (R == 4 || R == 5) {
+        return blockIdx.z * blockDim.z + threadIdx.z;
+      } else {
+        return m_lower[R];
+      }
+    } else {
+      // No packed index
+      if constexpr (Rank < 4) {
+        if constexpr (R == 0) {
+          return m_lower[R] + blockIdx.x * blockDim.x + threadIdx.x;
+        } else if constexpr (R == 1) {
+          return m_lower[R] + blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 2) {
+          return m_lower[R] + blockIdx.z * blockDim.z + threadIdx.z;
+        }
+      } else {
+        // Mix of packed and unpacked for Rank 4 and 5
+        if constexpr (R == 2) {
+          return m_lower[R] + blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 3) {
+          return m_lower[R] + blockIdx.z * blockDim.z + threadIdx.z;
+        } else if constexpr (R == 4) {
+          return m_lower[R] + blockIdx.z * blockDim.z + threadIdx.z;
         } else {
-          Impl::_tag_invoke<Tag>(m_func, idx_1, idx_0);
+          return m_lower[R];
         }
       }
     }
-  }  // end exec_range
+  }
 
- private:
-  const PolicyType& m_policy;
-  const Functor& m_func;
-  const MaxGridSize& m_max_grid_size;
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
-};
+  template <unsigned R>
+  KOKKOS_INLINE_FUNCTION constexpr index_type my_end() const noexcept {
+    static_assert(R < 6, "R must be smaller than 6");
+    if constexpr (is_packed_index<R>()) {
+      if constexpr (R % 2 == 0) {
+        return m_max_threads[R] * m_max_threads[R + 1];
+      } else {
+        return m_max_threads[R] * m_max_threads[R - 1];
+      }
+    } else {
+      return m_upper[R];
+    }
+  }
 
-// Rank 3
-template <typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
-  using index_type = typename PolicyType::index_type;
+  template <unsigned R>
+  KOKKOS_INLINE_FUNCTION constexpr index_type my_stride() const noexcept {
+    static_assert(R < 6, "R must be smaller than 6");
+    if constexpr (is_packed_index<R>()) {
+      if constexpr (R == 0 || R == 1) {
+        return static_cast<index_type>(blockDim.x * gridDim.x);
+      } else if constexpr (R == 2 || R == 3) {
+        return static_cast<index_type>(blockDim.y * gridDim.y);
+      } else if constexpr (R == 4 || R == 5) {
+        return static_cast<index_type>(blockDim.z * gridDim.z);
+      }
+    } else {
+      // No packed index for all ranks
+      if constexpr (Rank < 4) {
+        if constexpr (R == 0) {
+          return static_cast<index_type>(blockDim.x * gridDim.x);
+        } else if constexpr (R == 1) {
+          return static_cast<index_type>(blockDim.y * gridDim.y);
+        } else if constexpr (R == 2) {
+          return static_cast<index_type>(blockDim.z * gridDim.z);
+        }
+      } else {
+        // Mix of packed and unpacked for Rank 4 and 5
+        if constexpr (R == 2) {
+          return static_cast<index_type>(blockDim.y * gridDim.y);
+        } else if constexpr (R == 3) {
+          return static_cast<index_type>(blockDim.z * gridDim.z);
+        } else if constexpr (R == 4) {
+          return static_cast<index_type>(blockDim.z * gridDim.z);
+        }
+      }
+    }
+    return index_type{1};
+  }
 
-#ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_,
-      const EmulateCUDADim3<index_type> gridDim_,
-      const EmulateCUDADim3<index_type> blockDim_,
-      const EmulateCUDADim3<index_type> blockIdx_,
-      const EmulateCUDADim3<index_type> threadIdx_)
-      : m_policy(policy_),
-        m_func(f_),
-        m_max_grid_size(max_grid_size_),
-        gridDim(gridDim_),
-        blockDim(blockDim_),
-        blockIdx(blockIdx_),
-        threadIdx(threadIdx_) {}
-#else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_)
-      : m_policy(policy_), m_func(f_), m_max_grid_size(max_grid_size_) {}
-#endif
+  // Generate nested loops
+  template <unsigned R, typename... Idxs>
+  KOKKOS_INLINE_FUNCTION void iterate(std::integral_constant<unsigned, R>,
+                                      Idxs... idxs) const {
+    static_assert(R > 0, "R must be greater than 0");
+    constexpr unsigned rankIdx = R - 1;
+    const index_type start     = my_begin<rankIdx>();
+    const index_type end       = my_end<rankIdx>();
+    const index_type stride    = my_stride<rankIdx>();
 
-  KOKKOS_IMPL_DEVICE_FUNCTION
-  void exec_range() const {
-    // Map policy dimensions to hardware threads
-    constexpr Kokkos::Array<int, 3> idx =
-        (PolicyType::inner_direction == Iterate::Left)
-            ? Kokkos::Array<int, 3>{0, 1, 2}
-            : Kokkos::Array<int, 3>{2, 1, 0};
+    for (index_type idx = start; idx < end; idx += stride) {
+      if constexpr (is_packed_index<rankIdx>()) {
+        // Unpack two consecutive indices
+        constexpr index_type idx1 =
+            (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
+        constexpr index_type idx2 =
+            (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
 
-    const index_type stride_x = gridDim.x * blockDim.x;
-    const index_type stride_y = gridDim.y * blockDim.y;
-    const index_type stride_z = gridDim.z * blockDim.z;
+        const index_type id_1 = idx % m_max_threads[idx1] + m_lower[idx1];
+        const index_type id_2 = idx / m_max_threads[idx1] + m_lower[idx2];
 
-    const index_type start_0 =
-        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[idx[0]];
-    const index_type start_1 =
-        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[idx[1]];
-    const index_type start_2 =
-        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[idx[2]];
-
-    // Iterate over dimension 2, 1 and 0 with grid strides
-    for (index_type idx_2 = start_2;
-         idx_2 < static_cast<index_type>(m_policy.m_upper[idx[2]]);
-         idx_2 += stride_z) {
-      for (index_type idx_1 = start_1;
-           idx_1 < static_cast<index_type>(m_policy.m_upper[idx[1]]);
-           idx_1 += stride_y) {
-        for (index_type idx_0 = start_0;
-             idx_0 < static_cast<index_type>(m_policy.m_upper[idx[0]]);
-             idx_0 += stride_x) {
-          if constexpr (PolicyType::inner_direction == Iterate::Left) {
-            Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2);
+        if (id_1 < m_upper[idx1] && id_2 < m_upper[idx2]) {
+          if constexpr (Layout == Iterate::Left) {
+            iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2,
+                    idxs...);
           } else {
-            Impl::_tag_invoke<Tag>(m_func, idx_2, idx_1, idx_0);
+            iterate(std::integral_constant<unsigned, R - 2>(), idxs..., id_2,
+                    id_1);
           }
+        }
+      } else {
+        if constexpr (Layout == Iterate::Left) {
+          iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
+        } else {
+          iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);
         }
       }
     }
-  }  // end exec_range
+  }
 
- private:
-  const PolicyType& m_policy;
-  const Functor& m_func;
-  const MaxGridSize& m_max_grid_size;
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
-};
-
-// Rank 4
-template <typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile<4, PolicyType, Functor, MaxGridSize, Tag> {
-  using index_type = typename PolicyType::index_type;
-
-#ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_,
-      const EmulateCUDADim3<index_type> gridDim_,
-      const EmulateCUDADim3<index_type> blockDim_,
-      const EmulateCUDADim3<index_type> blockIdx_,
-      const EmulateCUDADim3<index_type> threadIdx_)
-      : m_policy(policy_),
-        m_func(f_),
-        m_max_grid_size(max_grid_size_),
-        gridDim(gridDim_),
-        blockDim(blockDim_),
-        blockIdx(blockIdx_),
-        threadIdx(threadIdx_) {}
-#else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_)
-      : m_policy(policy_), m_func(f_), m_max_grid_size(max_grid_size_) {}
-#endif
-
-  KOKKOS_IMPL_DEVICE_FUNCTION
-  void exec_range() const {
-    const index_type stride_01 = gridDim.x * blockDim.x;
-    const index_type stride_2  = gridDim.y * blockDim.y;
-    const index_type stride_3  = gridDim.z * blockDim.z;
-
-    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
-    const index_type start_2 =
-        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[2];
-    const index_type start_3 =
-        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[3];
-
-    // Maximum number of "virtual" threads needed to cover dimensions 0 and 1
-    const index_type max_threads_0 =
-        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
-    const index_type max_threads_1 =
-        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
-    const index_type max_threads_01 = max_threads_0 * max_threads_1;
-
-    // Iterate::Left, fastest index 0
-    if constexpr (PolicyType::inner_direction == Iterate::Left) {
-      // Iterate over dimension 3, 2 and packed 0 and 1 with grid strides
-
-      for (index_type idx_3 = start_3;
-           idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
-           idx_3 += stride_3) {
-        for (index_type idx_2 = start_2;
-             idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
-             idx_2 += stride_2) {
-          // Unpack from dimension x into thread_id_0 (fastest) and thread_id_1
-          for (index_type thread_id_01 = start_01;
-               thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
-            // Unpack flat thread_id_01 into 2D indices
-            const index_type thread_id_1 = thread_id_01 / max_threads_0;
-            const index_type thread_id_0 = thread_id_01 % max_threads_0;
-
-            const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-            const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-
-            if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
-                idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
-              Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3);
-            }
-          }
-        }
-      }
-
-    } else {  // Iterate::Right, fastest index 3
-      // Iterate over packed dimension 0 and 1 and over 2, 3 with grid strides
-
-      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
-      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
-           thread_id_01 += stride_01) {
-        // Unpack flat thread_id_01 into 2D indices
-        const index_type thread_id_0 = thread_id_01 / max_threads_1;
-        const index_type thread_id_1 = thread_id_01 % max_threads_1;
-
-        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-
-        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
-            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          for (index_type idx_2 = start_2;
-               idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
-               idx_2 += stride_2) {
-            for (index_type idx_3 = start_3;
-                 idx_3 < static_cast<index_type>(m_policy.m_upper[3]);
-                 idx_3 += stride_3) {
-              Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3);
-            }
-          }
-        }
-      }
-    }
-
-  }  // end exec_range
-
- private:
-  const PolicyType& m_policy;
-  const Functor& m_func;
-  const MaxGridSize& m_max_grid_size;
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
-};
-
-// Rank 5
-template <typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile<5, PolicyType, Functor, MaxGridSize, Tag> {
-  using index_type = typename PolicyType::index_type;
-
-#ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_,
-      const EmulateCUDADim3<index_type> gridDim_,
-      const EmulateCUDADim3<index_type> blockDim_,
-      const EmulateCUDADim3<index_type> blockIdx_,
-      const EmulateCUDADim3<index_type> threadIdx_)
-      : m_policy(policy_),
-        m_func(f_),
-        m_max_grid_size(max_grid_size_),
-        gridDim(gridDim_),
-        blockDim(blockDim_),
-        blockIdx(blockIdx_),
-        threadIdx(threadIdx_) {}
-#else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_)
-      : m_policy(policy_), m_func(f_), m_max_grid_size(max_grid_size_) {}
-#endif
-
-  KOKKOS_IMPL_DEVICE_FUNCTION
-  void exec_range() const {
-    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
-    const index_type start_23 = blockIdx.y * blockDim.y + threadIdx.y;
-    const index_type start_4 =
-        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[4];
-
-    const index_type stride_01 = gridDim.x * blockDim.x;
-    const index_type stride_23 = gridDim.y * blockDim.y;
-    const index_type stride_4  = gridDim.z * blockDim.z;
-
-    // Maximum number of "virtual" threads needed to cover dimensions 0-3
-    const index_type max_threads_0 =
-        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
-    const index_type max_threads_1 =
-        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
-    const index_type max_threads_2 =
-        (m_policy.m_tile[2] * m_policy.m_tile_end[2]);
-    const index_type max_threads_3 =
-        (m_policy.m_tile[3] * m_policy.m_tile_end[3]);
-    const index_type max_threads_01 = max_threads_0 * max_threads_1;
-    const index_type max_threads_23 = max_threads_2 * max_threads_3;
-
-    // Iterate::Left, fastest index 0
-    if (PolicyType::inner_direction == Iterate::Left) {
-      // Iterate over dimension 4, packed 3 and 2, packed 1 and 0 with grid
-      // strides
-
-      for (index_type idx_4 = start_4;
-           idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
-           idx_4 += stride_4) {
-        // Unpack from dimension y into thread_id_2 (fastest) and thread_id_3
-        for (index_type thread_id_23 = start_23; thread_id_23 < max_threads_23;
-             thread_id_23 += stride_23) {
-          // Unpack flat thread_id_23 into 2D indices
-          const index_type thread_id_3 = thread_id_23 / max_threads_2;
-          const index_type thread_id_2 = thread_id_23 % max_threads_2;
-
-          const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
-          const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
-
-          if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
-              idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-            // Unpack from dimension x into thread_id_0 (fastest) and
-            // thread_id_1
-            for (index_type thread_id_01 = start_01;
-                 thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
-              // Unpack flat thread_id_01 into 2D indices
-              const index_type thread_id_1 = thread_id_01 / max_threads_0;
-              const index_type thread_id_0 = thread_id_01 % max_threads_0;
-
-              const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-              const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-
-              if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
-                  idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
-                Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
-                                       idx_4);
-              }
-            }
-          }
-        }
-      }
-
-    } else {  // Iterate::Right, fastest index 4
-      // Iterate over packed dimension 0 and 1, packed 2 and 3, and over 4 with
-      // grid strides
-
-      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
-      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
-           thread_id_01 += stride_01) {
-        // Unpack flat thread_id_01 into 2D indices
-        const index_type thread_id_0 = thread_id_01 / max_threads_1;
-        const index_type thread_id_1 = thread_id_01 % max_threads_1;
-
-        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-
-        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
-            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Unpack from dimension y into thread_id_2 and thread_id_3 (fastest)
-          for (index_type thread_id_23 = start_23;
-               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
-            // Unpack flat thread_id_23 into 2D indices
-            const index_type thread_id_2 = thread_id_23 / max_threads_3;
-            const index_type thread_id_3 = thread_id_23 % max_threads_3;
-
-            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
-            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
-
-            if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
-                idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
-              for (index_type idx_4 = start_4;
-                   idx_4 < static_cast<index_type>(m_policy.m_upper[4]);
-                   idx_4 += stride_4) {
-                Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
-                                       idx_4);
-              }
-            }
-          }
-        }
-      }
-    }
-
-  }  // end exec_range
-
- private:
-  const PolicyType& m_policy;
-  const Functor& m_func;
-  const MaxGridSize& m_max_grid_size;
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
-};
-
-// Rank 6
-template <typename PolicyType, typename Functor, typename MaxGridSize,
-          typename Tag>
-struct DeviceIterateTile<6, PolicyType, Functor, MaxGridSize, Tag> {
-  using index_type = typename PolicyType::index_type;
-
-#ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_,
-      const EmulateCUDADim3<index_type> gridDim_,
-      const EmulateCUDADim3<index_type> blockDim_,
-      const EmulateCUDADim3<index_type> blockIdx_,
-      const EmulateCUDADim3<index_type> threadIdx_)
-      : m_policy(policy_),
-        m_func(f_),
-        m_max_grid_size(max_grid_size_),
-        gridDim(gridDim_),
-        blockDim(blockDim_),
-        blockIdx(blockIdx_),
-        threadIdx(threadIdx_) {}
-#else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
-      const PolicyType& policy_, const Functor& f_,
-      const MaxGridSize& max_grid_size_)
-      : m_policy(policy_), m_func(f_), m_max_grid_size(max_grid_size_) {}
-#endif
-
-  KOKKOS_IMPL_DEVICE_FUNCTION
-  void exec_range() const {
-    const index_type start_01 = blockIdx.x * blockDim.x + threadIdx.x;
-    const index_type start_23 = blockIdx.y * blockDim.y + threadIdx.y;
-    const index_type start_45 = blockIdx.z * blockDim.z + threadIdx.z;
-
-    const index_type stride_01 = gridDim.x * blockDim.x;
-    const index_type stride_23 = gridDim.y * blockDim.y;
-    const index_type stride_45 = gridDim.z * blockDim.z;
-
-    // Maximum number of "virtual" threads needed to cover dimensions 0-5
-    const index_type max_threads_0 =
-        (m_policy.m_tile[0] * m_policy.m_tile_end[0]);
-    const index_type max_threads_1 =
-        (m_policy.m_tile[1] * m_policy.m_tile_end[1]);
-    const index_type max_threads_2 =
-        (m_policy.m_tile[2] * m_policy.m_tile_end[2]);
-    const index_type max_threads_3 =
-        (m_policy.m_tile[3] * m_policy.m_tile_end[3]);
-    const index_type max_threads_4 =
-        (m_policy.m_tile[4] * m_policy.m_tile_end[4]);
-    const index_type max_threads_5 =
-        (m_policy.m_tile[5] * m_policy.m_tile_end[5]);
-
-    const index_type max_threads_01 = max_threads_0 * max_threads_1;
-    const index_type max_threads_23 = max_threads_2 * max_threads_3;
-    const index_type max_threads_45 = max_threads_4 * max_threads_5;
-
-    if (PolicyType::inner_direction == Iterate::Left) {
-      // Iterate over packed 5 and 4, packed 3 and 2, packed 1 and 0 with grid
-      // strides
-
-      // Unpack from dimension z into thread_id_4 (fastest) and thread_id_5
-      for (index_type thread_id_45 = start_45; thread_id_45 < max_threads_45;
-           thread_id_45 += stride_45) {
-        // Unpack flat thread_id_45 into 2D indices
-        const index_type thread_id_5 = thread_id_45 / max_threads_4;
-        const index_type thread_id_4 = thread_id_45 % max_threads_4;
-
-        const index_type idx_5 = thread_id_5 + m_policy.m_lower[5];
-        const index_type idx_4 = thread_id_4 + m_policy.m_lower[4];
-
-        if (idx_5 < static_cast<index_type>(m_policy.m_upper[5]) &&
-            idx_4 < static_cast<index_type>(m_policy.m_upper[4])) {
-          // Unpack from dimension y into thread_id_2 (fastest) and thread_id_3
-          for (index_type thread_id_23 = start_23;
-               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
-            // Unpack flat thread_id_23 into 2D indices
-            const index_type thread_id_3 = thread_id_23 / max_threads_2;
-            const index_type thread_id_2 = thread_id_23 % max_threads_2;
-
-            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
-            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
-
-            if (idx_3 < static_cast<index_type>(m_policy.m_upper[3]) &&
-                idx_2 < static_cast<index_type>(m_policy.m_upper[2])) {
-              // Unpack from dimension x into thread_id_0 (fastest) and
-              // thread_id_1
-              for (index_type thread_id_01 = start_01;
-                   thread_id_01 < max_threads_01; thread_id_01 += stride_01) {
-                // Unpack flat thread_id_01 into 2D indices
-                const index_type thread_id_1 = thread_id_01 / max_threads_0;
-                const index_type thread_id_0 = thread_id_01 % max_threads_0;
-
-                const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-                const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-
-                if (idx_1 < static_cast<index_type>(m_policy.m_upper[1]) &&
-                    idx_0 < static_cast<index_type>(m_policy.m_upper[0])) {
-                  Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
-                                         idx_4, idx_5);
-                }
-              }
-            }
-          }
-        }
-      }
-
-    } else {  // Iterate::Right
-      // Iterate over packed dimension 0 and 1, packed 2 and 3, packed 4 and 5
-      // with grid strides
-
-      // Unpack from dimension x into thread_id_0 and thread_id_1 (fastest)
-      for (index_type thread_id_01 = start_01; thread_id_01 < max_threads_01;
-           thread_id_01 += stride_01) {
-        // Unpack flat thread_id_01 into 2D indices
-        const index_type thread_id_0 = thread_id_01 / max_threads_1;
-        const index_type thread_id_1 = thread_id_01 % max_threads_1;
-
-        const index_type idx_0 = thread_id_0 + m_policy.m_lower[0];
-        const index_type idx_1 = thread_id_1 + m_policy.m_lower[1];
-
-        if (idx_0 < static_cast<index_type>(m_policy.m_upper[0]) &&
-            idx_1 < static_cast<index_type>(m_policy.m_upper[1])) {
-          // Unpack from dimension y into thread_id_2 and thread_id_3 (fastest)
-          for (index_type thread_id_23 = start_23;
-               thread_id_23 < max_threads_23; thread_id_23 += stride_23) {
-            // Unpack flat thread_id_23 into 2D indices
-            const index_type thread_id_2 = thread_id_23 / max_threads_3;
-            const index_type thread_id_3 = thread_id_23 % max_threads_3;
-
-            const index_type idx_2 = thread_id_2 + m_policy.m_lower[2];
-            const index_type idx_3 = thread_id_3 + m_policy.m_lower[3];
-
-            if (idx_2 < static_cast<index_type>(m_policy.m_upper[2]) &&
-                idx_3 < static_cast<index_type>(m_policy.m_upper[3])) {
-              // Unpack from dimension z into thread_id_4 and thread_id_5
-              // (fastest)
-              for (index_type thread_id_45 = start_45;
-                   thread_id_45 < max_threads_45; thread_id_45 += stride_45) {
-                // Unpack flat thread_id_45 into 2D indices
-                const index_type thread_id_4 = thread_id_45 / max_threads_5;
-                const index_type thread_id_5 = thread_id_45 % max_threads_5;
-
-                const index_type idx_4 = thread_id_4 + m_policy.m_lower[4];
-                const index_type idx_5 = thread_id_5 + m_policy.m_lower[5];
-
-                if (idx_4 < static_cast<index_type>(m_policy.m_upper[4]) &&
-                    idx_5 < static_cast<index_type>(m_policy.m_upper[5])) {
-                  Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2, idx_3,
-                                         idx_4, idx_5);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-  }  // end exec_range
-
- private:
-  const PolicyType& m_policy;
-  const Functor& m_func;
-  const MaxGridSize& m_max_grid_size;
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
+  template <typename... Idxs>
+  KOKKOS_INLINE_FUNCTION void iterate(std::integral_constant<unsigned, 0u>,
+                                      Idxs... idxs) const {
+    Impl::_tag_invoke<Tag>(m_functor, idxs...);
+  }
 };
 
 // ----------------------------------------------------------------------------------

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -183,28 +183,36 @@ struct DeviceIterate {
     static_assert(R < 6, "R must be smaller than 6");
     if constexpr (is_packed_index<R>()) {
       if constexpr (R == 0 || R == 1) {
-        return static_cast<index_type>(blockDim.x * gridDim.x);
+        return static_cast<index_type>(blockDim.x) *
+               static_cast<index_type>(gridDim.x);
       } else if constexpr (R == 2 || R == 3) {
-        return static_cast<index_type>(blockDim.y * gridDim.y);
+        return static_cast<index_type>(blockDim.y) *
+               static_cast<index_type>(gridDim.y);
       } else if constexpr (R == 4 || R == 5) {
-        return static_cast<index_type>(blockDim.z * gridDim.z);
+        return static_cast<index_type>(blockDim.z) *
+               static_cast<index_type>(gridDim.z);
       }
     } else {
       // No packed index for all ranks
       if constexpr (Rank < 4) {
         if constexpr (R == 0) {
-          return static_cast<index_type>(blockDim.x * gridDim.x);
+          return static_cast<index_type>(blockDim.x) *
+                 static_cast<index_type>(gridDim.x);
         } else if constexpr (R == 1) {
-          return static_cast<index_type>(blockDim.y * gridDim.y);
+          return static_cast<index_type>(blockDim.y) *
+                 static_cast<index_type>(gridDim.y);
         } else if constexpr (R == 2) {
-          return static_cast<index_type>(blockDim.z * gridDim.z);
+          return static_cast<index_type>(blockDim.z) *
+                 static_cast<index_type>(gridDim.z);
         }
       } else {
         // Mix of packed and unpacked for Rank 4 and 5
         if constexpr (R == 2) {
-          return static_cast<index_type>(blockDim.y * gridDim.y);
+          return static_cast<index_type>(blockDim.y) *
+                 static_cast<index_type>(gridDim.y);
         } else if constexpr (R == 3 || R == 4) {
-          return static_cast<index_type>(blockDim.z * gridDim.z);
+          return static_cast<index_type>(blockDim.z) *
+                 static_cast<index_type>(gridDim.z);
         }
       }
     }

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -58,8 +58,9 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
 // map 2D/3D hardware threads to N-D iteration space
 //
 // For ranks 2-3: Direct mapping of hardware threads to iteration space
-// dimensions For ranks 4-6: Multiple logical indices are packed into single
-// hardware dimensions
+// dimensions.
+// For ranks 4-6: Multiple logical indices are packed into single
+// hardware dimensions.
 //
 // 1. Start iterating at hardware thread identifier
 // 2. Extend iteration space range with stride loops using grid dimensions
@@ -99,36 +100,31 @@ struct DeviceIterateTile<2, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    const index_type stride_0 = gridDim.x * blockDim.x;
-    const index_type stride_1 = gridDim.y * blockDim.y;
+    // Map policy dimensions to hardware threads
+    constexpr Kokkos::Array<int, 2> idx =
+        (PolicyType::inner_direction == Iterate::Left)
+            ? Kokkos::Array<int, 2>{0, 1}
+            : Kokkos::Array<int, 2>{1, 0};
+
+    const index_type stride_x = gridDim.x * blockDim.x;
+    const index_type stride_y = gridDim.y * blockDim.y;
 
     const index_type start_0 =
-        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[0];
+        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[idx[0]];
     const index_type start_1 =
-        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[1];
+        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[idx[1]];
 
-    // Iterate::Left, fastest index 0
-    if constexpr (PolicyType::inner_direction == Iterate::Left) {
-      // Iterate over dimension 1 and 0 with grid strides
-      for (index_type idx_1 = start_1;
-           idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
-           idx_1 += stride_1) {
-        for (index_type idx_0 = start_0;
-             idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
-             idx_0 += stride_0) {
-          Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
-        }
-      }
-
-    } else {  // Iterate::Right, fastest index 1
-      // Iterate over dimension 0 and 1 with grid strides
+    // Iterate over dimension 0 and 1 with grid strides
+    for (index_type idx_1 = start_1;
+         idx_1 < static_cast<index_type>(m_policy.m_upper[idx[1]]);
+         idx_1 += stride_y) {
       for (index_type idx_0 = start_0;
-           idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
-           idx_0 += stride_0) {
-        for (index_type idx_1 = start_1;
-             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
-             idx_1 += stride_1) {
+           idx_0 < static_cast<index_type>(m_policy.m_upper[idx[0]]);
+           idx_0 += stride_x) {
+        if constexpr (PolicyType::inner_direction == Iterate::Left) {
           Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1);
+        } else {
+          Impl::_tag_invoke<Tag>(m_func, idx_1, idx_0);
         }
       }
     }
@@ -176,46 +172,37 @@ struct DeviceIterateTile<3, PolicyType, Functor, MaxGridSize, Tag> {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    const index_type stride_0 = gridDim.x * blockDim.x;
-    const index_type stride_1 = gridDim.y * blockDim.y;
-    const index_type stride_2 = gridDim.z * blockDim.z;
+    // Map policy dimensions to hardware threads
+    constexpr Kokkos::Array<int, 3> idx =
+        (PolicyType::inner_direction == Iterate::Left)
+            ? Kokkos::Array<int, 3>{0, 1, 2}
+            : Kokkos::Array<int, 3>{2, 1, 0};
+
+    const index_type stride_x = gridDim.x * blockDim.x;
+    const index_type stride_y = gridDim.y * blockDim.y;
+    const index_type stride_z = gridDim.z * blockDim.z;
 
     const index_type start_0 =
-        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[0];
+        blockIdx.x * blockDim.x + threadIdx.x + m_policy.m_lower[idx[0]];
     const index_type start_1 =
-        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[1];
+        blockIdx.y * blockDim.y + threadIdx.y + m_policy.m_lower[idx[1]];
     const index_type start_2 =
-        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[2];
+        blockIdx.z * blockDim.z + threadIdx.z + m_policy.m_lower[idx[2]];
 
-    // Iterate::Left, fastest index 0
-    if constexpr (PolicyType::inner_direction == Iterate::Left) {
-      // Iterate over dimension 2, 1 and 0 with grid strides
-      for (index_type idx_2 = start_2;
-           idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
-           idx_2 += stride_2) {
-        for (index_type idx_1 = start_1;
-             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
-             idx_1 += stride_1) {
-          for (index_type idx_0 = start_0;
-               idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
-               idx_0 += stride_0) {
+    // Iterate over dimension 2, 1 and 0 with grid strides
+    for (index_type idx_2 = start_2;
+         idx_2 < static_cast<index_type>(m_policy.m_upper[idx[2]]);
+         idx_2 += stride_z) {
+      for (index_type idx_1 = start_1;
+           idx_1 < static_cast<index_type>(m_policy.m_upper[idx[1]]);
+           idx_1 += stride_y) {
+        for (index_type idx_0 = start_0;
+             idx_0 < static_cast<index_type>(m_policy.m_upper[idx[0]]);
+             idx_0 += stride_x) {
+          if constexpr (PolicyType::inner_direction == Iterate::Left) {
             Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2);
-          }
-        }
-      }
-
-    } else {  // Iterate::Right, fastest index 2
-      // Iterate over dimension 0, 1 and 2 with grid strides
-      for (index_type idx_0 = start_0;
-           idx_0 < static_cast<index_type>(m_policy.m_upper[0]);
-           idx_0 += stride_0) {
-        for (index_type idx_1 = start_1;
-             idx_1 < static_cast<index_type>(m_policy.m_upper[1]);
-             idx_1 += stride_1) {
-          for (index_type idx_2 = start_2;
-               idx_2 < static_cast<index_type>(m_policy.m_upper[2]);
-               idx_2 += stride_2) {
-            Impl::_tag_invoke<Tag>(m_func, idx_0, idx_1, idx_2);
+          } else {
+            Impl::_tag_invoke<Tag>(m_func, idx_2, idx_1, idx_0);
           }
         }
       }

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -53,18 +53,132 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
                                 (Args&&)args...);
 }
 
-// ------------------------------------------------------------------ //
-// ParallelFor iteration pattern
-// map 2D/3D hardware threads to N-D iteration space
+// ------------------------------------------------------------------------- //
+// Compute GPU launch parameters (grid/block dimensions) for MDRangePolicy
+//
+// Ranks 2-3: Direct mapping - each policy dimension maps to one GPU dimension.
+// Ranks 4-6: Dimension packing - pairs of policy dimensions are packed
+//            into single GPU dimensions to fit the 3D hardware limit.
+//
+// Returns: CUDA/HIP: std::pair<dim3 grid, dim3 block>
+//          SYCL:     sycl::nd_range<3>{global, local}
+//
+template <typename... Traits, typename MaxGridSize>
+auto compute_device_launch_params(
+    const Kokkos::MDRangePolicy<Traits...>& policy,
+    const MaxGridSize& max_grid_size) {
+  using Policy           = Kokkos::MDRangePolicy<Traits...>;
+  using array_index_type = typename Policy::array_index_type;
+
+#ifdef KOKKOS_ENABLE_SYCL
+  EmulateCUDADim3 block{1, 1, 1};
+#else
+  dim3 block{1, 1, 1};
+#endif
+
+  array_index_type grid_0 = 1;
+  array_index_type grid_1 = 1;
+  array_index_type grid_2 = 1;
+
+  if constexpr (Policy::inner_direction == Iterate::Left) {
+    if constexpr (Policy::rank == 2) {
+      block.x = policy.m_tile[0];
+      block.y = policy.m_tile[1];
+      grid_0  = policy.m_tile_end[0];
+      grid_1  = policy.m_tile_end[1];
+    } else if constexpr (Policy::rank == 3) {
+      block.x = policy.m_tile[0];
+      block.y = policy.m_tile[1];
+      block.z = policy.m_tile[2];
+      grid_0  = policy.m_tile_end[0];
+      grid_1  = policy.m_tile_end[1];
+      grid_2  = policy.m_tile_end[2];
+    } else if constexpr (Policy::rank == 4) {
+      block.x = policy.m_tile[0] * policy.m_tile[1];
+      block.y = policy.m_tile[2];
+      block.z = policy.m_tile[3];
+      grid_0  = policy.m_tile_end[0] * policy.m_tile_end[1];
+      grid_1  = policy.m_tile_end[2];
+      grid_2  = policy.m_tile_end[3];
+    } else if constexpr (Policy::rank == 5) {
+      block.x = policy.m_tile[0] * policy.m_tile[1];
+      block.y = policy.m_tile[2] * policy.m_tile[3];
+      block.z = policy.m_tile[4];
+      grid_0  = policy.m_tile_end[0] * policy.m_tile_end[1];
+      grid_1  = policy.m_tile_end[2] * policy.m_tile_end[3];
+      grid_2  = policy.m_tile_end[4];
+    } else if constexpr (Policy::rank == 6) {
+      block.x = policy.m_tile[0] * policy.m_tile[1];
+      block.y = policy.m_tile[2] * policy.m_tile[3];
+      block.z = policy.m_tile[4] * policy.m_tile[5];
+      grid_0  = policy.m_tile_end[0] * policy.m_tile_end[1];
+      grid_1  = policy.m_tile_end[2] * policy.m_tile_end[3];
+      grid_2  = policy.m_tile_end[4] * policy.m_tile_end[5];
+    }
+  } else {  // InnerDirection == Right
+    if constexpr (Policy::rank == 2) {
+      block.x = policy.m_tile[1];
+      block.y = policy.m_tile[0];
+      grid_0  = policy.m_tile_end[1];
+      grid_1  = policy.m_tile_end[0];
+    } else if constexpr (Policy::rank == 3) {
+      block.x = policy.m_tile[2];
+      block.y = policy.m_tile[1];
+      block.z = policy.m_tile[0];
+      grid_0  = policy.m_tile_end[2];
+      grid_1  = policy.m_tile_end[1];
+      grid_2  = policy.m_tile_end[0];
+    } else if constexpr (Policy::rank == 4) {
+      block.x = policy.m_tile[3] * policy.m_tile[2];
+      block.y = policy.m_tile[1];
+      block.z = policy.m_tile[0];
+      grid_0  = policy.m_tile_end[3] * policy.m_tile_end[2];
+      grid_1  = policy.m_tile_end[1];
+      grid_2  = policy.m_tile_end[0];
+    } else if constexpr (Policy::rank == 5) {
+      block.x = policy.m_tile[4] * policy.m_tile[3];
+      block.y = policy.m_tile[2] * policy.m_tile[1];
+      block.z = policy.m_tile[0];
+      grid_0  = policy.m_tile_end[4] * policy.m_tile_end[3];
+      grid_1  = policy.m_tile_end[2] * policy.m_tile_end[1];
+      grid_2  = policy.m_tile_end[0];
+    } else if constexpr (Policy::rank == 6) {
+      block.x = policy.m_tile[5] * policy.m_tile[4];
+      block.y = policy.m_tile[3] * policy.m_tile[2];
+      block.z = policy.m_tile[1] * policy.m_tile[0];
+      grid_0  = policy.m_tile_end[5] * policy.m_tile_end[4];
+      grid_1  = policy.m_tile_end[3] * policy.m_tile_end[2];
+      grid_2  = policy.m_tile_end[1] * policy.m_tile_end[0];
+    }
+  }
+
+#ifdef KOKKOS_ENABLE_SYCL
+  // SYCL uses nd_range with global = grid * local sizes
+  sycl::range<3> local_sizes(block.x, block.y, block.z);
+  sycl::range<3> global_sizes(
+      std::min<array_index_type>(grid_0, max_grid_size[0]) * local_sizes[0],
+      std::min<array_index_type>(grid_1, max_grid_size[1]) * local_sizes[1],
+      std::min<array_index_type>(grid_2, max_grid_size[2]) * local_sizes[2]);
+  return sycl::nd_range<3>(global_sizes, local_sizes);
+#else
+  dim3 grid(std::min<array_index_type>(grid_0, max_grid_size[0]),
+            std::min<array_index_type>(grid_1, max_grid_size[1]),
+            std::min<array_index_type>(grid_2, max_grid_size[2]));
+  return std::pair(grid, block);
+#endif
+}
+
+// ------------------------------------------------------------------------- //
+// ParallelFor iteration pattern - maps GPU threads to N-D iteration space
 //
 // For ranks 2-3: Direct mapping of hardware threads to iteration space
 // dimensions.
 // For ranks 4-6: Multiple logical indices are packed into single
 // hardware dimensions.
 //
-// 1. Start iterating at hardware thread identifier
-// 2. Extend iteration space range with stride loops using grid dimensions
-// 3. Bound checking to ensure we do not exceed upper bounds
+// 1. Start iterating at the hardware thread identifier.
+// 2. Extend the iteration space range with stride loops using grid dimensions.
+// 3. Bounds check against m_upper to filter out-of-bounds iterations.
 //
 template <int Rank, typename array_index_type, typename index_type,
           typename Functor, Kokkos::Iterate Layout, typename Tag>
@@ -78,7 +192,7 @@ struct DeviceIterate {
  private:
   const array_type m_lower;
   const array_type m_upper;
-  const array_type m_max_threads;
+  const array_type m_extent;  // tile_size * num_tiles
   Functor m_functor;
 
 #ifdef KOKKOS_ENABLE_SYCL
@@ -92,14 +206,14 @@ struct DeviceIterate {
 #ifdef KOKKOS_ENABLE_SYCL
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterate(
       const array_type& lower, const array_type& upper,
-      const array_type& max_threads, const Functor& functor,
+      const array_type& extent, const Functor& functor,
       const EmulateCUDADim3<index_type> gridDim_,
       const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_lower(lower),
         m_upper(upper),
-        m_max_threads(max_threads),
+        m_extent(extent),
         m_functor(functor),
         gridDim(gridDim_),
         blockDim(blockDim_),
@@ -109,31 +223,29 @@ struct DeviceIterate {
 
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterate(const array_type& lower,
                                             const array_type& upper,
-                                            const array_type& max_threads,
+                                            const array_type& extent,
                                             const Functor& functor)
-      : m_lower(lower),
-        m_upper(upper),
-        m_max_threads(max_threads),
-        m_functor(functor) {}
+      : m_lower(lower), m_upper(upper), m_extent(extent), m_functor(functor) {}
 #endif
 
   KOKKOS_INLINE_FUNCTION
-  void exec_range() const {
-    // Execute nested loops directly without precomputing arrays
-    iterate(std::integral_constant<unsigned, Rank>());
-  }
+  void exec_range() const { iterate(std::integral_constant<unsigned, Rank>()); }
 
  private:
-  // Unpack happen on consecutive ranks
-  template <unsigned R>
+  // Runtime expression to determine if Dim is part of a packed pair
+  // Packing occurs on consecutive dimension pairs for rank > 3
+  template <unsigned Dim>
   KOKKOS_INLINE_FUNCTION static consteval bool is_packed_index() {
-    return ((R == 0 || R == 1) && Rank > 3) ||
-           ((R == 2 || R == 3) && Rank > 4) || ((R == 4 || R == 5) && Rank > 5);
+    return ((Dim == 0 || Dim == 1) && Rank > 3) ||
+           ((Dim == 2 || Dim == 3) && Rank > 4) ||
+           ((Dim == 4 || Dim == 5) && Rank > 5);
   }
 
+  // Packed: returns flat hardware thread ID (unpacking happens in iterate())
+  // Unpacked: returns global index (lower + blockIdx * blockDim + threadIdx)
   template <unsigned R>
   KOKKOS_INLINE_FUNCTION constexpr index_type my_begin() const noexcept {
-    static_assert(R < 6, "R must be smaller than 6");
+    static_assert(R < 6);
     if constexpr (is_packed_index<R>()) {
       if constexpr (R == 0 || R == 1) {
         return blockIdx.x * blockDim.x + threadIdx.x;
@@ -164,23 +276,26 @@ struct DeviceIterate {
     return m_lower[R];
   }
 
+  // Packed: end at the product of two consecutive extents
+  // Unpacked: directly use m_upper
   template <unsigned R>
   KOKKOS_INLINE_FUNCTION constexpr index_type my_end() const noexcept {
-    static_assert(R < 6, "R must be smaller than 6");
+    static_assert(R < 6);
     if constexpr (is_packed_index<R>()) {
       if constexpr (R % 2 == 0) {
-        return m_max_threads[R] * m_max_threads[R + 1];
+        return m_extent[R] * m_extent[R + 1];
       } else {
-        return m_max_threads[R] * m_max_threads[R - 1];
+        return m_extent[R] * m_extent[R - 1];
       }
     } else {
       return m_upper[R];
     }
   }
 
+  // Stride by the total number of threads in the GPU dimension
   template <unsigned R>
   KOKKOS_INLINE_FUNCTION constexpr index_type my_stride() const noexcept {
-    static_assert(R < 6, "R must be smaller than 6");
+    static_assert(R < 6);
     if constexpr (is_packed_index<R>()) {
       if constexpr (R == 0 || R == 1) {
         return static_cast<index_type>(blockDim.x) *
@@ -219,11 +334,25 @@ struct DeviceIterate {
     return index_type{1};
   }
 
-  // Generate nested loops
+  // ----------------------------------------------------------------------- //
+  // Nested loops with recursive template instantiation
+  //
+  // Accumulates indices in parameter pack Idxs...
+  // The fastest changing index is always i0 (innermost loop).
+  //
+  // Functor call order depends on the Layout:
+  //  Layout::Left:
+  //    functor(i0, i1, i2, ..., iR)
+  //  Layout::Right:
+  //    functor(iR, ..., i2, i1, i0)
+  //
+  // For Layout::Right, bounds were previously swapped during ParallelFor
+  // construction, so i0 correctly iterates over the range of iR while
+  // remaining the "fastest-changing" index.
+  //
   template <unsigned R, typename... Idxs>
   KOKKOS_INLINE_FUNCTION void iterate(std::integral_constant<unsigned, R>,
                                       Idxs... idxs) const {
-    static_assert(R > 0, "R must be greater than 0");
     constexpr unsigned rankIdx = R - 1;
     const index_type start     = my_begin<rankIdx>();
     const index_type end       = my_end<rankIdx>();
@@ -231,14 +360,13 @@ struct DeviceIterate {
 
     for (index_type idx = start; idx < end; idx += stride) {
       if constexpr (is_packed_index<rankIdx>()) {
+        static_assert(R >= 2);
         // Unpack two consecutive indices
-        constexpr index_type idx1 =
-            (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
-        constexpr index_type idx2 =
-            (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
+        constexpr unsigned idx1 = (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
+        constexpr unsigned idx2 = (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
 
-        const index_type id_1 = idx % m_max_threads[idx1] + m_lower[idx1];
-        const index_type id_2 = idx / m_max_threads[idx1] + m_lower[idx2];
+        const index_type id_1 = idx % m_extent[idx1] + m_lower[idx1];
+        const index_type id_2 = idx / m_extent[idx1] + m_lower[idx2];
 
         if (id_1 < m_upper[idx1] && id_2 < m_upper[idx2]) {
           if constexpr (Layout == Iterate::Left) {

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -126,7 +126,7 @@ struct DeviceIterate {
  private:
   // Unpack happen on consecutive ranks
   template <unsigned R>
-  static consteval __device__ bool is_packed_index() {
+  KOKKOS_INLINE_FUNCTION static consteval bool is_packed_index() {
     return ((R == 0 || R == 1) && Rank > 3) ||
            ((R == 2 || R == 3) && Rank > 4) || ((R == 4 || R == 5) && Rank > 5);
   }
@@ -141,8 +141,6 @@ struct DeviceIterate {
         return blockIdx.y * blockDim.y + threadIdx.y;
       } else if constexpr (R == 4 || R == 5) {
         return blockIdx.z * blockDim.z + threadIdx.z;
-      } else {
-        return m_lower[R];
       }
     } else {
       // No packed index
@@ -158,15 +156,12 @@ struct DeviceIterate {
         // Mix of packed and unpacked for Rank 4 and 5
         if constexpr (R == 2) {
           return m_lower[R] + blockIdx.y * blockDim.y + threadIdx.y;
-        } else if constexpr (R == 3) {
+        } else if constexpr (R == 3 || R == 4) {
           return m_lower[R] + blockIdx.z * blockDim.z + threadIdx.z;
-        } else if constexpr (R == 4) {
-          return m_lower[R] + blockIdx.z * blockDim.z + threadIdx.z;
-        } else {
-          return m_lower[R];
         }
       }
     }
+    return m_lower[R];
   }
 
   template <unsigned R>
@@ -208,9 +203,7 @@ struct DeviceIterate {
         // Mix of packed and unpacked for Rank 4 and 5
         if constexpr (R == 2) {
           return static_cast<index_type>(blockDim.y * gridDim.y);
-        } else if constexpr (R == 3) {
-          return static_cast<index_type>(blockDim.z * gridDim.z);
-        } else if constexpr (R == 4) {
+        } else if constexpr (R == 3 || R == 4) {
           return static_cast<index_type>(blockDim.z * gridDim.z);
         }
       }


### PR DESCRIPTION
### Summary

This PR introduces a refactoring of `DeviceIterateTile` that aims to improve performance, by attempting to reduce register pressure and minimizing the number of executed instructions in the `Kokkos` machinery.

- This version completely merges the concepts of tile and thread block.
- For ranks 2 and 3, I use grid strides to extend the range. `tile_end`, which corresponds to the repetition of tiles for each dimension, is no longer used (it's now considered identical to `gridDim`). `tile` is no longer used either, as it's now considered identical to `blockDim`.
- For ranks 4, 5, and 6, I reconstruct the thread ID of the combined dim. I start from where the kernel's execution configuration places us, then I iterate until the value calculated by the MDRangePolicy. ~Then I rebuild the block ID of the combined dim~ (e.g., idx 0 and 1 encoded in the x dimension for rank 4). Here too, I use grid stride.
- Upper bounds are now controlled only by the index and no longer by both index and position within the tile (tiles that no longer really exist).

### How index construction works

Index construction always goes from `Rank` down to `0`, regardless of layout. A recursive template generates the nested `for` loops.

The implementation always uses a maximum of 3 nested `for` loops, no matter the policy rank. These loops help bypass kernel limitations on maximum grid size.

Device parallelism is applied to these 3 nested `for` loops, specifically on the starting index. In most cases, the strides (therefore the for loops) are unnecessary since CUDA/HIP API already provides large grid sizes. But, this implementation aims to be general.

**Example with `Rank = 4`:**

Loop order: `RankIdx` = 3, 2, 1, 0
Indices 0 and 1 -> maps to x dimension (CUDA/HIP)
Index 2 -> maps to y dimension
Index 3 -> maps to z dimension

**What changes with different layout:**
The layout determines the order indices are passed to the functor.

**LayoutLeft:**
```cpp
functor(0, 1, 2, 3)  // Leftmost index (0) maps to x (innermost loop)
```
**LayoutRight:**
```cpp
functor(3, 2, 1, 0)  // Rightmost index (0) maps to x (innermost loop)
```

**Swap Indices for LayoutRight**
Before calling `deviceIterate`, we swap the bounds position for LayoutRight, this ensures the functor is called with the correct indexes (we actually call `functor(0, 1, 2, 3)`)
```CPP
// For LayoutRight
// So in reality we call:
functor(0, 1, 2, 3)  // Index 3 is the fastest-varying (innermost loop)
```