### PR TITLE
Array: Relax constraints on subscript operator

### DIFF
--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -84,19 +84,13 @@ struct Array {
     return N;
   }
 
-  template <typename iType>
-    requires((std::is_convertible_v<iType, size_type>) &&
-             (std::is_nothrow_constructible_v<size_type, iType>))
-  KOKKOS_INLINE_FUNCTION constexpr reference operator[](const iType& i) {
+  KOKKOS_INLINE_FUNCTION constexpr reference operator[](size_type i) {
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }
 
-  template <typename iType>
-    requires((std::is_convertible_v<iType, size_type>) &&
-             (std::is_nothrow_constructible_v<size_type, iType>))
   KOKKOS_INLINE_FUNCTION constexpr const_reference operator[](
-      const iType& i) const {
+      size_type i) const {
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -26,7 +26,7 @@ namespace Impl {
 struct ArrayBoundsCheck {
   KOKKOS_INLINE_FUNCTION
   constexpr ArrayBoundsCheck(size_t i, size_t N) {
-    if (size_t(i) >= N) {
+    if (i >= N) {
       char err[128] = "Kokkos::Array: index ";
       to_chars_i(err + strlen(err), err + 128, i);
       strcat(err, " >= ");

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -23,10 +23,9 @@ namespace Kokkos {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
 namespace Impl {
 
-template <typename Integral>
 struct ArrayBoundsCheck {
   KOKKOS_INLINE_FUNCTION
-  constexpr ArrayBoundsCheck(Integral i, size_t N) {
+  constexpr ArrayBoundsCheck(size_t i, size_t N) {
     if (size_t(i) >= N) {
       char err[128] = "Kokkos::Array: index ";
       to_chars_i(err + strlen(err), err + 128, i);
@@ -38,8 +37,7 @@ struct ArrayBoundsCheck {
 };
 }  // end namespace Impl
 
-#define KOKKOS_ARRAY_BOUNDS_CHECK(i, N) \
-  Kokkos::Impl::ArrayBoundsCheck<decltype(i)>(i, N)
+#define KOKKOS_ARRAY_BOUNDS_CHECK(i, N) Kokkos::Impl::ArrayBoundsCheck(i, N)
 
 #else  // !defined( KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK )
 

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -22,25 +22,9 @@ namespace Kokkos {
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
 namespace Impl {
-template <typename Integral, bool Signed = std::is_signed_v<Integral>>
-struct ArrayBoundsCheck;
 
 template <typename Integral>
-struct ArrayBoundsCheck<Integral, true> {
-  KOKKOS_INLINE_FUNCTION
-  constexpr ArrayBoundsCheck(Integral i, size_t N) {
-    if (i < 0) {
-      char err[128] = "Kokkos::Array: index ";
-      to_chars_i(err + strlen(err), err + 128, i);
-      strcat(err, " < 0");
-      Kokkos::abort(err);
-    }
-    ArrayBoundsCheck<Integral, false>(i, N);
-  }
-};
-
-template <typename Integral>
-struct ArrayBoundsCheck<Integral, false> {
+struct ArrayBoundsCheck {
   KOKKOS_INLINE_FUNCTION
   constexpr ArrayBoundsCheck(Integral i, size_t N) {
     if (size_t(i) >= N) {
@@ -101,18 +85,18 @@ struct Array {
   }
 
   template <typename iType>
+    requires((std::is_convertible_v<iType, size_type>) &&
+             (std::is_nothrow_constructible_v<size_type, iType>))
   KOKKOS_INLINE_FUNCTION constexpr reference operator[](const iType& i) {
-    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
-                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }
 
   template <typename iType>
+    requires((std::is_convertible_v<iType, size_type>) &&
+             (std::is_nothrow_constructible_v<size_type, iType>))
   KOKKOS_INLINE_FUNCTION constexpr const_reference operator[](
       const iType& i) const {
-    static_assert((std::is_integral_v<iType> || std::is_enum_v<iType>),
-                  "Must be integral argument");
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
     return m_internal_implementation_private_member_data[i];
   }

--- a/core/unit_test/TestArray.cpp
+++ b/core/unit_test/TestArray.cpp
@@ -375,4 +375,27 @@ constexpr bool test_array_equality_comparable() {
 
 static_assert(test_array_equality_comparable());
 
+struct IntegralConvertibleType {
+  KOKKOS_INLINE_FUNCTION constexpr operator std::size_t() const noexcept {
+    return static_cast<std::size_t>(v);
+  }
+  int v;
+};
+
+constexpr bool test_array_indexable_with_integral_convertible_type() {
+  using array_type = Kokkos::Array<int, 2>;
+  static_assert(!std::is_integral_v<IntegralConvertibleType>);
+  static_assert(std::is_nothrow_convertible_v<IntegralConvertibleType,
+                                              array_type::size_type>);
+  array_type arr{2, 3};
+  (void)arr[IntegralConvertibleType{0}];
+
+  enum Test { one };
+  (void)arr[one];
+
+  return true;
+}
+
+static_assert(test_array_indexable_with_integral_convertible_type());
+
 }  // namespace


### PR DESCRIPTION
This PR relaxes the constraints on `Kokkos::Array` `operator[]` to allow custom type indexers.

The current constraint, which requires `std::is_integral`, prevents the use of convertible types in its subscript operators, unlike `std::array`.

This change aligns with `Kokkos::View` interface, which previously also mandated `std::is_integral` in its legacy implementation:
https://github.com/kokkos/kokkos/blob/b402e369ed9c6967732d11f33360562c9ae6fa22/core/src/View/Kokkos_ViewLegacy.hpp#L507-L511

but was updated to:
https://github.com/kokkos/kokkos/blob/b402e369ed9c6967732d11f33360562c9ae6fa22/core/src/Kokkos_View.hpp#L548-L558