### PR TITLE
 Fix Custom Reduction with `MDRangePolicy`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -301,7 +301,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = 512;  // block size must less than or equal to 512
+    unsigned n = 512;  // block size must be less than or equal to 512
     int const maxShmemPerBlock =
         m_policy.space().cuda_device_prop().sharedMemPerBlock;
     int shmem_size =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -345,6 +345,7 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
+      // Note: block_size must be less than or equal to 512
       block_size = std::max(block_size, static_cast<int>(CudaTraits::WarpSize));
       block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -243,9 +243,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   inline __device__ void operator()() const {
-    const integral_nonzero_constant<word_size_type,
-                                    ReducerType::static_value_size() /
-                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(word_size_type)>
         word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(word_size_type));
 
@@ -294,8 +293,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncwarp(0xffffffff);
       }
 
-      for (word_size_type i = threadIdx.y; i < word_count.value;
-           i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }
@@ -303,7 +301,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = CudaTraits::WarpSize * 8;
+    unsigned n = 512;  // Algorithm constraint
     int const maxShmemPerBlock =
         m_policy.space().cuda_device_prop().sharedMemPerBlock;
     int shmem_size =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -326,6 +326,11 @@ class ParallelReduce<CombinedFunctorReducerType,
           cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
               f, n);
     }
+    if (n < CudaTraits::WarpSize) {
+      Kokkos::Impl::throw_runtime_exception(
+          std::string("Kokkos::Impl::ParallelReduce<Cuda> could not find a "
+                      "valid tile size."));
+    }
     return n;
   }
 
@@ -340,10 +345,8 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
-      block_size = (block_size > suggested_blocksize)
-                       ? block_size
-                       : suggested_blocksize;  // Note: block_size must be less
-                                               // than or equal to 512
+      block_size = std::max(block_size, static_cast<int>(CudaTraits::WarpSize));
+      block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
 
       m_scratch_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -324,11 +324,20 @@ class ParallelReduce<CombinedFunctorReducerType,
       shmem_size =
           cuda_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
               f, n);
-    }
-    if (n < CudaTraits::WarpSize) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce<Cuda> could not find a "
-                      "valid tile size."));
+
+      if (n < CudaTraits::WarpSize) {
+        std::string msg =
+            "Kokkos::parallel_reduce<Cuda, MDRangePolicy>: could not find a "
+            "valid tile size for inter block reduction. Shared memory per "
+            "block required (" +
+            std::to_string(
+                cuda_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                          value_type>(
+                    f, CudaTraits::WarpSize)) +
+            ") exceeds device limit (" + std::to_string(maxShmemPerBlock) +
+            ").";
+        Kokkos::Impl::throw_runtime_exception(msg);
+      }
     }
     return n;
   }
@@ -414,10 +423,7 @@ class ParallelReduce<CombinedFunctorReducerType,
                               typename ViewType::memory_space>::accessible),
         m_scratch_space(nullptr),
         m_scratch_flags(nullptr),
-        m_unified_space(nullptr) {
-    check_reduced_view_shmem_size<WorkTag, value_type>(
-        m_policy, m_functor_reducer.get_functor());
-  }
+        m_unified_space(nullptr) {}
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -301,7 +301,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = 512;  // Algorithm constraint
+    unsigned n = 512;  // block size must less than or equal to 512
     int const maxShmemPerBlock =
         m_policy.space().cuda_device_prop().sharedMemPerBlock;
     int shmem_size =
@@ -344,9 +344,9 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
-      // Note: block_size must be less than or equal to 512
-      block_size = std::max(block_size, static_cast<int>(CudaTraits::WarpSize));
-      block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
+      // Note: block_size must be between WarpSize and suggested_blocksize
+      block_size = std::clamp<int>(block_size, CudaTraits::WarpSize,
+                                   suggested_blocksize);
 
       m_scratch_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -294,7 +294,8 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncwarp(0xffffffff);
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (word_size_type i = threadIdx.y; i < word_count.value;
+           i += blockDim.y) {
         global[i] = shared[i];
       }
     }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -136,6 +136,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   using value_type     = typename ReducerType::value_type;
   using reference_type = typename ReducerType::reference_type;
   using functor_type   = FunctorType;
+  using size_type      = Cuda::size_type;
+
   // Conditionally set word_size_type to int16_t or int8_t if value_type is
   // smaller than int32_t (Kokkos::Cuda::size_type)
   // word_size_type is used to determine the word count, shared memory buffer
@@ -149,9 +151,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   // performed, we have the correct data that was copied over in chunks of 4
   // bytes.
   using word_size_type = std::conditional_t<
-      sizeof(value_type) < sizeof(Kokkos::Cuda::size_type),
-      std::conditional_t<sizeof(value_type) == 2, int16_t, int8_t>,
-      Kokkos::Cuda::size_type>;
+      sizeof(value_type) < sizeof(size_type),
+      std::conditional_t<sizeof(value_type) == 2, int16_t, int8_t>, size_type>;
   using index_type   = typename Policy::index_type;
   using reducer_type = ReducerType;
 
@@ -166,7 +167,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   word_size_type* m_scratch_space;
   // m_scratch_flags must be of type Cuda::size_type due to use of atomics
   // for tracking metadata in Kokkos_Cuda_ReduceScan.hpp
-  Cuda::size_type* m_scratch_flags;
+  size_type* m_scratch_flags;
   word_size_type* m_unified_space;
 
   // FIXME_CUDA Shall we use the shfl based reduction or not (only use it for
@@ -191,9 +192,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
   }
 
   __device__ inline void operator()() const {
-    const integral_nonzero_constant<word_size_type,
-                                    ReducerType::static_value_size() /
-                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(word_size_type)>
         word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(word_size_type));
 
@@ -254,7 +254,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
         __syncwarp(0xffffffff);
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }
@@ -303,8 +303,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
       // Intentionally do not downcast to word_size_type since we use Cuda
       // atomics in Kokkos_Cuda_ReduceScan.hpp
-      m_scratch_flags = cuda_internal_scratch_flags(m_policy.space(),
-                                                    sizeof(Cuda::size_type));
+      m_scratch_flags =
+          cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type));
       m_unified_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_unified(
               m_policy.space(), m_functor_reducer.get_reducer().value_size()));
@@ -460,8 +460,8 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(Analysis::value_size(m_functor_reducer.get_functor()) /
                    sizeof(word_size_type));
 
@@ -502,8 +502,8 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(Analysis::value_size(m_functor_reducer.get_functor()) /
                    sizeof(word_size_type));
 
@@ -567,7 +567,7 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
       {
         word_size_type* const block_total =
             shared_data + word_count.value * blockDim.y;
-        for (unsigned i = threadIdx.y; i < word_count.value; ++i) {
+        for (size_type i = threadIdx.y; i < word_count.value; ++i) {
           shared_accum[i] = block_total[i];
         }
       }
@@ -779,8 +779,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(Analysis::value_size(m_functor_reducer.get_functor()) /
                    sizeof(word_size_type));
 
@@ -821,8 +821,8 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(final_reducer.value_size() / sizeof(word_size_type));
 
     // Use shared memory as an exclusive scan: { 0 , value[0] , value[1] ,
@@ -861,7 +861,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
       // Copy previous block's accumulation total into thread[0] prefix and
       // inclusive scan value of this block
-      for (unsigned i = threadIdx.y; i < word_count.value; ++i) {
+      for (size_type i = threadIdx.y; i < word_count.value; ++i) {
         shared_data[i + word_count.value] = shared_data[i] = shared_accum[i];
       }
 
@@ -887,7 +887,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
       {
         word_size_type* const block_total =
             shared_data + word_count.value * blockDim.y;
-        for (unsigned i = threadIdx.y; i < word_count.value; ++i) {
+        for (size_type i = threadIdx.y; i < word_count.value; ++i) {
           shared_accum[i] = block_total[i];
         }
       }

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -722,9 +722,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   __device__ inline void run(SHMEMReductionTag, const int& threadid) const {
-    const integral_nonzero_constant<word_size_type,
-                                    ReducerType::static_value_size() /
-                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(word_size_type)>
         word_count(m_functor_reducer.get_reducer().value_size() /
                    sizeof(word_size_type));
 
@@ -782,7 +781,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncwarp(0xffffffff);
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }

--- a/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp
@@ -585,9 +585,9 @@ __device__ bool cuda_single_inter_block_reduce_scan2(
 
   // NOLINTBEGIN(bugprone-sizeof-expression)
   const integral_nonzero_constant<
-      size_type, std::is_pointer_v<typename FunctorType::reference_type>
-                     ? 0
-                     : sizeof(value_type) / sizeof(size_type)>
+      Cuda::size_type, std::is_pointer_v<typename FunctorType::reference_type>
+                           ? 0
+                           : sizeof(value_type) / sizeof(size_type)>
       word_count((sizeof(value_type) * functor.length()) / sizeof(size_type));
   // NOLINTEND(bugprone-sizeof-expression)
 
@@ -599,8 +599,8 @@ __device__ bool cuda_single_inter_block_reduce_scan2(
     size_type* const shared = shared_data + word_count.value * BlockSizeMask;
     size_type* const global = global_data + word_count.value * block_id;
 
-    for (int i = int(threadIdx.y); i < int(word_count.value);
-         i += int(blockDim.y)) {
+    for (Cuda::size_type i = threadIdx.y; i < word_count.value;
+         i += blockDim.y) {
       global[i] = shared[i];
     }
   }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -129,7 +129,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = 512;  // Algorithm constraint
+    unsigned n = 512;  // block size must less than or equal to 512
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::HIP>;
@@ -175,9 +175,9 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
-      // Note: block_size must be less than or equal to 512
-      block_size = std::max(block_size, static_cast<int>(HIPTraits::WarpSize));
-      block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
+      // Note: block_size must be between WarpSize and suggested_blocksize
+      block_size =
+          std::clamp<int>(block_size, HIPTraits::WarpSize, suggested_blocksize);
 
       m_scratch_space =
           reinterpret_cast<word_size_type*>(hip_internal_scratch_space(

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -122,7 +122,8 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncthreads();
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (word_size_type i = threadIdx.y; i < word_count.value;
+           i += blockDim.y) {
         global[i] = shared[i];
       }
     }
@@ -131,8 +132,18 @@ class ParallelReduce<CombinedFunctorReducerType,
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
     unsigned n = HIPTraits::WarpSize * 8;
+    using closure_type =
+        Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
+                             Policy, Kokkos::HIP>;
+    hipFuncAttributes attr =
+        HIPParallelLaunch<closure_type, LaunchBounds>::get_hip_func_attributes(
+            m_policy.space().hip_device());
+
+    // Compute the maximum dynamic shared memory per block allowed
+    // by subtracting the static shared memory used by the kernel
     int const maxShmemPerBlock =
-        m_policy.space().hip_device_prop().sharedMemPerBlock * 0.95;
+        m_policy.space().hip_device_prop().sharedMemPerBlock -
+        attr.sharedSizeBytes;
 
     int shmem_size =
         hip_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(f,

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -79,9 +79,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   inline __device__ void operator()() const {
     const ReducerType& reducer = m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type,
-                                    ReducerType::static_value_size() /
-                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(word_size_type)>
         word_count(reducer.value_size() / sizeof(word_size_type));
 
     {
@@ -122,8 +121,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncthreads();
       }
 
-      for (word_size_type i = threadIdx.y; i < word_count.value;
-           i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }
@@ -131,7 +129,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = HIPTraits::WarpSize * 8;
+    unsigned n = 512;  // Algorithm constraint
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::HIP>;

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -129,23 +129,28 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   // Determine block size constrained by shared memory:
-  // This is copy/paste from Kokkos_HIP_Parallel_Range
   inline unsigned local_block_size(const FunctorType& f) {
-    const auto& instance = m_policy.space().impl_internal_space_instance();
-    auto shmem_functor   = [&f](unsigned n) {
-      return hip_single_inter_block_reduce_scan_shmem<false, WorkTag,
-                                                      value_type>(f, n);
-    };
+    unsigned n = HIPTraits::WarpSize * 8;
+    int const maxShmemPerBlock =
+        m_policy.space().hip_device_prop().sharedMemPerBlock * 0.95;
 
-    unsigned block_size =
-        Kokkos::Impl::hip_get_preferred_blocksize<ParallelReduce, LaunchBounds>(
-            instance, shmem_functor);
-    if (block_size == 0) {
+    int shmem_size =
+        hip_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(f,
+                                                                             n);
+
+    while (n > 1 && shmem_size > maxShmemPerBlock) {
+      n >>= 1;
+      shmem_size =
+          hip_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
+              f, n);
+    }
+
+    if (n < HIPTraits::WarpSize) {
       Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce< HIP > could not find a "
+          std::string("Kokkos::Impl::ParallelReduce<HIP> could not find a "
                       "valid tile size."));
     }
-    return block_size;
+    return n;
   }
 
   inline void execute() {
@@ -161,10 +166,8 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
-      block_size = (block_size > suggested_blocksize)
-                       ? block_size
-                       : suggested_blocksize;  // Note: block_size must be less
-                                               // than or equal to 512
+      block_size = std::max(block_size, static_cast<int>(HIPTraits::WarpSize));
+      block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
 
       m_scratch_space =
           reinterpret_cast<word_size_type*>(hip_internal_scratch_space(

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -166,6 +166,7 @@ class ParallelReduce<CombinedFunctorReducerType,
       int suggested_blocksize =
           local_block_size(m_functor_reducer.get_functor());
 
+      // Note: block_size must be less than or equal to 512
       block_size = std::max(block_size, static_cast<int>(HIPTraits::WarpSize));
       block_size = std::min(block_size, static_cast<int>(suggested_blocksize));
 

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -147,17 +147,24 @@ class ParallelReduce<CombinedFunctorReducerType,
         hip_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(f,
                                                                              n);
 
-    while (n > 1 && shmem_size > maxShmemPerBlock) {
+    while (shmem_size > maxShmemPerBlock) {
       n >>= 1;
       shmem_size =
           hip_single_inter_block_reduce_scan_shmem<false, WorkTag, value_type>(
               f, n);
-    }
-
-    if (n < HIPTraits::WarpSize) {
-      Kokkos::Impl::throw_runtime_exception(
-          std::string("Kokkos::Impl::ParallelReduce<HIP> could not find a "
-                      "valid tile size."));
+      if (n < HIPTraits::WarpSize) {
+        std::string msg =
+            "Kokkos::parallel_reduce<HIP, MDRangePolicy>: could not find a "
+            "valid tile size for inter block reduction. Shared memory per "
+            "block required (" +
+            std::to_string(
+                hip_single_inter_block_reduce_scan_shmem<false, WorkTag,
+                                                         value_type>(
+                    f, HIPTraits::WarpSize)) +
+            ") exceeds device limit (" + std::to_string(maxShmemPerBlock) +
+            ").";
+        Kokkos::Impl::throw_runtime_exception(msg);
+      }
     }
     return n;
   }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_MDRange.hpp
@@ -129,7 +129,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    unsigned n = 512;  // block size must less than or equal to 512
+    unsigned n = 512;  // block size must be less than or equal to 512
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              Policy, Kokkos::HIP>;

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Range.hpp
@@ -91,9 +91,8 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
 
   __device__ inline void run(SHMEMReductionTag) const {
     const ReducerType& reducer = m_functor_reducer.get_reducer();
-    const integral_nonzero_constant<word_size_type,
-                                    ReducerType::static_value_size() /
-                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<
+        size_type, ReducerType::static_value_size() / sizeof(word_size_type)>
         word_count(reducer.value_size() / sizeof(word_size_type));
 
     {
@@ -143,7 +142,7 @@ class ParallelReduce<CombinedFunctorReducerType, Kokkos::RangePolicy<Traits...>,
         __syncthreads();
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }

--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -168,8 +168,8 @@ class ParallelReduce<CombinedFunctorReducerType,
   __device__ inline void run(SHMEMReductionTag, int const threadid) const {
     const ReducerType& reducer = m_functor_reducer.get_reducer();
 
-    integral_nonzero_constant<word_size_type, ReducerType::static_value_size() /
-                                                  sizeof(word_size_type)> const
+    integral_nonzero_constant<size_type, ReducerType::static_value_size() /
+                                             sizeof(word_size_type)> const
         word_count(reducer.value_size() / sizeof(word_size_type));
 
     reference_type value = reducer.init(reinterpret_cast<pointer_type>(
@@ -205,7 +205,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         __syncthreads();
       }
 
-      for (unsigned i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+      for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
         global[i] = shared[i];
       }
     }

--- a/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
@@ -87,8 +87,8 @@ class ParallelScanHIPBase {
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(final_reducer.value_size() / sizeof(word_size_type));
 
     pointer_type const shared_value = reinterpret_cast<pointer_type>(
@@ -126,8 +126,8 @@ class ParallelScanHIPBase {
     const typename Analysis::Reducer& final_reducer =
         m_functor_reducer.get_reducer();
 
-    const integral_nonzero_constant<word_size_type, Analysis::StaticValueSize /
-                                                        sizeof(word_size_type)>
+    const integral_nonzero_constant<size_type, Analysis::StaticValueSize /
+                                                   sizeof(word_size_type)>
         word_count(final_reducer.value_size() / sizeof(word_size_type));
 
     // Use shared memory as an exclusive scan: { 0 , value[0] , value[1] ,
@@ -164,7 +164,7 @@ class ParallelScanHIPBase {
 
       // Copy previous block's accumulation total into thread[0] prefix and
       // inclusive scan value of this block
-      for (unsigned i = threadIdx.y; i < word_count.value; ++i) {
+      for (size_type i = threadIdx.y; i < word_count.value; ++i) {
         shared_data[i + word_count.value] = shared_data[i] = shared_accum[i];
       }
 
@@ -189,7 +189,7 @@ class ParallelScanHIPBase {
       {
         word_size_type* const block_total =
             shared_data + word_count.value * blockDim.y;
-        for (unsigned i = threadIdx.y; i < word_count.value; ++i) {
+        for (size_type i = threadIdx.y; i < word_count.value; ++i) {
           shared_accum[i] = block_total[i];
         }
       }

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -379,7 +379,7 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
     size_type* const shared = shared_data + word_count.value * BlockSizeMask;
     size_type* const global = global_data + word_count.value * block_id;
 
-    for (size_t i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+    for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
       global[i] = shared[i];
     }
     __threadfence();

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -364,9 +364,9 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
 
   // NOLINTBEGIN(bugprone-sizeof-expression)
   const integral_nonzero_constant<
-      size_type, std::is_pointer_v<typename FunctorType::reference_type>
-                     ? 0
-                     : sizeof(value_type) / sizeof(size_type)>
+      HIP::size_type, std::is_pointer_v<typename FunctorType::reference_type>
+                          ? 0
+                          : sizeof(value_type) / sizeof(size_type)>
       word_count((sizeof(value_type) * functor.length()) / sizeof(size_type));
   // NOLINTEND(bugprone-sizeof-expression)
 
@@ -379,7 +379,8 @@ __device__ bool hip_single_inter_block_reduce_scan_impl(
     size_type* const shared = shared_data + word_count.value * BlockSizeMask;
     size_type* const global = global_data + word_count.value * block_id;
 
-    for (size_type i = threadIdx.y; i < word_count.value; i += blockDim.y) {
+    for (HIP::size_type i = threadIdx.y; i < word_count.value;
+         i += blockDim.y) {
       global[i] = shared[i];
     }
     __threadfence();

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -192,6 +192,9 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
               const index_type local_x    = 0;
               const index_type local_y    = item.get_local_id(0);
               const index_type local_z    = 0;
+              const index_type n_local_x  = 1;
+              const index_type n_local_y  = item.get_local_range(0);
+              const index_type n_local_z  = 1;
               const index_type global_y   = 0;
               const index_type global_z   = 0;
               const index_type n_global_x = n_tiles;
@@ -210,6 +213,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       typename Policy::work_tag, reference_type>(
                       bare_policy, functor, update,
                       {n_global_x, n_global_y, n_global_z},
+                      {n_local_x, n_local_y, n_local_z},
                       {global_x, global_y, global_z},
                       {local_x, local_y, local_z})
                       .exec_range();
@@ -257,6 +261,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
                       typename Policy::work_tag, reference_type>(
                       bare_policy, functor, update,
                       {n_global_x, n_global_y, n_global_z},
+                      {n_local_x, n_local_y, n_local_z},
                       {global_x, global_y, global_z},
                       {local_x, local_y, local_z})
                       .exec_range();

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -133,7 +133,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       // values in all workgroups separately, write the workgroup results back
       // to global memory and recurse until only one workgroup does the
       // reduction and thus gets the final value.
-      const int wgroup_size = Kokkos::bit_ceil(
+      int wgroup_size = Kokkos::bit_ceil(
           static_cast<unsigned int>(m_policy.m_prod_tile_dims));
 
       // FIXME_SYCL Find a better way to determine a good limit for the
@@ -142,6 +142,28 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       size_t max_work_groups =
           static_cast<size_t>(2) *
           q.get_device().get_info<sycl::info::device::max_compute_units>();
+
+      const auto sycl_single_inter_block_reduce_shmem = [&](int wgroup_size) {
+        return static_cast<int>(wgroup_size * value_count *
+                                sizeof(value_type)) +
+               256 * static_cast<int>(sizeof(unsigned int));
+      };
+
+      const int maxShmemPerBlock = instance.m_maxShmemPerBlock;
+      int shmem_size = sycl_single_inter_block_reduce_shmem(wgroup_size);
+
+      // FIXME_SYCL Find a better way to determine workgroup size with shared
+      // memory constraints.
+      while (shmem_size > maxShmemPerBlock) {
+        wgroup_size >>= 1;
+        shmem_size = sycl_single_inter_block_reduce_shmem(wgroup_size);
+        if (wgroup_size < 32) {
+          Kokkos::Impl::throw_runtime_exception(
+              std::string("Kokkos::Impl::ParallelReduce<SYCL> could not find "
+                          "a valid tile size."));
+        }
+      }
+
       int values_per_thread = 1;
       size_t n_wgroups      = n_tiles;
       while (n_wgroups > max_work_groups) {

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -143,12 +143,11 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
           static_cast<size_t>(2) *
           q.get_device().get_info<sycl::info::device::max_compute_units>();
 
-      // Shared memory needed per block for reduction, it depends on the
-      // workgroup size, put 256 bytes for safe-guard.
+      // Shared memory needed per block for reduction
       const auto sycl_single_inter_block_reduce_shmem = [&](int wgroup_size) {
         return static_cast<int>(static_cast<size_t>(wgroup_size) * value_count *
                                 sizeof(value_type)) +
-               256 * static_cast<int>(sizeof(unsigned int));
+               static_cast<int>(sizeof(unsigned int));
       };
 
       const int maxShmemPerBlock = instance.m_maxShmemPerBlock;
@@ -160,9 +159,14 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         wgroup_size >>= 1;
         shmem_size = sycl_single_inter_block_reduce_shmem(wgroup_size);
         if (wgroup_size < 32) {
-          Kokkos::Impl::throw_runtime_exception(
-              std::string("Kokkos::Impl::ParallelReduce<SYCL> could not find "
-                          "a valid tile size."));
+          std::string msg =
+              "Kokkos::parallel_reduce<SYCL, MDRangePolicy>: could not find a "
+              "valid tile size for inter block reduction. Shared memory per "
+              "block required (" +
+              std::to_string(sycl_single_inter_block_reduce_shmem(32)) +
+              ") exceeds device limit (" + std::to_string(maxShmemPerBlock) +
+              ").";
+          Kokkos::Impl::throw_runtime_exception(msg);
         }
       }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_MDRange.hpp
@@ -143,8 +143,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
           static_cast<size_t>(2) *
           q.get_device().get_info<sycl::info::device::max_compute_units>();
 
+      // Shared memory needed per block for reduction, it depends on the
+      // workgroup size, put 256 bytes for safe-guard.
       const auto sycl_single_inter_block_reduce_shmem = [&](int wgroup_size) {
-        return static_cast<int>(wgroup_size * value_count *
+        return static_cast<int>(static_cast<size_t>(wgroup_size) * value_count *
                                 sizeof(value_type)) +
                256 * static_cast<int>(sizeof(unsigned int));
       };

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -455,12 +455,14 @@ struct DeviceIterateTile {
   KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateTile(
       const PolicyType& policy_, const Functor& f_, value_type_storage v_,
       const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
       const EmulateCUDADim3<index_type> blockIdx_,
       const EmulateCUDADim3<index_type> threadIdx_)
       : m_policy(policy_),
         m_func(f_),
         m_v(v_),
         gridDim(gridDim_),
+        blockDim(blockDim_),
         blockIdx(blockIdx_),
         threadIdx(threadIdx_) {}
 #else
@@ -475,58 +477,64 @@ struct DeviceIterateTile {
     index_type m_offset[PolicyType::rank];  // tile starting global Id offset
     index_type
         m_local_offset[PolicyType::rank];  // tile starting local Id offset
+#ifdef KOKKOS_ENABLE_SYCL
+    if (blockIdx.x < m_policy.m_num_tiles &&
+        threadIdx.y < m_policy.m_prod_tile_dims) {
+#endif
+      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
+        for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
+             thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
+          index_type tile_idx =
+              tileidx;  // temp because tile_idx will be modified while
+                        // determining tile starting point offsets
+          index_type local_thrd_idx = thrd_idx;
+          bool in_bounds            = true;
 
-    for (index_type tileidx = static_cast<index_type>(blockIdx.x);
-         tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
-      for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
-           thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
-        index_type tile_idx =
-            tileidx;  // temp because tile_idx will be modified while
-                      // determining tile starting point offsets
-        index_type local_thrd_idx = thrd_idx;
-        bool in_bounds            = true;
+          if constexpr (PolicyType::inner_direction == Iterate::Left) {
+            for (int i = 0; i < PolicyType::rank; ++i) {
+              m_offset[i] =
+                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                  m_policy.m_lower[i];
+              tile_idx /= m_policy.m_tile_end[i];
 
-        if constexpr (PolicyType::inner_direction == Iterate::Left) {
-          for (int i = 0; i < PolicyType::rank; ++i) {
-            m_offset[i] =
-                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                m_policy.m_lower[i];
-            tile_idx /= m_policy.m_tile_end[i];
+              // tile-local indices identified with (index_type)threadIdx_y
+              m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+              local_thrd_idx /= m_policy.m_tile[i];
 
-            // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
-            local_thrd_idx /= m_policy.m_tile[i];
+              m_offset[i] += m_local_offset[i];
 
-            m_offset[i] += m_local_offset[i];
+              if (!(m_offset[i] < m_policy.m_upper[i])) {
+                in_bounds = false;
+              }
+            }
+          } else {
+            for (int i = PolicyType::rank - 1; i >= 0; --i) {
+              m_offset[i] =
+                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                  m_policy.m_lower[i];
+              tile_idx /= m_policy.m_tile_end[i];
 
-            if (!(m_offset[i] < m_policy.m_upper[i])) {
-              in_bounds = false;
+              // tile-local indices identified with (index_type)threadIdx_y
+              m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+              local_thrd_idx /= m_policy.m_tile[i];
+
+              m_offset[i] += m_local_offset[i];
+
+              if (!(m_offset[i] < m_policy.m_upper[i])) {
+                in_bounds = false;
+              }
             }
           }
-        } else {
-          for (int i = PolicyType::rank - 1; i >= 0; --i) {
-            m_offset[i] =
-                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                m_policy.m_lower[i];
-            tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
-            local_thrd_idx /= m_policy.m_tile[i];
-
-            m_offset[i] += m_local_offset[i];
-
-            if (!(m_offset[i] < m_policy.m_upper[i])) {
-              in_bounds = false;
-            }
+          if (in_bounds) {
+            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
           }
-        }
-
-        if (in_bounds) {
-          Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
         }
       }
+#ifdef KOKKOS_ENABLE_SYCL
     }
+#endif
   }  // end exec_range
 
  private:
@@ -535,6 +543,7 @@ struct DeviceIterateTile {
   value_type_storage m_v;
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
   const EmulateCUDADim3<index_type> blockIdx;
   const EmulateCUDADim3<index_type> threadIdx;
 #endif

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -477,64 +477,57 @@ struct DeviceIterateTile {
     index_type m_offset[PolicyType::rank];  // tile starting global Id offset
     index_type
         m_local_offset[PolicyType::rank];  // tile starting local Id offset
-#ifdef KOKKOS_ENABLE_SYCL
-    if (blockIdx.x < m_policy.m_num_tiles &&
-        threadIdx.y < m_policy.m_prod_tile_dims) {
-#endif
-      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
-           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
-        for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
-             thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
-          index_type tile_idx =
-              tileidx;  // temp because tile_idx will be modified while
-                        // determining tile starting point offsets
-          index_type local_thrd_idx = thrd_idx;
-          bool in_bounds            = true;
+    for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+         tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
+      for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
+           thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type local_thrd_idx = thrd_idx;
+        bool in_bounds            = true;
 
-          if constexpr (PolicyType::inner_direction == Iterate::Left) {
-            for (int i = 0; i < PolicyType::rank; ++i) {
-              m_offset[i] =
-                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                  m_policy.m_lower[i];
-              tile_idx /= m_policy.m_tile_end[i];
+        if constexpr (PolicyType::inner_direction == Iterate::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
 
-              // tile-local indices identified with (index_type)threadIdx_y
-              m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
-              local_thrd_idx /= m_policy.m_tile[i];
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+            local_thrd_idx /= m_policy.m_tile[i];
 
-              m_offset[i] += m_local_offset[i];
+            m_offset[i] += m_local_offset[i];
 
-              if (!(m_offset[i] < m_policy.m_upper[i])) {
-                in_bounds = false;
-              }
-            }
-          } else {
-            for (int i = PolicyType::rank - 1; i >= 0; --i) {
-              m_offset[i] =
-                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                  m_policy.m_lower[i];
-              tile_idx /= m_policy.m_tile_end[i];
-
-              // tile-local indices identified with (index_type)threadIdx_y
-              m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
-              local_thrd_idx /= m_policy.m_tile[i];
-
-              m_offset[i] += m_local_offset[i];
-
-              if (!(m_offset[i] < m_policy.m_upper[i])) {
-                in_bounds = false;
-              }
+            if (!(m_offset[i] < m_policy.m_upper[i])) {
+              in_bounds = false;
             }
           }
+        } else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
 
-          if (in_bounds) {
-            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+            local_thrd_idx /= m_policy.m_tile[i];
+
+            m_offset[i] += m_local_offset[i];
+
+            if (!(m_offset[i] < m_policy.m_upper[i])) {
+              in_bounds = false;
+            }
           }
         }
+
+        if (in_bounds) {
+          Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+        }
       }
-#ifdef KOKKOS_ENABLE_SYCL
     }
-#endif
   }  // end exec_range
 
  private:

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -471,65 +471,70 @@ struct DeviceIterateTile {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
       for (index_type tileidx = static_cast<index_type>(blockIdx.x);
            tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
-        index_type tile_idx =
-            tileidx;  // temp because tile_idx will be modified while
-                      // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
-        bool in_bounds      = true;
+        // Allow threads to stride through the work items in the tile
+        // This handles cases where blockDim.y != m_prod_tile_dims
+        for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
+             thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
+          index_type tile_idx =
+              tileidx;  // temp because tile_idx will be modified while
+                        // determining tile starting point offsets
 
-        // LL
-        if (PolicyType::inner_direction == Iterate::Left) {
-          for (int i = 0; i < PolicyType::rank; ++i) {
-            m_offset[i] =
-                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                m_policy.m_lower[i];
-            tile_idx /= m_policy.m_tile_end[i];
+          index_type local_thrd_idx = thrd_idx;
+          bool in_bounds            = true;
 
-            // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
-            thrd_idx /= m_policy.m_tile[i];
+          // LL
+          if constexpr (PolicyType::inner_direction == Iterate::Left) {
+            for (int i = 0; i < PolicyType::rank; ++i) {
+              m_offset[i] =
+                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                  m_policy.m_lower[i];
+              tile_idx /= m_policy.m_tile_end[i];
 
-            m_offset[i] += m_local_offset[i];
-            if (!(m_offset[i] < m_policy.m_upper[i] &&
-                  m_local_offset[i] < m_policy.m_tile[i])) {
-              in_bounds = false;
+              // tile-local indices identified with (index_type)threadIdx_y
+              m_local_offset[i] = (local_thrd_idx % m_policy.m_tile[i]);
+              local_thrd_idx /= m_policy.m_tile[i];
+
+              m_offset[i] += m_local_offset[i];
+              if (!(m_offset[i] < m_policy.m_upper[i] &&
+                    m_local_offset[i] < m_policy.m_tile[i])) {
+                in_bounds = false;
+              }
+            }
+            if (in_bounds) {
+              Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
             }
           }
-          if (in_bounds) {
-            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
-          }
-        }
-        // LR
-        else {
-          for (int i = PolicyType::rank - 1; i >= 0; --i) {
-            m_offset[i] =
-                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                m_policy.m_lower[i];
-            tile_idx /= m_policy.m_tile_end[i];
+          // LR
+          else {
+            for (int i = PolicyType::rank - 1; i >= 0; --i) {
+              m_offset[i] =
+                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                  m_policy.m_lower[i];
+              tile_idx /= m_policy.m_tile_end[i];
 
-            // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] =
-                (thrd_idx %
-                 m_policy.m_tile[i]);  // Move this to first computation,
-                                       // add to m_offset right away
-            thrd_idx /= m_policy.m_tile[i];
+              // tile-local indices identified with (index_type)threadIdx_y
+              m_local_offset[i] =
+                  (local_thrd_idx %
+                   m_policy.m_tile[i]);  // Move this to first computation,
+                                         // add to m_offset right away
+              local_thrd_idx /= m_policy.m_tile[i];
 
-            m_offset[i] += m_local_offset[i];
-            if (!(m_offset[i] < m_policy.m_upper[i] &&
-                  m_local_offset[i] < m_policy.m_tile[i])) {
-              in_bounds = false;
+              m_offset[i] += m_local_offset[i];
+              if (!(m_offset[i] < m_policy.m_upper[i] &&
+                    m_local_offset[i] < m_policy.m_tile[i])) {
+                in_bounds = false;
+              }
             }
-          }
-          if (in_bounds) {
-            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+            if (in_bounds) {
+              Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+            }
           }
         }
       }

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -471,70 +471,65 @@ struct DeviceIterateTile {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles) {
+    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
+        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
       index_type m_offset[PolicyType::rank];  // tile starting global id offset
       index_type
           m_local_offset[PolicyType::rank];  // tile starting global id offset
 
       for (index_type tileidx = static_cast<index_type>(blockIdx.x);
            tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
-        // Allow threads to stride through the work items in the tile
-        // This handles cases where blockDim.y != m_prod_tile_dims
-        for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
-             thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
-          index_type tile_idx =
-              tileidx;  // temp because tile_idx will be modified while
-                        // determining tile starting point offsets
+        index_type tile_idx =
+            tileidx;  // temp because tile_idx will be modified while
+                      // determining tile starting point offsets
+        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
+        bool in_bounds      = true;
 
-          index_type local_thrd_idx = thrd_idx;
-          bool in_bounds            = true;
+        // LL
+        if (PolicyType::inner_direction == Iterate::Left) {
+          for (int i = 0; i < PolicyType::rank; ++i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
 
-          // LL
-          if constexpr (PolicyType::inner_direction == Iterate::Left) {
-            for (int i = 0; i < PolicyType::rank; ++i) {
-              m_offset[i] =
-                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                  m_policy.m_lower[i];
-              tile_idx /= m_policy.m_tile_end[i];
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
+            thrd_idx /= m_policy.m_tile[i];
 
-              // tile-local indices identified with (index_type)threadIdx_y
-              m_local_offset[i] = (local_thrd_idx % m_policy.m_tile[i]);
-              local_thrd_idx /= m_policy.m_tile[i];
-
-              m_offset[i] += m_local_offset[i];
-              if (!(m_offset[i] < m_policy.m_upper[i] &&
-                    m_local_offset[i] < m_policy.m_tile[i])) {
-                in_bounds = false;
-              }
-            }
-            if (in_bounds) {
-              Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds = false;
             }
           }
-          // LR
-          else {
-            for (int i = PolicyType::rank - 1; i >= 0; --i) {
-              m_offset[i] =
-                  (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
-                  m_policy.m_lower[i];
-              tile_idx /= m_policy.m_tile_end[i];
+          if (in_bounds) {
+            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
+          }
+        }
+        // LR
+        else {
+          for (int i = PolicyType::rank - 1; i >= 0; --i) {
+            m_offset[i] =
+                (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
+                m_policy.m_lower[i];
+            tile_idx /= m_policy.m_tile_end[i];
 
-              // tile-local indices identified with (index_type)threadIdx_y
-              m_local_offset[i] =
-                  (local_thrd_idx %
-                   m_policy.m_tile[i]);  // Move this to first computation,
-                                         // add to m_offset right away
-              local_thrd_idx /= m_policy.m_tile[i];
+            // tile-local indices identified with (index_type)threadIdx_y
+            m_local_offset[i] =
+                (thrd_idx %
+                 m_policy.m_tile[i]);  // Move this to first computation,
+                                       // add to m_offset right away
+            thrd_idx /= m_policy.m_tile[i];
 
-              m_offset[i] += m_local_offset[i];
-              if (!(m_offset[i] < m_policy.m_upper[i] &&
-                    m_local_offset[i] < m_policy.m_tile[i])) {
-                in_bounds = false;
-              }
+            m_offset[i] += m_local_offset[i];
+            if (!(m_offset[i] < m_policy.m_upper[i] &&
+                  m_local_offset[i] < m_policy.m_tile[i])) {
+              in_bounds = false;
             }
-            if (in_bounds) {
-              Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
-            }
+          }
+          if (in_bounds) {
+            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
           }
         }
       }

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -436,8 +436,9 @@ using value_type_storage_t =
 // 1. create offset arrays
 // 2. loop over number of tiles, striding by griddim (equal to num tiles, or max
 // num blocks)
-// 3. temps set for tile_idx and thrd_idx, which will be modified
-// 4. if LL vs LR:
+// 3. loop over threads within block, striding by blockdim ()
+// 4. temps set for tile_idx and thrd_idx, which will be modified
+// 5. if LL vs LR:
 //      determine tile starting point offsets (multidim)
 //      determine local index offsets (multidim)
 //      concatentate tile offset + local offset for global multi-dim index
@@ -471,22 +472,21 @@ struct DeviceIterateTile {
 
   KOKKOS_IMPL_DEVICE_FUNCTION
   void exec_range() const {
-    if (static_cast<index_type>(blockIdx.x) < m_policy.m_num_tiles &&
-        static_cast<index_type>(threadIdx.y) < m_policy.m_prod_tile_dims) {
-      index_type m_offset[PolicyType::rank];  // tile starting global id offset
-      index_type
-          m_local_offset[PolicyType::rank];  // tile starting global id offset
+    index_type m_offset[PolicyType::rank];  // tile starting global Id offset
+    index_type
+        m_local_offset[PolicyType::rank];  // tile starting local Id offset
 
-      for (index_type tileidx = static_cast<index_type>(blockIdx.x);
-           tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
+    for (index_type tileidx = static_cast<index_type>(blockIdx.x);
+         tileidx < m_policy.m_num_tiles; tileidx += gridDim.x) {
+      for (index_type thrd_idx = static_cast<index_type>(threadIdx.y);
+           thrd_idx < m_policy.m_prod_tile_dims; thrd_idx += blockDim.y) {
         index_type tile_idx =
             tileidx;  // temp because tile_idx will be modified while
                       // determining tile starting point offsets
-        index_type thrd_idx = static_cast<index_type>(threadIdx.y);
-        bool in_bounds      = true;
+        index_type local_thrd_idx = thrd_idx;
+        bool in_bounds            = true;
 
-        // LL
-        if (PolicyType::inner_direction == Iterate::Left) {
+        if constexpr (PolicyType::inner_direction == Iterate::Left) {
           for (int i = 0; i < PolicyType::rank; ++i) {
             m_offset[i] =
                 (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
@@ -494,21 +494,16 @@ struct DeviceIterateTile {
             tile_idx /= m_policy.m_tile_end[i];
 
             // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] = (thrd_idx % m_policy.m_tile[i]);
-            thrd_idx /= m_policy.m_tile[i];
+            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+            local_thrd_idx /= m_policy.m_tile[i];
 
             m_offset[i] += m_local_offset[i];
-            if (!(m_offset[i] < m_policy.m_upper[i] &&
-                  m_local_offset[i] < m_policy.m_tile[i])) {
+
+            if (!(m_offset[i] < m_policy.m_upper[i])) {
               in_bounds = false;
             }
           }
-          if (in_bounds) {
-            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
-          }
-        }
-        // LR
-        else {
+        } else {
           for (int i = PolicyType::rank - 1; i >= 0; --i) {
             m_offset[i] =
                 (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +
@@ -516,21 +511,19 @@ struct DeviceIterateTile {
             tile_idx /= m_policy.m_tile_end[i];
 
             // tile-local indices identified with (index_type)threadIdx_y
-            m_local_offset[i] =
-                (thrd_idx %
-                 m_policy.m_tile[i]);  // Move this to first computation,
-                                       // add to m_offset right away
-            thrd_idx /= m_policy.m_tile[i];
+            m_local_offset[i] = local_thrd_idx % m_policy.m_tile[i];
+            local_thrd_idx /= m_policy.m_tile[i];
 
             m_offset[i] += m_local_offset[i];
-            if (!(m_offset[i] < m_policy.m_upper[i] &&
-                  m_local_offset[i] < m_policy.m_tile[i])) {
+
+            if (!(m_offset[i] < m_policy.m_upper[i])) {
               in_bounds = false;
             }
           }
-          if (in_bounds) {
-            Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
-          }
+        }
+
+        if (in_bounds) {
+          Impl::_tag_invoke_array<Tag>(m_func, m_offset, m_v);
         }
       }
     }

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -95,7 +95,8 @@ void MDRangeReduceViewTester(const int reduce_view_size) {
   auto host_data_1D =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, data_1D);
   for (int i = 0; i < reduce_view_size; i++) {
-    ASSERT_EQ(host_data_1D(i), T(N * N));
+    ASSERT_EQ(host_data_1D(i), T(N * N))
+        << " at index " << i << " for reduce_view_size " << reduce_view_size;
   }
 }
 

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -37,6 +37,24 @@ void MDRangeReduceTester([[maybe_unused]] int bound, int k) {
   }
 }
 
+TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  GTEST_SKIP() << "FIXME OPENMPTARGET Tests of MDRange reduce over values "
+                  "smaller than int would fail";
+#else
+  for (int bound : {0, 1, 7, 32, 65, 7000}) {
+    for (int k = 0; k < bound; ++k) {
+      MDRangeReduceTester<bool>(bound, k);
+      MDRangeReduceTester<signed char>(bound, k);
+      MDRangeReduceTester<int8_t>(bound, k);
+      MDRangeReduceTester<int16_t>(bound, k);
+      MDRangeReduceTester<int32_t>(bound, k);
+      MDRangeReduceTester<int64_t>(bound, k);
+    }
+  }
+#endif
+}
+
 template <typename T>
 struct MDReduceFunctor {
   using value_type = T[];
@@ -66,19 +84,19 @@ struct MDReduceFunctor {
 };
 
 template <typename T>
-void MDRangeReduceViewTester(const int reduce_view_size) {
+void MDRangeReduceViewTester(const int reduce_view_size, int view_size,
+                             int tile_x, int tile_y) {
   using PolicyType =
       Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>;
-  using point_t    = typename PolicyType::point_type;
-  using index_type = typename PolicyType::index_type;
-
-  const index_type N(111);
+  using point_t = typename PolicyType::point_type;
+  using tile_t  = typename PolicyType::tile_type;
 
   point_t lower_bound{0, 0};
-  point_t upper_bound{N, N};
+  point_t upper_bound{view_size, view_size};
+  tile_t tile{tile_x, tile_y};
 
-  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> data_3D("data_3D", N, N,
-                                                            reduce_view_size);
+  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> data_3D(
+      "data_3D", view_size, view_size, reduce_view_size);
   Kokkos::View<T*, Kokkos::DefaultExecutionSpace> data_1D("data_1D",
                                                           reduce_view_size);
 
@@ -86,7 +104,7 @@ void MDRangeReduceViewTester(const int reduce_view_size) {
   Kokkos::deep_copy(data_3D, static_cast<T>(1.0));
 
   // Perform MDRange parallel reduce
-  PolicyType policy(lower_bound, upper_bound);
+  PolicyType policy(lower_bound, upper_bound, tile);
   MDReduceFunctor<T> functor(data_3D, reduce_view_size);
   Kokkos::parallel_reduce(policy, functor, data_1D);
   Kokkos::fence();
@@ -95,8 +113,11 @@ void MDRangeReduceViewTester(const int reduce_view_size) {
   auto host_data_1D =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, data_1D);
   for (int i = 0; i < reduce_view_size; i++) {
-    ASSERT_EQ(host_data_1D(i), T(N * N))
-        << " at index " << i << " for reduce_view_size " << reduce_view_size;
+    ASSERT_EQ(host_data_1D(i), T(view_size * view_size))
+        << " with"
+        << " i: " << i << ", view_size: " << view_size
+        << ", reduce_view_size: " << reduce_view_size << ", tile: {" << tile_x
+        << "," << tile_y << "}";
   }
 }
 
@@ -110,15 +131,6 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
       MDRangeReduceTester<int32_t>(bound, k);
       MDRangeReduceTester<int64_t>(bound, k);
     }
-  }
-}
-
-TEST(TEST_CATEGORY, mdrange_parallel_reduce_view_type) {
-  for (int reduce_view_size : {1, 2, 3, 15, 16, 17, 31, 32, 33, 64}) {
-    MDRangeReduceViewTester<double>(reduce_view_size);
-    MDRangeReduceViewTester<float>(reduce_view_size);
-    MDRangeReduceViewTester<int32_t>(reduce_view_size);
-    MDRangeReduceViewTester<int16_t>(reduce_view_size);
   }
 }
 

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -84,8 +84,8 @@ struct MDReduceFunctor {
 };
 
 template <typename T>
-void MDRangeReduceViewTester(const int reduce_view_size, int view_size,
-                             int tile_x, int tile_y) {
+void MDRangeReduceViewTester(int view_size, int reduce_view_size, int tile_x,
+                             int tile_y) {
   using PolicyType =
       Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>;
   using point_t = typename PolicyType::point_type;

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -55,21 +55,22 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
 #endif
 }
 
+// Functor for reduction tests, reducing over a 3D View into a 1D View
 template <typename T>
-struct MDReduceFunctor {
+struct MDArrayReduceFunctor {
   using value_type = T[];
 
   const int value_count;
-  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> m;
+  Kokkos::View<T***, TEST_EXECSPACE> m_input_view;
 
-  MDReduceFunctor(const Kokkos::View<T***, Kokkos::DefaultExecutionSpace>& m_,
-                  int reduce_view_size)
-      : value_count(reduce_view_size), m(m_) {}
+  MDArrayReduceFunctor(const Kokkos::View<T***, TEST_EXECSPACE>& input_view,
+                       int reduce_view_size)
+      : value_count(reduce_view_size), m_input_view(input_view) {}
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int i, const int j, value_type sum) const {
     for (int k = 0; k < value_count; ++k) {
-      sum[k] += m(i, j, k);
+      sum[k] += m_input_view(i, j, k);
     }
   }
 
@@ -86,30 +87,29 @@ struct MDReduceFunctor {
 template <typename T>
 void MDRangeReduceViewTester(int view_size, int reduce_view_size, int tile_x,
                              int tile_y) {
-  using PolicyType =
-      Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>;
-  using point_t = typename PolicyType::point_type;
-  using tile_t  = typename PolicyType::tile_type;
+  using PolicyType = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
+  using point_t    = typename PolicyType::point_type;
+  using tile_t     = typename PolicyType::tile_type;
 
   point_t lower_bound{0, 0};
   point_t upper_bound{view_size, view_size};
   tile_t tile{tile_x, tile_y};
 
-  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> data_3D(
-      "data_3D", view_size, view_size, reduce_view_size);
-  Kokkos::View<T*, Kokkos::DefaultExecutionSpace> data_1D("data_1D",
-                                                          reduce_view_size);
+  Kokkos::View<T***, TEST_EXECSPACE> data_3D("data_3D", view_size, view_size,
+                                             reduce_view_size);
+  Kokkos::View<T*, TEST_EXECSPACE> data_1D("data_1D", reduce_view_size);
 
   Kokkos::deep_copy(data_1D, static_cast<T>(0.0));
   Kokkos::deep_copy(data_3D, static_cast<T>(1.0));
 
-  // Perform MDRange parallel reduce
   PolicyType policy(lower_bound, upper_bound, tile);
-  MDReduceFunctor<T> functor(data_3D, reduce_view_size);
+  MDArrayReduceFunctor<T> functor(data_3D, reduce_view_size);
+
+  // Perform MDRange parallel reduce with 1D View as reduction result
   Kokkos::parallel_reduce(policy, functor, data_1D);
   Kokkos::fence();
 
-  // Verify results
+  // Verify results on host
   auto host_data_1D =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, data_1D);
   for (int i = 0; i < reduce_view_size; i++) {
@@ -132,6 +132,31 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
       MDRangeReduceTester<int64_t>(bound, k);
     }
   }
+}
+
+TEST(TEST_CATEGORY, mdrange_parallel_reduce_view_size_limit) {
+#if defined(KOKKOS_ENABLE_OPENMPTARGET)
+  GTEST_SKIP()
+      << "FIXME_OPENMPTARGET custom reduction with MDRangePolicy is not "
+         "yet implemented";
+#elif defined(KOKKOS_ENABLE_OPENACC)
+  GTEST_SKIP() << "FIXME_OPENACC custom reduction with MDRangePolicy is not "
+                  "yet implemented";
+#else
+  const int view_size        = 100;
+  const int reduce_view_size = 1000;
+  const int tile_x           = 32;
+  const int tile_y           = 4;
+  if constexpr (std::is_same_v<TEST_EXECSPACE,
+                               Kokkos::DefaultHostExecutionSpace>) {
+    EXPECT_NO_THROW(MDRangeReduceViewTester<double>(view_size, reduce_view_size,
+                                                    tile_x, tile_y));
+  } else {
+    EXPECT_THROW(MDRangeReduceViewTester<double>(view_size, reduce_view_size,
+                                                 tile_x, tile_y),
+                 std::runtime_error);
+  }
+#endif
 }
 
 }  // namespace

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -37,6 +37,68 @@ void MDRangeReduceTester([[maybe_unused]] int bound, int k) {
   }
 }
 
+template <typename T>
+struct MDReduceFunctor {
+  using value_type = T[];
+
+  const int value_count;
+  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> m;
+
+  MDReduceFunctor(const Kokkos::View<T***, Kokkos::DefaultExecutionSpace>& m_,
+                  int reduce_view_size)
+      : value_count(reduce_view_size), m(m_) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int i, const int j, value_type sum) const {
+    for (int k = 0; k < value_count; ++k) {
+      sum[k] += m(i, j, k);
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void init(value_type update) const {
+    for (int k = 0; k < value_count; ++k) {
+      update[k] = 0;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION void final(value_type) const {}
+};
+
+template <typename T>
+void MDRangeReduceViewTester(const int reduce_view_size) {
+  using PolicyType =
+      Kokkos::MDRangePolicy<Kokkos::DefaultExecutionSpace, Kokkos::Rank<2>>;
+  using point_t    = typename PolicyType::point_type;
+  using index_type = typename PolicyType::index_type;
+
+  const index_type N(111);
+
+  point_t lower_bound{0, 0};
+  point_t upper_bound{N, N};
+
+  Kokkos::View<T***, Kokkos::DefaultExecutionSpace> data_3D("data_3D", N, N,
+                                                            reduce_view_size);
+  Kokkos::View<T*, Kokkos::DefaultExecutionSpace> data_1D("data_1D",
+                                                          reduce_view_size);
+
+  Kokkos::deep_copy(data_1D, static_cast<T>(0.0));
+  Kokkos::deep_copy(data_3D, static_cast<T>(1.0));
+
+  // Perform MDRange parallel reduce
+  PolicyType policy(lower_bound, upper_bound);
+  MDReduceFunctor<T> functor(data_3D, reduce_view_size);
+  Kokkos::parallel_reduce(policy, functor, data_1D);
+  Kokkos::fence();
+
+  // Verify results
+  auto host_data_1D =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, data_1D);
+  for (int i = 0; i < reduce_view_size; i++) {
+    ASSERT_EQ(host_data_1D(i), T(N * N));
+  }
+}
+
 TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
   for (int bound : {0, 1, 7, 32, 65, 7000}) {
     for (int k = 0; k < bound; ++k) {
@@ -47,6 +109,15 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
       MDRangeReduceTester<int32_t>(bound, k);
       MDRangeReduceTester<int64_t>(bound, k);
     }
+  }
+}
+
+TEST(TEST_CATEGORY, mdrange_parallel_reduce_view_type) {
+  for (int reduce_view_size : {1, 2, 3, 15, 16, 17, 31, 32, 33, 64}) {
+    MDRangeReduceViewTester<double>(reduce_view_size);
+    MDRangeReduceViewTester<float>(reduce_view_size);
+    MDRangeReduceViewTester<int32_t>(reduce_view_size);
+    MDRangeReduceViewTester<int16_t>(reduce_view_size);
   }
 }
 

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -38,10 +38,6 @@ void MDRangeReduceTester([[maybe_unused]] int bound, int k) {
 }
 
 TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "FIXME OPENMPTARGET Tests of MDRange reduce over values "
-                  "smaller than int would fail";
-#else
   for (int bound : {0, 1, 7, 32, 65, 7000}) {
     for (int k = 0; k < bound; ++k) {
       MDRangeReduceTester<bool>(bound, k);
@@ -52,7 +48,6 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
       MDRangeReduceTester<int64_t>(bound, k);
     }
   }
-#endif
 }
 
 // Functor for reduction tests, reducing over a 3D View into a 1D View
@@ -121,25 +116,8 @@ void MDRangeReduceViewTester(int view_size, int reduce_view_size, int tile_x,
   }
 }
 
-TEST(TEST_CATEGORY, mdrange_parallel_reduce_primitive_types) {
-  for (int bound : {0, 1, 7, 32, 65, 7000}) {
-    for (int k = 0; k < bound; ++k) {
-      MDRangeReduceTester<bool>(bound, k);
-      MDRangeReduceTester<signed char>(bound, k);
-      MDRangeReduceTester<int8_t>(bound, k);
-      MDRangeReduceTester<int16_t>(bound, k);
-      MDRangeReduceTester<int32_t>(bound, k);
-      MDRangeReduceTester<int64_t>(bound, k);
-    }
-  }
-}
-
 TEST(TEST_CATEGORY, mdrange_parallel_reduce_view_size_limit) {
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP()
-      << "FIXME_OPENMPTARGET custom reduction with MDRangePolicy is not "
-         "yet implemented";
-#elif defined(KOKKOS_ENABLE_OPENACC)
+#if defined(KOKKOS_ENABLE_OPENACC)
   GTEST_SKIP() << "FIXME_OPENACC custom reduction with MDRangePolicy is not "
                   "yet implemented";
 #else

--- a/core/unit_test/TestMDRangeReduce.hpp
+++ b/core/unit_test/TestMDRangeReduce.hpp
@@ -147,14 +147,23 @@ TEST(TEST_CATEGORY, mdrange_parallel_reduce_view_size_limit) {
   const int reduce_view_size = 1000;
   const int tile_x           = 32;
   const int tile_y           = 4;
-  if constexpr (std::is_same_v<TEST_EXECSPACE,
-                               Kokkos::DefaultHostExecutionSpace>) {
-    EXPECT_NO_THROW(MDRangeReduceViewTester<double>(view_size, reduce_view_size,
-                                                    tile_x, tile_y));
-  } else {
+  if constexpr (
+#if defined(KOKKOS_ENABLE_CUDA)
+      std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>
+#elif defined(KOKKOS_ENABLE_HIP)
+      std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>
+#elif defined(KOKKOS_ENABLE_SYCL)
+      std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>
+#else
+      false
+#endif
+  ) {
     EXPECT_THROW(MDRangeReduceViewTester<double>(view_size, reduce_view_size,
                                                  tile_x, tile_y),
                  std::runtime_error);
+  } else {
+    EXPECT_NO_THROW(MDRangeReduceViewTester<double>(view_size, reduce_view_size,
+                                                    tile_x, tile_y));
   }
 #endif
 }

--- a/core/unit_test/cuda/TestCuda_ReducerViewSizeLimit.cpp
+++ b/core/unit_test/cuda/TestCuda_ReducerViewSizeLimit.cpp
@@ -52,32 +52,6 @@ struct ArrayReduceFunctor {
   KOKKOS_INLINE_FUNCTION void final(value_type) const {}
 };
 
-struct MDArrayReduceFunctor {
-  using value_type = ValueType[];
-
-  int value_count;
-  Matrix3D m;
-
-  MDArrayReduceFunctor(const Matrix3D& m_) : value_count(m_.extent(2)), m(m_) {}
-
-  KOKKOS_INLINE_FUNCTION void operator()(const int i, const int j,
-                                         value_type sum) const {
-    const int numVecs = value_count;
-    for (int k = 0; k < numVecs; ++k) {
-      sum[k] += m(i, j, k);
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void init(value_type update) const {
-    const int numVecs = value_count;
-    for (int j = 0; j < numVecs; ++j) {
-      update[j] = 0.0;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION void final(value_type) const {}
-};
-
 struct ReduceViewSizeLimitTester {
   const ValueType initValue           = 3;
   const size_t nGlobalEntries         = 100;
@@ -107,31 +81,6 @@ struct ReduceViewSizeLimitTester {
       }
     }
   }
-
-  void run_test_md_range_2D() {
-    Matrix3D matrix;
-    Vector sum;
-
-    for (int i = 0; i < testViewSize; ++i) {
-      size_t sumInitShmemSize = (initBlockSize + 2) * sizeof(ValueType) * i;
-
-      Kokkos::resize(Kokkos::WithoutInitializing, sum, i);
-      Kokkos::resize(Kokkos::WithoutInitializing, matrix, nGlobalEntries,
-                     nGlobalEntries, i);
-      Kokkos::deep_copy(matrix, initValue);
-
-      auto policy = Kokkos::MDRangePolicy<Kokkos::Rank<2>>(
-          {0, 0}, {nGlobalEntries, nGlobalEntries});
-      auto functor = MDArrayReduceFunctor(matrix);
-
-      if (sumInitShmemSize < expectedInitShmemLimit) {
-        EXPECT_NO_THROW(Kokkos::parallel_reduce(policy, functor, sum));
-      } else {
-        EXPECT_THROW(Kokkos::parallel_reduce(policy, functor, sum),
-                     std::runtime_error);
-      }
-    }
-  }
 };
 
 }  // namespace Impl
@@ -140,12 +89,6 @@ TEST(cuda, reduceRangePolicyViewSizeLimit) {
   Impl::ReduceViewSizeLimitTester reduceViewSizeLimitTester;
 
   reduceViewSizeLimitTester.run_test_range();
-}
-
-TEST(cuda, reduceMDRangePolicyViewSizeLimit) {
-  Impl::ReduceViewSizeLimitTester reduceViewSizeLimitTester;
-
-  reduceViewSizeLimitTester.run_test_md_range_2D();
 }
 
 }  // namespace Test


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/kokkos/kokkos/issues/8625

### Context
In `MDRangePolicy` with `parallel_reduce`, when the return type is a `Kokkos::View,` the algorithm uses shared memory to store the view and must adjust the block size accordingly. However, the size was **not** properly adjusted based on shared memory usage. 
Even if the block size was reduced, the change was not propagated to the `Policy`. I modified `DeviceIterateTile` to allow a thread to process multiple elements in a tile. I added tests to cover this case.

### Changes made
- HIP: Corrected the block size calculation based on shared memory usage.
- HIP and CUDA: The minimum block size is now set to the warp size.
- `DeviceIterateTile`: Allow threads to process multiple elements in the tile when the block size is reduced.
- SYCL: Reduce workgroup size until reduction is possible. Add an error if the reduction algorithm uses too much local memory.
- Clearer error message
- Made `word_count` type independent of the reduced type.
- CUDA: Remove unnecessary calls to `check_reduced_view_shmem_size` since we do a better check later in the execution.

### Differences between host and device backends
- For Hosts backends, there is no limit on the maximum size of custom reductions.
- For Device backends, the reduction algorithm uses shared memory and is quickly limited to a few hundred elements for this type of reduction.

### Tests
- `TestMDRangeReduce`: Added test cases where the block size is effectively reduced based on shared memory usage. Checked the correctness of reduction results.
- Generalize test `reduceMDRangePolicyViewSizeLimit` (related to issue https://github.com/kokkos/kokkos/issues/4743). Now the test checks only one size, previously it tested a range of sizes.
