### PR TITLE
Disable a View move test on MI300 with ROCm 7.1

### DIFF
--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -148,8 +148,14 @@ TEST(TEST_CATEGORY, view_moved_from) {
   test_moved_from_view(Kokkos::View<int, ExecutionSpace>("v0"));
   test_moved_from_view(Kokkos::View<float*, ExecutionSpace>("v1", 1));
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
+  // FIXME_HIP On MI300 with ROCm 7.1, the compiler ICES in the check macro
+#if !(                                                    \
+    defined(KOKKOS_ENABLE_HIP) &&                         \
+    (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1) && \
+    (defined(KOKKOS_ARCH_AMD_GFX942) || defined(KOKKOS_ARCH_AMD_GFX942_APU)))
   test_moved_from_view(Kokkos::View<double**, ExecutionSpace>(
       v2.data(), v2.extent(0), v2.extent(1)));
+#endif
   test_moved_from_view(Kokkos::View<double**, ExecutionSpace,
                                     Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
       v2.data(), v2.extent(0), v2.extent(1)));

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -148,8 +148,8 @@ TEST(TEST_CATEGORY, view_moved_from) {
   test_moved_from_view(Kokkos::View<int, ExecutionSpace>("v0"));
   test_moved_from_view(Kokkos::View<float*, ExecutionSpace>("v1", 1));
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
-  // FIXME_HIP ROCm 7.1 on MI300 triggers an internal compiler error in the CHECK
-  // macro
+  // FIXME_HIP ROCm 7.1 on MI300 triggers an internal compiler error in the
+  // CHECK macro
 #if !(                                                    \
     defined(KOKKOS_ENABLE_HIP) &&                         \
     (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1) && \

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -148,7 +148,7 @@ TEST(TEST_CATEGORY, view_moved_from) {
   test_moved_from_view(Kokkos::View<int, ExecutionSpace>("v0"));
   test_moved_from_view(Kokkos::View<float*, ExecutionSpace>("v1", 1));
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
-  // FIXME_HIP OCm 7.1 on MI300 triggers an internal compiler error in the CHECK
+  // FIXME_HIP ROCm 7.1 on MI300 triggers an internal compiler error in the CHECK
   // macro
 #if !(                                                    \
     defined(KOKKOS_ENABLE_HIP) &&                         \

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -148,7 +148,8 @@ TEST(TEST_CATEGORY, view_moved_from) {
   test_moved_from_view(Kokkos::View<int, ExecutionSpace>("v0"));
   test_moved_from_view(Kokkos::View<float*, ExecutionSpace>("v1", 1));
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
-  // FIXME_HIP On MI300 with ROCm 7.1, the compiler ICES in the check macro
+  // FIXME_HIP OCm 7.1 on MI300 triggers an internal compiler error in the CHECK
+  // macro
 #if !(                                                    \
     defined(KOKKOS_ENABLE_HIP) &&                         \
     (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1) && \


### PR DESCRIPTION
We hit a compiler bug with ROCm 7.1 on MI300. The compiler ICES in one of the test because of a `printf` in  macros. I couldn't find a nice way to modify the macro, so I disabled the test instead. I can create a different macro for MI300 with ROCm 7.1 if you think it's important to run the test.