### PR TITLE
Fix reduction_identity for BAnd

### DIFF
--- a/core/src/Kokkos_ReductionIdentity.hpp
+++ b/core/src/Kokkos_ReductionIdentity.hpp
@@ -26,7 +26,7 @@ struct reduction_identity<Integral> {
   KOKKOS_FUNCTION constexpr static Integral max() noexcept { return min_; }
   KOKKOS_FUNCTION constexpr static Integral min() noexcept { return max_; }
   KOKKOS_FUNCTION constexpr static Integral bor() noexcept { return 0x0; }
-  KOKKOS_FUNCTION constexpr static Integral band() noexcept { return 0x0; }
+  KOKKOS_FUNCTION constexpr static Integral band() noexcept { return ~(0x0); }
   KOKKOS_FUNCTION constexpr static Integral lor() noexcept { return 0; }
   KOKKOS_FUNCTION constexpr static Integral land() noexcept { return 1; }
 };

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -768,8 +768,6 @@ class TestReductionIdentityBitwiseAndOr {
 };
 
 TEST(TEST_CATEGORY, reduction_identity_bitwise_and_or_integral_types) {
-  TestReductionIdentityBitwiseAndOr<signed char>();
-  TestReductionIdentityBitwiseAndOr<unsigned char>();
   TestReductionIdentityBitwiseAndOr<short>();
   TestReductionIdentityBitwiseAndOr<unsigned short>();
   TestReductionIdentityBitwiseAndOr<int>();

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -739,9 +739,9 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
 
 template <typename ScalarType>
-class TestReductionIdentityLogicalReducers {
+class TestReductionIdentityBitwiseAndOr {
  public:
-  TestReductionIdentityLogicalReducers() { runTest(); }
+  TestReductionIdentityBitwiseAndOr() { runTest(); }
 
   void runTest() {
     const int N = 100;
@@ -768,16 +768,16 @@ class TestReductionIdentityLogicalReducers {
 };
 
 TEST(TEST_CATEGORY, reduction_identity_bitwise_and_or_integral_types) {
-  TestReductionIdentityLogicalReducers<signed char>();
-  TestReductionIdentityLogicalReducers<unsigned char>();
-  TestReductionIdentityLogicalReducers<short>();
-  TestReductionIdentityLogicalReducers<unsigned short>();
-  TestReductionIdentityLogicalReducers<int>();
-  TestReductionIdentityLogicalReducers<unsigned int>();
-  TestReductionIdentityLogicalReducers<long>();
-  TestReductionIdentityLogicalReducers<unsigned long>();
-  TestReductionIdentityLogicalReducers<long long>();
-  TestReductionIdentityLogicalReducers<unsigned long long>();
+  TestReductionIdentityBitwiseAndOr<signed char>();
+  TestReductionIdentityBitwiseAndOr<unsigned char>();
+  TestReductionIdentityBitwiseAndOr<short>();
+  TestReductionIdentityBitwiseAndOr<unsigned short>();
+  TestReductionIdentityBitwiseAndOr<int>();
+  TestReductionIdentityBitwiseAndOr<unsigned int>();
+  TestReductionIdentityBitwiseAndOr<long>();
+  TestReductionIdentityBitwiseAndOr<unsigned long>();
+  TestReductionIdentityBitwiseAndOr<long long>();
+  TestReductionIdentityBitwiseAndOr<unsigned long long>();
 }
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -767,7 +767,7 @@ class TestReductionIdentityLogicalReducers {
   }
 };
 
-TEST(TEST_CATEGORY, reduction_identity_bitwise_logical_reducers) {
+TEST(TEST_CATEGORY, reduction_identity_bitwise_and_or_integral_types) {
   TestReductionIdentityLogicalReducers<signed char>();
   TestReductionIdentityLogicalReducers<unsigned char>();
   TestReductionIdentityLogicalReducers<short>();

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -744,7 +744,7 @@ class TestReductionIdentityLogicalReducers {
   TestReductionIdentityLogicalReducers() { runTest(); }
 
   void runTest() {
-    const unsigned int N = 100;
+    const int N = 100;
 
     std::random_device r;
 

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -14,6 +14,7 @@ import kokkos.core;
 #include <Kokkos_TypeInfo.hpp>
 
 #include <cmath>
+#include <random>
 
 namespace Test {
 
@@ -736,5 +737,49 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
 #endif
 }
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()
+
+template <typename ScalarType>
+class TestReductionIdentityLogicalReducers {
+ public:
+  TestReductionIdentityLogicalReducers() { runTest(); }
+
+  void runTest() {
+    const unsigned int N = 100;
+
+    std::random_device r;
+
+    std::default_random_engine e(r());
+    std::uniform_int_distribution<ScalarType> uniform_dist(
+        std::numeric_limits<ScalarType>::min(),
+        std::numeric_limits<ScalarType>::max());
+
+    ScalarType bor_identity = Kokkos::reduction_identity<ScalarType>::bor();
+    for (int i = 0; i < N; ++i) {
+      ScalarType value = uniform_dist(e);
+      EXPECT_EQ(value | bor_identity, value);
+    }
+
+    ScalarType band_identity = Kokkos::reduction_identity<ScalarType>::band();
+    for (int i = 0; i < N; ++i) {
+      ScalarType value = uniform_dist(e);
+      EXPECT_EQ(value & band_identity, value);
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, reduction_identity_bitwise_logical_reducers) {
+  TestReductionIdentityLogicalReducers<signed char>();
+  TestReductionIdentityLogicalReducers<unsigned char>();
+  TestReductionIdentityLogicalReducers<short>();
+  TestReductionIdentityLogicalReducers<unsigned short>();
+  TestReductionIdentityLogicalReducers<int>();
+  TestReductionIdentityLogicalReducers<unsigned int>();
+  TestReductionIdentityLogicalReducers<short>();
+  TestReductionIdentityLogicalReducers<unsigned short>();
+  TestReductionIdentityLogicalReducers<long>();
+  TestReductionIdentityLogicalReducers<unsigned long>();
+  TestReductionIdentityLogicalReducers<long long>();
+  TestReductionIdentityLogicalReducers<unsigned long long>();
+}
 
 }  // namespace Test

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -774,8 +774,6 @@ TEST(TEST_CATEGORY, reduction_identity_bitwise_logical_reducers) {
   TestReductionIdentityLogicalReducers<unsigned short>();
   TestReductionIdentityLogicalReducers<int>();
   TestReductionIdentityLogicalReducers<unsigned int>();
-  TestReductionIdentityLogicalReducers<short>();
-  TestReductionIdentityLogicalReducers<unsigned short>();
   TestReductionIdentityLogicalReducers<long>();
   TestReductionIdentityLogicalReducers<unsigned long>();
   TestReductionIdentityLogicalReducers<long long>();

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1426,10 +1426,6 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(band_scalar, reference_band);
 
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
-                              reducer_scalar);
-      ASSERT_EQ(band_scalar, ~Scalar{});
-
       band_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1438,6 +1434,24 @@ struct TestReducers {
       Scalar band_scalar_view = reducer_scalar.reference();
 
       ASSERT_EQ(band_scalar_view, reference_band);
+    }
+
+    {
+      Scalar band_scalar = 1;
+      Kokkos::BAnd<Scalar> reducer_scalar(band_scalar);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_EQ(band_scalar, ~Scalar{});
+
+      band_scalar = 1;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int, Scalar& value) {
+            value = value & ~Scalar{};
+          },
+          reducer_scalar);
+      ASSERT_EQ(band_scalar, ~Scalar{});
     }
 
     {
@@ -1481,10 +1495,6 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(bor_scalar, reference_bor);
 
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
-                              reducer_scalar);
-      ASSERT_EQ(bor_scalar, Scalar{});
-
       bor_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1492,6 +1502,22 @@ struct TestReducers {
 
       Scalar bor_scalar_view = reducer_scalar.reference();
       ASSERT_EQ(bor_scalar_view, reference_bor);
+    }
+
+    {
+      Scalar bor_scalar = 1;
+      Kokkos::BOr<Scalar> reducer_scalar(bor_scalar);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_EQ(bor_scalar, Scalar{});
+
+      bor_scalar = 1;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int, Scalar& value) { value = value | Scalar{}; },
+          reducer_scalar);
+      ASSERT_EQ(bor_scalar, Scalar{});
     }
 
     {
@@ -1535,10 +1561,6 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(land_scalar, reference_land);
 
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
-                              reducer_scalar);
-      ASSERT_TRUE(land_scalar);
-
       land_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1546,6 +1568,22 @@ struct TestReducers {
 
       Scalar land_scalar_view = reducer_scalar.reference();
       ASSERT_EQ(land_scalar_view, reference_land);
+    }
+
+    {
+      Scalar land_scalar = 0;
+      Kokkos::LAnd<Scalar> reducer_scalar(land_scalar);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_TRUE(land_scalar);
+
+      land_scalar = 0;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int, Scalar& value) { value = value && true; },
+          reducer_scalar);
+      ASSERT_TRUE(land_scalar);
     }
 
     {
@@ -1600,6 +1638,22 @@ struct TestReducers {
 
       Scalar lor_scalar_view = reducer_scalar.reference();
       ASSERT_EQ(lor_scalar_view, reference_lor);
+    }
+
+    {
+      Scalar lor_scalar = 1;
+      Kokkos::LOr<Scalar> reducer_scalar(lor_scalar);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_FALSE(lor_scalar);
+
+      lor_scalar = 1;
+      Kokkos::parallel_reduce(
+          Kokkos::RangePolicy<ExecSpace>(0, N),
+          KOKKOS_LAMBDA(const int, Scalar& value) { value = value || false; },
+          reducer_scalar);
+      ASSERT_FALSE(lor_scalar);
     }
 
     {

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1443,15 +1443,6 @@ struct TestReducers {
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
       ASSERT_EQ(band_scalar, ~Scalar{});
-
-      band_scalar = 1;
-      Kokkos::parallel_reduce(
-          Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int, Scalar& value) {
-            value = value & ~Scalar{};
-          },
-          reducer_scalar);
-      ASSERT_EQ(band_scalar, ~Scalar{});
     }
 
     {
@@ -1510,13 +1501,6 @@ struct TestReducers {
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
-      ASSERT_EQ(bor_scalar, Scalar{});
-
-      bor_scalar = 1;
-      Kokkos::parallel_reduce(
-          Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int, Scalar& value) { value = value | Scalar{}; },
-          reducer_scalar);
       ASSERT_EQ(bor_scalar, Scalar{});
     }
 
@@ -1577,13 +1561,6 @@ struct TestReducers {
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
       ASSERT_TRUE(land_scalar);
-
-      land_scalar = 0;
-      Kokkos::parallel_reduce(
-          Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int, Scalar& value) { value = value && true; },
-          reducer_scalar);
-      ASSERT_TRUE(land_scalar);
     }
 
     {
@@ -1627,10 +1604,6 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(lor_scalar, reference_lor);
 
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
-                              reducer_scalar);
-      ASSERT_FALSE(lor_scalar);
-
       lor_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1646,13 +1619,6 @@ struct TestReducers {
 
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
                               reducer_scalar);
-      ASSERT_FALSE(lor_scalar);
-
-      lor_scalar = 1;
-      Kokkos::parallel_reduce(
-          Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int, Scalar& value) { value = value || false; },
-          reducer_scalar);
       ASSERT_FALSE(lor_scalar);
     }
 

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -1426,6 +1426,10 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(band_scalar, reference_band);
 
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_EQ(band_scalar, ~Scalar{});
+
       band_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1477,6 +1481,10 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(bor_scalar, reference_bor);
 
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_EQ(bor_scalar, Scalar{});
+
       bor_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1527,6 +1535,10 @@ struct TestReducers {
                               reducer_scalar);
       ASSERT_EQ(land_scalar, reference_land);
 
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_TRUE(land_scalar);
+
       land_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),
                               f_tag, reducer_scalar);
@@ -1576,6 +1588,10 @@ struct TestReducers {
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, N), f,
                               reducer_scalar);
       ASSERT_EQ(lor_scalar, reference_lor);
+
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 0), f,
+                              reducer_scalar);
+      ASSERT_FALSE(lor_scalar);
 
       lor_scalar = init;
       Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace, ReducerTag>(0, N),

--- a/core/unit_test/TestReducers_a.hpp
+++ b/core/unit_test/TestReducers_a.hpp
@@ -12,4 +12,8 @@ TEST(TEST_CATEGORY, reducers_int) {
   TestReducers<int, TEST_EXECSPACE>::execute_integer();
 }
 
+TEST(TEST_CATEGORY, reducers_unsigned_int) {
+  TestReducers<unsigned int, TEST_EXECSPACE>::execute_integer();
+}
+
 }  // namespace Test


### PR DESCRIPTION
As discussed in https://kokkosteam.slack.com/archives/G5CBLMFLP/p1764323555905049. Also adding tests for `BOr`, `LAnd` and `LOr` and testing with `unsigned int`.