### PR TITLE
Remove IMPL_NVHPC_AS_DEVICE_COMPILER cmake option

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -36,7 +36,6 @@ kokkos_enable_option(
 # As of 09/2024, cudaMallocAsync causes issues with ICP and older version of UCX
 # as MPI communication layer.
 kokkos_enable_option(IMPL_CUDA_MALLOC_ASYNC OFF "Whether to enable CudaMallocAsync (requires CUDA Toolkit 11.2)")
-kokkos_enable_option(IMPL_NVHPC_AS_DEVICE_COMPILER OFF "Whether to allow nvc++ as Cuda device compiler")
 kokkos_enable_option(IMPL_CUDA_UNIFIED_MEMORY OFF "Whether to leverage unified memory architectures for CUDA")
 
 kokkos_enable_option(DEPRECATED_CODE_4 OFF "Whether code deprecated in major release 4 is available")


### PR DESCRIPTION
Likely oversight from https://github.com/kokkos/kokkos/pull/6987
Given we have removed the support of `nvhpc` as a unified host/device compiler, we should get rid of this cmake option as well.