### PR TITLE
Allow and test rank_dynamic args to required_allocation_size

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1221,8 +1221,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     static_assert(traits::array_layout::is_extent_constructible,
                   "Layout is not constructible from extent arguments. Use "
                   "overload taking a layout object instead.");
-    static_assert(sizeof...(Args) >= rank(),
-                  "Number of extents is insufficient");
+    static_assert(sizeof...(Args) == rank_dynamic || sizeof...(Args) >= rank(),
+                  "Number of extents is invalid");
     return impl_required_allocation_size(std::make_index_sequence<rank()>(),
                                          args...);
   }

--- a/core/unit_test/view/TestAllocationAndSpanSize.hpp
+++ b/core/unit_test/view/TestAllocationAndSpanSize.hpp
@@ -26,9 +26,11 @@ void test_required_span_size_single_rank(size_t expected_size,
   size_t req_allocation_size = ViewT::required_allocation_size(sizes...);
   ASSERT_EQ(req_allocation_size, expected_size);
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  size_t req_allocation_size_extra =
-      ViewT::required_allocation_size(sizes..., 3);
-  ASSERT_EQ(req_allocation_size_extra, expected_size);
+  if constexpr (sizeof...(Sizes) == ViewT::rank()) {
+    size_t req_allocation_size_extra =
+        ViewT::required_allocation_size(sizes..., 3);
+    ASSERT_EQ(req_allocation_size_extra, expected_size);
+  }
 #endif
 }
 
@@ -44,16 +46,23 @@ void test_required_span_size_layout() {
   test_required_span_size_single_rank<
       Kokkos::View<double[7], Layout, TEST_EXECSPACE>>(7 * 8, "A", 7);
   test_required_span_size_single_rank<
+      Kokkos::View<double[7], Layout, TEST_EXECSPACE>>(7 * 8, "A");
+  test_required_span_size_single_rank<
       Kokkos::View<double**, Layout, TEST_EXECSPACE>>(7 * 11 * 8, "A", 7, 11);
   test_required_span_size_single_rank<
       Kokkos::View<double* [11], Layout, TEST_EXECSPACE>>(7 * 11 * 8, "A", 7,
                                                           11);
+  test_required_span_size_single_rank<
+      Kokkos::View<double* [11], Layout, TEST_EXECSPACE>>(7 * 11 * 8, "A", 7);
   test_required_span_size_single_rank<
       Kokkos::View<double*******, Layout, TEST_EXECSPACE>>(
       7 * 11 * 13 * 17 * 19 * 2 * 3 * 8, "A", 7, 11, 13, 17, 19, 2, 3);
   test_required_span_size_single_rank<
       Kokkos::View<double***** [2][3], Layout, TEST_EXECSPACE>>(
       7 * 11 * 13 * 17 * 19 * 2 * 3 * 8, "A", 7, 11, 13, 17, 19, 2, 3);
+  test_required_span_size_single_rank<
+      Kokkos::View<double***** [2][3], Layout, TEST_EXECSPACE>>(
+      7 * 11 * 13 * 17 * 19 * 2 * 3 * 8, "A", 7, 11, 13, 17, 19);
 }
 
 TEST(TEST_CATEGORY, view_required_span_size) {


### PR DESCRIPTION
Looks like people are calling required_allocation_size without arguments for purely static sized views. So I guess we need to allow for that. 