### PR TITLE
OpenMPTarget: Delete remaining code

### DIFF
--- a/.gitlab/nersc-gitlab-ci.yml
+++ b/.gitlab/nersc-gitlab-ci.yml
@@ -71,18 +71,6 @@ EPYC-OMP-clang:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-unknown-cuda-version'"
     - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="AMD-EPYC-OpenMP-clang/20.1.3"
 
-A100-OpenMPTarget-clang:
-  stage: test
-  script:
-    - echo "Kokkos-OpenMPTarget tests by $GITLAB_USER_LOGIN using clang."
-    - module load llvm/20.1.3
-    - export BUILD_DIR=${SOURCE_DIR}/build_ompt_clang
-    - export ENV_CMAKE_OPTIONS="${ENV_KOKKOS_OPTIONS}"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DCMAKE_CXX_COMPILER=clang++"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ARCH_AMPERE80=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_OPENMPTARGET=ON"
-    - ctest -VV -D CDASH_MODEL="Nightly" -D CTEST_SITE="nersc" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S ${SCRIPT_FILE} -D CTEST_BUILD_NAME="NVIDIA-A100-OpenMPTarget-clang/20.1.3"
-
 clear-ci-builds:
   stage: clean_up
   script:

--- a/algorithms/CMakeLists.txt
+++ b/algorithms/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT Kokkos_INSTALL_TESTING)
   add_subdirectory(src)
 endif()
 # FIXME_OPENACC: temporarily disabled due to unimplemented features
-if(NOT ((KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL NVHPC) OR KOKKOS_ENABLE_OPENACC))
+if(NOT KOKKOS_ENABLE_OPENACC)
   kokkos_add_test_directories(unit_tests)
 endif()
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -611,11 +611,6 @@ struct Random_XorShift1024_UseCArrayState<Kokkos::Cuda> : std::false_type {};
 template <>
 struct Random_XorShift1024_UseCArrayState<Kokkos::HIP> : std::false_type {};
 #endif
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-template <>
-struct Random_XorShift1024_UseCArrayState<Kokkos::Experimental::OpenMPTarget>
-    : std::false_type {};
-#endif
 #ifdef KOKKOS_ENABLE_OPENACC
 template <>
 struct Random_XorShift1024_UseCArrayState<Kokkos::Experimental::OpenACC>
@@ -710,28 +705,6 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
       if (i >= static_cast<int>(locks_.extent(0))) {
         i = i_offset;
       }
-    }
-    return i;
-  }
-};
-#endif
-
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-template <class MemorySpace>
-struct Random_UniqueIndex<
-    Kokkos::Device<Kokkos::Experimental::OpenMPTarget, MemorySpace>> {
-  using locks_view_type =
-      View<int**,
-           Kokkos::Device<Kokkos::Experimental::OpenMPTarget, MemorySpace>>;
-  KOKKOS_FUNCTION
-  static int get_state_idx(const locks_view_type& locks) {
-    const int team_size = omp_get_num_threads();
-    int i               = omp_get_team_num() * team_size + omp_get_thread_num();
-    const int lock_size = locks.extent_int(0);
-
-    i %= lock_size;
-    while (Kokkos::atomic_compare_exchange(&locks(i, 0), 0, 1)) {
-      i = (i + 1) % lock_size;
     }
     return i;
   }

--- a/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
@@ -28,9 +28,11 @@ OutputIteratorType exclusive_scan(const ExecutionSpace& ex,
                                   ValueType init_value) {
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
-  return Impl::exclusive_scan_default_op_exespace_impl(
+  using binary_op = Impl::StdExclusiveScanDefaultJoinFunctor<ValueType>;
+
+  return Impl::exclusive_scan_exespace_impl(
       "Kokkos::exclusive_scan_default_functors_iterator_api", ex, first, last,
-      first_dest, std::move(init_value));
+      first_dest, std::move(init_value), binary_op());
 }
 
 template <typename ExecutionSpace, typename InputIteratorType,
@@ -47,8 +49,10 @@ OutputIteratorType exclusive_scan(const std::string& label,
                                   ValueType init_value) {
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
-  return Impl::exclusive_scan_default_op_exespace_impl(
-      label, ex, first, last, first_dest, std::move(init_value));
+  using binary_op = Impl::StdExclusiveScanDefaultJoinFunctor<ValueType>;
+
+  return Impl::exclusive_scan_exespace_impl(label, ex, first, last, first_dest,
+                                            std::move(init_value), binary_op());
 }
 
 template <
@@ -63,11 +67,13 @@ auto exclusive_scan(const ExecutionSpace& ex,
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
+  using binary_op = Impl::StdExclusiveScanDefaultJoinFunctor<ValueType>;
+
   namespace KE = ::Kokkos::Experimental;
-  return Impl::exclusive_scan_default_op_exespace_impl(
+  return Impl::exclusive_scan_exespace_impl(
       "Kokkos::exclusive_scan_default_functors_view_api", ex,
       KE::cbegin(view_from), KE::cend(view_from), KE::begin(view_dest),
-      std::move(init_value));
+      std::move(init_value), binary_op());
 }
 
 template <
@@ -82,10 +88,12 @@ auto exclusive_scan(const std::string& label, const ExecutionSpace& ex,
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
+  using binary_op = Impl::StdExclusiveScanDefaultJoinFunctor<ValueType>;
+
   namespace KE = ::Kokkos::Experimental;
-  return Impl::exclusive_scan_default_op_exespace_impl(
+  return Impl::exclusive_scan_exespace_impl(
       label, ex, KE::cbegin(view_from), KE::cend(view_from),
-      KE::begin(view_dest), std::move(init_value));
+      KE::begin(view_dest), std::move(init_value), binary_op());
 }
 
 // overload set 2
@@ -103,7 +111,7 @@ OutputIteratorType exclusive_scan(const ExecutionSpace& ex,
                                   ValueType init_value, BinaryOpType bop) {
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
-  return Impl::exclusive_scan_custom_op_exespace_impl(
+  return Impl::exclusive_scan_exespace_impl(
       "Kokkos::exclusive_scan_custom_functors_iterator_api", ex, first, last,
       first_dest, std::move(init_value), bop);
 }
@@ -123,8 +131,8 @@ OutputIteratorType exclusive_scan(const std::string& label,
                                   ValueType init_value, BinaryOpType bop) {
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
-  return Impl::exclusive_scan_custom_op_exespace_impl(
-      label, ex, first, last, first_dest, std::move(init_value), bop);
+  return Impl::exclusive_scan_exespace_impl(label, ex, first, last, first_dest,
+                                            std::move(init_value), bop);
 }
 
 template <
@@ -141,7 +149,7 @@ auto exclusive_scan(const ExecutionSpace& ex,
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   namespace KE = ::Kokkos::Experimental;
-  return Impl::exclusive_scan_custom_op_exespace_impl(
+  return Impl::exclusive_scan_exespace_impl(
       "Kokkos::exclusive_scan_custom_functors_view_api", ex,
       KE::cbegin(view_from), KE::cend(view_from), KE::begin(view_dest),
       std::move(init_value), bop);
@@ -161,7 +169,7 @@ auto exclusive_scan(const std::string& label, const ExecutionSpace& ex,
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   namespace KE = ::Kokkos::Experimental;
-  return Impl::exclusive_scan_custom_op_exespace_impl(
+  return Impl::exclusive_scan_exespace_impl(
       label, ex, KE::cbegin(view_from), KE::cend(view_from),
       KE::begin(view_dest), std::move(init_value), bop);
 }

--- a/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_ExclusiveScan.hpp
@@ -101,7 +101,6 @@ OutputIteratorType exclusive_scan(const ExecutionSpace& ex,
                                   InputIteratorType last,
                                   OutputIteratorType first_dest,
                                   ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::exclusive_scan_custom_op_exespace_impl(
@@ -122,7 +121,6 @@ OutputIteratorType exclusive_scan(const std::string& label,
                                   InputIteratorType last,
                                   OutputIteratorType first_dest,
                                   ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::exclusive_scan_custom_op_exespace_impl(
@@ -138,7 +136,6 @@ auto exclusive_scan(const ExecutionSpace& ex,
                     const ::Kokkos::View<DataType1, Properties1...>& view_from,
                     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
                     ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -159,7 +156,6 @@ auto exclusive_scan(const std::string& label, const ExecutionSpace& ex,
                     const ::Kokkos::View<DataType1, Properties1...>& view_from,
                     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
                     ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -223,7 +219,6 @@ KOKKOS_FUNCTION OutputIteratorType
 exclusive_scan(const TeamHandleType& teamHandle, InputIteratorType first,
                InputIteratorType last, OutputIteratorType first_dest,
                ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::exclusive_scan_custom_op_team_impl(
@@ -239,7 +234,6 @@ KOKKOS_FUNCTION auto exclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     ValueType init_value, BinaryOpType bop) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,

--- a/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSorted.hpp
@@ -59,7 +59,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool is_sorted(const ExecutionSpace& ex, IteratorType first, IteratorType last,
                ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
   return Impl::is_sorted_exespace_impl("Kokkos::is_sorted_iterator_api_default",
                                        ex, first, last, std::move(comp));
 }
@@ -69,7 +68,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 bool is_sorted(const std::string& label, const ExecutionSpace& ex,
                IteratorType first, IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
   return Impl::is_sorted_exespace_impl(label, ex, first, last, std::move(comp));
 }
 
@@ -81,7 +79,6 @@ bool is_sorted(const ExecutionSpace& ex,
                const ::Kokkos::View<DataType, Properties...>& view,
                ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_exespace_impl("Kokkos::is_sorted_view_api_default", ex,
@@ -97,7 +94,6 @@ bool is_sorted(const std::string& label, const ExecutionSpace& ex,
                const ::Kokkos::View<DataType, Properties...>& view,
                ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_exespace_impl(label, ex, KE::cbegin(view),
@@ -134,7 +130,6 @@ template <typename TeamHandleType, typename IteratorType,
 KOKKOS_FUNCTION bool is_sorted(const TeamHandleType& teamHandle,
                                IteratorType first, IteratorType last,
                                ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   return Impl::is_sorted_team_impl(teamHandle, first, last, std::move(comp));
 }
 
@@ -145,7 +140,6 @@ KOKKOS_FUNCTION bool is_sorted(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType, Properties...>& view, ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_team_impl(teamHandle, KE::cbegin(view), KE::cend(view),

--- a/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IsSortedUntil.hpp
@@ -60,7 +60,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 IteratorType is_sorted_until(const ExecutionSpace& ex, IteratorType first,
                              IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
   return Impl::is_sorted_until_exespace_impl(
       "Kokkos::is_sorted_until_iterator_api_default", ex, first, last,
       std::move(comp));
@@ -72,8 +71,6 @@ template <
 IteratorType is_sorted_until(const std::string& label, const ExecutionSpace& ex,
                              IteratorType first, IteratorType last,
                              ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::is_sorted_until_exespace_impl(label, ex, first, last,
                                              std::move(comp));
 }
@@ -86,7 +83,6 @@ auto is_sorted_until(const ExecutionSpace& ex,
                      const ::Kokkos::View<DataType, Properties...>& view,
                      ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_until_exespace_impl(
@@ -102,7 +98,6 @@ auto is_sorted_until(const std::string& label, const ExecutionSpace& ex,
                      const ::Kokkos::View<DataType, Properties...>& view,
                      ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_until_exespace_impl(label, ex, KE::begin(view),
@@ -139,7 +134,6 @@ KOKKOS_FUNCTION IteratorType is_sorted_until(const TeamHandleType& teamHandle,
                                              IteratorType first,
                                              IteratorType last,
                                              ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   return Impl::is_sorted_until_team_impl(teamHandle, first, last,
                                          std::move(comp));
 }
@@ -151,7 +145,6 @@ KOKKOS_FUNCTION auto is_sorted_until(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType, Properties...>& view, ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
 
   namespace KE = ::Kokkos::Experimental;
   return Impl::is_sorted_until_team_impl(teamHandle, KE::begin(view),

--- a/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MaxElement.hpp
@@ -36,8 +36,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto max_element(const ExecutionSpace& ex, IteratorType first,
                  IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::min_or_max_element_exespace_impl<MaxFirstLocCustomComparator>(
       "Kokkos::max_element_iterator_api_default", ex, first, last,
       std::move(comp));
@@ -48,8 +46,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto max_element(const std::string& label, const ExecutionSpace& ex,
                  IteratorType first, IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::min_or_max_element_exespace_impl<MaxFirstLocCustomComparator>(
       label, ex, first, last, std::move(comp));
 }
@@ -84,7 +80,6 @@ auto max_element(const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& v,
                  ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::min_or_max_element_exespace_impl<MaxFirstLocCustomComparator>(
       "Kokkos::max_element_view_api_default", ex, begin(v), end(v),
@@ -99,7 +94,6 @@ auto max_element(const std::string& label, const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& v,
                  ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::min_or_max_element_exespace_impl<MaxFirstLocCustomComparator>(
       label, ex, begin(v), end(v), std::move(comp));
@@ -135,7 +129,6 @@ template <typename TeamHandleType, typename IteratorType,
 KOKKOS_FUNCTION auto max_element(const TeamHandleType& teamHandle,
                                  IteratorType first, IteratorType last,
                                  ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   return Impl::min_or_max_element_team_impl<MaxFirstLocCustomComparator>(
       teamHandle, first, last, std::move(comp));
 }
@@ -147,7 +140,6 @@ KOKKOS_FUNCTION auto max_element(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType, Properties...>& v, ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   return Impl::min_or_max_element_team_impl<MaxFirstLocCustomComparator>(
       teamHandle, begin(v), end(v), std::move(comp));
 }

--- a/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinElement.hpp
@@ -36,8 +36,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto min_element(const ExecutionSpace& ex, IteratorType first,
                  IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::min_or_max_element_exespace_impl<MinFirstLocCustomComparator>(
       "Kokkos::min_element_iterator_api_default", ex, first, last,
       std::move(comp));
@@ -48,8 +46,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto min_element(const std::string& label, const ExecutionSpace& ex,
                  IteratorType first, IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::min_or_max_element_exespace_impl<MinFirstLocCustomComparator>(
       label, ex, first, last, std::move(comp));
 }
@@ -73,7 +69,6 @@ auto min_element(const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& v,
                  ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::min_or_max_element_exespace_impl<MinFirstLocCustomComparator>(
       "Kokkos::min_element_view_api_default", ex, begin(v), end(v),
@@ -99,7 +94,6 @@ auto min_element(const std::string& label, const ExecutionSpace& ex,
                  const ::Kokkos::View<DataType, Properties...>& v,
                  ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::min_or_max_element_exespace_impl<MinFirstLocCustomComparator>(
       label, ex, begin(v), end(v), std::move(comp));
@@ -135,7 +129,6 @@ template <typename TeamHandleType, typename IteratorType,
 KOKKOS_FUNCTION auto min_element(const TeamHandleType& teamHandle,
                                  IteratorType first, IteratorType last,
                                  ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   return Impl::min_or_max_element_team_impl<MinFirstLocCustomComparator>(
       teamHandle, first, last, std::move(comp));
 }
@@ -146,7 +139,6 @@ template <typename TeamHandleType, typename DataType, typename ComparatorType,
 KOKKOS_FUNCTION auto min_element(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType, Properties...>& v, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
   return Impl::min_or_max_element_team_impl<MinFirstLocCustomComparator>(
       teamHandle, begin(v), end(v), std::move(comp));

--- a/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_MinMaxElement.hpp
@@ -36,8 +36,6 @@ template <
     std::enable_if_t<::Kokkos::is_execution_space_v<ExecutionSpace>, int> = 0>
 auto minmax_element(const ExecutionSpace& ex, IteratorType first,
                     IteratorType last, ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::minmax_element_exespace_impl<MinMaxFirstLastLocCustomComparator>(
       "Kokkos::minmax_element_iterator_api_default", ex, first, last,
       std::move(comp));
@@ -49,8 +47,6 @@ template <
 auto minmax_element(const std::string& label, const ExecutionSpace& ex,
                     IteratorType first, IteratorType last,
                     ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::minmax_element_exespace_impl<MinMaxFirstLastLocCustomComparator>(
       label, ex, first, last, std::move(comp));
 }
@@ -85,7 +81,6 @@ auto minmax_element(const ExecutionSpace& ex,
                     const ::Kokkos::View<DataType, Properties...>& v,
                     ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::minmax_element_exespace_impl<MinMaxFirstLastLocCustomComparator>(
       "Kokkos::minmax_element_view_api_default", ex, begin(v), end(v),
@@ -100,7 +95,6 @@ auto minmax_element(const std::string& label, const ExecutionSpace& ex,
                     const ::Kokkos::View<DataType, Properties...>& v,
                     ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(ex);
 
   return Impl::minmax_element_exespace_impl<MinMaxFirstLastLocCustomComparator>(
       label, ex, begin(v), end(v), std::move(comp));
@@ -125,8 +119,6 @@ template <typename TeamHandleType, typename IteratorType,
 KOKKOS_FUNCTION auto minmax_element(const TeamHandleType& teamHandle,
                                     IteratorType first, IteratorType last,
                                     ComparatorType comp) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
-
   return Impl::minmax_element_team_impl<MinMaxFirstLastLocCustomComparator>(
       teamHandle, first, last, std::move(comp));
 }
@@ -149,7 +141,6 @@ KOKKOS_FUNCTION auto minmax_element(
     const TeamHandleType& teamHandle,
     const ::Kokkos::View<DataType, Properties...>& v, ComparatorType comp) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(v);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
 
   return Impl::minmax_element_team_impl<MinMaxFirstLastLocCustomComparator>(
       teamHandle, begin(v), end(v), std::move(comp));

--- a/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformExclusiveScan.hpp
@@ -24,7 +24,6 @@ OutputIteratorType transform_exclusive_scan(
     const ExecutionSpace& ex, InputIteratorType first, InputIteratorType last,
     OutputIteratorType first_dest, ValueType init_value, BinaryOpType binary_op,
     UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::transform_exclusive_scan_exespace_impl(
@@ -43,7 +42,6 @@ OutputIteratorType transform_exclusive_scan(
     const std::string& label, const ExecutionSpace& ex, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest, ValueType init_value,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::transform_exclusive_scan_exespace_impl(
@@ -61,7 +59,6 @@ auto transform_exclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     ValueType init_value, BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -83,7 +80,6 @@ auto transform_exclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     ValueType init_value, BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -110,7 +106,6 @@ KOKKOS_FUNCTION OutputIteratorType transform_exclusive_scan(
     const TeamHandleType& teamHandle, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest, ValueType init_value,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
   return Impl::transform_exclusive_scan_team_impl(
@@ -127,7 +122,6 @@ KOKKOS_FUNCTION auto transform_exclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     ValueType init_value, BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,

--- a/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_TransformInclusiveScan.hpp
@@ -28,8 +28,6 @@ OutputIteratorType transform_inclusive_scan(const ExecutionSpace& ex,
                                             OutputIteratorType first_dest,
                                             BinaryOpType binary_op,
                                             UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::transform_inclusive_scan_exespace_impl(
       "Kokkos::transform_inclusive_scan_custom_functors_iterator_api", ex,
       first, last, first_dest, binary_op, unary_op);
@@ -46,8 +44,6 @@ OutputIteratorType transform_inclusive_scan(
     const std::string& label, const ExecutionSpace& ex, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
-
   return Impl::transform_inclusive_scan_exespace_impl(
       label, ex, first, last, first_dest, binary_op, unary_op);
 }
@@ -62,7 +58,6 @@ auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   namespace KE = ::Kokkos::Experimental;
@@ -82,7 +77,6 @@ auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   namespace KE = ::Kokkos::Experimental;
@@ -104,7 +98,6 @@ OutputIteratorType transform_inclusive_scan(
     const ExecutionSpace& ex, InputIteratorType first, InputIteratorType last,
     OutputIteratorType first_dest, BinaryOpType binary_op, UnaryOpType unary_op,
     ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
@@ -125,7 +118,6 @@ OutputIteratorType transform_inclusive_scan(
     const std::string& label, const ExecutionSpace& ex, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest,
     BinaryOpType binary_op, UnaryOpType unary_op, ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(ex);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
@@ -144,7 +136,6 @@ auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op, ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -167,7 +158,6 @@ auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op, ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,
@@ -197,8 +187,6 @@ KOKKOS_FUNCTION OutputIteratorType transform_inclusive_scan(
     const TeamHandleType& teamHandle, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
-
   return Impl::transform_inclusive_scan_team_impl(
       teamHandle, first, last, first_dest, binary_op, unary_op);
 }
@@ -212,7 +200,6 @@ KOKKOS_FUNCTION auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   namespace KE = ::Kokkos::Experimental;
@@ -233,7 +220,6 @@ KOKKOS_FUNCTION OutputIteratorType transform_inclusive_scan(
     const TeamHandleType& teamHandle, InputIteratorType first,
     InputIteratorType last, OutputIteratorType first_dest,
     BinaryOpType binary_op, UnaryOpType unary_op, ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   static_assert(std::is_move_constructible_v<ValueType>,
                 "ValueType must be move constructible.");
 
@@ -251,7 +237,6 @@ KOKKOS_FUNCTION auto transform_inclusive_scan(
     const ::Kokkos::View<DataType1, Properties1...>& view_from,
     const ::Kokkos::View<DataType2, Properties2...>& view_dest,
     BinaryOpType binary_op, UnaryOpType unary_op, ValueType init_value) {
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_from);
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view_dest);
   static_assert(std::is_move_constructible_v<ValueType>,

--- a/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Constraints.hpp
@@ -191,28 +191,6 @@ static_assert_iterators_have_matching_difference_type(IteratorType1 it1,
 }
 
 //
-// not_openmptarget
-//
-template <class ExeSpace>
-struct not_openmptarget {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-  static constexpr bool value = true;
-#else
-  static constexpr bool value =
-      !std::is_same<std::decay_t<ExeSpace>,
-                    ::Kokkos::Experimental::OpenMPTarget>::value;
-#endif
-};
-
-template <class ExecutionSpaceOrTeamHandleType>
-KOKKOS_INLINE_FUNCTION constexpr void static_assert_is_not_openmptarget(
-    const ExecutionSpaceOrTeamHandleType& /*ex_or_th*/) {
-  static_assert(not_openmptarget<ExecutionSpaceOrTeamHandleType>::value,
-                "Currently, Kokkos standard algorithms do not support custom "
-                "comparators in OpenMPTarget");
-}
-
-//
 // valid range
 //
 template <class IteratorType>

--- a/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
@@ -23,56 +23,17 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-//
-// exespace impl
-//
-template <class ExecutionSpace, class InputIteratorType,
-          class OutputIteratorType, class ValueType>
-OutputIteratorType exclusive_scan_default_op_exespace_impl(
-    const std::string& label, const ExecutionSpace& ex,
-    InputIteratorType first_from, InputIteratorType last_from,
-    OutputIteratorType first_dest, ValueType init_value) {
-  // checks
-  Impl::static_assert_random_access_and_accessible(ex, first_from, first_dest);
-  Impl::static_assert_iterators_have_matching_difference_type(first_from,
-                                                              first_dest);
-  Impl::expect_valid_range(first_from, last_from);
-
-  // does it make sense to do this static_assert too?
-  // using input_iterator_value_type = typename InputIteratorType::value_type;
-  // static_assert
-  //   (std::is_convertible<std::remove_cv_t<input_iterator_value_type>,
-  //   ValueType>::value,
-  //    "exclusive_scan: InputIteratorType::value_type not convertible to
-  //    ValueType");
-
-  // aliases
-  using index_type = typename InputIteratorType::difference_type;
-  using func_type  = std::conditional_t<
-      ::Kokkos::is_detected<ex_scan_has_reduction_identity_sum_t,
-                            ValueType>::value,
-      ExclusiveScanDefaultFunctorForKnownNeutralElement<
-          ExecutionSpace, index_type, ValueType, InputIteratorType,
-          OutputIteratorType>,
-      ExclusiveScanDefaultFunctorWithValueWrapper<ExecutionSpace, index_type,
-                                                  ValueType, InputIteratorType,
-                                                  OutputIteratorType>>;
-
-  // run
-  const auto num_elements =
-      Kokkos::Experimental::distance(first_from, last_from);
-  ::Kokkos::parallel_scan(
-      label, RangePolicy<ExecutionSpace>(ex, 0, num_elements),
-      func_type(std::move(init_value), first_from, first_dest));
-
-  ex.fence("Kokkos::exclusive_scan_default_op: fence after operation");
-
-  return first_dest + num_elements;
-}
+template <class ValueType>
+struct StdExclusiveScanDefaultJoinFunctor {
+  KOKKOS_FUNCTION
+  constexpr ValueType operator()(const ValueType& a, const ValueType& b) const {
+    return a + b;
+  }
+};
 
 template <class ExecutionSpace, class InputIteratorType,
           class OutputIteratorType, class ValueType, class BinaryOpType>
-OutputIteratorType exclusive_scan_custom_op_exespace_impl(
+OutputIteratorType exclusive_scan_exespace_impl(
     const std::string& label, const ExecutionSpace& ex,
     InputIteratorType first_from, InputIteratorType last_from,
     OutputIteratorType first_dest, ValueType init_value, BinaryOpType bop) {
@@ -96,7 +57,7 @@ OutputIteratorType exclusive_scan_custom_op_exespace_impl(
                           RangePolicy<ExecutionSpace>(ex, 0, num_elements),
                           func_type(std::move(init_value), first_from,
                                     first_dest, bop, unary_op_type()));
-  ex.fence("Kokkos::exclusive_scan_custom_op: fence after operation");
+  ex.fence("Kokkos::exclusive_scan: fence after operation");
 
   // return
   return first_dest + num_elements;

--- a/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_ExclusiveScan.hpp
@@ -46,17 +46,6 @@ OutputIteratorType exclusive_scan_default_op_exespace_impl(
   //    "exclusive_scan: InputIteratorType::value_type not convertible to
   //    ValueType");
 
-  // we are unnecessarily duplicating code, but this is on purpose
-  // so that we can use the default_op for OpenMPTarget.
-  // Originally, I had this implemented as:
-  // '''
-  // using bop_type   = StdExclusiveScanDefaultJoinFunctor<ValueType>;
-  // call exclusive_scan_custom_op_impl(..., bop_type());
-  // '''
-  // which avoids duplicating the functors, but for OpenMPTarget
-  // I cannot use a custom binary op.
-  // This is the same problem that occurs for reductions.
-
   // aliases
   using index_type = typename InputIteratorType::difference_type;
   using func_type  = std::conditional_t<

--- a/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_Reduce.hpp
@@ -82,7 +82,6 @@ ValueType reduce_custom_functors_exespace_impl(
     IteratorType last, ValueType init_reduction_value, JoinerType joiner) {
   // checks
   Impl::static_assert_random_access_and_accessible(ex, first);
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::expect_valid_range(first, last);
 
   if (first == last) {
@@ -113,7 +112,6 @@ ValueType reduce_default_functors_exespace_impl(
     IteratorType last, ValueType init_reduction_value) {
   // checks
   Impl::static_assert_random_access_and_accessible(ex, first);
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::expect_valid_range(first, last);
 
   using value_type = std::remove_cvref_t<ValueType>;
@@ -157,7 +155,6 @@ KOKKOS_FUNCTION ValueType reduce_custom_functors_team_impl(
     ValueType init_reduction_value, JoinerType joiner) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::expect_valid_range(first, last);
 
   if (first == last) {
@@ -188,7 +185,6 @@ KOKKOS_FUNCTION ValueType reduce_default_functors_team_impl(
     ValueType init_reduction_value) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::expect_valid_range(first, last);
 
   using value_type = std::remove_cvref_t<ValueType>;

--- a/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_TransformReduce.hpp
@@ -114,7 +114,6 @@ ValueType transform_reduce_custom_functors_exespace_impl(
     UnaryTransformerType transformer) {
   // checks
   Impl::static_assert_random_access_and_accessible(ex, first);
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::expect_valid_range(first, last);
 
   if (first == last) {
@@ -153,7 +152,6 @@ ValueType transform_reduce_custom_functors_exespace_impl(
     JoinerType joiner, BinaryTransformerType transformer) {
   // checks
   Impl::static_assert_random_access_and_accessible(ex, first1, first2);
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_iterators_have_matching_difference_type(first1, first2);
   Impl::expect_valid_range(first1, last1);
 
@@ -192,7 +190,6 @@ ValueType transform_reduce_default_functors_exespace_impl(
     IteratorType1 last1, IteratorType2 first2, ValueType init_reduction_value) {
   // checks
   Impl::static_assert_random_access_and_accessible(ex, first1, first2);
-  Impl::static_assert_is_not_openmptarget(ex);
   Impl::static_assert_iterators_have_matching_difference_type(first1, first2);
   Impl::expect_valid_range(first1, last1);
 
@@ -218,7 +215,6 @@ KOKKOS_FUNCTION ValueType transform_reduce_custom_functors_team_impl(
     UnaryTransformerType transformer) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::expect_valid_range(first, last);
 
   if (first == last) {
@@ -256,7 +252,6 @@ KOKKOS_FUNCTION ValueType transform_reduce_custom_functors_team_impl(
     BinaryTransformerType transformer) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first1, first2);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_iterators_have_matching_difference_type(first1, first2);
   Impl::expect_valid_range(first1, last1);
 
@@ -296,7 +291,6 @@ KOKKOS_FUNCTION ValueType transform_reduce_default_functors_team_impl(
     IteratorType2 first2, ValueType init_reduction_value) {
   // checks
   Impl::static_assert_random_access_and_accessible(teamHandle, first1, first2);
-  Impl::static_assert_is_not_openmptarget(teamHandle);
   Impl::static_assert_iterators_have_matching_difference_type(first1, first2);
   Impl::expect_valid_range(first1, last1);
 

--- a/algorithms/unit_tests/CMakeLists.txt
+++ b/algorithms/unit_tests/CMakeLists.txt
@@ -6,7 +6,7 @@ kokkos_include_directories(${KOKKOS_SOURCE_DIR}/core/unit_test/category_files)
 
 set(ALGORITHM UnitTestMain.cpp)
 
-foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL;OpenMPTarget)
+foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)
   string(TOLOWER ${Tag} dir)
 
@@ -150,11 +150,6 @@ set(STDALGO_TEAM_SOURCES_P)
 foreach(Name StdAlgorithmsCommon StdAlgorithmsTeamExclusiveScan StdAlgorithmsTeamTransformExclusiveScan)
   list(APPEND STDALGO_TEAM_SOURCES_P Test${Name}.cpp)
 endforeach()
-if(KOKKOS_ENABLE_OPENMPTARGET) # FIXME_OPENMPTARGET
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_P TestStdAlgorithmsTeamExclusiveScan.cpp
-       TestStdAlgorithmsTeamTransformExclusiveScan.cpp
-  )
-endif()
 
 # ------------------------------------------
 # std team M
@@ -205,12 +200,6 @@ foreach(
 )
   list(APPEND STDALGO_TEAM_SOURCES_H Test${Name}.cpp)
 endforeach()
-
-if(KOKKOS_ENABLE_OPENMPTARGET) # FIXME_OPENMPTARGET
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_H TestStdAlgorithmsTeamCopyIf.cpp TestStdAlgorithmsTeamUniqueCopy.cpp
-       TestStdAlgorithmsTeamRemoveCopy.cpp TestStdAlgorithmsTeamRemoveCopyIf.cpp
-  )
-endif()
 
 # ------------------------------------------
 # std team G
@@ -303,60 +292,9 @@ foreach(
   list(APPEND STDALGO_TEAM_SOURCES_A Test${Name}.cpp)
 endforeach()
 
-# FIXME_OPENMPTARGET - remove sort test as it leads to ICE with clang/16 and above at compile time.
-if(KOKKOS_ENABLE_OPENMPTARGET AND KOKKOS_CXX_COMPILER_ID STREQUAL "Clang" AND KOKKOS_CXX_COMPILER_VERSION
-                                                                              VERSION_GREATER_EQUAL 16.0.0
-)
-  list(REMOVE_ITEM ALGO_SORT_SOURCES TestSort.cpp)
-endif()
-
-# FIXME_OPENMPTARGET remove tests for OpenMPTarget because in these cases
-# the impl needs to use either Kokkos or tailored reducers
-# which results in runtime memory errors.
-if(KOKKOS_ENABLE_OPENMPTARGET)
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_L TestStdAlgorithmsTeamIsPartitioned.cpp
-       TestStdAlgorithmsTeamPartitionPoint.cpp TestStdAlgorithmsTeamPartitionCopy.cpp
-  )
-endif()
-
-# FIXME_OPENMPTARGET need to remove tests for OpenMPTarget because
-# in these cases the impl needs to use either Kokkos or
-# tailored reducers which results in runtime memory errors.
-if(KOKKOS_ENABLE_OPENMPTARGET)
-  list(
-    REMOVE_ITEM
-    STDALGO_TEAM_SOURCES_C
-    TestStdAlgorithmsTeamFind.cpp
-    TestStdAlgorithmsTeamFindIf.cpp
-    TestStdAlgorithmsTeamFindIfNot.cpp
-    TestStdAlgorithmsTeamAllOf.cpp
-    TestStdAlgorithmsTeamAnyOf.cpp
-    TestStdAlgorithmsTeamNoneOf.cpp
-    TestStdAlgorithmsTeamSearchN.cpp
-  )
-endif()
-
 kokkos_add_executable_and_test(UnitTest_Sort SOURCES UnitTestMain.cpp TestStdAlgorithmsCommon.cpp ${ALGO_SORT_SOURCES})
 
 kokkos_add_executable_and_test(UnitTest_Random SOURCES UnitTestMain.cpp ${ALGO_RANDOM_SOURCES})
-
-# FIXME_OPENMPTARGET remove tests for OpenMPTarget
-# causing failures for various reasons
-if(KOKKOS_ENABLE_OPENMPTARGET)
-  # the following use either Kokkos or tailored reducers
-  # which results in runtime memory errors.
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_B TestStdAlgorithmsTeamFindEnd.cpp TestStdAlgorithmsTeamFindFirstOf.cpp
-       TestStdAlgorithmsTeamSearch.cpp
-  )
-
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_A TestStdAlgorithmsTeamAdjacentFind.cpp
-       TestStdAlgorithmsTeamLexicographicalCompare.cpp TestStdAlgorithmsTeamMismatch.cpp
-  )
-
-  # this causes an illegal memory access if team_members_have_matching_result
-  # is called
-  list(REMOVE_ITEM STDALGO_TEAM_SOURCES_M TestStdAlgorithmsTeamTransformBinaryOp.cpp)
-endif()
 
 foreach(ID A;B;C;D;E)
   kokkos_add_executable_and_test(AlgorithmsUnitTest_StdSet_${ID} SOURCES UnitTestMain.cpp ${STDALGO_SOURCES_${ID}})

--- a/algorithms/unit_tests/TestBinSortA.hpp
+++ b/algorithms/unit_tests/TestBinSortA.hpp
@@ -217,10 +217,6 @@ void test_sort_integer_overflow() {
 }  // namespace BinSortSetA
 
 TEST(TEST_CATEGORY, BinSortGenericTests) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
   using ExecutionSpace = TEST_EXECSPACE;
   using key_type       = unsigned;
   constexpr int N      = 171;

--- a/algorithms/unit_tests/TestBinSortB.hpp
+++ b/algorithms/unit_tests/TestBinSortB.hpp
@@ -178,10 +178,6 @@ void run_for_rank2() {
 }  // namespace BinSortSetB
 
 TEST(TEST_CATEGORY, BinSortUnsignedKeyLayoutStrideValues) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
   using ExeSpace = TEST_EXECSPACE;
   using key_type = unsigned;
   BinSortSetB::run_for_rank1<ExeSpace, key_type, int>();

--- a/algorithms/unit_tests/TestNestedSort.hpp
+++ b/algorithms/unit_tests/TestNestedSort.hpp
@@ -379,11 +379,6 @@ void test_nested_sort_by_key(unsigned int N, KeyType minKey, KeyType maxKey,
 }  // namespace NestedSortImpl
 
 TEST(TEST_CATEGORY, NestedSort) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
-
   using ExecutionSpace = TEST_EXECSPACE;
   NestedSortImpl::test_nested_sort<ExecutionSpace, unsigned>(171, 0U, UINT_MAX);
   NestedSortImpl::test_nested_sort<ExecutionSpace, float>(42, -1e6f, 1e6f);
@@ -392,11 +387,6 @@ TEST(TEST_CATEGORY, NestedSort) {
 }
 
 TEST(TEST_CATEGORY, NestedSortByKey) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
-
   using ExecutionSpace = TEST_EXECSPACE;
 
   // Second/third template arguments are key and value respectively.

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -643,13 +643,6 @@ TEST(TEST_CATEGORY, Random_XorShift1024_0) {
 
 TEST(TEST_CATEGORY, Multi_streams) {
   using ExecutionSpace = TEST_EXECSPACE;
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-  if constexpr (std::is_same_v<ExecutionSpace,
-                               Kokkos::Experimental::OpenMPTarget>) {
-    GTEST_SKIP() << "Libomptarget error";  // FIXME_OPENMPTARGET
-  }
-#endif
-
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
     GTEST_SKIP() << "Failing on NVIDIA GPUs";  // FIXME_SYCL

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -71,17 +71,6 @@ struct RandomProperties {
   }
 };
 
-/*// FIXME_OPENMPTARGET: Need this for OpenMPTarget because contra to the
- * standard*/
-/*// llvm requires the binary operator defined not just the +=*/
-/*KOKKOS_INLINE_FUNCTION*/
-/*RandomProperties operator+(const RandomProperties& org,*/
-/*                           const RandomProperties& add) {*/
-/*  RandomProperties val = org;*/
-/*  val += add;*/
-/*  return val;*/
-/*}*/
-
 template <class GeneratorPool, class Scalar>
 struct test_random_functor {
   using rnd_type = typename GeneratorPool::generator_type;

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -595,11 +595,6 @@ void test_async_initialization(Args... args) {
 }  // namespace AlgoRandomImpl
 
 TEST(TEST_CATEGORY, Random_XorShift64) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
-
   using ExecutionSpace = TEST_EXECSPACE;
 
 #if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_CUDA) || \
@@ -620,10 +615,6 @@ TEST(TEST_CATEGORY, Random_XorShift64) {
 
 TEST(TEST_CATEGORY, Random_XorShift1024_0) {
   using ExecutionSpace = TEST_EXECSPACE;
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
 
 #if defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_CUDA) || \
     defined(KOKKOS_ENABLE_HIP)

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -71,15 +71,16 @@ struct RandomProperties {
   }
 };
 
-// FIXME_OPENMPTARGET: Need this for OpenMPTarget because contra to the standard
-// llvm requires the binary operator defined not just the +=
-KOKKOS_INLINE_FUNCTION
-RandomProperties operator+(const RandomProperties& org,
-                           const RandomProperties& add) {
-  RandomProperties val = org;
-  val += add;
-  return val;
-}
+/*// FIXME_OPENMPTARGET: Need this for OpenMPTarget because contra to the
+ * standard*/
+/*// llvm requires the binary operator defined not just the +=*/
+/*KOKKOS_INLINE_FUNCTION*/
+/*RandomProperties operator+(const RandomProperties& org,*/
+/*                           const RandomProperties& add) {*/
+/*  RandomProperties val = org;*/
+/*  val += add;*/
+/*  return val;*/
+/*}*/
 
 template <class GeneratorPool, class Scalar>
 struct test_random_functor {

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -207,29 +207,18 @@ void test_sort_integer_overflow() {
 }  // namespace SortImpl
 
 TEST(TEST_CATEGORY, SortUnsignedValueType) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
   using ExecutionSpace = TEST_EXECSPACE;
   using key_type       = unsigned;
   constexpr int N      = 171;
 
   SortImpl::test_1D_sort_impl<ExecutionSpace, key_type>(N * N * N);
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-  // FIXME_OPENMPTARGET: OpenMPTarget doesn't support DynamicView yet.
   SortImpl::test_dynamic_view_sort_impl<ExecutionSpace, key_type>(N * N);
-#endif
 
   SortImpl::test_issue_4978_impl<ExecutionSpace>();
 }
 
 TEST(TEST_CATEGORY, SortEmptyView) {
-  // FIXME_OPENMPTARGET - causes runtime failure with CrayClang compiler
-#if defined(KOKKOS_COMPILER_CRAY_LLVM) && defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "known to fail with OpenMPTarget+Cray LLVM";
-#endif
   using ExecutionSpace = TEST_EXECSPACE;
 
   // does not matter if we use int or something else

--- a/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsCompileOnly.cpp
@@ -387,18 +387,14 @@ struct TestStruct {
     TEST_ALGO_MACRO_B1E1(is_sorted_until);
     TEST_ALGO_MACRO_V1(is_sorted_until);
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted_until, TrivialComparator<T>());
     TEST_ALGO_MACRO_V1_VARIAD(is_sorted_until, TrivialComparator<T>());
-#endif
 
     TEST_ALGO_MACRO_B1E1(is_sorted);
     TEST_ALGO_MACRO_V1(is_sorted);
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1_VARIAD(is_sorted, TrivialComparator<T>());
     TEST_ALGO_MACRO_V1_VARIAD(is_sorted, TrivialComparator<T>());
-#endif
   }
 
   void minmax_ops() {
@@ -409,14 +405,12 @@ struct TestStruct {
     TEST_ALGO_MACRO_B1E1(minmax_element);
     TEST_ALGO_MACRO_V1(minmax_element);
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1_VARIAD(min_element, TrivialComparator<T>());
     TEST_ALGO_MACRO_V1_VARIAD(min_element, TrivialComparator<T>());
     TEST_ALGO_MACRO_B1E1_VARIAD(max_element, TrivialComparator<T>());
     TEST_ALGO_MACRO_V1_VARIAD(max_element, TrivialComparator<T>());
     TEST_ALGO_MACRO_B1E1_VARIAD(minmax_element, TrivialComparator<T>());
     TEST_ALGO_MACRO_V1_VARIAD(minmax_element, TrivialComparator<T>());
-#endif
   }
 
   void partitionig_ops() {
@@ -439,7 +433,6 @@ struct TestStruct {
 
     TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{});
     TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{});
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1B2_VARIAD(exclusive_scan, T{},
                                   TrivialBinaryFunctor<T>());
     TEST_ALGO_MACRO_V1V2_VARIAD(exclusive_scan, T{}, TrivialBinaryFunctor<T>());
@@ -450,11 +443,9 @@ struct TestStruct {
     TEST_ALGO_MACRO_V1V2_VARIAD(transform_exclusive_scan, T{},
                                 TrivialBinaryFunctor<T>(),
                                 TrivialUnaryFunctor<T>());
-#endif
 
     TEST_ALGO_MACRO_B1E1B2(inclusive_scan);
     TEST_ALGO_MACRO_V1V2(inclusive_scan);
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
     TEST_ALGO_MACRO_V1V2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>());
     TEST_ALGO_MACRO_B1E1B2_VARIAD(inclusive_scan, TrivialBinaryFunctor<T>(),
@@ -473,9 +464,7 @@ struct TestStruct {
     TEST_ALGO_MACRO_V1V2_VARIAD(transform_inclusive_scan,
                                 TrivialBinaryFunctor<T>(),
                                 TrivialUnaryFunctor<T>(), T{});
-#endif
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
     TEST_ALGO_MACRO_B1E1(reduce);
     TEST_ALGO_MACRO_V1(reduce);
     TEST_ALGO_MACRO_B1E1_VARIAD(reduce, T{});
@@ -498,7 +487,6 @@ struct TestStruct {
     TEST_ALGO_MACRO_V1_VARIAD(transform_reduce, T{},
                               TrivialReduceJoinFunctor<T>(),
                               TrivialTransformReduceUnaryTransformer<T>());
-#endif
   }
 };
 

--- a/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsExclusiveScan.cpp
@@ -292,7 +292,6 @@ void run_exclusive_scan_all_scenarios() {
     run_single_scenario_inplace<Tag, ValueType>(it, ValueType{0});
     run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2});
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
     // custom multiply op is only run for small views otherwise it overflows
     if (it.first == "small-a" || it.first == "small-b") {
       using custom_bop_t = MultiplyFunctor<ValueType>;
@@ -317,7 +316,6 @@ void run_exclusive_scan_all_scenarios() {
                                                 custom_bop_t());
     run_single_scenario_inplace<Tag, ValueType>(it, ValueType{-2},
                                                 custom_bop_t());
-#endif
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsInclusiveScan.cpp
@@ -285,7 +285,6 @@ void run_inclusive_scan_all_scenarios() {
     run_single_scenario<Tag, ValueType>(it);
     run_single_scenario_inplace<Tag, ValueType>(it);
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
     // the sum custom op is always run
     using sum_binary_op = SumFunctor<ValueType>;
     sum_binary_op sbop;
@@ -312,7 +311,6 @@ void run_inclusive_scan_all_scenarios() {
       run_single_scenario_inplace<Tag, ValueType>(it, mbop, ValueType{0});
       run_single_scenario_inplace<Tag, ValueType>(it, mbop, ValueType{-2});
     }
-#endif
   }
 }
 

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSorted.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSorted.cpp
@@ -138,7 +138,6 @@ void run_single_scenario(const InfoType& scenario_info) {
                                 [=](bool v) { return v == gold; });
   EXPECT_TRUE(allA) << name << ", " << view_tag_to_string(Tag{});
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
   std::vector<bool> resultsB(4);
   resultsB[0] =
@@ -150,7 +149,6 @@ void run_single_scenario(const InfoType& scenario_info) {
   const auto allB = std::all_of(resultsB.cbegin(), resultsB.cend(),
                                 [=](bool v) { return v == gold; });
   EXPECT_TRUE(allB) << name << ", " << view_tag_to_string(Tag{});
-#endif
 
   Kokkos::fence();
 }

--- a/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsIsSortedUntil.cpp
@@ -140,7 +140,6 @@ void run_single_scenario(const InfoType& scenario_info) {
   ASSERT_EQ(r3, gold) << name << ", " << view_tag_to_string(Tag{});
   ASSERT_EQ(r4, gold) << name << ", " << view_tag_to_string(Tag{});
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
   CustomLessThanComparator<ValueType, ValueType> comp;
   [[maybe_unused]] auto r5 =
       KE::is_sorted_until(exespace(), KE::cbegin(view), KE::cend(view), comp);
@@ -149,7 +148,6 @@ void run_single_scenario(const InfoType& scenario_info) {
   [[maybe_unused]] auto r7 = KE::is_sorted_until(exespace(), view, comp);
   [[maybe_unused]] auto r8 =
       KE::is_sorted_until("label", exespace(), view, comp);
-#endif
 
   ASSERT_EQ(r1, gold) << name << ", " << view_tag_to_string(Tag{});
   ASSERT_EQ(r2, gold) << name << ", " << view_tag_to_string(Tag{});

--- a/algorithms/unit_tests/TestStdAlgorithmsLexicographicalCompare.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsLexicographicalCompare.cpp
@@ -127,12 +127,9 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_lexicographical_compare_test, test) {
-// FIXME: should this disable only custom comparator tests?
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoTag, int>();
   run_all_scenarios<StridedThreeTag, unsigned>();
-#endif
 }
 
 }  // namespace LexicographicalCompare

--- a/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsMinMaxElementOps.cpp
@@ -297,7 +297,6 @@ void std_algorithms_min_max_element_test::test_minmax_element_non_trivial_data(
   }
 }
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
 template <class ViewType>
 void std_algorithms_min_max_element_test::
     test_max_element_non_trivial_data_custom_comp(ViewType view) {
@@ -378,7 +377,6 @@ void std_algorithms_min_max_element_test::
     }
   }
 }
-#endif
 
 // trivial case
 TEST_F(std_algorithms_min_max_element_test, min_element_empty_range) {
@@ -406,7 +404,6 @@ TEST_F(std_algorithms_min_max_element_test, max_element_non_trivial_data) {
   test_max_element_non_trivial_data(m_strided_view);
 }
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
 // non-trivial data, custom comp
 TEST_F(std_algorithms_min_max_element_test,
        min_element_non_trivial_data_custom_comp) {
@@ -421,9 +418,7 @@ TEST_F(std_algorithms_min_max_element_test,
   test_max_element_non_trivial_data_custom_comp(m_dynamic_view);
   test_max_element_non_trivial_data_custom_comp(m_strided_view);
 }
-#endif
 
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
 TEST_F(std_algorithms_min_max_element_test, minmax_element_empty_range) {
   test_minmax_element_empty_range(m_static_view);
   test_minmax_element_empty_range(m_dynamic_view);
@@ -435,17 +430,13 @@ TEST_F(std_algorithms_min_max_element_test, minmax_element_non_trivial_data) {
   test_minmax_element_non_trivial_data(m_dynamic_view);
   test_minmax_element_non_trivial_data(m_strided_view);
 }
-#endif
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
-// OpenMPTarget does not yet support custom comparator
 TEST_F(std_algorithms_min_max_element_test,
        minmax_element_non_trivial_data_custom_comp) {
   test_minmax_element_non_trivial_data_custom_comp(m_static_view);
   test_minmax_element_non_trivial_data_custom_comp(m_dynamic_view);
   test_minmax_element_non_trivial_data_custom_comp(m_strided_view);
 }
-#endif
 
 }  // namespace stdalgos
 }  // namespace Test

--- a/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsNumerics.cpp
@@ -117,8 +117,6 @@ struct std_algorithms_numerics_test : public ::testing::Test {
   }
 };
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
-
 // -------------------------------------------------------------------
 // test default case of transform_reduce
 //
@@ -582,8 +580,6 @@ TEST_F(std_algorithms_numerics_test,
   run_and_check_reduce_overloadC<exespace>(m_strided_view_cs, gold, init,
                                            joiner_type());
 }
-
-#endif  // not defined KOKKOS_ENABLE_OPENMPTARGET
 
 }  // namespace stdalgos
 }  // namespace Test

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -190,7 +190,6 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
         break;
       }
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
       case 2:
       case 3: {
         auto it = std::exclusive_scan(KE::cbegin(rowFrom), KE::cend(rowFrom),
@@ -200,7 +199,6 @@ void test_A(std::size_t numTeams, std::size_t numCols, int apiId) {
 
         break;
       }
-#endif
       default: Kokkos::abort("unreachable");
     }
   }
@@ -218,11 +216,7 @@ template <class LayoutTag, class ValueType, class InPlaceOrVoid = void>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 8153}) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
-#else
-      for (int apiId : {0, 1}) {
-#endif
         test_A<LayoutTag, ValueType, InPlaceOrVoid>(numTeams, numCols, apiId);
       }
     }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamExclusiveScan.cpp
@@ -72,8 +72,6 @@ struct TestFunctorA {
         break;
       }
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-
       case 2: {
         auto it = KE::exclusive_scan(
             member, KE::cbegin(rowViewSrc), KE::cend(rowViewSrc),
@@ -94,7 +92,6 @@ struct TestFunctorA {
 
         break;
       }
-#endif
     }
 
     // store result of checking if all members have their local

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
@@ -258,10 +258,6 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_inclusive_scan_team_test, test) {
-// FIXME_OPENMPTARGET
-#if defined(KOKKOS_ENABLE_OPENMPTARGET)
-  GTEST_SKIP() << "the test is known to fail with OpenMPTarget";
-#endif
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedTwoRowsTag, int>();
   run_all_scenarios<StridedThreeRowsTag, unsigned>();

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
@@ -38,9 +38,7 @@ struct TestFunctorA {
       result = KE::is_sorted(member, myRowView);
       Kokkos::single(Kokkos::PerTeam(member),
                      [=, *this]() { m_returnsView(myRowIndex) = result; });
-    }
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-    else if (m_apiPick == 2) {
+    } else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       result = KE::is_sorted(member, KE::cbegin(myRowView), KE::cend(myRowView),
                              CustomLessThanComparator<value_type>{});
@@ -53,7 +51,6 @@ struct TestFunctorA {
       Kokkos::single(Kokkos::PerTeam(member),
                      [=, *this]() { m_returnsView(myRowIndex) = result; });
     }
-#endif
 
     // store result of checking if all members have their local
     // values matching the one stored in m_distancesView

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSorted.cpp
@@ -163,11 +163,7 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios(bool makeDataSortedOnPurpose) {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 5153}) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
-#else
-      for (int apiId : {0, 1}) {
-#endif
         test_A<LayoutTag, ValueType>(numTeams, numCols, apiId,
                                      makeDataSortedOnPurpose);
       }

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamIsSortedUntil.cpp
@@ -60,9 +60,7 @@ struct TestFunctorA {
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
         m_distancesView(myRowIndex) = resultDist;
       });
-    }
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-    else if (m_apiPick == 2) {
+    } else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it          = KE::is_sorted_until(member, KE::cbegin(myRowView),
                                              KE::cend(myRowView),
@@ -82,7 +80,6 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#endif
 
     // store result of checking if all members have their local
     // values matching the one stored in m_distancesView
@@ -214,11 +211,7 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios(const std::string& name, const std::vector<int>& cols) {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : cols) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
       for (int apiId : {0, 1, 2, 3}) {
-#else
-      for (int apiId : {0, 1}) {
-#endif
         test_A<LayoutTag, ValueType>(numTeams, numCols, apiId, name);
       }
     }
@@ -243,10 +236,6 @@ TEST(std_algorithms_is_sorted_until_team_test, test_trivialB) {
 }
 
 TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialA) {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET Failing with clang 17
-  GTEST_SKIP() << "Known to fail with OpenMPTarget and clang 17";
-#endif
-
   const std::string name      = "nontrivialUntilLast";
   const std::vector<int> cols = {13, 101, 1444, 5153};
   run_all_scenarios<DynamicTag, double>(name, cols);
@@ -255,10 +244,6 @@ TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialA) {
 }
 
 TEST(std_algorithms_is_sorted_until_team_test, test_nontrivialB) {
-#ifdef KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET Failing with clang 17
-  GTEST_SKIP() << "Known to fail with OpenMPTarget and clang 17";
-#endif
-
   const std::string name      = "nontrivialRandom";
   const std::vector<int> cols = {13, 101, 1444, 5153};
   run_all_scenarios<DynamicTag, double>(name, cols);

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMaxElement.cpp
@@ -45,9 +45,7 @@ struct TestFunctorA {
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
         m_distancesView(myRowIndex) = resultDist;
       });
-    }
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-    else if (m_apiPick == 2) {
+    } else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it =
           KE::max_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
@@ -67,7 +65,6 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#endif
 
     // store result of checking if all members have their local
     // values matching the one stored in m_distancesView
@@ -147,8 +144,6 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 5113}) {
-      // for OpenMPTarget we need to avod api accepting a custom
-      // comparator because it is not supported
       for (int apiId : {0, 1, 2, 3}) {
         test_A<LayoutTag, ValueType>(numTeams, numCols, apiId);
       }
@@ -157,11 +152,9 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_max_element_team_test, test) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();
-#endif
 }
 
 }  // namespace TeamMaxElement

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinElement.cpp
@@ -45,9 +45,7 @@ struct TestFunctorA {
       Kokkos::single(Kokkos::PerTeam(member), [=, *this]() {
         m_distancesView(myRowIndex) = resultDist;
       });
-    }
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-    else if (m_apiPick == 2) {
+    } else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto it =
           KE::min_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
@@ -67,7 +65,6 @@ struct TestFunctorA {
         m_distancesView(myRowIndex) = resultDist;
       });
     }
-#endif
 
     // store result of checking if all members have their local
     // values matching the one stored in m_distancesView
@@ -146,8 +143,6 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 5113}) {
-      // for OpenMPTarget we need to avod api accepting a custom
-      // comparator because it is not supported
       for (int apiId : {0, 1, 2, 3}) {
         test_A<LayoutTag, ValueType>(numTeams, numCols, apiId);
       }
@@ -156,11 +151,9 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_min_element_team_test, test) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();
-#endif
 }
 
 }  // namespace TeamMinElement

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamMinMaxElement.cpp
@@ -52,9 +52,7 @@ struct TestFunctorA {
         m_distancesView(myRowIndex, 0) = resultDist1;
         m_distancesView(myRowIndex, 1) = resultDist2;
       });
-    }
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-    else if (m_apiPick == 2) {
+    } else if (m_apiPick == 2) {
       using value_type = typename ViewType::value_type;
       auto itPair =
           KE::minmax_element(member, KE::cbegin(myRowView), KE::cend(myRowView),
@@ -80,7 +78,6 @@ struct TestFunctorA {
         m_distancesView(myRowIndex, 1) = resultDist2;
       });
     }
-#endif
 
     // store result of checking if all members have their local
     // values matching the one stored in m_distancesView
@@ -165,8 +162,6 @@ template <class LayoutTag, class ValueType>
 void run_all_scenarios() {
   for (int numTeams : teamSizesToTest) {
     for (const auto& numCols : {0, 1, 2, 13, 101, 1444, 5113}) {
-      // for OpenMPTarget we need to avod api accepting a custom
-      // comparator because it is not supported
       for (int apiId : {0, 1, 2, 3}) {
         test_A<LayoutTag, ValueType>(numTeams, numCols, apiId);
       }
@@ -175,11 +170,9 @@ void run_all_scenarios() {
 }
 
 TEST(std_algorithms_minmax_element_team_test, test) {
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedTwoRowsTag, double>();
   run_all_scenarios<StridedThreeRowsTag, int>();
-#endif
 }
 
 }  // namespace TeamMinMaxElement

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamReduce.cpp
@@ -3,8 +3,6 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-
 namespace Test {
 namespace stdalgos {
 namespace TeamReduce {
@@ -243,5 +241,3 @@ TEST(std_algorithms_reduce_team_test, test) {
 }  // namespace TeamReduce
 }  // namespace stdalgos
 }  // namespace Test
-
-#endif

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformExclusiveScan.cpp
@@ -3,8 +3,6 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-
 namespace Test {
 namespace stdalgos {
 namespace TeamTransformExclusiveScan {
@@ -219,5 +217,3 @@ TEST(std_algorithms_transform_exclusive_scan_team_test, test) {
 }  // namespace TeamTransformExclusiveScan
 }  // namespace stdalgos
 }  // namespace Test
-
-#endif

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformInclusiveScan.cpp
@@ -3,8 +3,6 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-
 namespace Test {
 namespace stdalgos {
 namespace TeamTransformInclusiveScan {
@@ -256,5 +254,3 @@ TEST(std_algorithms_transform_inclusive_scan_team_test, test) {
 }  // namespace TeamTransformInclusiveScan
 }  // namespace stdalgos
 }  // namespace Test
-
-#endif

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamTransformReduce.cpp
@@ -3,8 +3,6 @@
 
 #include <TestStdAlgorithmsCommon.hpp>
 
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
-
 namespace Test {
 namespace stdalgos {
 namespace TeamTransformReduce {
@@ -295,5 +293,3 @@ TEST(std_algorithms_transform_reduce_team_test, test) {
 }  // namespace TeamTransformReduce
 }  // namespace stdalgos
 }  // namespace Test
-
-#endif

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformExclusiveScan.cpp
@@ -299,14 +299,12 @@ void run_all_scenarios() {
   }
 }
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET
 TEST(std_algorithms_numeric_ops_test, transform_exclusive_scan) {
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedThreeTag, double>();
   run_all_scenarios<DynamicTag, int>();
   run_all_scenarios<StridedThreeTag, int>();
 }
-#endif
 
 template <class ValueType>
 struct MultiplyFunctor {

--- a/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTransformInclusiveScan.cpp
@@ -298,7 +298,6 @@ void run_all_scenarios() {
   }
 }
 
-#if !defined KOKKOS_ENABLE_OPENMPTARGET  // FIXME_OPENMPTARGET
 TEST(std_algorithms_numeric_ops_test, transform_inclusive_scan) {
   run_all_scenarios<DynamicTag, double>();
   run_all_scenarios<StridedThreeTag, double>();
@@ -373,7 +372,6 @@ TEST(std_algorithms_numeric_ops_test, transform_inclusive_scan_functor) {
     test_lambda(functor);
   }
 }
-#endif
 
 }  // namespace TransformIncScan
 }  // namespace stdalgos

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,12 +1,8 @@
-#FIXME_OPENMPTARGET - compiling in debug mode causes ICE.
 kokkos_add_benchmark_directories(atomic)
 kokkos_add_benchmark_directories(gather)
 kokkos_add_benchmark_directories(gups)
 kokkos_add_benchmark_directories(launch_latency)
 kokkos_add_benchmark_directories(stream)
 kokkos_add_benchmark_directories(view_copy_constructor)
-#FIXME_OPENMPTARGET - These two benchmarks cause ICE. Commenting them for now but a deeper analysis on the cause and a possible fix will follow.
-if(NOT Kokkos_ENABLE_OPENMPTARGET)
-  kokkos_add_benchmark_directories(policy_performance)
-  kokkos_add_benchmark_directories(bytes_and_flops)
-endif()
+kokkos_add_benchmark_directories(policy_performance)
+kokkos_add_benchmark_directories(bytes_and_flops)

--- a/containers/src/Kokkos_ScatterView.hpp
+++ b/containers/src/Kokkos_ScatterView.hpp
@@ -92,23 +92,6 @@ struct DefaultContribution<Kokkos::OpenMP,
 };
 #endif
 
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-template <>
-struct DefaultDuplication<Kokkos::Experimental::OpenMPTarget> {
-  using type = Kokkos::Experimental::ScatterNonDuplicated;
-};
-template <>
-struct DefaultContribution<Kokkos::Experimental::OpenMPTarget,
-                           Kokkos::Experimental::ScatterNonDuplicated> {
-  using type = Kokkos::Experimental::ScatterAtomic;
-};
-template <>
-struct DefaultContribution<Kokkos::Experimental::OpenMPTarget,
-                           Kokkos::Experimental::ScatterDuplicated> {
-  using type = Kokkos::Experimental::ScatterNonAtomic;
-};
-#endif
-
 #ifdef KOKKOS_ENABLE_HPX
 template <>
 struct DefaultDuplication<Kokkos::Experimental::HPX> {

--- a/containers/unit_tests/TestWithoutInitializing.hpp
+++ b/containers/unit_tests/TestWithoutInitializing.hpp
@@ -629,8 +629,6 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_offsetview) {
   ASSERT_TRUE(success);
 }
 
-// FIXME OPENMPTARGET
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
@@ -707,10 +705,7 @@ TEST(TEST_CATEGORY, create_mirror_view_and_copy_dynamicview) {
       });
   ASSERT_TRUE(success);
 }
-#endif
 
-// FIXME OPENMPTARGET
-#ifndef KOKKOS_ENABLE_OPENMPTARGET
 TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview_view_ctor) {
   using namespace Kokkos::Test::Tools;
   listen_tool_events(Config::DisableAll(), Config::EnableKernels());
@@ -756,4 +751,3 @@ TEST(TEST_CATEGORY, create_mirror_no_init_dynamicview_view_ctor) {
       });
   ASSERT_TRUE(success);
 }
-#endif

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -41,7 +41,7 @@ T host_atomic_exchange(T* dest, T value, MemoryOrder, MemoryScope) {
 }
 
 // OpenMP doesn't have compare exchange, so we use built-in functions and rely on
-// testing that this works Note that means we test this in OpenMPTarget offload regions!
+// testing that this works 
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<host_atomic_always_lock_free<T>, T> host_atomic_compare_exchange(
     T* dest, T compare, T value, MemoryOrder, MemoryScope) {

--- a/tpls/desul/include/desul/atomics/Compare_Exchange_OpenMP.hpp
+++ b/tpls/desul/include/desul/atomics/Compare_Exchange_OpenMP.hpp
@@ -41,7 +41,7 @@ T host_atomic_exchange(T* dest, T value, MemoryOrder, MemoryScope) {
 }
 
 // OpenMP doesn't have compare exchange, so we use built-in functions and rely on
-// testing that this works 
+// testing that this works Note that means we test this in OpenMPTarget offload regions!
 template <class T, class MemoryOrder, class MemoryScope>
 std::enable_if_t<host_atomic_always_lock_free<T>, T> host_atomic_compare_exchange(
     T* dest, T compare, T value, MemoryOrder, MemoryScope) {


### PR DESCRIPTION
The PR deletes remaining OpenMPTarget specific code. Mainly from algorithms directory.