### PR TITLE
Ensure all execution space's move assignment/constructors copy

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -144,9 +144,7 @@ class Cuda {
   //! \name  Cuda space instances
 
   Cuda(const Cuda&)            = default;
-  Cuda(Cuda&&)                 = default;
   Cuda& operator=(const Cuda&) = default;
-  Cuda& operator=(Cuda&&)      = default;
   ~Cuda();
   Cuda();
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -143,6 +143,10 @@ class Cuda {
   //--------------------------------------------------
   //! \name  Cuda space instances
 
+  Cuda(const Cuda&)            = default;
+  Cuda(Cuda&&)                 = default;
+  Cuda& operator=(const Cuda&) = default;
+  Cuda& operator=(Cuda&&)      = default;
   ~Cuda();
   Cuda();
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -34,6 +34,10 @@ class HIP {
 
   using scratch_memory_space = ScratchMemorySpace<HIP>;
 
+  HIP(const HIP&)            = default;
+  HIP(HIP&&)                 = default;
+  HIP& operator=(const HIP&) = default;
+  HIP& operator=(HIP&&)      = default;
   ~HIP();
   HIP();
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -35,9 +35,7 @@ class HIP {
   using scratch_memory_space = ScratchMemorySpace<HIP>;
 
   HIP(const HIP&)            = default;
-  HIP(HIP&&)                 = default;
   HIP& operator=(const HIP&) = default;
-  HIP& operator=(HIP&&)      = default;
   ~HIP();
   HIP();
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -199,10 +199,7 @@ class HPX {
       : HPX(std::move(sender)) {}
 #endif
 
-  HPX(HPX &&other)      = default;
-  HPX(const HPX &other) = default;
-
-  HPX &operator=(HPX &&)      = default;
+  HPX(const HPX &other)       = default;
   HPX &operator=(const HPX &) = default;
 
   void print_configuration(std::ostream &os, bool /*verbose*/ = false) const;

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -62,6 +62,10 @@ class OpenACC {
 
   using scratch_memory_space = ScratchMemorySpace<OpenACC>;
 
+  OpenACC(const OpenACC&)            = default;
+  OpenACC(OpenACC&&)                 = default;
+  OpenACC& operator=(const OpenACC&) = default;
+  OpenACC& operator=(OpenACC&&)      = default;
   ~OpenACC();
   OpenACC();
 

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -63,9 +63,7 @@ class OpenACC {
   using scratch_memory_space = ScratchMemorySpace<OpenACC>;
 
   OpenACC(const OpenACC&)            = default;
-  OpenACC(OpenACC&&)                 = default;
   OpenACC& operator=(const OpenACC&) = default;
-  OpenACC& operator=(OpenACC&&)      = default;
   ~OpenACC();
   OpenACC();
 

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -52,9 +52,7 @@ class OpenMP {
   using scratch_memory_space = ScratchMemorySpace<OpenMP>;
 
   OpenMP(const OpenMP&)            = default;
-  OpenMP(OpenMP&&)                 = default;
   OpenMP& operator=(const OpenMP&) = default;
-  OpenMP& operator=(OpenMP&&)      = default;
   ~OpenMP();
   OpenMP();
 

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -51,6 +51,10 @@ class OpenMP {
   using size_type            = memory_space::size_type;
   using scratch_memory_space = ScratchMemorySpace<OpenMP>;
 
+  OpenMP(const OpenMP&)            = default;
+  OpenMP(OpenMP&&)                 = default;
+  OpenMP& operator=(const OpenMP&) = default;
+  OpenMP& operator=(OpenMP&&)      = default;
   ~OpenMP();
   OpenMP();
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -84,6 +84,10 @@ class OpenMPTarget {
     return m_space_instance;
   }
 
+  OpenMPTarget(const OpenMPTarget&)            = default;
+  OpenMPTarget(OpenMPTarget&&)                 = default;
+  OpenMPTarget& operator=(const OpenMPTarget&) = default;
+  OpenMPTarget& operator=(OpenMPTarget&&)      = default;
   OpenMPTarget();
   uint32_t impl_instance_id() const noexcept;
 

--- a/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
+++ b/core/src/OpenMPTarget/Kokkos_OpenMPTarget.hpp
@@ -85,9 +85,7 @@ class OpenMPTarget {
   }
 
   OpenMPTarget(const OpenMPTarget&)            = default;
-  OpenMPTarget(OpenMPTarget&&)                 = default;
   OpenMPTarget& operator=(const OpenMPTarget&) = default;
-  OpenMPTarget& operator=(OpenMPTarget&&)      = default;
   OpenMPTarget();
   uint32_t impl_instance_id() const noexcept;
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -49,9 +49,7 @@ class SYCL {
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
   SYCL(const SYCL&)            = default;
-  SYCL(SYCL&&)                 = default;
   SYCL& operator=(const SYCL&) = default;
-  SYCL& operator=(SYCL&&)      = default;
   ~SYCL();
   SYCL();
   explicit SYCL(const sycl::queue&);

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -48,6 +48,10 @@ class SYCL {
 
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
+  SYCL(const SYCL&)            = default;
+  SYCL(SYCL&&)                 = default;
+  SYCL& operator=(const SYCL&) = default;
+  SYCL& operator=(SYCL&&)      = default;
   ~SYCL();
   SYCL();
   explicit SYCL(const sycl::queue&);

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -96,6 +96,10 @@ class Serial {
 
   //@}
 
+  Serial(const Serial&)            = default;
+  Serial(Serial&&)                 = default;
+  Serial& operator=(const Serial&) = default;
+  Serial& operator=(Serial&&)      = default;
   ~Serial();
   Serial();
 

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -97,9 +97,7 @@ class Serial {
   //@}
 
   Serial(const Serial&)            = default;
-  Serial(Serial&&)                 = default;
   Serial& operator=(const Serial&) = default;
-  Serial& operator=(Serial&&)      = default;
   ~Serial();
   Serial();
 

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -111,6 +111,11 @@ class Threads {
 
   uint32_t impl_instance_id() const noexcept { return 1; }
 
+  Threads(const Threads&)            = default;
+  Threads(Threads&&)                 = default;
+  Threads& operator=(const Threads&) = default;
+  Threads& operator=(Threads&&)      = default;
+
   ~Threads() { Impl::check_execution_space_destructor_precondition(name()); }
 
   Threads() { Impl::check_execution_space_constructor_precondition(name()); }

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -112,9 +112,7 @@ class Threads {
   uint32_t impl_instance_id() const noexcept { return 1; }
 
   Threads(const Threads&)            = default;
-  Threads(Threads&&)                 = default;
   Threads& operator=(const Threads&) = default;
-  Threads& operator=(Threads&&)      = default;
 
   ~Threads() { Impl::check_execution_space_destructor_precondition(name()); }
 

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -36,33 +36,14 @@ TEST(TEST_CATEGORY, execution_space_as_class_data_member) {
 }
 #endif
 
-template <class ExecutionSpace>
-struct CheckMovedFromExecutionSpaceIsUsable {
-  KOKKOS_FUNCTION void operator()(int i, int& e) const { e += i; }
-
-  void check_exec(const ExecutionSpace& exec) {
-    int errors;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
-                            *this, errors);
-    EXPECT_EQ(errors, 0);
-  }
-
-  CheckMovedFromExecutionSpaceIsUsable() {
-    ExecutionSpace exec;
-    check_exec(exec);
-    ExecutionSpace other = std::move(exec);
-    // NOLINTNEXTLINE(bugprone-use-after-move)
-    check_exec(exec);
-    check_exec(other);
-    exec = std::move(other);
-    check_exec(exec);
-    // NOLINTNEXTLINE(bugprone-use-after-move)
-    check_exec(other);
-  }
-};
-
-TEST(TEST_CATEGORY, move_from_execution_space) {
-  CheckMovedFromExecutionSpaceIsUsable<TEST_EXECSPACE>();
+TEST(TEST_CATEGORY, execution_space_moved_from) {
+  TEST_EXECSPACE exec;
+  TEST_EXECSPACE other = std::move(exec);
+  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  ASSERT_EQ(other, exec);
+  exec = std::move(other);
+  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  ASSERT_EQ(exec, other);
 }
 
 constexpr bool test_execspace_explicit_construction() {

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -39,10 +39,10 @@ TEST(TEST_CATEGORY, execution_space_as_class_data_member) {
 TEST(TEST_CATEGORY, execution_space_moved_from) {
   TEST_EXECSPACE exec;
   TEST_EXECSPACE other = std::move(exec);
-  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   ASSERT_EQ(other, exec);
   exec = std::move(other);
-  // NOLINTNEXTLINE(bugprone-use-after-move,-warnings-as-errors)
+  // NOLINTNEXTLINE(bugprone-use-after-move)
   ASSERT_EQ(exec, other);
 }
 

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -36,6 +36,35 @@ TEST(TEST_CATEGORY, execution_space_as_class_data_member) {
 }
 #endif
 
+template <class ExecutionSpace>
+struct CheckMovedFromExecutionSpaceIsUsable {
+  KOKKOS_FUNCTION void operator()(int i, int& e) const { e += i; }
+
+  void check_exec(const ExecutionSpace& exec) {
+    int errors;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(exec, 0, 1),
+                            *this, errors);
+    EXPECT_EQ(errors, 0);
+  }
+
+  CheckMovedFromExecutionSpaceIsUsable() {
+    ExecutionSpace exec;
+    check_exec(exec);
+    ExecutionSpace other = std::move(exec);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    check_exec(exec);
+    check_exec(other);
+    exec = std::move(other);
+    check_exec(exec);
+    // NOLINTNEXTLINE(bugprone-use-after-move)
+    check_exec(other);
+  }
+};
+
+TEST(TEST_CATEGORY, move_from_execution_space) {
+  CheckMovedFromExecutionSpaceIsUsable<TEST_EXECSPACE>();
+}
+
 constexpr bool test_execspace_explicit_construction() {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #ifdef KOKKOS_ENABLE_SERIAL


### PR DESCRIPTION
As requested in https://github.com/kokkos/kokkos/pull/8546#issuecomment-3532862996. Declaring a non-default destructor causes move assignment and move constructor to copy. This was witnessed in https://github.com/kokkos/kokkos/pull/8626 which relies on the move behavior in a test.

Previously, this pull request defined all other special member functions as defaulted. Now, this pull request only defines copy constructors and copy assignment clarifying that we really want the move constructors/assignments to copy.