### PR TITLE
Ignore bugprone-exception-escape in benchmarks (and HPX)

### DIFF
--- a/benchmarks/.clang-tidy
+++ b/benchmarks/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: >
+   -bugprone-exception-escape
+
+InheritParentConfig: true

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -358,6 +358,7 @@ class HPX {
                        hpx::threads::thread_stacksize stacksize =
                            hpx::threads::thread_stacksize::default_) const {
     impl_bulk_plain_erased(force_synchronous, is_light_weight_policy,
+                           // NOLINTNEXTLINE(bugprone-exception-escape)
                            {[functor](Index i) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
                              impl_in_parallel_scope p;


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/8626. There were more complains about `bugprone-exception-escape` and running locally it complained about a buch of `main` functions. ~~clang-tidy 22 introduces `CheckMain` but before that we can only ignore them with `NOLINTNEXTLINE`. This pull request still adds the relevant option in `.clang-tidy` already.~~