### PR TITLE
Moved test testing AtomicRef equivalence with atomic View into a new file due to better fit

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(COMPILE_ONLY_SOURCES
     view/TestViewCustomization.cpp
     view/TestExtentsDatatypeConversion.cpp
     view/TestConversionFromPointer.cpp
+    view/TestMemoryTraitTypes.cpp
 )
 
 if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")

--- a/core/unit_test/view/TestConversionFromPointer.cpp
+++ b/core/unit_test/view/TestConversionFromPointer.cpp
@@ -8,7 +8,7 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
-#include<type_traits>
+#include <type_traits>
 
 // Checking requirement of explict type conversion to View
 

--- a/core/unit_test/view/TestConversionFromPointer.cpp
+++ b/core/unit_test/view/TestConversionFromPointer.cpp
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
 #include <Kokkos_Core.hpp>
-#include <type_traits>
-
+#endif
 // Checking requirement of explict type conversion to View
 
 namespace {

--- a/core/unit_test/view/TestConversionFromPointer.cpp
+++ b/core/unit_test/view/TestConversionFromPointer.cpp
@@ -7,6 +7,9 @@ import kokkos.core;
 #else
 #include <Kokkos_Core.hpp>
 #endif
+
+#include<type_traits>
+
 // Checking requirement of explict type conversion to View
 
 namespace {

--- a/core/unit_test/view/TestMemoryTraitTypes.cpp
+++ b/core/unit_test/view/TestMemoryTraitTypes.cpp
@@ -11,6 +11,8 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <type_traits.hpp>
+
 namespace {
 
 using test_atomic_view =

--- a/core/unit_test/view/TestMemoryTraitTypes.cpp
+++ b/core/unit_test/view/TestMemoryTraitTypes.cpp
@@ -11,6 +11,8 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <desul/atomics.hpp>
+
 #include <type_traits>
 
 namespace {

--- a/core/unit_test/view/TestMemoryTraitTypes.cpp
+++ b/core/unit_test/view/TestMemoryTraitTypes.cpp
@@ -11,7 +11,7 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
-#include <type_traits.hpp>
+#include <type_traits>
 
 namespace {
 

--- a/core/unit_test/view/TestMemoryTraitTypes.cpp
+++ b/core/unit_test/view/TestMemoryTraitTypes.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+import kokkos.core_impl;
+#endif
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+namespace {
+
+using test_atomic_view =
+    Kokkos::View<double *, Kokkos::MemoryTraits<Kokkos::Atomic>>;
+static_assert(
+    std::is_same_v<
+        decltype(std::declval<test_atomic_view>()(std::declval<int>())),
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+        Kokkos::Impl::AtomicDataElement<
+            Kokkos::ViewTraits<double *, Kokkos::MemoryTraits<Kokkos::Atomic>>>
+#else
+        desul::AtomicRef<double, desul::MemoryOrderRelaxed,
+                         desul::MemoryScopeDevice>
+#endif
+        >);
+
+}  // namespace


### PR DESCRIPTION
- Compile only.
- We can extend this by more tests to see if Views and their members are of the right type if specialized via mem traits.
- Drive-by change in `core/unit_test/view/TestConversionFromPointer.cpp`

Split-out from https://github.com/kokkos/kokkos/pull/8684