### PR TITLE
Cleanup SYCL compatibility header include

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -14,12 +14,7 @@
 #include <type_traits>
 
 #ifdef KOKKOS_ENABLE_SYCL
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 #endif
 
 namespace Kokkos {

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -12,12 +12,7 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 
 #ifdef KOKKOS_ENABLE_SYCL
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 #include <SYCL/Kokkos_SYCL_Space.hpp>
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_ScratchSpace.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_SYCL_ABORT_HPP
 
 #include <Kokkos_Printf.hpp>
+#if defined(KOKKOS_ENABLE_SYCL)
 #include <sycl/sycl.hpp>
 
 namespace Kokkos {

--- a/core/src/SYCL/Kokkos_SYCL_Abort.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Abort.hpp
@@ -5,13 +5,7 @@
 #define KOKKOS_SYCL_ABORT_HPP
 
 #include <Kokkos_Printf.hpp>
-#if defined(KOKKOS_ENABLE_SYCL)
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -6,12 +6,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 // Make sure no one else tries to define half_t
 #ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -5,12 +5,7 @@
 #define KOKKOS_SYCL_INSTANCE_HPP_
 
 #include <optional>
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -4,12 +4,7 @@
 #ifndef KOKKOS_SETUP_SYCL_HPP_
 #define KOKKOS_SETUP_SYCL_HPP_
 
-// FIXME_SYCL
-#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
 
 #ifndef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES
 #define KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES


### PR DESCRIPTION
Unconditionally include SYCL standard header and drop compatibilty guards for earlier versions that do not meet our new minimum toolchain requirements.