### PR TITLE
Add a missing sstream include in Kokkos_ViewLegacy.hpp

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -13,6 +13,7 @@ static_assert(false,
 #include <string>
 #include <algorithm>
 #include <initializer_list>
+#include <sstream>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_HostSpace.hpp>


### PR DESCRIPTION
Kokkos fails to compile on recent gcc with `Kokkos_ENABLE_IMPL_MDSPAN=OFF` because `<sstream>` is not included in `core/src/View/Kokkos_ViewLegacy.hpp`, I tried with gcc 15.2.1 and 14.1.0.