### PR TITLE
[5.0] cherry-pick #8614: Revise ViewTrait deprecations for legacy View interop

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -239,10 +239,10 @@ class View : public ViewTraits<DataType, Properties...> {
   /** \brief  Compatible view of data type */
   using type = std::conditional_t<
       has_hooks_policy,
-      View<typename traits::data_type, typename traits::array_layout,
+      View<typename traits::scalar_array_type, typename traits::array_layout,
            typename traits::device_type, typename traits::hooks_policy,
            typename traits::memory_traits>,
-      View<typename traits::data_type, typename traits::array_layout,
+      View<typename traits::scalar_array_type, typename traits::array_layout,
            typename traits::device_type, typename traits::memory_traits>>;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -488,20 +488,37 @@ struct ViewTraits {
  public:
   //------------------------------------
   // Data type traits:
-
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using data_type           = typename data_analysis::type;
+  using const_data_type     = typename data_analysis::const_type;
+  using non_const_data_type = typename data_analysis::non_const_type;
+#else
   using data_type           = typename data_analysis::data_type;
   using const_data_type     = typename data_analysis::const_data_type;
   using non_const_data_type = typename data_analysis::non_const_data_type;
+#endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   //------------------------------------
   // Compatible array of trivial type traits:
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Only supported with KOKKOS_ENABLE_IMPL_VIEW_LEGACY, to be removed after "
+      "5.0 release") = typename data_analysis::scalar_array_type;
+  using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Only supported with KOKKOS_ENABLE_IMPL_VIEW_LEGACY, to be removed after "
+      "5.0 release.") = typename data_analysis::const_scalar_array_type;
+  using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
+      "Only supported with KOKKOS_ENABLE_IMPL_VIEW_LEGACY, to be removed after "
+      "5.0 release.") = typename data_analysis::non_const_scalar_array_type;
+#else
   using scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use data_type instead.") = data_type;
   using const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use const_data_type instead.") = const_data_type;
   using non_const_scalar_array_type KOKKOS_DEPRECATED_WITH_COMMENT(
       "Use non_const_data_type instead.") = non_const_data_type;
+#endif
 #endif
   //------------------------------------
   // Value type traits:


### PR DESCRIPTION
* Revise ViewTrait deprecations for legacy View interop

Changes made to restore legacy View support with Sacado/Stokhos in Trilinos



* apply clang-format



* revert changes to core/src/Kokkos_View.hpp

unused for legacy View



* fix deprecation comment for scalar_array_type with legacy View



* drop KOKKOS_ENABLE_IMPL_VIEW_LEGACY guards in Kokkos_ViewLegacy

unnecessary since Kokkos_ViewLegacy.hpp only included when KOKKOS_ENABLE_IMPL_VIEW_LEGACY is true



---------