### PR TITLE
Fix team_size_max/recommended with reducer

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelReduce_Team.hpp
@@ -313,7 +313,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     auto internal_space_instance =
         m_policy.space().impl_internal_space_instance();
     if (m_team_size < 0) {
-      m_team_size = arg_policy.team_size_recommended(
+      m_team_size = arg_policy.team_size_recommended_internal(
           arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
           ParallelReduceTag());
       if (m_team_size <= 0)
@@ -382,7 +382,7 @@ class ParallelReduce<CombinedFunctorReducerType,
                       "L0 scratch memory"));
     }
 
-    size_t max_size = arg_policy.team_size_max(
+    size_t max_size = arg_policy.team_size_max_internal(
         arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
         ParallelReduceTag());
     if (static_cast<int>(m_team_size) > static_cast<int>(max_size)) {

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -74,8 +74,18 @@ class TeamPolicyInternal<HIP, Properties...>
   }
 
   template <typename FunctorType, typename ReducerType>
-  inline int team_size_max(const FunctorType& f, const ReducerType&,
-                           const ParallelReduceTag&) const {
+  inline int team_size_max(const FunctorType& f, const ReducerType& reducer,
+                           const ParallelReduceTag& tag) const {
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, ReducerType, void>;
+    return team_size_max_internal(
+        f, typename functor_analysis_type::Reducer{reducer}, tag);
+  }
+
+  template <typename FunctorType, typename ReducerType>
+  inline int team_size_max_internal(const FunctorType& f, const ReducerType&,
+                                    const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::HIP>;
@@ -108,8 +118,18 @@ class TeamPolicyInternal<HIP, Properties...>
   }
 
   template <typename FunctorType, typename ReducerType>
-  int team_size_recommended(FunctorType const& f, ReducerType const&,
-                            ParallelReduceTag const&) const {
+  int team_size_recommended(const FunctorType& f, const ReducerType& reducer,
+                            const ParallelReduceTag& tag) const {
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, ReducerType, void>;
+    return team_size_recommended_internal(
+        f, typename functor_analysis_type::Reducer{reducer}, tag);
+  }
+
+  template <typename FunctorType, typename ReducerType>
+  int team_size_recommended_internal(const FunctorType& f, const ReducerType&,
+                                     const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::HIP>;

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -41,10 +41,20 @@ struct FunctorReduce {
   }
 };
 }  // namespace
+}  // namespace Test
+
+template <class T, int N>
+struct Kokkos::reduction_identity<Test::MyArray<T, N>> {
+  KOKKOS_FUNCTION static Test::MyArray<T, N> sum() {
+    return Test::MyArray<T, N>{};
+  }
+};
+
+namespace Test {
 
 using policy_type = Kokkos::TeamPolicy<TEST_EXECSPACE>;
 using policy_type_128_8 =
-    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 8> >;
+    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<128, 8>>;
 
 // We need to special case for NVIDIA architectures which don't have space for
 // 2048 threads ptxas warns and with errors as warning errors out: "ptxas error
@@ -55,10 +65,10 @@ using policy_type_128_8 =
     defined(KOKKOS_ARCH_AMPERE87) || defined(KOKKOS_ARCH_ADA89) ||    \
     defined(KOKKOS_ARCH_BLACKWELL120)
 using policy_type_1024_2 =
-    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<1024, 1> >;
+    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<1024, 1>>;
 #else
 using policy_type_1024_2 =
-    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<1024, 2> >;
+    Kokkos::TeamPolicy<TEST_EXECSPACE, Kokkos::LaunchBounds<1024, 2>>;
 #endif
 
 template <class T, int N, class PolicyType, int S>
@@ -71,11 +81,19 @@ void test_team_policy_max_recommended_static_size(int scratch_size) {
       FunctorFor<T, N, PolicyType, S>(), Kokkos::ParallelForTag());
   int team_size_max_reduce = p.team_size_max(
       FunctorReduce<T, N, PolicyType, S>(), Kokkos::ParallelReduceTag());
+  MyArray<T, N> dummy;
+  int team_size_max_reduce_reducer = p.team_size_max(
+      FunctorReduce<T, N, PolicyType, S>(), Kokkos::Sum<MyArray<T, N>>{dummy},
+      Kokkos::ParallelReduceTag());
   int team_size_rec_reduce = p.team_size_recommended(
       FunctorReduce<T, N, PolicyType, S>(), Kokkos::ParallelReduceTag());
+  int team_size_rec_reduce_reducer = p.team_size_recommended(
+      FunctorReduce<T, N, PolicyType, S>(), Kokkos::Sum<MyArray<T, N>>{dummy},
+      Kokkos::ParallelReduceTag());
 
   ASSERT_GE(team_size_max_for, team_size_rec_for);
   ASSERT_GE(team_size_max_reduce, team_size_rec_reduce);
+  ASSERT_GE(team_size_max_reduce_reducer, team_size_rec_reduce_reducer);
   ASSERT_GE(team_size_max_for, team_size_max_reduce);
 
   Kokkos::parallel_for(PolicyType(10000, team_size_max_for, 4)


### PR DESCRIPTION
Split from #7445. The current `team_size_max/team_size_recommended` implementations don't compile if goven a reducer for all backends.
All `ParallelReduce` classes wrap the reducer in a `FunctorAnalysis::Reducer` type that defines all possible members that reducers can optionally have. Within the `ParallelReduce` implementations, we call `team_size_max/recommended` when using `Kokkos::AUTO` or to check bounds. Since a `FunctorAnalysis::Reducer` doesn't fulfill the reducer concept itself, the interfaces need to be different. Of course, we can always wrap a reducer and then call the other implementations which is done here. Apparently, no one has used this `team_size_max/recommended` overload since refactoring the `ParallelReduce` classes to use `CombinedFunctorReducer`/`FunctorAnalysis::Reducer`.