### PR TITLE
Constrain Views used as result in parallel_reduce

### DIFF
--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -71,11 +71,7 @@ struct ParallelReduceReturnValue<
   using return_type  = ReturnType;
   using reducer_type = InvalidType;
 
-  using value_type_scalar = typename return_type::value_type;
-  using value_type_array  = typename return_type::value_type* const;
-
-  using value_type = std::conditional_t<return_type::rank == 0,
-                                        value_type_scalar, value_type_array>;
+  using value_type = typename return_type::value_type;
 
   static return_type& return_value(ReturnType& return_val, const FunctorType&) {
     return return_val;  // NOLINT(bugprone-return-const-ref-from-parameter)
@@ -163,6 +159,11 @@ struct ParallelReduceAdaptor {
   using return_value_adapter =
       Impl::ParallelReduceReturnValue<void, ReturnType, FunctorType>;
 
+  static constexpr bool is_array_reduction =
+      Impl::FunctorAnalysis<
+          Impl::FunctorPatternInterface::REDUCE, PolicyType, FunctorType,
+          typename return_value_adapter::value_type>::StaticValueSize == 0;
+
   // Equivalent to std::get<I>(std::tuple) but callable on the device.
   template <bool B, class T1, class T2>
   static KOKKOS_FUNCTION std::conditional_t<B, T1&&, T2&&> forwarding_switch(
@@ -173,10 +174,11 @@ struct ParallelReduceAdaptor {
       return static_cast<T2&&>(v2);
   }
 
-  static inline void execute_impl(const std::string& label,
-                                  const PolicyType& policy,
-                                  const FunctorType& functor,
-                                  ReturnType& return_value) {
+  static inline void execute(const std::string& label, const PolicyType& policy,
+                             const FunctorType& functor,
+                             ReturnType& return_value)
+    requires(!(is_array_reduction && std::is_pointer_v<ReturnType>))
+  {
     using PassedReducerType = typename return_value_adapter::reducer_type;
     uint64_t kpID           = 0;
 
@@ -200,6 +202,21 @@ struct ParallelReduceAdaptor {
                                                      label, kpID);
     const auto& inner_policy = response.policy;
 
+    if constexpr (Kokkos::is_view_v<ReturnType>) {
+      if constexpr (is_array_reduction)
+        static_assert(
+            ReturnType::rank == 1,
+            "Array reductions with a View result type require a rank-1 View!");
+      if constexpr (!is_array_reduction)
+        static_assert(
+            ReturnType::rank == 0,
+            "Scalar reductions with a View result type require a rank-0 View!");
+      if (!return_value.span_is_contiguous())
+        Kokkos::abort(
+            "Reductions with a View result type must use a View with "
+            "contiguous memory!");
+    }
+
     auto closure = construct_with_shared_allocation_tracking_disabled<
         Impl::ParallelReduce<CombinedFunctorReducerType, PolicyType,
                              typename Impl::FunctorPolicyExecutionSpace<
@@ -210,19 +227,6 @@ struct ParallelReduceAdaptor {
 
     Kokkos::Tools::Impl::end_parallel_reduce<PassedReducerType>(
         inner_policy, functor, label, kpID);
-  }
-
-  static constexpr bool is_array_reduction =
-      Impl::FunctorAnalysis<
-          Impl::FunctorPatternInterface::REDUCE, PolicyType, FunctorType,
-          typename return_value_adapter::value_type>::StaticValueSize == 0;
-
-  template <typename Dummy = ReturnType>
-  static inline std::enable_if_t<!(is_array_reduction &&
-                                   std::is_pointer_v<Dummy>)>
-  execute(const std::string& label, const PolicyType& policy,
-          const FunctorType& functor, ReturnType& return_value) {
-    execute_impl(label, policy, functor, return_value);
   }
 };
 }  // namespace Impl

--- a/core/src/Kokkos_Parallel_Reduce.hpp
+++ b/core/src/Kokkos_Parallel_Reduce.hpp
@@ -207,7 +207,7 @@ struct ParallelReduceAdaptor {
         static_assert(
             ReturnType::rank == 1,
             "Array reductions with a View result type require a rank-1 View!");
-      if constexpr (!is_array_reduction)
+      else
         static_assert(
             ReturnType::rank == 0,
             "Scalar reductions with a View result type require a rank-0 View!");


### PR DESCRIPTION
In response to https://kokkosteam.slack.com/archives/G5CBLMFLP/p1762470537449599?thread_ts=1762446275.847549&cid=G5CBLMFLP, this pull request make sure that `Views` used as result type for `parallel_reduce` have contiguous memory and rank-0 for scalar reductions and rank-1 for array reductions.