### PR TITLE
Disable rocm 7.1

### DIFF
--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -95,7 +95,7 @@ if(Kokkos_ENABLE_HIP)
   string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" TEMP_CXX_COMPILER_VERSION ${INTERNAL_COMPILER_VERSION_ONE_LINE})
   set(KOKKOS_CXX_COMPILER_VERSION ${TEMP_CXX_COMPILER_VERSION})
 
-  #FIXME HIP
+  #FIXME_HIP
   if(KOKKOS_CXX_COMPILER_VERSION VERSION_EQUAL 7.1)
     message(FATAL_ERROR "Found ROCm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
   endif()

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -96,7 +96,7 @@ if(Kokkos_ENABLE_HIP)
   set(KOKKOS_CXX_COMPILER_VERSION ${TEMP_CXX_COMPILER_VERSION})
 
   #FIXME HIP
-  if(KOKKOS_CXX_COMPILER_VERSION MATCHES "7\\.1")
+  if(KOKKOS_CXX_COMPILER_VERSION VERSION_EQUAL 7.1)
     message(FATAL_ERROR "Found ROCm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
   endif()
 endif()

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -97,7 +97,7 @@ if(Kokkos_ENABLE_HIP)
 
   #FIXME_HIP
   if(KOKKOS_CXX_COMPILER_VERSION VERSION_EQUAL 7.1)
-    message(FATAL_ERROR "Found ROCm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
+    message(FATAL_ERROR "Found ROCm 7.1 which leads to wrong code when used with Kokkos. Please use an older version of ROCm.")
   endif()
 endif()
 

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -97,7 +97,7 @@ if(Kokkos_ENABLE_HIP)
 
   #FIXME HIP
   if(KOKKOS_CXX_COMPILER_VERSION MATCHES "7\\.1")
-    message(FATAL_ERROR "Found Rocm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
+    message(FATAL_ERROR "Found ROCm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
   endif()
 endif()
 

--- a/cmake/kokkos_compiler_id.cmake
+++ b/cmake/kokkos_compiler_id.cmake
@@ -94,6 +94,11 @@ if(Kokkos_ENABLE_HIP)
 
   string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" TEMP_CXX_COMPILER_VERSION ${INTERNAL_COMPILER_VERSION_ONE_LINE})
   set(KOKKOS_CXX_COMPILER_VERSION ${TEMP_CXX_COMPILER_VERSION})
+
+  #FIXME HIP
+  if(KOKKOS_CXX_COMPILER_VERSION MATCHES "7\\.1")
+    message(FATAL_ERROR "Found Rocm 7.1 which leads to wrong code when used with Kokkos. Please use an older version")
+  endif()
 endif()
 
 if(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)


### PR DESCRIPTION
A bunch of unit test are broken with `MALLOC_ASYNC` and on MI300A the compiler failed to build the unit tests, see https://github.com/kokkos/kokkos/issues/8635

This PR proposes to break if we detect Rocm 7.1 at configure time in the compiler detection.
Breaking when the library is found would require to update how we find rocm but the check can be moved there after this is modernized