### PR TITLE
simd: Add missing `include(CheckIncludeFileCXX)` in the simd CMakeLists

### DIFF
--- a/simd/src/CMakeLists.txt
+++ b/simd/src/CMakeLists.txt
@@ -38,6 +38,7 @@ kokkos_link_internal_library(kokkossimd kokkoscore)
 
 # If ARM-SVE, check and warn for available arm_neon_sve_bridge.h
 if(KOKKOS_ARCH_ARM_SVE)
+  include(CheckIncludeFileCXX)
   check_include_file_cxx(arm_neon_sve_bridge.h KOKKOS_COMPILER_SUPPORTS_ARM_NEON_SVE_BRIDGE)
   if(NOT KOKKOS_COMPILER_SUPPORTS_ARM_NEON_SVE_BRIDGE)
     message(


### PR DESCRIPTION
This PR adds a missing `include(CheckIncludeFileCXX)` in the simd cmake file.

Currently, kokkos fails to configure with SVE enabled, except when `Kokkos_ENABLE_TESTS=ON` and we're using the bundled gtest, as `tpls/gtest/CMakeLists.txt` does a `find_package(Threads)` and `FindThreads.cmake` calls `include(CheckIncludeFileCXX)` (see https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindThreads.cmake?ref_type=heads#L126)