### PR TITLE
Cleanup ScatterValue

### DIFF
--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -195,9 +195,7 @@ struct DefaultContribution<Kokkos::SYCL,
 #endif
 
 // FIXME All these scatter values need overhaul:
-//   - like should they be copyable at all?
 //   - what is the internal handle type
-//   - remove join
 //   - consistently use the update function in operators
 template <typename ValueType, typename Op, typename DeviceType,
           typename Contribution>
@@ -255,27 +253,22 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
   KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
   KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
   KOKKOS_FORCEINLINE_FUNCTION void operator+=(ValueType const& rhs) {
-    this->join(value, rhs);
+    Kokkos::atomic_add(&value, rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION void operator++() { this->join(value, 1); }
-  KOKKOS_FORCEINLINE_FUNCTION void operator++(int) { this->join(value, 1); }
+  KOKKOS_FORCEINLINE_FUNCTION void operator++() { Kokkos::atomic_inc(&value); }
+  KOKKOS_FORCEINLINE_FUNCTION void operator++(int) {
+    Kokkos::atomic_inc(&value);
+  }
   KOKKOS_FORCEINLINE_FUNCTION void operator-=(ValueType const& rhs) {
-    this->join(value, ValueType(-rhs));
+    Kokkos::atomic_sub(&value, rhs);
   }
-  KOKKOS_FORCEINLINE_FUNCTION void operator--() {
-    this->join(value, ValueType(-1));
-  }
+  KOKKOS_FORCEINLINE_FUNCTION void operator--() { Kokkos::atomic_dec(&value); }
   KOKKOS_FORCEINLINE_FUNCTION void operator--(int) {
-    this->join(value, ValueType(-1));
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void join(ValueType& dest, const ValueType& src) const {
-    Kokkos::atomic_add(&dest, src);
+    Kokkos::atomic_dec(&value);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
-    this->join(value, rhs);
+    Kokkos::atomic_add(&value, rhs);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION void reset() {
@@ -343,11 +336,6 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
     Kokkos::atomic_div(&value, rhs);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  void join(ValueType& dest, const ValueType& src) const {
-    atomic_prod(&dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     atomic_prod(&value, rhs);
   }
@@ -399,13 +387,8 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
   KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
   KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
 
-  KOKKOS_INLINE_FUNCTION
-  void join(ValueType& dest, const ValueType& src) const {
-    atomic_min(&dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
-    this->join(value, rhs);
+    Kokkos::atomic_min(&value, rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION void reset() {
     value = reduction_identity<ValueType>::min();
@@ -457,13 +440,8 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
   KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
   KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
 
-  KOKKOS_INLINE_FUNCTION
-  void join(ValueType& dest, const ValueType& src) const {
-    atomic_max(&dest, src);
-  }
-
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
-    this->join(value, rhs);
+    Kokkos::atomic_max(&value, rhs);
   }
   KOKKOS_FORCEINLINE_FUNCTION void reset() {
     value = reduction_identity<ValueType>::max();

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -202,10 +202,7 @@ template <typename ValueType, typename Op, typename DeviceType,
 struct ScatterValue;
 
 /* ScatterValue <Op=ScatterSum, Contribution=ScatterNonAtomic> is
-   the object returned by the access operator() of ScatterAccess.
-   operator+=, etc. Note the addition of update(ValueType const& rhs) and
-   reset()  so that all reducers can have common functions See ReduceDuplicates
-   and ResetDuplicates ) */
+   the object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
                     Kokkos::Experimental::ScatterNonAtomic> {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -202,8 +202,7 @@ template <typename ValueType, typename Op, typename DeviceType,
 struct ScatterValue;
 
 /* ScatterValue <Op=ScatterSum, Contribution=ScatterNonAtomic> is
-   the object returned by the access operator() of ScatterAccess. This class
-   inherits from the Sum<> reducer and it wraps join(dest, src) with convenient
+   the object returned by the access operator() of ScatterAccess.
    operator+=, etc. Note the addition of update(ValueType const& rhs) and
    reset()  so that all reducers can have common functions See ReduceDuplicates
    and ResetDuplicates ) */
@@ -237,10 +236,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterSum, Contribution=ScatterAtomic> is the
- object returned by the access operator() of ScatterAccess. This class inherits
- from the Sum<> reducer, and similar to that returned by an Atomic View, it
- wraps Kokkos::atomic_add with convenient operator+=, etc. This version also has
- the update(rhs) and reset() functions. */
+ object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
                     Kokkos::Experimental::ScatterAtomic> {
@@ -277,11 +273,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterProd, Contribution=ScatterNonAtomic> is
-   the object returned by the access operator() of ScatterAccess.  This class
-   inherits from the Prod<> reducer, and it wraps join(dest, src) with
-   convenient operator*=, etc. Note the addition of update(ValueType const& rhs)
-   and reset()  so that all reducers can have common functions See
-   ReduceDuplicates and ResetDuplicates ) */
+   the object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
                     Kokkos::Experimental::ScatterNonAtomic> {
@@ -311,11 +303,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterProd, Contribution=ScatterAtomic> is the
- object returned by the access operator() of ScatterAccess.  This class
- inherits from the Prod<> reducer, and similar to that returned by an Atomic
- View, it wraps and atomic_prod with convenient operator*=, etc. atomic_prod
- uses the atomic_compare_exchange. This version also has the update(rhs)
- and reset() functions. */
+ object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
                     Kokkos::Experimental::ScatterAtomic> {
@@ -337,7 +325,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
   }
 
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
-    atomic_prod(&value, rhs);
+    *this *= rhs;
   }
   KOKKOS_FORCEINLINE_FUNCTION void reset() {
     value = reduction_identity<ValueType>::prod();
@@ -345,11 +333,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterMin, Contribution=ScatterNonAtomic> is
-   the object returned by the access operator() of ScatterAccess. This class
-   inherits from the Min<> reducer and it wraps join(dest, src) with convenient
-   update(rhs). Note the addition of update(ValueType const& rhs) and reset()
-   are so that all reducers can have a common update function See
-   ReduceDuplicates and ResetDuplicates ) */
+   the object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
                     Kokkos::Experimental::ScatterNonAtomic> {
@@ -370,11 +354,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterMin, Contribution=ScatterAtomic> is the
-   object returned by the access operator() of ScatterAccess. This class
-   inherits from the Min<> reducer, and similar to that returned by an Atomic
-   View, it wraps atomic_min with join(), etc. atomic_min uses the
-   atomic_compare_exchange. This version also has the update(rhs) and reset()
-   functions. */
+   object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
                     Kokkos::Experimental::ScatterAtomic> {
@@ -396,11 +376,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterMax, Contribution=ScatterNonAtomic> is
-   the object returned by the access operator() of ScatterAccess. This class
-   inherits from the Max<> reducer and it wraps join(dest, src) with convenient
-   update(rhs). Note the addition of update(ValueType const& rhs) and reset()
-   are so that all reducers can have a common update function See
-   ReduceDuplicates and ResetDuplicates ) */
+   the object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
                     Kokkos::Experimental::ScatterNonAtomic> {
@@ -423,11 +399,7 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
 };
 
 /* ScatterValue <Op=ScatterMax, Contribution=ScatterAtomic> is the
-   object returned by the access operator() of ScatterAccess. This class
-   inherits from the Max<> reducer, and similar to that returned by an Atomic
-   View, it wraps atomic_max with join(), etc. atomic_max uses the
-   atomic_compare_exchange. This version also has the update(rhs) and reset()
-   functions. */
+   object returned by the access operator() of ScatterAccess. */
 template <typename ValueType, typename DeviceType>
 struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
                     Kokkos::Experimental::ScatterAtomic> {

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -217,8 +217,9 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
   KOKKOS_FORCEINLINE_FUNCTION void operator+=(ValueType const& rhs) {
     update(rhs);
   }
@@ -250,7 +251,9 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterSum, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
   KOKKOS_FORCEINLINE_FUNCTION void operator+=(ValueType const& rhs) {
     this->join(value, rhs);
   }
@@ -294,8 +297,11 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
+
   KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
     value *= rhs;
   }
@@ -325,8 +331,10 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterProd, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
 
   KOKKOS_FORCEINLINE_FUNCTION void operator*=(ValueType const& rhs) {
     Kokkos::atomic_mul(&value, rhs);
@@ -360,10 +368,11 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
   ValueType& value;
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
 
- public:
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
+
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     value = rhs < value ? rhs : value;
   }
@@ -386,8 +395,9 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMin, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
 
   KOKKOS_INLINE_FUNCTION
   void join(ValueType& dest, const ValueType& src) const {
@@ -416,8 +426,11 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
+
   KOKKOS_FORCEINLINE_FUNCTION void update(ValueType const& rhs) {
     value = rhs > value ? rhs : value;
   }
@@ -440,8 +453,9 @@ struct ScatterValue<ValueType, Kokkos::Experimental::ScatterMax, DeviceType,
  public:
   KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ValueType& value_in)
       : value(value_in) {}
-  KOKKOS_FORCEINLINE_FUNCTION ScatterValue(ScatterValue&& other)
-      : value(other.value) {}
+  KOKKOS_FUNCTION ScatterValue(const ScatterValue&)            = delete;
+  KOKKOS_FUNCTION ScatterValue& operator=(const ScatterValue&) = delete;
+  KOKKOS_DEFAULTED_FUNCTION ~ScatterValue()                    = default;
 
   KOKKOS_INLINE_FUNCTION
   void join(ValueType& dest, const ValueType& src) const {
@@ -914,8 +928,6 @@ class ScatterAccess<DataType, Op, DeviceType, Layout, ScatterNonDuplicated,
 
   KOKKOS_INLINE_FUNCTION
   ScatterAccess(view_type const& view_in) : view(view_in) {}
-  KOKKOS_DEFAULTED_FUNCTION
-  ~ScatterAccess() = default;
 
   template <typename... Args>
   KOKKOS_FORCEINLINE_FUNCTION value_type operator()(Args... args) const {

--- a/containers/unit_tests/TestScatterView.hpp
+++ b/containers/unit_tests/TestScatterView.hpp
@@ -79,6 +79,8 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       --scatter_access_atomic(k, 9);
       ++scatter_access_atomic(k, 10);
       scatter_access(k, 11) -= 3;
+      scatter_access(k, 0).update(0);
+      scatter_access_atomic(k, 0).update(0);
     }
   }
 
@@ -175,6 +177,8 @@ struct test_scatter_view_impl_cls<DeviceType, Layout, Duplication, Contribution,
       scatter_access(k, 0) *= 4.0;
       scatter_access_atomic(k, 1) *= 2.0;
       scatter_access(k, 2) *= 1.0;
+      scatter_access(k, 2).update(1.0);
+      scatter_access_atomic(k, 1).update(1.0);
     }
   }
 


### PR DESCRIPTION
Split-up from #8689.
`ScatterValue` wraps a reference and the current implementation only implements a move constructor out of all the special member functions. This move constructor behaves like a copy constructor. Thus, the moved from object still impacts the moved-to object which appears unintended. Instead, this pull request proposes to delete the copy constructor and copy assignment operator implying that the move constructor and move assignment operator are also implicitly deleted.

We do some more cleanup by removing the (unused) `join` operator as was already mentioned in a comment.

Drive-by:  Remove `ScatterAccess`'s default destructor.