### PR TITLE
Setup pre-commit

### DIFF
--- a/.github/workflows/continuous-integration-stager.yml
+++ b/.github/workflows/continuous-integration-stager.yml
@@ -17,6 +17,9 @@ permissions: read-all
 
 jobs:
   # pre-stage
+  pre-commit-check:
+    uses: ./.github/workflows/pre-commit.yml
+
   clang-format-check:
     uses: ./.github/workflows/clang-format-check.yml
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
+    hooks:
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-yaml
+    #- id: end-of-file-fixer
+    - id: forbid-submodules
+    #- id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 579d9fe3b1ee34ddd6ebc5def531f2f1acce622e # v16.0.0
+    hooks:
+    - id: clang-format
+
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: e2c2116d86a80e72e7146a06e68b7c228afc6319 # v0.6.13
+    hooks:
+    - id: cmake-format


### PR DESCRIPTION
The main goal is to lower the bar to entry for new contributors.  [pre-commit](https://pre-commit.com) is a powerful tool.  In this PR, it is configured to check clang-format and cmake-format.
We can look into adding other things (in follow up PRs) such as a spellchecker, other hooks that would check the license headers or that the commits are signed off.