### PR TITLE
Cleanup: move precondition check helper to impl/ and drop forward declarations

### DIFF
--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -13,7 +13,6 @@ static_assert(false,
 #define KOKKOS_PARALLEL_HPP
 
 #include <Kokkos_Core_fwd.hpp>
-#include <Kokkos_CheckUsage.hpp>
 #include <Kokkos_DetectionIdiom.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_View.hpp>
@@ -21,8 +20,9 @@ static_assert(false,
 #include <impl/Kokkos_Tools.hpp>
 #include <impl/Kokkos_Tools_Generic.hpp>
 
-#include <impl/Kokkos_Traits.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
+#include <impl/Kokkos_Traits.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -10,7 +10,7 @@ static_assert(false,
 #define KOKKOS_PARALLEL_REDUCE_HPP
 
 #include <impl/Kokkos_BuiltinReducers.hpp>
-#include <Kokkos_CheckUsage.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_View.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>

--- a/core/src/impl/Kokkos_CheckUsage.hpp
+++ b/core/src/impl/Kokkos_CheckUsage.hpp
@@ -4,20 +4,18 @@
 #ifndef KOKKOS_CHECK_USAGE_HPP
 #define KOKKOS_CHECK_USAGE_HPP
 
-#include <sstream>
-#include <type_traits>
-
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Macros.hpp>
+#include <impl/Kokkos_InitializeFinalize.hpp>
 #include <impl/Kokkos_Utilities.hpp>
+
+#include <sstream>
+#include <type_traits>
 
 // FIXME: Obtain file and line number information via std::source_location
 // (since C++20) which requires GCC 11 etc.
 
 namespace Kokkos {
-
-[[nodiscard]] bool is_initialized() noexcept;
-[[nodiscard]] bool is_finalized() noexcept;
 
 template <typename... Args>
 class RangePolicy;


### PR DESCRIPTION
Because that is where the header belong and forward declaration were unwarranted.
Splitting this off from upcoming changes adding more precondition check helpers.