### PR TITLE
Replace calls to kokkos_malloc/free with HostSpace::[de]allocate during the initialization and destruction of Threads backend

### DIFF
--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -167,7 +167,8 @@ ThreadsInternal::~ThreadsInternal() {
   const unsigned entry = m_pool_size - (m_pool_rank + 1);
 
   if (m_scratch) {
-    Kokkos::kokkos_free<Kokkos::HostSpace>(m_scratch);
+    Kokkos::HostSpace{}.deallocate("Kokkos::thread_scratch", m_scratch,
+                                   m_scratch_thread_end);
     m_scratch = nullptr;
   }
 
@@ -306,7 +307,8 @@ void ThreadsInternal::execute_resize_scratch_in_serial() {
 
   auto deallocate_scratch_memory = [](ThreadsInternal &exec) {
     if (exec.m_scratch) {
-      Kokkos::kokkos_free<Kokkos::HostSpace>(exec.m_scratch);
+      Kokkos::HostSpace{}.deallocate("Kokkos::thread_scratch", exec.m_scratch,
+                                     exec.m_scratch_thread_end);
       exec.m_scratch = nullptr;
     }
   };
@@ -358,8 +360,8 @@ void ThreadsInternal::first_touch_allocate_thread_private_scratch(
   if (s_threads_process.m_scratch_thread_end) {
     // Allocate tracked memory:
     {
-      exec.m_scratch = Kokkos::kokkos_malloc<Kokkos::HostSpace>(
-          "Kokkos::thread_scratch", s_threads_process.m_scratch_thread_end);
+      exec.m_scratch = Kokkos::HostSpace{}.allocate("Kokkos::thread_scratch",
+                                                    exec.m_scratch_thread_end);
     }
 
     unsigned *ptr = reinterpret_cast<unsigned *>(exec.m_scratch);

--- a/core/src/impl/Kokkos_CStyleMemoryManagement.hpp
+++ b/core/src/impl/Kokkos_CStyleMemoryManagement.hpp
@@ -20,10 +20,6 @@
 namespace Kokkos::Impl {
 
 inline void check_init_final([[maybe_unused]] char const* func_name) {
-// FIXME_THREADS: Checking for calls to kokkos_malloc, kokkos_realloc,
-// kokkos_free before initialize or after finalize is currently disabled
-// for the Threads backend. Refer issue #7944.
-#if !defined(KOKKOS_ENABLE_THREADS)
   if (is_finalized()) {
     std::stringstream ss;
     ss << "Kokkos ERROR: attempting to perform C-style memory management "
@@ -37,7 +33,6 @@ inline void check_init_final([[maybe_unused]] char const* func_name) {
     ss << func_name << "() **before** Kokkos::initialize() was called\n";
     Kokkos::abort(ss.str().c_str());
   }
-#endif
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -37,9 +37,7 @@ void *HostSpace::allocate(const size_t arg_alloc_size) const {
   return allocate("[unlabeled]", arg_alloc_size);
 }
 void *HostSpace::allocate(const char *arg_label, const size_t arg_alloc_size,
-                          const size_t
-
-                              arg_logical_size) const {
+                          const size_t arg_logical_size) const {
   return impl_allocate(arg_label, arg_alloc_size, arg_logical_size);
 }
 void *HostSpace::impl_allocate(

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -114,13 +114,6 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        c_style_memory_management) {
-// FIXME_THREADS: Checking for calls to kokkos_malloc, kokkos_realloc,
-// kokkos_free before initialize or after finalize is currently disabled
-// for the Threads backend. Refer issue #7944.
-#ifdef KOKKOS_ENABLE_THREADS
-  GTEST_SKIP()
-      << "skipping since initializing Threads backend calls kokkos_malloc";
-#endif
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   EXPECT_DEATH(


### PR DESCRIPTION
Fixes [7944](https://github.com/kokkos/kokkos/issues/7944).

Since [7676](https://github.com/kokkos/kokkos/pull/7676) C-sytle memory management functions (kokkos_malloc, kokkos_realloc, kokkos_free) can be called only inside an active Kokkos execution environment.

The changes concern `core/src/Threads/Kokkos_Threads_Instance.cpp`.
In the Threads backend, `kokkos_malloc` (and potentially `kokkos_free`) are currently called during the initialization of the Threads backend. Refer the functions `resize_scratch`, `execute_resize_scratch_in_serial` and `first_touch_allocate_thread_private_scratch`.
`kokkos_free` is also called in the destructor of `ThreadsInternal`.

`allocate` and `deallocate` from `core/src/Kokkos_HostSpace.hpp` and `core/src/impl/Kokkos_HostSpace.cpp` could substitute for `kokkos_malloc` and `kokkos_free` to allocate and deallocate the scratch space.

As a result of these changes, the checks and tests that were so far disabled for the Threads backend have been enabled.