### PR TITLE
Replace thrust::distance with cuda::std::distance for Cuda 13.1

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -185,11 +185,7 @@ OutputIteratorType inclusive_scan_default_op_exespace_impl(
 
   Kokkos::Profiling::popRegion();
 
-#if CUDA_VERSION >= 13010
-  const auto num_elements = cuda::std::distance(first_from, last_from);
-#else
   const auto num_elements = thrust::distance(first_from, last_from);
-#endif
 
   return first_dest + num_elements;
 }
@@ -280,11 +276,8 @@ OutputIteratorType inclusive_scan_custom_binary_op_exespace_impl(
                          binary_op);
 
   Kokkos::Profiling::popRegion();
-#if CUDA_VERSION >= 13010
-  const auto num_elements = cuda::std::distance(first_from, last_from);
-#else
+
   const auto num_elements = thrust::distance(first_from, last_from);
-#endif
 
   return first_dest + num_elements;
 }

--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -51,7 +51,11 @@ import kokkos.core;
 #include <thrust/scan.h>
 #pragma pop_macro("_CubLog")
 #else
+#if CUDA_VERSION >= 13010
+#include <cuda/std/iterator>
+#else
 #include <thrust/distance.h>
+#endif
 #include <thrust/scan.h>
 #endif
 
@@ -158,7 +162,11 @@ OutputIteratorType inclusive_scan_default_op_exespace_impl(
 
   Kokkos::Profiling::popRegion();
 
+#if CUDA_VERSION >= 13010
+  const auto num_elements = cuda::std::distance(first_from, last_from);
+#else
   const auto num_elements = thrust::distance(first_from, last_from);
+#endif
 
   return first_dest + num_elements;
 }
@@ -177,7 +185,11 @@ OutputIteratorType inclusive_scan_default_op_exespace_impl(
 
   Kokkos::Profiling::popRegion();
 
+#if CUDA_VERSION >= 13010
+  const auto num_elements = cuda::std::distance(first_from, last_from);
+#else
   const auto num_elements = thrust::distance(first_from, last_from);
+#endif
 
   return first_dest + num_elements;
 }
@@ -244,7 +256,11 @@ OutputIteratorType inclusive_scan_custom_binary_op_exespace_impl(
 
   Kokkos::Profiling::popRegion();
 
+#if CUDA_VERSION >= 13010
+  const auto num_elements = cuda::std::distance(first_from, last_from);
+#else
   const auto num_elements = thrust::distance(first_from, last_from);
+#endif
 
   return first_dest + num_elements;
 }
@@ -264,8 +280,11 @@ OutputIteratorType inclusive_scan_custom_binary_op_exespace_impl(
                          binary_op);
 
   Kokkos::Profiling::popRegion();
-
+#if CUDA_VERSION >= 13010
+  const auto num_elements = cuda::std::distance(first_from, last_from);
+#else
   const auto num_elements = thrust::distance(first_from, last_from);
+#endif
 
   return first_dest + num_elements;
 }


### PR DESCRIPTION
This avoids warnings such as
```
/app/kokkos/algorithms/unit_tests/../src/std_algorithms/impl/Kokkos_InclusiveScan.hpp:161:43: warning: 'constexpr typename cuda::std::__4::iterator_traits< <template-parameter-1-1> >::difference_type thrust::THRUST_300102_SM_800_NS::distance(InputIter, InputIter) [with InputIter = Kokkos::Experimental::Impl::RandomAccessIterator<Kokkos::View<const double*, Kokkos::LayoutLeft, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<0> > >; typename cuda::std::__4::iterator_traits< <template-parameter-1-1> >::difference_type = long int]' is deprecated: Use cuda::std::distance instead [-Wdeprecated-declarations]
  161 |   const auto num_elements = thrust::distance(first_from, last_from);
      |                           ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
/usr/local/cuda-13.1/targets/x86_64-linux/include/cccl/thrust/distance.h:38:1: note: declared here
   38 |   distance(InputIter first, InputIter last)
      | ^ ~~~~~~
```