### PR TITLE
CI: Test Cuda+Threads

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -595,6 +595,9 @@ pipeline {
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
+                    environment {
+                        KOKKOS_NUM_THREADS = 8
+                    }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -617,7 +617,7 @@ pipeline {
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_CUDA=ON \
                                 -DKokkos_ENABLE_LIBDL=OFF \
-                                -DKokkos_ENABLE_OPENMP=ON \
+                                -DKokkos_ENABLE_THREADS=ON \
                                 -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON \
                               .. && \
                               set +x && \

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -64,36 +64,43 @@ class ThreadsExecTeamMember {
   }
 
  public:
+  // clang-format off
+
   // Fan-in and wait until the matching fan-out is called.
   // The root thread which does not wait will return true.
   // All other threads will return false during the fan-out.
   KOKKOS_INLINE_FUNCTION bool team_fan_in() const {
-    int n, j;
+    KOKKOS_IF_ON_HOST((
+      int n, j;
 
-    // Wait for fan-in threads
-    for (n = 1;
-         (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
-         n <<= 1) {
-      spinwait_while_equal(m_team_base[j]->state(), ThreadState::Active);
-    }
+      // Wait for fan-in threads
+      for (n = 1;
+           (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
+           n <<= 1) {
+        spinwait_while_equal(m_team_base[j]->state(), ThreadState::Active);
+      }
 
-    // If not root then wait for release
-    if (m_team_rank_rev) {
-      m_instance->state() = ThreadState::Rendezvous;
-      spinwait_while_equal(m_instance->state(), ThreadState::Rendezvous);
-    }
+      // If not root then wait for release
+      if (m_team_rank_rev) {
+        m_instance->state() = ThreadState::Rendezvous;
+        spinwait_while_equal(m_instance->state(), ThreadState::Rendezvous);
+      }
+    ))
 
     return !m_team_rank_rev;
   }
 
   KOKKOS_INLINE_FUNCTION void team_fan_out() const {
-    int n, j;
-    for (n = 1;
-         (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
-         n <<= 1) {
-      m_team_base[j]->state() = ThreadState::Active;
-    }
+    KOKKOS_IF_ON_HOST((
+      int n, j;
+      for (n = 1;
+           (!(m_team_rank_rev & n)) && ((j = m_team_rank_rev + n) < m_team_size);
+           n <<= 1) {
+        m_team_base[j]->state() = ThreadState::Active;
+      }
+    ))
   }
+  // clang-format on
 
  public:
   KOKKOS_INLINE_FUNCTION static int team_reduce_size() {

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -161,14 +161,16 @@ TEST(TEST_CATEGORY, large_team_scratch_size) {
   const int level   = 1;
   const int n_teams = 1;
 
-#if defined(KOKKOS_ENABLE_LARGE_MEM_TESTS) || defined(KOKKOS_ENABLE_CUDA) || \
-    defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
   //  The GPU backends use unsigned as size_type and we need to check that we
   //  didn't screw the scratch space calculation up, CPU backends anyway use
   //  size_t so less likely to screw up
+#ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS
   const size_t per_team_extent = 502795560;
 #else
-  const size_t per_team_extent = 268435460;
+  const size_t per_team_extent =
+      std::is_same_v<TEST_EXECSPACE::memory_space, Kokkos::HostSpace>
+          ? 268435460
+          : 502795560;
 #endif
 
   const size_t per_team_bytes = std::min<size_t>(


### PR DESCRIPTION
`ThreadsExecTeamMember` needs to annotate member functions with `KOKKOS_FUNCTION` since they might be used inside a `TeamPolicy` functor. On the other hand, some host only functions are used in `team_fan_[in|out]`. The simplest solution is to just define them empty when on the device.