### PR TITLE
Further clean-up of core/src/impl/KokkosExp_Host_InterateTile.hpp

### DIFF
--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -21,79 +21,6 @@
 namespace Kokkos {
 namespace Impl {
 
-#define KOKKOS_IMPL_LOOP_1L(type, tile) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE           \
-  for (type i0 = 0; i0 < static_cast<type>(tile[0]); ++i0)
-
-#define KOKKOS_IMPL_LOOP_2L(type, tile)                    \
-  for (type i1 = 0; i1 < static_cast<type>(tile[1]); ++i1) \
-  KOKKOS_IMPL_LOOP_1L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_3L(type, tile)                    \
-  for (type i2 = 0; i2 < static_cast<type>(tile[2]); ++i2) \
-  KOKKOS_IMPL_LOOP_2L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_4L(type, tile)                    \
-  for (type i3 = 0; i3 < static_cast<type>(tile[3]); ++i3) \
-  KOKKOS_IMPL_LOOP_3L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_5L(type, tile)                    \
-  for (type i4 = 0; i4 < static_cast<type>(tile[4]); ++i4) \
-  KOKKOS_IMPL_LOOP_4L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_6L(type, tile)                    \
-  for (type i5 = 0; i5 < static_cast<type>(tile[5]); ++i5) \
-  KOKKOS_IMPL_LOOP_5L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_7L(type, tile)                    \
-  for (type i6 = 0; i6 < static_cast<type>(tile[6]); ++i6) \
-  KOKKOS_IMPL_LOOP_6L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_8L(type, tile)                    \
-  for (type i7 = 0; i7 < static_cast<type>(tile[7]); ++i7) \
-  KOKKOS_IMPL_LOOP_7L(type, tile)
-
-#define KOKKOS_IMPL_LOOP_1R(type, tile) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE           \
-  for (type i0 = 0; i0 < static_cast<type>(tile[0]); ++i0)
-
-#define KOKKOS_IMPL_LOOP_2R(type, tile) \
-  KOKKOS_IMPL_LOOP_1R(type, tile)       \
-  for (type i1 = 0; i1 < static_cast<type>(tile[1]); ++i1)
-
-#define KOKKOS_IMPL_LOOP_3R(type, tile) \
-  KOKKOS_IMPL_LOOP_2R(type, tile)       \
-  for (type i2 = 0; i2 < static_cast<type>(tile[2]); ++i2)
-
-#define KOKKOS_IMPL_LOOP_4R(type, tile) \
-  KOKKOS_IMPL_LOOP_3R(type, tile)       \
-  for (type i3 = 0; i3 < static_cast<type>(tile[3]); ++i3)
-
-#define KOKKOS_IMPL_LOOP_5R(type, tile) \
-  KOKKOS_IMPL_LOOP_4R(type, tile)       \
-  for (type i4 = 0; i4 < static_cast<type>(tile[4]); ++i4)
-
-#define KOKKOS_IMPL_LOOP_6R(type, tile) \
-  KOKKOS_IMPL_LOOP_5R(type, tile)       \
-  for (type i5 = 0; i5 < static_cast<type>(tile[5]); ++i5)
-
-#define KOKKOS_IMPL_LOOP_7R(type, tile) \
-  KOKKOS_IMPL_LOOP_6R(type, tile)       \
-  for (type i6 = 0; i6 < static_cast<type>(tile[6]); ++i6)
-
-#define KOKKOS_IMPL_LOOP_8R(type, tile) \
-  KOKKOS_IMPL_LOOP_7R(type, tile)       \
-  for (type i7 = 0; i7 < static_cast<type>(tile[7]); ++i7)
-
-#define KOKKOS_IMPL_LOOP_ARGS_1 i0 + m_offset[0]
-#define KOKKOS_IMPL_LOOP_ARGS_2 KOKKOS_IMPL_LOOP_ARGS_1, i1 + m_offset[1]
-#define KOKKOS_IMPL_LOOP_ARGS_3 KOKKOS_IMPL_LOOP_ARGS_2, i2 + m_offset[2]
-#define KOKKOS_IMPL_LOOP_ARGS_4 KOKKOS_IMPL_LOOP_ARGS_3, i3 + m_offset[3]
-#define KOKKOS_IMPL_LOOP_ARGS_5 KOKKOS_IMPL_LOOP_ARGS_4, i4 + m_offset[4]
-#define KOKKOS_IMPL_LOOP_ARGS_6 KOKKOS_IMPL_LOOP_ARGS_5, i5 + m_offset[5]
-#define KOKKOS_IMPL_LOOP_ARGS_7 KOKKOS_IMPL_LOOP_ARGS_6, i6 + m_offset[6]
-#define KOKKOS_IMPL_LOOP_ARGS_8 KOKKOS_IMPL_LOOP_ARGS_7, i7 + m_offset[7]
-
 // New Loop Macros...
 // parallel_for, non-tagged
 #define KOKKOS_IMPL_APPLY(func, ...) func(__VA_ARGS__);
@@ -1845,30 +1772,6 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
 // ------------------------------------------------------------------ //
 
-#undef KOKKOS_IMPL_LOOP_1L
-#undef KOKKOS_IMPL_LOOP_2L
-#undef KOKKOS_IMPL_LOOP_3L
-#undef KOKKOS_IMPL_LOOP_4L
-#undef KOKKOS_IMPL_LOOP_5L
-#undef KOKKOS_IMPL_LOOP_6L
-#undef KOKKOS_IMPL_LOOP_7L
-#undef KOKKOS_IMPL_LOOP_8L
-#undef KOKKOS_IMPL_LOOP_1R
-#undef KOKKOS_IMPL_LOOP_2R
-#undef KOKKOS_IMPL_LOOP_3R
-#undef KOKKOS_IMPL_LOOP_4R
-#undef KOKKOS_IMPL_LOOP_5R
-#undef KOKKOS_IMPL_LOOP_6R
-#undef KOKKOS_IMPL_LOOP_7R
-#undef KOKKOS_IMPL_LOOP_8R
-#undef KOKKOS_IMPL_LOOP_ARGS_1
-#undef KOKKOS_IMPL_LOOP_ARGS_2
-#undef KOKKOS_IMPL_LOOP_ARGS_3
-#undef KOKKOS_IMPL_LOOP_ARGS_4
-#undef KOKKOS_IMPL_LOOP_ARGS_5
-#undef KOKKOS_IMPL_LOOP_ARGS_6
-#undef KOKKOS_IMPL_LOOP_ARGS_7
-#undef KOKKOS_IMPL_LOOP_ARGS_8
 #undef KOKKOS_IMPL_APPLY
 #undef KOKKOS_IMPL_LOOP_R_1
 #undef KOKKOS_IMPL_LOOP_R_2


### PR DESCRIPTION
This PR cleans up `core/src/impl/KokkosExp_Host_InterateTile.hpp` further on top of #[8673](https://github.com/kokkos/kokkos/pull/8673), which removed logic that was disabled with a macro (`KOKKOS_ENABLE_NEW_LOOP_MACROS`).

I have also been looking at this file, since a week or so, regarding MDRangePolicy in Serial backend. Further simplification of the code can be made.

The macros removed in this PR are not used in the current implementation of the logic in `core/src/impl/KokkosExp_Host_InterateTile.hpp`. These macros have not been in use for a while in Kokkos. In dac21c753ec3e4c7663c0aff5992636a4f5a88e0, which was just before f3d9efbd59fcf648a07fdebc78479f9d5992647c, the macros `LOOP_1L` etc were not used but `LOOP_ARGS_1` etc were used. f3d9efbd59fcf648a07fdebc78479f9d5992647c renamed them to `KOKKOS_IMPL_LOOP_1L` etc and `KOKKOS_IMPL_LOOP_ARGS_1` etc but the change `KOKKOS_IMPL_LOOP_ARGS_1` etc were not made inside the code, where `LOOP_ARGS_1` etc were used. Those parts of the code were disabled back then itself (using the macro `KOKKOS_ENABLE_NEW_LOOP_MACROS`) and no error showed-up.