### PR TITLE
Jenkins: Build unified runtime for SYCL in docker

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -394,7 +394,6 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
-                                -DoneDPL_ROOT=/opt/intel/oneapi/dpl/2022.7 \
                                 -DKokkos_ENABLE_SYCL=ON \
                                 -DKokkos_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -394,6 +394,7 @@ pipeline {
                                 -DKokkos_ENABLE_EXAMPLES=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_BENCHMARKS=ON \
+                                -DoneDPL_ROOT=/opt/intel/oneapi/dpl/2022.9 \
                                 -DKokkos_ENABLE_SYCL=ON \
                                 -DKokkos_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE=ON \
                                 -DKokkos_ENABLE_UNSUPPORTED_ARCHS=ON \

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -868,12 +868,17 @@ endif()
 #   implementation. Otherwise, the feature is not supported when building shared
 #   libraries. Thus, we don't even check for support if shared libraries are
 #   requested and SYCL_EXT_ONEAPI_DEVICE_GLOBAL is not defined.
-#   As of oneAPI 2025.0.0, this feature only works well for Intel GPUs.
-#   For simplicity only test for JIT and PVC
+#   As of oneAPI 2025.0.0, the codeplay documentation indicates support
+#   for device_global on Nvidia and AMD GPUs. However, testing suggested
+#   that the feature only works well as of oneAPI 2025.1.1.
+#   Otherwise, for simplicity we only test for JIT and PVC.
 if(KOKKOS_ENABLE_SYCL)
   string(REPLACE ";" " " CMAKE_REQUIRED_FLAGS "${KOKKOS_COMPILE_OPTIONS}")
   include(CheckCXXSymbolExists)
-  if(Kokkos_ARCH_INTEL_PVC OR Kokkos_ARCH_INTEL_GEN)
+  if(Kokkos_ARCH_INTEL_PVC OR Kokkos_ARCH_INTEL_GEN
+     OR (KOKKOS_ENABLE_UNSUPPORTED_ARCHS AND KOKKOS_CXX_COMPILER_ID STREQUAL IntelLLVM
+         AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 2025.1.1)
+  )
     check_cxx_symbol_exists(
       SYCL_EXT_ONEAPI_DEVICE_GLOBAL "sycl/sycl.hpp" KOKKOS_IMPL_HAVE_SYCL_EXT_ONEAPI_DEVICE_GLOBAL
     )

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -2,6 +2,7 @@ ARG BASE=nvcr.io/nvidia/cuda:12.0.0-devel-ubuntu22.04@sha256:0578d90ce082ed37cdc
 FROM $BASE
 
 ARG ADDITIONAL_PACKAGES
+ARG ONEAPI_VERSION=2025.2
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
@@ -47,7 +48,7 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     | tee /etc/apt/sources.list.d/oneAPI.list
 
 RUN apt-get update && apt-get install -y \
-        intel-oneapi-compiler-dpcpp-cpp-2025.2 \
+        intel-oneapi-compiler-dpcpp-cpp-${ONEAPI_VERSION} \
         curl \
         && \
     apt-get clean && \
@@ -62,10 +63,10 @@ RUN cd /tmp && git clone https://github.com/intel/llvm.git -b v6.2.0 --depth=1 &
       -DUR_BUILD_ADAPTER_OPENCL=ON \
       -DCMAKE_BUILD_TYPE=Release && \
     cmake --build build_ur -j 8 && \
-    cp -r build_ur/lib/* /opt/intel/oneapi/compiler/2025.2/lib/ && \
+    cp -r build_ur/lib/* /opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib/ && \
     rm -r /tmp/llvm
 
 # sycl-ls, icpx
-ENV PATH=/opt/intel/oneapi/compiler/2025.2/bin/:$PATH
+ENV PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/bin/:$PATH
 # libsycl, libsvml
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.2/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib:$LD_LIBRARY_PATH

--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -47,17 +47,25 @@ RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRO
     | tee /etc/apt/sources.list.d/oneAPI.list
 
 RUN apt-get update && apt-get install -y \
-        intel-oneapi-compiler-dpcpp-cpp-2025.0 \
+        intel-oneapi-compiler-dpcpp-cpp-2025.2 \
         curl \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -LOJ "https://cloud1.cees.ornl.gov/download/oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh" && \
-    chmod +x oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh && \
-    ./oneapi-for-nvidia-gpus-2025.0.0-cuda-12.0-linux.sh
+RUN cd /tmp && git clone https://github.com/intel/llvm.git -b v6.2.0 --depth=1 && cd llvm && \
+    cmake -S unified-runtime -B build_ur \
+      -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
+      -DUR_BUILD_TESTS=OFF \
+      -DUR_ENABLE_TRACING=ON \
+      -DUR_BUILD_ADAPTER_CUDA=ON \
+      -DUR_BUILD_ADAPTER_OPENCL=ON \
+      -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build_ur -j 8 && \
+    cp -r build_ur/lib/* /opt/intel/oneapi/compiler/2025.2/lib/ && \
+    rm -r /tmp/llvm
 
 # sycl-ls, icpx
-ENV PATH=/opt/intel/oneapi/compiler/2025.0/bin/:$PATH
+ENV PATH=/opt/intel/oneapi/compiler/2025.2/bin/:$PATH
 # libsycl, libsvml
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.0/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/2025.2/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Should supersedes #8491. Building the uniied runtime in the CI, we don't rely on a Codeplay plugin anymore.
Additionally, this updates the tested icpx version to 2025.2.0 which is slightly newer than the minimum to support device global variables. This pull request then also enables supports for this feature. 