### PR TITLE
[CI] Change hpsf CI on Hopper to Cuda 13

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -48,7 +48,7 @@ NVIDIA-RTX5080:
 NVIDIA-GH200:
   extends: .common-setup
   tags: [nvidia-gh200]
-  image: nvcr.io/nvidia/cuda:12.6.1-devel-ubuntu24.04
+  image: nvcr.io/nvidia/cuda:13.0.2-devel-ubuntu24.04
   script:
     - apt-get update && apt-get install -y cmake git python3
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
@@ -57,12 +57,19 @@ NVIDIA-GH200:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=`pwd`/bin/nvcc_wrapper"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror'"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_STANDARD=20"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_DEBUG=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_DEBUG_BOUNDS_CHECK=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_HOPPER90=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_CUDA=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_OPENMP=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_IMPL_CUDA_UNIFIED_MEMORY=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_LARGE_MEM_TESTS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_LIBDL=OFF"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_BENCHMARKS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON"
     - export CTEST_BUILD_NAME="NVIDIA-GH200"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -48,7 +48,7 @@ NVIDIA-RTX5080:
 NVIDIA-GH200:
   extends: .common-setup
   tags: [nvidia-gh200]
-  image: nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04
+  image: nvcr.io/nvidia/cuda:13.0.2-devel-ubuntu24.04
   script:
     - apt-get update && apt-get install -y cmake git python3
     - export CMAKE_BUILD_PARALLEL_LEVEL=48

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -48,7 +48,7 @@ NVIDIA-RTX5080:
 NVIDIA-GH200:
   extends: .common-setup
   tags: [nvidia-gh200]
-  image: nvcr.io/nvidia/cuda:13.0.2-devel-ubuntu24.04
+  image: nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu24.04
   script:
     - apt-get update && apt-get install -y cmake git python3
     - export CMAKE_BUILD_PARALLEL_LEVEL=48


### PR DESCRIPTION
This bumps the HPSF onto the Hopper machines to cuda 13. We had spurious issues in Jenkins with this build that gave:
```
[CUDA-13.0-NVCC-DEBUG] /usr/bin/ld: ../src/libkokkoscore.so.5.0.99: undefined reference to `cuStreamGetCtx'
```
They are fixed now. Nevertheless, the CI-WG thinks a cuda13 build on `GH200` is useful (and already identified a deprecation of runtime API that we missed).