### PR TITLE
Deprecate `cudaMemAdvise_v2` on CUDART > 13000

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -170,7 +170,7 @@ void *impl_allocate_common(const int device_id,
                 "Please update your CUDA runtime version or "
                 "reconfigure with "
                 "-D Kokkos_ENABLE_IMPL_CUDA_UNIFIED_MEMORY=OFF");
-  if (arg_alloc_size) {  // cudaMemAdvise_v2 does not work with nullptr
+  if (arg_alloc_size) {  // cudaMemAdvise does not work with nullptr
     error_code = cudaMallocManaged(&ptr, arg_alloc_size, cudaMemAttachGlobal);
     if (error_code == cudaSuccess) {
       // One would think cudaMemLocation{device_id,
@@ -179,8 +179,14 @@ void *impl_allocate_common(const int device_id,
       cudaMemLocation loc;
       loc.id   = device_id;
       loc.type = cudaMemLocationTypeDevice;
+#if CUDART_VERSION < 13000  // cudaMemAdvise_v2 was deprecated in CUDA 13, it is
+                            // now the same as cudaMemAdvise
       KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemAdvise_v2(
           ptr, arg_alloc_size, cudaMemAdviseSetPreferredLocation, loc));
+#else
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemAdvise(
+          ptr, arg_alloc_size, cudaMemAdviseSetPreferredLocation, loc));
+#endif
     }
   }
 #elif (defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC) && CUDART_VERSION >= 11020)


### PR DESCRIPTION
It seems like Cuda 13 deprecated `cudaMemAdvise_v2`, as there is no mention in the runtime API https://docs.nvidia.com/cuda/archive/13.0.0/cuda-runtime-api/group__CUDART__MEMORY.html#group__CUDART__MEMORY_1g5584e2dac446bebc695da3bb1c162607
It was still existing on 12.9 https://docs.nvidia.com/cuda/archive/12.9.1/cuda-driver-api/group__CUDA__UNIFIED.html#group__CUDA__UNIFIED_1g1ee1ef51ac4f44b4cf5d54711f227584

diffing the two yields that it was simply renamed.

This PR fixes compiling with CUDA >= 13 on GH200
https://github.com/kokkos/kokkos/pull/8657 is rebased on this PR to show that it works in the hpsf CI, since we have nothing that triggers this in our current CI