### PR TITLE
Suppress `bugprone-multi-level-implicit-pointer-conversion` warning with CUDA

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -529,7 +529,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
           driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
 
-      void const* args[] = {static_cast<void const*>(&driver_ptr)};
+      // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
+      void* args[] = {static_cast<void*>(&driver_ptr)};
 
       cudaKernelNodeParams params = {};
 
@@ -538,7 +539,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       params.sharedMemBytes = shmem;
       // Casting a function pointer to a data pointer...
       params.func         = reinterpret_cast<void*>(base_t::get_kernel_func());
-      params.kernelParams = const_cast<void**>(args);
+      params.kernelParams = args;
       params.extra        = nullptr;
 
       KOKKOS_IMPL_CUDA_SAFE_CALL(

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -529,7 +529,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
           driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
 
-      void const* args[] = {&driver_ptr};
+      void const* args[] = {static_cast<void const*>(driver_ptr)};
 
       cudaKernelNodeParams params = {};
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -530,7 +530,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
           driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
 
       // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
-      void* args[] = {static_cast<void*>(&driver_ptr)};
+      void* args[] = {&driver_ptr};
 
       cudaKernelNodeParams params = {};
 

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -529,7 +529,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
           driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
 
-      void const* args[] = {static_cast<void const*>(driver_ptr)};
+      void const* args[] = {static_cast<void const*>(&driver_ptr)};
 
       cudaKernelNodeParams params = {};
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -451,7 +451,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       // FIXME_HIP Modifying the assignment to args causes a segfault in
       // hip_graph.force_global_launch
       // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
-      void *args[] = {static_cast<void *>(&driver_ptr)};
+      void *args[] = {&driver_ptr};
 
       hipKernelNodeParams params = {};
 

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -448,7 +448,10 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       KOKKOS_IMPL_HIP_SAFE_CALL(hip_instance->hip_memcpy_async_wrapper(
           driver_ptr, &driver, sizeof(DriverType), hipMemcpyDefault));
 
-      void const *args[] = {static_cast<void const *>(&driver_ptr)};
+      // FIXME_HIP Modifying the assignment to args causes a segfault in
+      // hip_graph.force_global_launch
+      // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
+      void *args[] = {static_cast<void *>(&driver_ptr)};
 
       hipKernelNodeParams params = {};
 
@@ -457,7 +460,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       params.sharedMemBytes = shmem;
       // Casting a function pointer to a data pointer...
       params.func         = reinterpret_cast<void *>(base_t::get_kernel_func());
-      params.kernelParams = const_cast<void **>(args);
+      params.kernelParams = args;
       params.extra        = nullptr;
 
       KOKKOS_IMPL_HIP_SAFE_CALL(hip_instance->hip_graph_add_kernel_node_wrapper(

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -448,10 +448,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       KOKKOS_IMPL_HIP_SAFE_CALL(hip_instance->hip_memcpy_async_wrapper(
           driver_ptr, &driver, sizeof(DriverType), hipMemcpyDefault));
 
-      // FIXME_HIP Modifying the assignment to args causes a segfault in
-      // hip_graph.force_global_launch
-      // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
-      void const *args[] = {&driver_ptr};
+      void const *args[] = {static_cast<void const *>(&driver_ptr)};
 
       hipKernelNodeParams params = {};
 


### PR DESCRIPTION
LLVM 18.0.8 + CUDA 12.5

```
/ascldap/users/crtrott/Kokkos/kokkos/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp:532:29: error: multilevel pointer conversion from 'base_t **' (aka 'Kokkos::Impl::ParallelFor<Test::SizedFunctor<Kokkos::View<int, Kokkos::Cuda, Kokkos::MemoryTraits<4>>, 100000>, Kokkos::RangePolicy<Kokkos::Cuda, Kokkos::Impl::IsGraphKernelTag>, Kokkos::Cuda> **') to 'const void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion,-warnings-as-errors]
  532 |       void const* args[] = {&driver_ptr};
      |                             ^
/ascldap/users/crtrott/Kokkos/kokkos/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp:532:29: error: multilevel pointer conversion from 'base_t **' (aka 'Kokkos::Impl::ParallelFor<Test::SizedFunctor<Kokkos::View<int, Kokkos::Cuda, Kokkos::MemoryTraits<4>>, 32769>, Kokkos::RangePolicy<Kokkos::Cuda, Kokkos::Experimental::WorkItemProperty::ImplWorkItemProperty<2>, Kokkos::Impl::IsGraphKernelTag>, Kokkos::Cuda> **') to 'const void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion,-warnings-as-errors]
/ascldap/users/crtrott/Kokkos/kokkos/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp:532:29: error: multilevel pointer conversion from 'base_t **' (aka 'Kokkos::Impl::ParallelFor<Test::SizedFunctor<Kokkos::View<int, Kokkos::Cuda, Kokkos::MemoryTraits<4>>, 6000>, Kokkos::RangePolicy<Kokkos::Cuda, Kokkos::Impl::IsGraphKernelTag>, Kokkos::Cuda> **') to 'const void *', please use explicit cast [bugprone-multi-level-implicit-pointer-conversion,-warnings-as-errors]
50760 warnings generated when compiling for sm_70.
Suppressed 50814 warnings (50757 in non-user code, 57 NOLINT).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
3 warnings treated as errors
make[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Cuda1.dir/build.make:527: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Cuda1.dir/cuda/TestCuda_Graph.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```