### PR TITLE
Conditionally reenable test for constructibility of basic view

### DIFF
--- a/core/unit_test/view/TestBasicView.hpp
+++ b/core/unit_test/view/TestBasicView.hpp
@@ -185,34 +185,30 @@ TEST(TEST_CATEGORY, basic_view_access) {
                                Kokkos::dynamic_extent>>();
 }
 
-#if 0  // TODO: this test should be active after View is put on top of BasicView
-  template <class T, template <std::size_t> class LayoutType, class SrcViewType,
-            class ExtentsType>
-  void test_construct_from_view(const ExtentsType &extents,
-                                       std::size_t padding) {
-    using extents_type  = ExtentsType;
-    using layout_type   = LayoutType<Kokkos::dynamic_extent>;
-    using mapping_type  = typename layout_type::template mapping<ExtentsType>;
-    using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
-        T, typename ExecutionSpace::memory_space>;
-    using basic_view_type =
-        Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
-    using view_type = SrcViewType;
-    static_assert(std::is_constructible_v<basic_view_type, SrcViewType>);
-  }
-#endif
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+template <class T, template <std::size_t> class LayoutType, class SrcViewType,
+          class ExtentsType>
+void test_construct_from_view() {
+  using extents_type  = ExtentsType;
+  using layout_type   = LayoutType<Kokkos::dynamic_extent>;
+  using accessor_type = Kokkos::Impl::CheckedReferenceCountedAccessor<
+      T, typename ExecutionSpace::memory_space>;
+  using basic_view_type =
+      Kokkos::Impl::BV::BasicView<T, extents_type, layout_type, accessor_type>;
+  using view_type = SrcViewType;
+  static_assert(std::is_constructible_v<basic_view_type, view_type>);
+}
 
-#if 0  // TODO: this test should be active after View is put on top of BasicView
 TEST(TEST_CATEGORY, basic_view_view_ctor) {
-    test_construct_from_view<double,
-        Kokkos::Experimental::layout_left_padded,
-        Kokkos::View<double[3], Kokkos::LayoutLeft, ExecutionSpace>>(
-        Kokkos::extents<std::size_t, 3>(), 0);
+  test_construct_from_view<
+      double, Kokkos::Experimental::layout_left_padded,
+      Kokkos::View<double[3], Kokkos::LayoutLeft, ExecutionSpace>,
+      Kokkos::extents<std::size_t, 3>>();
 
-    test_construct_from_view<size_t,
-        Kokkos::Experimental::layout_left_padded,
-        Kokkos::View<double[3], Kokkos::LayoutLeft, ExecutionSpace>>(
-        Kokkos::extents<std::size_t, Kokkos::dynamic_extent>(3), 0);
+  test_construct_from_view<
+      int, Kokkos::Experimental::layout_left_padded,
+      Kokkos::View<int *, Kokkos::LayoutLeft, ExecutionSpace>,
+      Kokkos::extents<std::size_t, Kokkos::dynamic_extent>>();
 }
 #endif
 

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -12,14 +12,14 @@ import kokkos.core_impl;
 #include <type_traits>
 
 using Kokkos::Impl::BV::BasicView;
-#if 0  // TODO: after View is using BasicView this should be true
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
 static_assert(
     std::is_convertible_v<
-        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
+        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::HostSpace>,
         BasicView<long long, Kokkos::dextents<size_t, 4>,
                   Kokkos::Experimental::layout_right_padded<>,
                   Kokkos::Impl::CheckedReferenceCountedAccessor<
-                    long long, Kokkos::HostSpace>>>);
+                      long long, Kokkos::HostSpace>>>);
 #endif
 
 static_assert(std::is_convertible_v<
@@ -31,21 +31,14 @@ static_assert(std::is_convertible_v<
                         Kokkos::Experimental::layout_right_padded<>,
                         Kokkos::Impl::CheckedReferenceCountedAccessor<
                             const long long, Kokkos::HostSpace>>>);
-#if 0  // TODO: after View is using BasicView this should be true
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
 static_assert(
     std::is_convertible_v<
-        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::Serial>,
+        Kokkos::View<long long ****, Kokkos::LayoutRight, Kokkos::HostSpace>,
         BasicView<const long long, Kokkos::dextents<size_t, 4>,
                   Kokkos::Experimental::layout_right_padded<>,
                   Kokkos::Impl::CheckedReferenceCountedAccessor<
-                    const long long, Kokkos::HostSpace>>>);
-
-using test_atomic_view = Kokkos::View<double *, Kokkos::Serial,
-                                      Kokkos::MemoryTraits<Kokkos::Atomic>>;
-static_assert(std::is_same_v<
-              decltype(std::declval<test_atomic_view>()(std::declval<int>())),
-              desul::AtomicRef<double, desul::MemoryOrderRelaxed,
-                               desul::MemoryScopeDevice>>);
+                      const long long, Kokkos::HostSpace>>>);
 #endif
 
 static_assert(std::is_convertible_v<Kokkos::default_accessor<double>,


### PR DESCRIPTION
Enables `is_convertible_v`-check from View to BaseView if KOKKOS_ENABLE_IMPL_VIEW_LEGACY is disabled
Split-out from https://github.com/kokkos/kokkos/pull/8684