### PR TITLE
Fix required_allocation_size for customized View

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1172,16 +1172,58 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
            sizeof(raw_allocation_value_type);
   }
 
-  KOKKOS_FUNCTION
-  static constexpr size_t required_allocation_size(
-      const size_t arg_N0 = 0, const size_t arg_N1 = 0, const size_t arg_N2 = 0,
-      const size_t arg_N3 = 0, const size_t arg_N4 = 0, const size_t arg_N5 = 0,
-      const size_t arg_N6 = 0, const size_t arg_N7 = 0) {
+ private:
+  template <size_t... RankIdx, std::integral... Args>
+  KOKKOS_FUNCTION static constexpr size_t impl_required_allocation_size(
+      std::index_sequence<RankIdx...>, Args... args) {
+    constexpr size_t num_passed_args = sizeof...(Args);
+    // Deal with customized view with extra args first.
+    // Secondly, handle case where the number of arguments is valid.
+    // Thirdly, deal with the case where the number of arguments is
+    // invalid, which the old impl allowed.
+    if constexpr (traits::impl_is_customized && num_passed_args == rank() + 1) {
+      size_t args_array[num_passed_args] = {static_cast<size_t>(args)...};
+      size_t req_span_size =
+          typename base_t::mapping_type(
+              typename base_t::extents_type{args_array[RankIdx]...})
+              .required_span_size();
+      return req_span_size * args_array[rank()] *
+             sizeof(raw_allocation_value_type);
+    } else if constexpr (num_passed_args == rank_dynamic ||
+                         num_passed_args == rank()) {
+      size_t req_span_size =
+          typename base_t::mapping_type(typename base_t::extents_type{args...})
+              .required_span_size();
+      return req_span_size * sizeof(typename base_t::element_type);
+    }
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    static_assert(
+        (traits::impl_is_customized && num_passed_args == rank() + 1) ||
+            num_passed_args == rank_dynamic || num_passed_args == rank(),
+        "Kokkos::View::required_span_size(...) - invalid number of arguments");
+#else
+    else {
+      size_t args_array[num_passed_args] = {static_cast<size_t>(args)...};
+      size_t req_span_size =
+          typename base_t::mapping_type(
+              typename base_t::extents_type{args_array[RankIdx]...})
+              .required_span_size();
+      return req_span_size * sizeof(typename base_t::element_type);
+    }
+#endif
+  }
+
+ public:
+  template <std::integral... Args>
+  KOKKOS_FUNCTION static constexpr size_t required_allocation_size(
+      Args... args) {
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");
-    return required_allocation_size(typename traits::array_layout(
-        arg_N0, arg_N1, arg_N2, arg_N3, arg_N4, arg_N5, arg_N6, arg_N7));
+    static_assert(sizeof...(Args) >= rank(),
+                  "Number of extents is insufficient");
+    return impl_required_allocation_size(std::make_index_sequence<rank()>(),
+                                         args...);
   }
 
   //----------------------------------------

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -327,7 +327,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # ViewSupport should eventually contain the new implementation
     # detail tests for the mdspan based View
     if(Kokkos_ENABLE_IMPL_MDSPAN)
-      set(BV_TestNames BasicView ReferenceCountedAccessor ReferenceCountedDataHandle)
+      set(BV_TestNames BasicView ReferenceCountedAccessor ReferenceCountedDataHandle AllocationAndSpanSize)
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_OPENACC)
         list(APPEND BV_TestNames ViewCustomizationAccessorArg ViewCustomizationAllocationType
              ViewCustomizationAccessorFromMapping

--- a/core/unit_test/view/TestAllocationAndSpanSize.hpp
+++ b/core/unit_test/view/TestAllocationAndSpanSize.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <gtest/gtest.h>
+
+template <class ViewT, std::integral... Sizes>
+void test_required_span_size_single_rank(size_t expected_size,
+                                         std::string label, Sizes... sizes) {
+  ViewT view(label, sizes...);
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  // Lets get the required size two ways: based on mapping + accessor and using
+  // the required_allocation_size
+  size_t span_size = view.mapping().required_span_size();
+  size_t span_size_based_bytes =
+      span_size * sizeof(typename ViewT::element_type);
+  ASSERT_EQ(span_size_based_bytes, expected_size);
+#endif
+  size_t req_allocation_size = ViewT::required_allocation_size(sizes...);
+  ASSERT_EQ(req_allocation_size, expected_size);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  size_t req_allocation_size_extra =
+      ViewT::required_allocation_size(sizes..., 3);
+  ASSERT_EQ(req_allocation_size_extra, expected_size);
+#endif
+}
+
+template <class Layout>
+void test_required_span_size_layout() {
+  // 8 is the size of the element types we store.
+  // While Foo::Bar uses float, the accessor and reference type associated
+  // with Foo::Bar actually make the allocation store double!
+  test_required_span_size_single_rank<
+      Kokkos::View<double, Layout, TEST_EXECSPACE>>(8, "A");
+  test_required_span_size_single_rank<
+      Kokkos::View<double*, Layout, TEST_EXECSPACE>>(7 * 8, "A", 7);
+  test_required_span_size_single_rank<
+      Kokkos::View<double[7], Layout, TEST_EXECSPACE>>(7 * 8, "A", 7);
+  test_required_span_size_single_rank<
+      Kokkos::View<double**, Layout, TEST_EXECSPACE>>(7 * 11 * 8, "A", 7, 11);
+  test_required_span_size_single_rank<
+      Kokkos::View<double* [11], Layout, TEST_EXECSPACE>>(7 * 11 * 8, "A", 7,
+                                                          11);
+  test_required_span_size_single_rank<
+      Kokkos::View<double*******, Layout, TEST_EXECSPACE>>(
+      7 * 11 * 13 * 17 * 19 * 2 * 3 * 8, "A", 7, 11, 13, 17, 19, 2, 3);
+  test_required_span_size_single_rank<
+      Kokkos::View<double***** [2][3], Layout, TEST_EXECSPACE>>(
+      7 * 11 * 13 * 17 * 19 * 2 * 3 * 8, "A", 7, 11, 13, 17, 19, 2, 3);
+}
+
+TEST(TEST_CATEGORY, view_required_span_size) {
+  test_required_span_size_layout<Kokkos::LayoutLeft>();
+  test_required_span_size_layout<Kokkos::LayoutRight>();
+}


### PR DESCRIPTION
It also makes the primary function (taking ints) somewhat safer to use. Note that `shmem_size` and `required_allocation_size` work differently due to preexisting behavior: `required_allocation_size` for customized views allows rank+1 args, while `shmem_size` takes rank_dynamic+1. View constructors also requires rank+1 in that case, so I think that is more consistent. Also for `shmem_size` we can't actually distinguish you passed in an extra argument vs you passed in rank arguments if you have something like `View<int*[4]>`.