### PR TITLE
Demonstrate how to fix code with static exec spaces

### DIFF
--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -425,7 +425,7 @@ Kokkos::DefaultExecutionSpace replace_static_execution_space() {
     return true;
   }();
   KOKKOS_ASSERT(exec.has_value());
-  return *exec;
+  return *exec;  // NOLINT(bugprone-unchecked-optional-access)
 }
 
 void compute_stuff(Kokkos::DefaultExecutionSpace exec) {

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -428,6 +428,18 @@ Kokkos::DefaultExecutionSpace replace_static_execution_space() {
   return *exec;
 }
 
+void compute_stuff(Kokkos::DefaultExecutionSpace exec) {
+  int const N = 10;
+  Kokkos::View<int*> v("v", N);
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy(exec, 0, N), KOKKOS_LAMBDA(int i) { v(i) = i + 1; });
+  int sum;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(exec, 0, N),
+      KOKKOS_LAMBDA(int i, int& partial_sum) { partial_sum += v(i); }, sum);
+  KOKKOS_ASSERT(sum == (N + 1) * N / 2);
+}
+
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        static_execution_space) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -437,18 +449,7 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
         Kokkos::initialize();
         {
           auto exec = replace_static_execution_space();
-
-          int const N = 10;
-          Kokkos::View<int*> v("v", N);
-          Kokkos::parallel_for(
-              Kokkos::RangePolicy(exec, 0, N),
-              KOKKOS_LAMBDA(int i) { v(i) = i + 1; });
-          int sum;
-          Kokkos::parallel_reduce(
-              Kokkos::RangePolicy(exec, 0, N),
-              KOKKOS_LAMBDA(int i, int& partial_sum) { partial_sum += v(i); },
-              sum);
-          KOKKOS_ASSERT(sum == (N + 1) * N / 2);
+          compute_stuff(exec);
         }
         Kokkos::finalize();
         std::exit(EXIT_SUCCESS);

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -417,4 +417,43 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
   }
 }
 
+Kokkos::DefaultExecutionSpace replace_static_execution_space() {
+  static std::optional<Kokkos::DefaultExecutionSpace> exec;
+  [[maybe_unused]] static bool once = [] {
+    exec = Kokkos::DefaultExecutionSpace();
+    Kokkos::push_finalize_hook([] { exec.reset(); });
+    return true;
+  }();
+  KOKKOS_ASSERT(exec.has_value());
+  return *exec;
+}
+
+TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
+       static_execution_space) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_EXIT(
+      {
+        Kokkos::initialize();
+        {
+          auto exec = replace_static_execution_space();
+
+          int const N = 10;
+          Kokkos::View<int*> v("v", N);
+          Kokkos::parallel_for(
+              Kokkos::RangePolicy(exec, 0, N),
+              KOKKOS_LAMBDA(int i) { v(i) = i + 1; });
+          int sum;
+          Kokkos::parallel_reduce(
+              Kokkos::RangePolicy(exec, 0, N),
+              KOKKOS_LAMBDA(int i, int& partial_sum) { partial_sum += v(i); },
+              sum);
+          KOKKOS_ASSERT(sum == (N + 1) * N / 2);
+        }
+        Kokkos::finalize();
+        std::exit(EXIT_SUCCESS);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+
 }  // namespace

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -6,6 +6,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+#include <Kokkos_Assert.hpp>
 #else
 #include <Kokkos_Core.hpp>
 #endif


### PR DESCRIPTION
Following up on #8546 in anticipation of downstream reports.
This PR adds a test with an idiom that can be suggested to users to replace code with static exec spaces.