### PR TITLE
Add missing cstdint include for simd_size_t and missing Kokkos::Impl::integral_constant symbol

### DIFF
--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -86,6 +86,7 @@ export {
   // miscellaneous
   namespace Impl {
   using ::Kokkos::Impl::FunctorAnalysis;
+  using ::Kokkos::Impl::integral_constant;
   using ::Kokkos::Impl::python_view_type_impl_t;
   using ::Kokkos::Impl::throw_runtime_exception;
   }  // namespace Impl

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -7,6 +7,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -10,6 +10,7 @@ import kokkos.core;
 #else
 #include <Kokkos_Core.hpp>
 #endif
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <utility>


### PR DESCRIPTION
This CI fails because of a missing `<cstdint>` include https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8647/11/pipeline-overview/

I guess we didn't catch this in #6535 because IIRC the Jenkins CI was not working when we merged it.