### PR TITLE
Jenkins CI: Remove empty Cuda driver library

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -183,7 +183,7 @@ pipeline {
                         }
                     }
                 }
-/*
+
                 stage('CUDA-12.2-NVCC-RDC') {
                     agent {
                         dockerfile {
@@ -274,10 +274,11 @@ pipeline {
                     post {
                         always {
                             sh 'ccache --show-stats'
+                            xunit([CTest(deleteOutputFiles: true, failIfNotNew: true, pattern: 'build-tests/Testing/**/Test.xml', skipNoTestFiles: false, stopProcessingIfError: true)])
                         }
                     }
                 }
-*/
+
             }
         }
         stage('Build-2') {

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -36,3 +36,6 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
+
+# /usr/lib/x86_64-linux-gnu/libcuda.so being empty caused problems
+RUN rm -f /usr/lib/x86_64-linux-gnu/libcuda.so

--- a/scripts/docker/Dockerfile.nvhpc
+++ b/scripts/docker/Dockerfile.nvhpc
@@ -31,3 +31,6 @@ RUN CMAKE_URL=https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSIO
     sh ${CMAKE_SCRIPT} --skip-license --prefix=${CMAKE_DIR} && \
     rm cmake*
 ENV PATH=${CMAKE_DIR}/bin:$PATH
+
+# /usr/lib/x86_64-linux-gnu/libcuda.so being empty caused problems
+RUN rm -f /usr/lib/x86_64-linux-gnu/libcuda.so


### PR DESCRIPTION
It turned out that /usr/lib/x86_64-linux-gnu/libcuda.so is empty for some images which makes nvlink fail. This pull request tries ot delete it so that alternatives can be found.
Alternative to https://github.com/kokkos/kokkos/pull/8616.