### PR TITLE
Make DynRankView test stronger and clarify comparisons

### DIFF
--- a/containers/unit_tests/TestDynRankView_LayoutMember.hpp
+++ b/containers/unit_tests/TestDynRankView_LayoutMember.hpp
@@ -9,7 +9,6 @@ namespace {
 
 template <class Layout>
 void test_dyn_rank_view_layout_member() {
-  bool is_ll = std::is_same_v<Layout, Kokkos::LayoutLeft>;
   {
     Kokkos::DynRankView<int, Layout> a(
         Kokkos::View<int***, Layout>("A", 11, 7, 5));
@@ -20,7 +19,9 @@ void test_dyn_rank_view_layout_member() {
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
     ASSERT_EQ(l.stride, KOKKOS_INVALID_INDEX);
 #else
-    ASSERT_EQ(l.stride, (is_ll ? 11lu : KOKKOS_INVALID_INDEX));
+    ASSERT_EQ(l.stride, (std::is_same_v<Layout, Kokkos::LayoutLeft>
+                             ? 11lu
+                             : KOKKOS_INVALID_INDEX));
 #endif
   }
   {
@@ -31,7 +32,8 @@ void test_dyn_rank_view_layout_member() {
 #ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
     ASSERT_EQ(l.stride, KOKKOS_INVALID_INDEX);
 #else
-    ASSERT_EQ(l.stride, (is_ll ? 7lu : 5lu));
+    ASSERT_EQ(l.stride,
+              (std::is_same_v<Layout, Kokkos::LayoutLeft> ? 7lu : 5lu));
 #endif
   }
 }

--- a/containers/unit_tests/TestDynRankView_LayoutMember.hpp
+++ b/containers/unit_tests/TestDynRankView_LayoutMember.hpp
@@ -17,16 +17,22 @@ void test_dyn_rank_view_layout_member() {
     ASSERT_EQ(l.dimension[0], 11lu);
     ASSERT_EQ(l.dimension[1], 7lu);
     ASSERT_EQ(l.dimension[2], 5lu);
-    ASSERT_TRUE(
-        (l.stride == is_ll ? 11lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(l.stride, KOKKOS_INVALID_INDEX);
+#else
+    ASSERT_EQ(l.stride, (is_ll ? 11lu : KOKKOS_INVALID_INDEX));
+#endif
   }
   {
     Kokkos::DynRankView<int, Layout> a(Kokkos::View<int**, Layout>("A", 7, 5));
     auto l = a.layout();
     ASSERT_EQ(l.dimension[0], 7lu);
     ASSERT_EQ(l.dimension[1], 5lu);
-    ASSERT_TRUE(
-        (l.stride == is_ll ? 7lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(l.stride, KOKKOS_INVALID_INDEX);
+#else
+    ASSERT_EQ(l.stride, (is_ll ? 7lu : 5lu));
+#endif
   }
 }
 


### PR DESCRIPTION
While looking at the MSVC+Cuda warnings in https://github.com/kokkos/kokkos/pull/8750, I noticed that the checks in `containers/unit_tests/TestDynRankView_LayoutMember.hpp` 
```
l.stride == is_ll ? 11lu : 5lu
```
probably aren't working as intended. This pull request makes it clear that only one value is allowed.