### PR TITLE
[5.0] cherry-pick #8659: Add a missing sstream include in Kokkos_ViewLegacy.hpp

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -13,6 +13,7 @@ static_assert(false,
 #include <string>
 #include <algorithm>
 #include <initializer_list>
+#include <sstream>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_HostSpace.hpp>


### PR DESCRIPTION
Cherry-pick of #8659