### PR TITLE
Implement bhalf_t for HIP and add mathematical functions

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -184,17 +184,13 @@ KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
 KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(float val) { return bhalf_t(__float2bfloat16(val)); }
+bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
 
 KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(bool val) {
-  return cast_to_bhalf(static_cast<float>(val));
-}
+bhalf_t cast_to_bhalf(bool val) { return bhalf_t::impl_type(val); }
 
 KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(double val) {
-  return bhalf_t(__float2bfloat16(static_cast<float>(val)));
-}
+bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
 
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -178,6 +178,125 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
 cast_from_half(half_t val) {
   return static_cast<T>(cast_from_half<unsigned long long>(val));
 }
+
+/************************** bhalf conversions *********************************/
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(float val) { return bhalf_t(__float2bfloat16(val)); }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(bool val) {
+  return cast_to_bhalf(static_cast<float>(val));
+}
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(double val) {
+  return bhalf_t(__float2bfloat16(static_cast<float>(val)));
+}
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned short val) { return bhalf_t::impl_type(val); }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(int val) { return bhalf_t::impl_type(val); }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned int val) { return bhalf_t::impl_type(val); }
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(long long val) {
+  // FIXME_HIP
+  return bhalf_t::impl_type(static_cast<double>(val));
+}
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned long long val) {
+  // FIXME_HIP
+  return bhalf_t::impl_type(static_cast<double>(val));
+}
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(long val) {
+  return cast_to_bhalf(static_cast<long long>(val));
+}
+
+KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(unsigned long val) {
+  return cast_to_bhalf(static_cast<unsigned long long>(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, float>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, bool>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, short>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned short>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, int>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long long>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION
+    std::enable_if_t<std::is_same_v<T, unsigned long long>, T>
+    cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+
 }  // namespace Kokkos::Experimental
 
 #endif

--- a/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_HIP_HALF_IMPL_TYPE_HPP_
 
 #include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
@@ -18,8 +19,6 @@ struct half_impl_t {
 }  // namespace Impl
 }  // namespace Kokkos
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
-
-#include <hip/hip_bf16.h>
 
 #ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 // Make sure no one else tries to define bhalf_t

--- a/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
@@ -22,7 +22,7 @@ struct half_impl_t {
 #include <hip/hip_bf16.h>
 
 #ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
-// Make sure no one else tries to define half_t
+// Make sure no one else tries to define bhalf_t
 #define KOKKOS_IMPL_BHALF_TYPE_DEFINED
 namespace Kokkos::Impl {
 struct bhalf_impl_t {

--- a/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
@@ -9,7 +9,6 @@
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
 // Make sure no one else tries to define half_t
 #define KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_IMPL_HIP_HALF_TYPE_DEFINED
 
 namespace Kokkos {
 namespace Impl {
@@ -19,4 +18,19 @@ struct half_impl_t {
 }  // namespace Impl
 }  // namespace Kokkos
 #endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
+
+#include <hip/hip_bf16.h>
+
+#ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+// Make sure no one else tries to define half_t
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+namespace Kokkos::Impl {
+struct bhalf_impl_t {
+  using type = __hip_bfloat16;
+};
+
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+
 #endif  // KOKKOS_ENABLE_HIP

--- a/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_HIP_HALF_MATHEMATICAL_FUNCTIONS_HPP_
+#define KOKKOS_HIP_HALF_MATHEMATICAL_FUNCTIONS_HPP_
+
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+#define KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, HALF_TYPE) \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##OP(HALF_TYPE x) {     \
+    return HIP_NAME(HALF_TYPE::impl_type(x));                   \
+  }
+
+#define KOKKOS_HIP_HALF_BINARY_FUNCTION(OP, HIP_NAME, HALF_TYPE)         \
+  KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##OP(HALF_TYPE x, HALF_TYPE y) { \
+    return HIP_NAME(HALF_TYPE::impl_type(x), HALF_TYPE::impl_type(y));   \
+  }
+
+#define KOKKOS_HIP_HALF_UNARY_PREDICATE(OP, HIP_NAME, HALF_TYPE) \
+  KOKKOS_INLINE_FUNCTION bool impl_##OP(HALF_TYPE x) {           \
+    return HIP_NAME(HALF_TYPE::impl_type(x));                    \
+  }
+
+#define KOKKOS_HIP_HALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, Kokkos::Experimental::half_t)
+#define KOKKOS_HIP_HALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_BINARY_FUNCTION(OP, HIP_NAME, Kokkos::Experimental::half_t)
+#define KOKKOS_HIP_HALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_PREDICATE(OP, HIP_NAME, Kokkos::Experimental::half_t)
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+    Kokkos::Experimental::half_t) {
+  return Kokkos::Experimental::half_t(0.f);
+}
+
+// Function for bhalf are not available prior to Ampere
+#if defined(KOKKOS_IMPL_BHALF_TYPE_DEFINED)
+
+#define KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, Kokkos::Experimental::bhalf_t)
+#define KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_BINARY_FUNCTION(OP, HIP_NAME, Kokkos::Experimental::bhalf_t)
+#define KOKKOS_HIP_BHALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_PREDICATE(OP, HIP_NAME, Kokkos::Experimental::bhalf_t)
+
+KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+    Kokkos::Experimental::bhalf_t) {
+  return Kokkos::Experimental::bhalf_t(0.f);
+}
+
+#else
+#define KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME)
+#define KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME)
+#define KOKKOS_HIP_BHALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME)
+#endif
+
+#define KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME)                 \
+  KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME)
+
+#define KOKKOS_HIP_HALF_AND_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME)                 \
+  KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME)
+
+#define KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME) \
+  KOKKOS_HIP_HALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME)                 \
+  KOKKOS_HIP_BHALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME)
+
+// Basic operations
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(abs, __habs)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(fabs, __habs)
+// fmod
+// remainder
+KOKKOS_HIP_HALF_AND_BHALF_BINARY_FUNCTION_IMPL(fmax, __hmax)
+KOKKOS_HIP_HALF_AND_BHALF_BINARY_FUNCTION_IMPL(fmin, __hmin)
+// fdim
+// Exponential functions
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(exp, hexp)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(exp2, hexp2)
+// expm1
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(log, hlog)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(log10, hlog10)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(log2, hlog2)
+// log1p
+// Power functions
+// pow
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(sqrt, hsqrt)
+// cbrt
+// hypot
+// Trigonometric functions
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(sin, hsin)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(cos, hcos)
+// tan
+// asin
+// acos
+// atan
+// atan2
+// Hyperbolic functions
+// sinh
+// cosh
+// tanh
+// asinh
+// acosh
+// atanh
+// Error and gamma functions
+// erf
+// erfc
+// tgamma
+// lgamma
+// Nearest integer floating point functions
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(ceil, hceil)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(floor, hfloor)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(trunc, htrunc)
+// round
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(nearbyint, hrint)
+// logb
+// nextafter
+// copysign
+// isfinite
+
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL(isinf, __hisinf)
+KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL(isnan, __hisnan)
+// signbit
+
+#undef KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_HALF_AND_BHALF_BINARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL
+
+#undef KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_BHALF_UNARY_PREDICATE_IMPL
+
+#undef KOKKOS_HIP_HALF_UNARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_HALF_BINARY_FUNCTION_IMPL
+#undef KOKKOS_HIP_HALF_UNARY_PREDICATE_IMPL
+
+#undef KOKKOS_HIP_HALF_UNARY_FUNCTION
+#undef KOKKOS_HIP_HALF_BINARY_FUNCTION
+#undef KOKKOS_HIP_HALF_UNARY_PREDICATE
+
+#endif  // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
@@ -9,7 +9,9 @@
 namespace Kokkos {
 namespace Impl {
 
-#ifdef KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+// Mathematical functions are only available on the device
+#if defined(__HIP_DEVICE_COMPILE__)
+
 #define KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, HALF_TYPE) \
   KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##OP(HALF_TYPE x) {     \
     return HIP_NAME(HALF_TYPE::impl_type(x));                   \
@@ -37,9 +39,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
   return Kokkos::Experimental::half_t(0.f);
 }
 
-// Function for bhalf are not available prior to Ampere
-#if defined(KOKKOS_IMPL_BHALF_TYPE_DEFINED)
-
 #define KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME) \
   KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, Kokkos::Experimental::bhalf_t)
 #define KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME) \
@@ -51,12 +50,6 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
     Kokkos::Experimental::bhalf_t) {
   return Kokkos::Experimental::bhalf_t(0.f);
 }
-
-#else
-#define KOKKOS_HIP_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME)
-#define KOKKOS_HIP_BHALF_BINARY_FUNCTION_IMPL(OP, HIP_NAME)
-#define KOKKOS_HIP_BHALF_UNARY_PREDICATE_IMPL(OP, HIP_NAME)
-#endif
 
 #define KOKKOS_HIP_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME) \
   KOKKOS_HIP_HALF_UNARY_FUNCTION_IMPL(OP, HIP_NAME)                 \
@@ -142,7 +135,7 @@ KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL(isnan, __hisnan)
 #undef KOKKOS_HIP_HALF_BINARY_FUNCTION
 #undef KOKKOS_HIP_HALF_UNARY_PREDICATE
 
-#endif  // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+#endif  // __HIP_DEVICE_COMPILE__
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp
@@ -10,8 +10,7 @@ namespace Kokkos {
 namespace Impl {
 
 // Mathematical functions are only available on the device
-#if defined(__HIP_DEVICE_COMPILE__)
-
+#if defined(KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH) && defined(__HIP_DEVICE_COMPILE__)
 #define KOKKOS_HIP_HALF_UNARY_FUNCTION(OP, HIP_NAME, HALF_TYPE) \
   KOKKOS_INLINE_FUNCTION HALF_TYPE impl_##OP(HALF_TYPE x) {     \
     return HIP_NAME(HALF_TYPE::impl_type(x));                   \
@@ -135,7 +134,8 @@ KOKKOS_HIP_HALF_AND_BHALF_UNARY_PREDICATE_IMPL(isnan, __hisnan)
 #undef KOKKOS_HIP_HALF_BINARY_FUNCTION
 #undef KOKKOS_HIP_HALF_UNARY_PREDICATE
 
-#endif  // __HIP_DEVICE_COMPILE__
+#endif  // defined(KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH) &&
+        // defined(__HIP_DEVICE_COMPILE__)
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/decl/Kokkos_Declare_HIP.hpp
+++ b/core/src/decl/Kokkos_Declare_HIP.hpp
@@ -10,6 +10,7 @@
 #include <HIP/Kokkos_HIP_DeepCopy.hpp>
 #include <HIP/Kokkos_HIP_Half_Impl_Type.hpp>
 #include <HIP/Kokkos_HIP_Half_Conversion.hpp>
+#include <HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_MDRangePolicy.hpp>
 #include <HIP/Kokkos_HIP_ParallelFor_Range.hpp>

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -29,7 +29,8 @@ struct is_bfloat16 : std::false_type {};
 // floating_pointer_wrapper operator paths should be used. For CUDA, let the
 // compiler conditionally select when device ops are used For SYCL, we have a
 // full half type on both host and device
-#if defined(__CUDA_ARCH__) || defined(KOKKOS_ENABLE_SYCL)
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
+    defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
 #endif
 

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -27,9 +27,9 @@ struct is_bfloat16 : std::false_type {};
 
 // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH: A macro to select which
 // floating_pointer_wrapper operator paths should be used. For CUDA, let the
-// compiler conditionally select when device ops are used For SYCL, we have a
-// full half type on both host and device
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || \
+// compiler conditionally select when device ops are used. For SYCL and HIP, we
+// have a full half type on both host and device
+#if defined(__CUDA_ARCH__) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
 #endif

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -29,10 +29,12 @@ struct is_bfloat16 : std::false_type {};
 // floating_pointer_wrapper operator paths should be used. For CUDA, let the
 // compiler conditionally select when device ops are used. For SYCL, we have a
 // full half type on both host and device. For HIP, we have a full half type on
-// host and device only for ROCm 7 and later.
-#if defined(__CUDA_ARCH__) ||                                        \
-    (defined(KOKKOS_ENABLE_HIP) &&                                   \
-     (HIP_VERSION_MAJOR >= 7 || defined(__HIP_DEVICE_COMPILE__))) || \
+// host and device only for ROCm 6.4 and later.
+#if defined(__CUDA_ARCH__) ||                                 \
+    (defined(KOKKOS_ENABLE_HIP) &&                            \
+     ((HIP_VERSION_MAJOR > 6 ||                               \
+       (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)) || \
+      defined(__HIP_DEVICE_COMPILE__))) ||                    \
     defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
 #endif

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -27,9 +27,12 @@ struct is_bfloat16 : std::false_type {};
 
 // KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH: A macro to select which
 // floating_pointer_wrapper operator paths should be used. For CUDA, let the
-// compiler conditionally select when device ops are used. For SYCL and HIP, we
-// have a full half type on both host and device
-#if defined(__CUDA_ARCH__) || defined(KOKKOS_ENABLE_HIP) || \
+// compiler conditionally select when device ops are used. For SYCL, we have a
+// full half type on both host and device. For HIP, we have a full half type on
+// host and device only for ROCm 7 and later.
+#if defined(__CUDA_ARCH__) ||                                        \
+    (defined(KOKKOS_ENABLE_HIP) &&                                   \
+     (HIP_VERSION_MAJOR >= 7 || defined(__HIP_DEVICE_COMPILE__))) || \
     defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
 #endif

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -17,6 +17,10 @@
 #include <Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp>
 #endif
 
+#ifdef KOKKOS_ENABLE_HIP
+#include <HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp>
+#endif
+
 #ifdef KOKKOS_ENABLE_SYCL
 #include <SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp>
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1969,8 +1969,9 @@ KE::bhalf_t ref_test_fallback_bhalf(KE::bhalf_t) {
   } else {
     return KE::bhalf_t(1.f);
   }
-  return KE::bhalf_t(0.f);
 #elif defined(KOKKOS_ENABLE_HIP)
+  // bhalf_t is supported on host and device for HIP but the mathematical
+  // functions only have have a native implementation on the device
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
     return KE::bhalf_t(0.f);
   } else {

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1946,6 +1946,12 @@ KE::half_t ref_test_fallback_half(KE::half_t) {
   } else {
     return KE::half_t(1.f);
   }
+#elif defined(KOKKOS_ENABLE_HIP)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
+    return KE::half_t(0.f);
+  } else {
+    return KE::half_t(1.f);
+  }
 #else
   return KE::half_t(1.f);
 #endif
@@ -1959,6 +1965,13 @@ KE::bhalf_t ref_test_fallback_bhalf(KE::bhalf_t) {
     (KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80)
   // bhalf_t support for CUDA is only available starting with Ampere (80)
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
+    return KE::bhalf_t(0.f);
+  } else {
+    return KE::bhalf_t(1.f);
+  }
+  return KE::bhalf_t(0.f);
+#elif defined(KOKKOS_ENABLE_HIP)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
     return KE::bhalf_t(0.f);
   } else {
     return KE::bhalf_t(1.f);


### PR DESCRIPTION
This pull request adds support for HIP native `bhalf_t` and mathematical functions for the native half types.

Half mathematical functions are only provided on the device while the half types themselves are usable on both host and device. 