### PR TITLE
Update export-ignore directives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 .cmake* export-ignore
 .git* export-ignore
 .jenkins* export-ignore
-.appveyor.yml export-ignore
+.mailmap export-ignore
+.pre-commit-config.yaml export-ignore
 scripts/ export-ignore
 CTestConfig.cmake export-ignore


### PR DESCRIPTION
Do not include the mailmap nor the pre-commit configuration in the release archives