### PR TITLE
simd: add memory permute functions

### DIFF
--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -54,6 +54,8 @@ export {
   using ::Kokkos::Experimental::basic_simd_mask;
   using ::Kokkos::Experimental::condition;
   using ::Kokkos::Experimental::none_of;
+  using ::Kokkos::Experimental::partial_gather_from;
+  using ::Kokkos::Experimental::partial_scatter_to;
   using ::Kokkos::Experimental::reduce;
   using ::Kokkos::Experimental::reduce_max;
   using ::Kokkos::Experimental::reduce_min;
@@ -62,14 +64,12 @@ export {
   using ::Kokkos::Experimental::simd_flag_aligned;
   using ::Kokkos::Experimental::simd_flag_default;
   using ::Kokkos::Experimental::simd_mask;
-  using ::Kokkos::Experimental::simd_partial_gather_from;
   using ::Kokkos::Experimental::simd_partial_load;
-  using ::Kokkos::Experimental::simd_partial_scatter_to;
   using ::Kokkos::Experimental::simd_partial_store;
-  using ::Kokkos::Experimental::simd_unchecked_gather_from;
   using ::Kokkos::Experimental::simd_unchecked_load;
-  using ::Kokkos::Experimental::simd_unchecked_scatter_to;
   using ::Kokkos::Experimental::simd_unchecked_store;
+  using ::Kokkos::Experimental::unchecked_gather_from;
+  using ::Kokkos::Experimental::unchecked_scatter_to;
 
   using ::Kokkos::Experimental::operator+=;
   using ::Kokkos::Experimental::operator*=;

--- a/simd/src/Kokkos_SIMD.cppm
+++ b/simd/src/Kokkos_SIMD.cppm
@@ -62,9 +62,13 @@ export {
   using ::Kokkos::Experimental::simd_flag_aligned;
   using ::Kokkos::Experimental::simd_flag_default;
   using ::Kokkos::Experimental::simd_mask;
+  using ::Kokkos::Experimental::simd_partial_gather_from;
   using ::Kokkos::Experimental::simd_partial_load;
+  using ::Kokkos::Experimental::simd_partial_scatter_to;
   using ::Kokkos::Experimental::simd_partial_store;
+  using ::Kokkos::Experimental::simd_unchecked_gather_from;
   using ::Kokkos::Experimental::simd_unchecked_load;
+  using ::Kokkos::Experimental::simd_unchecked_scatter_to;
   using ::Kokkos::Experimental::simd_unchecked_store;
 
   using ::Kokkos::Experimental::operator+=;

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -240,8 +240,7 @@ simd_unchecked_load(const T* ptr,
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::NonScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
   return unchecked_gather_from<
@@ -251,8 +250,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::ScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
   return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices,
@@ -262,8 +260,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::NonScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> flag = simd_flag_default) {
@@ -275,8 +272,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::ScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> flag = simd_flag_default) {
@@ -287,8 +283,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::NonScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
   return partial_gather_from<
@@ -298,8 +293,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::ScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
   return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices,
@@ -309,8 +303,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::NonScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> flag = simd_flag_default) {
@@ -322,8 +315,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
 template <std::ranges::contiguous_range R, Impl::simd_integral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
-           Impl::ScalarAbi<
-               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+           Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> flag = simd_flag_default) {

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -10,7 +10,6 @@
 
 #include <climits>
 #include <cstdint>
-#include <ranges>
 
 #if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
 #error "__AVX__ must be defined for KOKKOS_ARCH_AVX"

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -236,6 +236,78 @@ simd_unchecked_load(const T* ptr,
   return simd_unchecked_load<basic_simd<T, simd_abi::scalar>>(ptr, flag);
 }
 
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  auto 
+  unchecked_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return unchecked_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto 
+  unchecked_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  auto 
+  unchecked_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return unchecked_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto 
+  unchecked_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  auto 
+  partial_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return partial_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto 
+  partial_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+  auto 
+  partial_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return partial_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices, flag);
+}
+
+template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto 
+  partial_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
+{
+  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask, indices, flag);
+}
+
 namespace Impl {
 
 template <class... Abis>

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -236,76 +236,98 @@ simd_unchecked_load(const T* ptr,
   return simd_unchecked_load<basic_simd<T, simd_abi::scalar>>(ptr, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  auto 
-  unchecked_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return unchecked_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::NonScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<
+      basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_FORCEINLINE_FUNCTION
-  auto 
-  unchecked_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::ScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices,
+                                                                flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  auto 
-  unchecked_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return unchecked_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::NonScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<
+      basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices,
+                                                           flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_FORCEINLINE_FUNCTION
-  auto 
-  unchecked_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::ScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask,
+                                                                indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  auto 
-  partial_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return partial_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::NonScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+  return partial_gather_from<
+      basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_FORCEINLINE_FUNCTION
-  auto 
-  partial_gather_from(R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::ScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, indices,
+                                                              flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-  auto 
-  partial_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return partial_gather_from<basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::NonScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return partial_gather_from<
+      basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, mask, indices,
+                                                           flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I, typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> && Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
-  KOKKOS_FORCEINLINE_FUNCTION
-  auto 
-  partial_gather_from(R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default)
-{
-  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask, indices, flag);
+template <std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags, typename T = std::ranges::range_value_t<R>>
+  requires std::ranges::sized_range<R> &&
+           Impl::ScalarAbi<
+               simd_abi::Impl::host_fixed_native<std::ranges::range_value_t<R>>>
+KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return partial_gather_from<basic_simd<T, simd_abi::scalar>>(in, mask, indices,
+                                                              flag);
 }
 
 namespace Impl {

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -236,7 +236,7 @@ simd_unchecked_load(const T* ptr,
   return simd_unchecked_load<basic_simd<T, simd_abi::scalar>>(ptr, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -246,7 +246,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -256,7 +256,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                                 flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -268,7 +268,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                            flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -279,7 +279,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                                 indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -289,7 +289,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -299,7 +299,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
                                                               flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
@@ -311,7 +311,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
                                                            flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::simd_integral I,
+template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
           typename... Flags, typename T = std::ranges::range_value_t<R>>
   requires std::ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -10,6 +10,7 @@
 
 #include <climits>
 #include <cstdint>
+#include <ranges>
 
 #if defined(KOKKOS_ARCH_AVX) && !defined(__AVX__)
 #error "__AVX__ must be defined for KOKKOS_ARCH_AVX"

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -3422,7 +3422,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm256_i32gather_pd(in, idx, 8));
+      return V(_mm256_i32gather_pd(std::ranges::data(in), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3433,8 +3433,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
       __m256d mmask =
           static_cast<__m256d>(basic_simd_mask<double, abi_type>{mask});
-      return V(_mm256_mask_i32gather_pd(_mm256_set1_pd(value_type{}), in, idx,
-                                        mmask, 8));
+      return V(_mm256_mask_i32gather_pd(_mm256_set1_pd(value_type{}),
+                                        std::ranges::data(in), idx, mmask, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3471,7 +3471,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm_i32gather_ps(in, idx, 4));
+      return V(_mm_i32gather_ps(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3482,8 +3482,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
       __m128 mmask =
           static_cast<__m128>(basic_simd_mask<float, abi_type>{mask});
-      return V(
-          _mm_mask_i32gather_ps(_mm_set1_ps(value_type{}), in, idx, mmask, 4));
+      return V(_mm_mask_i32gather_ps(_mm_set1_ps(value_type{}),
+                                     std::ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3520,7 +3520,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx2_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_ps(in, idx, 4));
+      return V(_mm256_i32gather_ps(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3531,8 +3531,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd<std::int32_t, abi_type>{indices});
       __m256 mmask =
           static_cast<__m256>(basic_simd_mask<float, abi_type>{mask});
-      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in, idx,
-                                        mmask, 4));
+      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}),
+                                        std::ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3569,7 +3569,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm_i32gather_epi32(in, idx, 4));
+      return V(_mm_i32gather_epi32(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3580,8 +3580,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
       __m128i mmask =
           static_cast<__m128i>(basic_simd_mask<std::int32_t, abi_type>{mask});
-      return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in, idx,
-                                        mmask, 4));
+      return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}),
+                                        std::ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3618,7 +3618,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_epi32(in, idx, 4));
+      return V(_mm256_i32gather_epi32(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3629,8 +3629,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd<std::int32_t, abi_type>{indices});
       __m256i mmask =
           static_cast<__m256i>(basic_simd_mask<std::int32_t, abi_type>{mask});
-      return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
-                                           idx, mmask, 4));
+      return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
+                                           std::ranges::data(in), idx, mmask,
+                                           4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3667,8 +3668,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                      idx, 8));
+      return V(_mm256_i32gather_epi64(
+          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3681,7 +3682,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
       return V(_mm256_mask_i32gather_epi64(
           _mm256_set1_epi64x(value_type{}),
-          reinterpret_cast<long long const*>(in), idx, mmask, 8));
+          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, mmask,
+          8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3718,8 +3720,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint64_t, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                      idx, 8));
+      return V(_mm256_i32gather_epi64(
+          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3732,7 +3734,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
       return V(_mm256_mask_i32gather_epi64(
           _mm256_set1_epi64x(value_type{}),
-          reinterpret_cast<long long const*>(in), idx, mmask, 8));
+          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, mmask,
+          8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -9,6 +9,7 @@
 
 #include <Kokkos_SIMD_Common.hpp>
 #include <Kokkos_BitManipulation.hpp>  // bit_cast
+#include "impl/Kokkos_SIMD_Impl_Macros.hpp"
 
 #include <immintrin.h>
 
@@ -1150,108 +1151,69 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256d>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::avx2_fixed_size<4>, {
   __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
   __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-
   __m128i rindices =
       _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
                     _mm_cvtsi128_si32(upper),
                     _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
                     _mm_cvtsi128_si32(lower));
-
   return V(_mm256_i32gather_pd(in, rindices, 8));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(_mm256_mask_i32gather_pd(
+          _mm256_set1_pd(value_type{}), in, rindices,
+          _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
+    })
 
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
-
-  return V(_mm256_mask_i32gather_pd(
-      _mm256_set1_pd(value_type{}), in, rindices,
-      _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
-}
-
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::avx2_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
+                                             simd_abi::avx2_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::avx2_fixed_size<4>, {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(double,
+                                              simd_abi::avx2_fixed_size<4>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::avx2_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
+                                            simd_abi::avx2_fixed_size<4>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
@@ -1637,90 +1599,53 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                    static_cast<__m128>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx2_fixed_size<4>, {
   return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm_mask_i32gather_ps(
-      _mm_set1_ps(value_type{}), in, static_cast<__m128i>(indices),
-      _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      return V(_mm_mask_i32gather_ps(
+          _mm_set1_ps(value_type{}), in, static_cast<__m128i>(indices),
+          _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx2_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::avx2_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx2_fixed_size<4>, {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
+                                              simd_abi::avx2_fixed_size<4>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx2_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::avx2_fixed_size<4>,
+                                            {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
@@ -2114,90 +2039,53 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx2_fixed_size<8>, {
   return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm256_mask_i32gather_ps(
-      _mm256_set1_ps(value_type{}), in, static_cast<__m256i>(indices),
-      _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm256_mask_i32gather_ps(
+          _mm256_set1_ps(value_type{}), in, static_cast<__m256i>(indices),
+          _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx2_fixed_size<8>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::avx2_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx2_fixed_size<8>, {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
+                                              simd_abi::avx2_fixed_size<8>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx2_fixed_size<8>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::avx2_fixed_size<8>,
+                                            {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
@@ -2543,98 +2431,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m128i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4)); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in,
-                                    static_cast<__m128i>(indices),
-                                    static_cast<__m128i>(mask), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in,
+                                        static_cast<__m128i>(indices),
+                                        static_cast<__m128i>(mask), 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx2_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::avx2_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<4>,
+                                    {
+                                      for (Impl::simd_size_t lane = 0;
+                                           lane < v.size(); ++lane) {
+                                        out[indices[lane]] = v[lane];
+                                      }
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
+                                              simd_abi::avx2_fixed_size<4>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::avx2_fixed_size<4>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -2982,98 +2827,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
-                                       static_cast<__m256i>(indices),
-                                       static_cast<__m256i>(mask), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
+                                           static_cast<__m256i>(indices),
+                                           static_cast<__m256i>(mask), 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx2_fixed_size<8>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::avx2_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<8>,
+                                    {
+                                      for (Impl::simd_size_t lane = 0;
+                                           lane < v.size(); ++lane) {
+                                        out[indices[lane]] = v[lane];
+                                      }
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
+                                              simd_abi::avx2_fixed_size<8>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<8>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::avx2_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
@@ -3442,116 +3244,76 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                      rindices, 8));
+    })
 
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(
+          _mm256_mask_i32gather_epi64(_mm256_set1_epi64x(value_type{}),
+                                      reinterpret_cast<long long const*>(in),
+                                      rindices, static_cast<__m256i>(mask), 8));
+    })
 
-  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                  rindices, 8));
-}
-
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
-  return V(_mm256_mask_i32gather_epi64(
-      _mm256_set1_epi64x(value_type{}), reinterpret_cast<long long const*>(in),
-      rindices, static_cast<__m256i>(mask), 8));
-}
-
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::avx2_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
+                                             simd_abi::avx2_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int64_t, simd_abi::avx2_fixed_size<4>,
+                                    {
+                                      for (Impl::simd_size_t lane = 0;
+                                           lane < v.size(); ++lane) {
+                                        out[indices[lane]] = v[lane];
+                                      }
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int64_t,
+                                              simd_abi::avx2_fixed_size<4>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::avx2_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
+                                            simd_abi::avx2_fixed_size<4>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -3916,115 +3678,78 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                      rindices, 8));
+    })
 
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
-  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                  rindices, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(
+          _mm256_mask_i32gather_epi64(_mm256_set1_epi64x(value_type{}),
+                                      reinterpret_cast<long long const*>(in),
+                                      rindices, static_cast<__m256i>(mask), 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t, simd_abi::avx2_fixed_size<4>,
+                                   {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
-  return V(_mm256_mask_i32gather_epi64(
-      _mm256_set1_epi64x(value_type{}), reinterpret_cast<long long const*>(in),
-      rindices, static_cast<__m256i>(mask), 8));
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
+                                             simd_abi::avx2_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint64_t, simd_abi::avx2_fixed_size<4>,
+                                    {
+                                      for (Impl::simd_size_t lane = 0;
+                                           lane < v.size(); ++lane) {
+                                        out[indices[lane]] = v[lane];
+                                      }
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::uint64_t,
+                                              simd_abi::avx2_fixed_size<4>, {
+                                                for (Impl::simd_size_t lane = 0;
+                                                     lane < v.size(); ++lane) {
+                                                  if (mask[lane])
+                                                    out[indices[lane]] =
+                                                        v[lane];
+                                                }
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-}
-
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    if (mask[lane]) out[indices[lane]] = v[lane];
-  }
-}
-
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::avx2_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
+                                            simd_abi::avx2_fixed_size<4>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -9,7 +9,6 @@
 
 #include <Kokkos_SIMD_Common.hpp>
 #include <Kokkos_BitManipulation.hpp>  // bit_cast
-#include "impl/Kokkos_SIMD_Impl_Macros.hpp"
 
 #include <immintrin.h>
 
@@ -1151,18 +1150,21 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256d>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::avx2_fixed_size<4>, {
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-  __m128i rindices =
-      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                    _mm_cvtsi128_si32(upper),
-                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                    _mm_cvtsi128_si32(lower));
-  return V(_mm256_i32gather_pd(in, rindices, 8));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::avx2_fixed_size<4>, {
+      __m128i lower =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+      __m128i upper =
+          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+      __m128i rindices =
+          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                        _mm_cvtsi128_si32(upper),
+                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                        _mm_cvtsi128_si32(lower));
+      return V(_mm256_i32gather_pd(in, rindices, 8));
+    })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     double, simd_abi::avx2_fixed_size<4>, {
       using value_type = typename V::value_type;
       __m128i lower =
@@ -1179,41 +1181,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::avx2_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
-                                             simd_abi::avx2_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::avx2_fixed_size<4>, {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(double,
-                                              simd_abi::avx2_fixed_size<4>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::avx2_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
-                                            simd_abi::avx2_fixed_size<4>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
@@ -1599,11 +1595,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                    static_cast<__m128>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx2_fixed_size<4>, {
-  return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<4>,
+    { return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::avx2_fixed_size<4>, {
       using value_type = typename V::value_type;
       return V(_mm_mask_i32gather_ps(
@@ -1611,41 +1607,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx2_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::avx2_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx2_fixed_size<4>, {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
-                                              simd_abi::avx2_fixed_size<4>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx2_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::avx2_fixed_size<4>,
-                                            {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
@@ -2039,11 +2029,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx2_fixed_size<8>, {
-  return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<8>,
+    { return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::avx2_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm256_mask_i32gather_ps(
@@ -2051,41 +2041,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx2_fixed_size<8>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::avx2_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx2_fixed_size<8>, {
-  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-    out[indices[lane]] = v[lane];
-  }
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
-                                              simd_abi::avx2_fixed_size<8>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx2_fixed_size<8>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::avx2_fixed_size<8>,
-                                            {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
@@ -2431,11 +2415,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m128i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<4>,
     { return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::avx2_fixed_size<4>, {
       using value_type = typename V::value_type;
       return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in,
@@ -2443,43 +2427,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                         static_cast<__m128i>(mask), 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx2_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::avx2_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<4>,
-                                    {
-                                      for (Impl::simd_size_t lane = 0;
-                                           lane < v.size(); ++lane) {
-                                        out[indices[lane]] = v[lane];
-                                      }
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
-                                              simd_abi::avx2_fixed_size<4>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::avx2_fixed_size<4>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -2827,11 +2803,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<8>,
     { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::avx2_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
@@ -2839,43 +2815,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                            static_cast<__m256i>(mask), 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx2_fixed_size<8>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::avx2_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<8>,
-                                    {
-                                      for (Impl::simd_size_t lane = 0;
-                                           lane < v.size(); ++lane) {
-                                        out[indices[lane]] = v[lane];
-                                      }
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
-                                              simd_abi::avx2_fixed_size<8>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx2_fixed_size<8>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::avx2_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
@@ -3244,7 +3212,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::avx2_fixed_size<4>, {
       __m128i lower =
           _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
@@ -3259,7 +3227,7 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
                                       rindices, 8));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::avx2_fixed_size<4>, {
       using value_type = typename V::value_type;
       __m128i lower =
@@ -3277,43 +3245,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                       rindices, static_cast<__m256i>(mask), 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::avx2_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
-                                             simd_abi::avx2_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int64_t, simd_abi::avx2_fixed_size<4>,
-                                    {
-                                      for (Impl::simd_size_t lane = 0;
-                                           lane < v.size(); ++lane) {
-                                        out[indices[lane]] = v[lane];
-                                      }
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int64_t,
-                                              simd_abi::avx2_fixed_size<4>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::avx2_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
-                                            simd_abi::avx2_fixed_size<4>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -3678,7 +3638,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint64_t, simd_abi::avx2_fixed_size<4>, {
       __m128i lower =
           _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
@@ -3693,7 +3653,7 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
                                       rindices, 8));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint64_t, simd_abi::avx2_fixed_size<4>, {
       using value_type = typename V::value_type;
       __m128i lower =
@@ -3711,45 +3671,35 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                       rindices, static_cast<__m256i>(mask), 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t, simd_abi::avx2_fixed_size<4>,
-                                   {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
-                                             simd_abi::avx2_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint64_t, simd_abi::avx2_fixed_size<4>,
-                                    {
-                                      for (Impl::simd_size_t lane = 0;
-                                           lane < v.size(); ++lane) {
-                                        out[indices[lane]] = v[lane];
-                                      }
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::uint64_t,
-                                              simd_abi::avx2_fixed_size<4>, {
-                                                for (Impl::simd_size_t lane = 0;
-                                                     lane < v.size(); ++lane) {
-                                                  if (mask[lane])
-                                                    out[indices[lane]] =
-                                                        v[lane];
-                                                }
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::avx2_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
-                                            simd_abi::avx2_fixed_size<4>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1150,6 +1150,113 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256d>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+
+  return V(_mm256_i32gather_pd(in, rindices, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+      using value_type = typename V::value_type;
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+
+    return V(_mm256_mask_i32gather_pd(
+        __m256d{value_type{}}, in, rindices,
+        _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
     basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
@@ -1532,6 +1639,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm_mask_i32gather_ps(
+        __m128{value_type{}}, in, static_cast<__m128i>(indices),
+        _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1926,6 +2120,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm256_mask_i32gather_ps(
+        __m256{value_type{}}, in, static_cast<__m256i>(indices),
+        _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
     basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
@@ -2268,6 +2549,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm_mask_i32gather_epi32(
+        __m128i{value_type{}}, in, static_cast<__m128i>(indices),
+        static_cast<__m128i>(mask), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2614,6 +2982,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm256_mask_i32gather_epi32(
+        __m256i{value_type{}}, in, static_cast<__m256i>(indices),
+        static_cast<__m256i>(mask), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2983,6 +3438,112 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+
+  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in), rindices, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+    return V(_mm256_mask_i32gather_epi64(
+        __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
+        static_cast<__m256i>(mask), 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
     basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
@@ -3344,6 +3905,111 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in), rindices, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+
+  __m128i rindices = _mm_set_epi32(
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+      _mm_cvtsi128_si32(upper),
+      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+      _mm_cvtsi128_si32(lower)
+  );
+    return V(_mm256_mask_i32gather_epi64(
+        __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
+        static_cast<__m256i>(mask), 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+    if (mask[lane]) out[indices[lane]] = v[lane];
+  }
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1150,110 +1150,106 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256d>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
   __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
 
   return V(_mm256_i32gather_pd(in, rindices, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-      using value_type = typename V::value_type;
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
 
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
-
-    return V(_mm256_mask_i32gather_pd(
-        __m256d{value_type{}}, in, rindices,
-        _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
+  return V(_mm256_mask_i32gather_pd(
+      __m256d{value_type{}}, in, rindices,
+      _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1641,90 +1637,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                    static_cast<__m128>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm_mask_i32gather_ps(
-        __m128{value_type{}}, in, static_cast<__m128i>(indices),
-        _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm_mask_i32gather_ps(
+      __m128{value_type{}}, in, static_cast<__m128i>(indices),
+      _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2120,90 +2114,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm256_mask_i32gather_ps(
-        __m256{value_type{}}, in, static_cast<__m256i>(indices),
-        _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm256_mask_i32gather_ps(
+      __m256{value_type{}}, in, static_cast<__m256i>(indices),
+      _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2551,90 +2543,96 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m128i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm_mask_i32gather_epi32(
-        __m128i{value_type{}}, in, static_cast<__m128i>(indices),
-        static_cast<__m128i>(mask), 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm_mask_i32gather_epi32(__m128i{value_type{}}, in,
+                                    static_cast<__m128i>(indices),
+                                    static_cast<__m128i>(mask), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2984,90 +2982,96 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm256_mask_i32gather_epi32(
-        __m256i{value_type{}}, in, static_cast<__m256i>(indices),
-        static_cast<__m256i>(mask), 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm256_mask_i32gather_epi32(__m256i{value_type{}}, in,
+                                       static_cast<__m256i>(indices),
+                                       static_cast<__m256i>(mask), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3438,109 +3442,114 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
   __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
 
-  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in), rindices, 8));
+  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                  rindices, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-    using value_type = typename V::value_type;
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
-    return V(_mm256_mask_i32gather_epi64(
-        __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
-        static_cast<__m256i>(mask), 8));
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
+  return V(_mm256_mask_i32gather_epi64(
+      __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
+      static_cast<__m256i>(mask), 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3907,108 +3916,113 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
   __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
-  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in), rindices, 8));
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
+  return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                  rindices, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  __m128i lower    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
+  __m128i upper    = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
 
-    using value_type = typename V::value_type;
-  __m128i lower = _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-  __m128i upper = _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-
-  __m128i rindices = _mm_set_epi32(
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-      _mm_cvtsi128_si32(upper),
-      _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-      _mm_cvtsi128_si32(lower)
-  );
-    return V(_mm256_mask_i32gather_epi64(
-        __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
-        static_cast<__m256i>(mask), 8));
+  __m128i rindices =
+      _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
+                    _mm_cvtsi128_si32(upper),
+                    _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
+                    _mm_cvtsi128_si32(lower));
+  return V(_mm256_mask_i32gather_epi64(
+      __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
+      static_cast<__m256i>(mask), 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
     if (mask[lane]) out[indices[lane]] = v[lane];
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1150,67 +1150,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256d>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    double, simd_abi::avx2_fixed_size<4>, {
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(_mm256_i32gather_pd(in, rindices, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    double, simd_abi::avx2_fixed_size<4>, {
-      using value_type = typename V::value_type;
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(_mm256_mask_i32gather_pd(
-          _mm256_set1_pd(value_type{}), in, rindices,
-          _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    double, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    double, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    double, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    double, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    double, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    double, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
     basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
@@ -1594,48 +1533,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    float, simd_abi::avx2_fixed_size<4>,
-    { return V(_mm_i32gather_ps(in, static_cast<__m128i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<4>, {
-      using value_type = typename V::value_type;
-      return V(_mm_mask_i32gather_ps(
-          _mm_set1_ps(value_type{}), in, static_cast<__m128i>(indices),
-          _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    float, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    float, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    float, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
@@ -2029,48 +1926,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                       static_cast<__m256>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    float, simd_abi::avx2_fixed_size<8>,
-    { return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm256_mask_i32gather_ps(
-          _mm256_set1_ps(value_type{}), in, static_cast<__m256i>(indices),
-          _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    float, simd_abi::avx2_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    float, simd_abi::avx2_fixed_size<8>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<8>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    float, simd_abi::avx2_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx2_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
     basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
@@ -2414,48 +2269,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::avx2_fixed_size<4>,
-    { return V(_mm_i32gather_epi32(in, static_cast<__m128i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<4>, {
-      using value_type = typename V::value_type;
-      return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in,
-                                        static_cast<__m128i>(indices),
-                                        static_cast<__m128i>(mask), 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int32_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int32_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int32_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
@@ -2802,48 +2615,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::avx2_fixed_size<8>,
-    { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
-                                           static_cast<__m256i>(indices),
-                                           static_cast<__m256i>(mask), 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int32_t, simd_abi::avx2_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int32_t, simd_abi::avx2_fixed_size<8>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<8>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int32_t, simd_abi::avx2_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx2_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
@@ -3212,69 +2983,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int64_t, simd_abi::avx2_fixed_size<4>, {
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                      rindices, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::avx2_fixed_size<4>, {
-      using value_type = typename V::value_type;
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(
-          _mm256_mask_i32gather_epi64(_mm256_set1_epi64x(value_type{}),
-                                      reinterpret_cast<long long const*>(in),
-                                      rindices, static_cast<__m256i>(mask), 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int64_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int64_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int64_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
     basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
@@ -3638,69 +3346,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                          static_cast<__m256i>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
-                                      rindices, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
-      using value_type = typename V::value_type;
-      __m128i lower =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 0);
-      __m128i upper =
-          _mm256_extracti128_si256(static_cast<__m256i>(indices), 1);
-      __m128i rindices =
-          _mm_set_epi32(_mm_cvtsi128_si32(_mm_unpackhi_epi64(upper, upper)),
-                        _mm_cvtsi128_si32(upper),
-                        _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
-                        _mm_cvtsi128_si32(lower));
-      return V(
-          _mm256_mask_i32gather_epi64(_mm256_set1_epi64x(value_type{}),
-                                      reinterpret_cast<long long const*>(in),
-                                      rindices, static_cast<__m256i>(mask), 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
-      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
-        if (mask[lane]) out[indices[lane]] = v[lane];
-      }
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx2_fixed_size<4>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
     basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
@@ -3772,6 +3417,353 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int64_t, abi_type> const& other) noexcept
     : m_value(static_cast<__m256i>(other)) {}
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::avx2_fixed_size<4>, {
+      __m128i idx = static_cast<__m128i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
+      return V(_mm256_i32gather_pd(in, idx, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m128i idx =
+          static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m256d mmask =
+          static_cast<__m256d>(basic_simd_mask<double, abi_type>{mask});
+      return V(_mm256_mask_i32gather_pd(_mm256_set1_pd(value_type{}), in, idx,
+                                        mmask, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<4>, {
+      __m128i idx = static_cast<__m128i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
+      return V(_mm_i32gather_ps(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m128i idx =
+          static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m128 mmask =
+          static_cast<__m128>(basic_simd_mask<float, abi_type>{mask});
+      return V(
+          _mm_mask_i32gather_ps(_mm_set1_ps(value_type{}), in, idx, mmask, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
+      return V(_mm256_i32gather_ps(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m256i idx =
+          static_cast<__m256i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m256 mmask =
+          static_cast<__m256>(basic_simd_mask<float, abi_type>{mask});
+      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in, idx,
+                                        mmask, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      __m128i idx = static_cast<__m128i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
+      return V(_mm_i32gather_epi32(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m128i idx =
+          static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m128i mmask =
+          static_cast<__m128i>(basic_simd_mask<std::int32_t, abi_type>{mask});
+      return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in, idx,
+                                        mmask, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
+      return V(_mm256_i32gather_epi32(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m256i idx =
+          static_cast<__m256i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m256i mmask =
+          static_cast<__m256i>(basic_simd_mask<std::int32_t, abi_type>{mask});
+      return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
+                                           idx, mmask, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx2_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      __m128i idx = static_cast<__m128i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
+      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                      idx, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m128i idx =
+          static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m256i mmask =
+          static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
+      return V(_mm256_mask_i32gather_epi64(
+          _mm256_set1_epi64x(value_type{}),
+          reinterpret_cast<long long const*>(in), idx, mmask, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      __m128i idx = static_cast<__m128i>(
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
+      return V(_mm256_i32gather_epi64(reinterpret_cast<long long const*>(in),
+                                      idx, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      using value_type = typename V::value_type;
+      using abi_type   = typename V::abi_type;
+      __m128i idx =
+          static_cast<__m128i>(basic_simd<std::int32_t, abi_type>{indices});
+      __m256i mmask =
+          static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
+      return V(_mm256_mask_i32gather_epi64(
+          _mm256_set1_epi64x(value_type{}),
+          reinterpret_cast<long long const*>(in), idx, mmask, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      for (Impl::simd_size_t lane = 0; lane < v.size(); ++lane) {
+        if (mask[lane]) out[indices[lane]] = v[lane];
+      }
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx2_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1186,7 +1186,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
                     _mm_cvtsi128_si32(lower));
 
   return V(_mm256_mask_i32gather_pd(
-      __m256d{value_type{}}, in, rindices,
+      _mm256_set1_pd(value_type{}), in, rindices,
       _mm256_castsi256_pd(static_cast<__m256i>(mask)), 8));
 }
 
@@ -1655,7 +1655,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
   return V(_mm_mask_i32gather_ps(
-      __m128{value_type{}}, in, static_cast<__m128i>(indices),
+      _mm_set1_ps(value_type{}), in, static_cast<__m128i>(indices),
       _mm256_cvtpd_ps(_mm256_cvtepi32_pd(static_cast<__m128i>(mask))), 4));
 }
 
@@ -2132,7 +2132,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
   return V(_mm256_mask_i32gather_ps(
-      __m256{value_type{}}, in, static_cast<__m256i>(indices),
+      _mm256_set1_ps(value_type{}), in, static_cast<__m256i>(indices),
       _mm256_castsi256_ps(static_cast<__m256i>(mask)), 4));
 }
 
@@ -2562,7 +2562,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm_mask_i32gather_epi32(__m128i{value_type{}}, in,
+  return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}), in,
                                     static_cast<__m128i>(indices),
                                     static_cast<__m128i>(mask), 4));
 }
@@ -3001,7 +3001,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm256_mask_i32gather_epi32(__m256i{value_type{}}, in,
+  return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}), in,
                                        static_cast<__m256i>(indices),
                                        static_cast<__m256i>(mask), 4));
 }
@@ -3480,8 +3480,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
                     _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
                     _mm_cvtsi128_si32(lower));
   return V(_mm256_mask_i32gather_epi64(
-      __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
-      static_cast<__m256i>(mask), 8));
+      _mm256_set1_epi64x(value_type{}), reinterpret_cast<long long const*>(in),
+      rindices, static_cast<__m256i>(mask), 8));
 }
 
 template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
@@ -3953,8 +3953,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
                     _mm_cvtsi128_si32(_mm_unpackhi_epi64(lower, lower)),
                     _mm_cvtsi128_si32(lower));
   return V(_mm256_mask_i32gather_epi64(
-      __m256i{value_type{}}, reinterpret_cast<long long const*>(in), rindices,
-      static_cast<__m256i>(mask), 8));
+      _mm256_set1_epi64x(value_type{}), reinterpret_cast<long long const*>(in),
+      rindices, static_cast<__m256i>(mask), 8));
 }
 
 template <Impl::simd_vec_type V, std::ranges::contiguous_range R,

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -700,92 +700,52 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512d>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::avx512_fixed_size<8>, {
   return V(_mm512_i32gather_pd(
       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_pd(
-      _mm512_set1_pd(value_type{}), static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_pd(
+          _mm512_set1_pd(value_type{}), static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::avx512_fixed_size<8>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::avx512_fixed_size<8>, {
   _mm512_i32scatter_pd(out,
                        _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
                        static_cast<__m512d>(v), 8);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_pd(
-      out, static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-      static_cast<__m512d>(v), 8);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>, {
+      _mm512_mask_i32scatter_pd(
+          out, static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+          static_cast<__m512d>(v), 8);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::avx512_fixed_size<8>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
@@ -1185,90 +1145,50 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m256>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx512_fixed_size<8>, {
   return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
-  __m256 m         = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
-  return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in,
-                                    static_cast<__m256i>(indices), m, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
+      __m256 m         = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
+      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in,
+                                        static_cast<__m256i>(indices), m, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx512_fixed_size<8>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx512_fixed_size<8>, {
   _mm256_i32scatter_ps(out, static_cast<__m256i>(indices),
                        static_cast<__m256>(v), 4);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
-                            static_cast<__m256i>(indices),
-                            static_cast<__m256>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>, {
+      _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
+                                static_cast<__m256i>(indices),
+                                static_cast<__m256>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx512_fixed_size<8>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<8>> condition(
@@ -1670,89 +1590,49 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx512_fixed_size<16>, {
   return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4));
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
-                                    static_cast<__mmask16>(mask),
-                                    static_cast<__m512i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
+                                        static_cast<__mmask16>(mask),
+                                        static_cast<__m512i>(indices), in, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx512_fixed_size<16>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::avx512_fixed_size<16>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx512_fixed_size<16>, {
   _mm512_i32scatter_ps(out, static_cast<__m512i>(indices),
                        static_cast<__m512>(v), 4);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
-                            static_cast<__m512i>(indices),
-                            static_cast<__m512>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>, {
+      _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
+                                static_cast<__m512i>(indices),
+                                static_cast<__m512>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx512_fixed_size<16>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float,
+                                            simd_abi::avx512_fixed_size<16>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
@@ -2128,97 +2008,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
-                                        static_cast<__mmask8>(mask),
-                                        static_cast<__m256i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm256_mmask_i32gather_epi32(
+          _mm256_set1_epi32(value_type{}), static_cast<__mmask8>(mask),
+          static_cast<__m256i>(indices), in, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx512_fixed_size<8>,
+                                   {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
-                          static_cast<__m256i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t,
+                                    simd_abi::avx512_fixed_size<8>, {
+                                      _mm256_i32scatter_epi32(
+                                          out, static_cast<__m256i>(indices),
+                                          static_cast<__m256i>(v), 4);
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                               static_cast<__m256i>(indices),
-                               static_cast<__m256i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                                   static_cast<__m256i>(indices),
+                                   static_cast<__m256i>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx512_fixed_size<8>,
+                                  {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -2600,97 +2438,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
-                                       static_cast<__mmask16>(mask),
-                                       static_cast<__m512i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_epi32(
+          _mm512_set1_epi32(value_type{}), static_cast<__mmask16>(mask),
+          static_cast<__m512i>(indices), in, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t,
+                                   simd_abi::avx512_fixed_size<16>, {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::avx512_fixed_size<16>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
-                          static_cast<__m512i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t,
+                                    simd_abi::avx512_fixed_size<16>, {
+                                      _mm512_i32scatter_epi32(
+                                          out, static_cast<__m512i>(indices),
+                                          static_cast<__m512i>(v), 4);
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                               static_cast<__m512i>(indices),
-                               static_cast<__m512i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                                   static_cast<__m512i>(indices),
+                                   static_cast<__m512i>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx512_fixed_size<16>,
+                                  {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::avx512_fixed_size<16>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
@@ -3061,98 +2857,58 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in),
-                                  static_cast<__m256i>(indices), 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::uint32_t,
+                                     simd_abi::avx512_fixed_size<8>, {
+                                       return V(_mm256_i32gather_epi32(
+                                           reinterpret_cast<const int*>(in),
+                                           static_cast<__m256i>(indices), 4));
+                                     })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
-                                        static_cast<__mmask8>(mask),
-                                        static_cast<__m256i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm256_mmask_i32gather_epi32(
+          _mm256_set1_epi32(value_type{}), static_cast<__mmask8>(mask),
+          static_cast<__m256i>(indices), in, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint32_t,
+                                   simd_abi::avx512_fixed_size<8>, {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint32_t,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
-                          static_cast<__m256i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint32_t,
+                                    simd_abi::avx512_fixed_size<8>, {
+                                      _mm256_i32scatter_epi32(
+                                          out, static_cast<__m256i>(indices),
+                                          static_cast<__m256i>(v), 4);
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                               static_cast<__m256i>(indices),
-                               static_cast<__m256i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                                   static_cast<__m256i>(indices),
+                                   static_cast<__m256i>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint32_t, simd_abi::avx512_fixed_size<8>,
+                                  {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint32_t,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -3534,97 +3290,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
-                                       static_cast<__mmask16>(mask),
-                                       static_cast<__m512i>(indices), in, 4));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_epi32(
+          _mm512_set1_epi32(value_type{}), static_cast<__mmask16>(mask),
+          static_cast<__m512i>(indices), in, 4));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint32_t,
+                                   simd_abi::avx512_fixed_size<16>, {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint32_t,
+                                             simd_abi::avx512_fixed_size<16>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
-                          static_cast<__m512i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint32_t,
+                                    simd_abi::avx512_fixed_size<16>, {
+                                      _mm512_i32scatter_epi32(
+                                          out, static_cast<__m512i>(indices),
+                                          static_cast<__m512i>(v), 4);
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                               static_cast<__m512i>(indices),
-                               static_cast<__m512i>(v), 4);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                                   static_cast<__m512i>(indices),
+                                   static_cast<__m512i>(v), 4);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint32_t,
+                                  simd_abi::avx512_fixed_size<16>, {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint32_t,
+                                            simd_abi::avx512_fixed_size<16>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
@@ -3991,100 +3705,58 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm512_i32gather_epi64(
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      return V(_mm512_i32gather_epi64(
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi64(
-      _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_epi64(
+          _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::avx512_fixed_size<8>,
+                                   {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_i32scatter_epi64(out,
-                          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                          static_cast<__m512i>(v), 8);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      _mm512_i32scatter_epi64(
+          out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+          static_cast<__m512i>(v), 8);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_epi64(
-      out, static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-      static_cast<__m512i>(v), 8);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      _mm512_mask_i32scatter_epi64(
+          out, static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+          static_cast<__m512i>(v), 8);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::avx512_fixed_size<8>,
+                                  {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -4443,100 +4115,58 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(_mm512_i32gather_epi64(
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      return V(_mm512_i32gather_epi64(
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi64(
-      _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      return V(_mm512_mask_i32gather_epi64(
+          _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t,
+                                   simd_abi::avx512_fixed_size<8>, {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
+                                             simd_abi::avx512_fixed_size<8>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_i32scatter_epi64(out,
-                          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                          static_cast<__m512i>(v), 8);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      _mm512_i32scatter_epi64(
+          out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+          static_cast<__m512i>(v), 8);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  _mm512_mask_i32scatter_epi64(
-      out, static_cast<__mmask8>(mask),
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-      static_cast<__m512i>(v), 8);
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      _mm512_mask_i32scatter_epi64(
+          out, static_cast<__mmask8>(mask),
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+          static_cast<__m512i>(v), 8);
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::avx512_fixed_size<8>,
+                                  {
+                                    unchecked_scatter_to<V>(v, out, indices,
+                                                            flag);
+                                  })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
+                                            simd_abi::avx512_fixed_size<8>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -700,6 +700,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512d>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_pd(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_pd(
+        __m512d{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_pd(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512d>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_pd(out, static_cast<__mmask8>(mask),
+                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                              static_cast<__m512d>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
@@ -1096,6 +1180,92 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m256>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    __m256 on   = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
+    __m256 m = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
+    return V(_mm256_mask_i32gather_ps(
+        __m256{value_type{}}, in, static_cast<__m256i>(indices), m, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_i32scatter_ps(out, static_cast<__m256i>(indices), static_cast<__m256>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
+                              static_cast<__m256i>(indices),
+                              static_cast<__m256>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1498,6 +1668,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_ps(
+        __m512{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_ps(out, static_cast<__m512i>(indices), static_cast<__m512>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
+                              static_cast<__m512i>(indices),
+                              static_cast<__m512>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
@@ -1870,6 +2124,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm256_mmask_i32gather_epi32(
+        __m256i{value_type{}}, static_cast<__mmask8>(mask), static_cast<__m256i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices), static_cast<__m256i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                              static_cast<__m256i>(indices),
+                              static_cast<__m256i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2252,6 +2590,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_epi32(
+        __m512i{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices), static_cast<__m512i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                              static_cast<__m512i>(indices),
+                              static_cast<__m512i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
@@ -2619,6 +3041,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in), static_cast<__m256i>(indices), 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm256_mmask_i32gather_epi32(
+        __m256i{value_type{}}, static_cast<__mmask8>(mask), static_cast<__m256i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices), static_cast<__m256i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                              static_cast<__m256i>(indices),
+                              static_cast<__m256i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3001,6 +3507,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_epi32(
+        __m512i{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices), static_cast<__m512i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                              static_cast<__m512i>(indices),
+                              static_cast<__m512i>(v), 4);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
 condition(
@@ -3366,6 +3956,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_epi64(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_epi64(
+        __m512i{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_epi64(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512i>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask),
+                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                              static_cast<__m512i>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
@@ -3721,6 +4395,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m512i>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(_mm512_i32gather_epi64(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    using value_type = typename V::value_type;
+    return V(_mm512_mask_i32gather_epi64(
+        __m512i{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_i32scatter_epi64(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512i>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask),
+                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                              static_cast<__m512i>(v), 8);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -700,87 +700,90 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512d>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(_mm512_i32gather_pd(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+  return V(_mm512_i32gather_pd(
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_pd(
-        __m512d{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_pd(
+      __m512d{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_pd(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512d>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_pd(out,
+                       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                       static_cast<__m512d>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_pd(out, static_cast<__mmask8>(mask),
-                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                              static_cast<__m512d>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_pd(
+      out, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+      static_cast<__m512d>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1182,89 +1185,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m256>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    __m256 on   = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
-    __m256 m = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
-    return V(_mm256_mask_i32gather_ps(
-        __m256{value_type{}}, in, static_cast<__m256i>(indices), m, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
+  __m256 m         = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
+  return V(_mm256_mask_i32gather_ps(__m256{value_type{}}, in,
+                                    static_cast<__m256i>(indices), m, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_i32scatter_ps(out, static_cast<__m256i>(indices), static_cast<__m256>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_i32scatter_ps(out, static_cast<__m256i>(indices),
+                       static_cast<__m256>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
-                              static_cast<__m256i>(indices),
-                              static_cast<__m256>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
+                            static_cast<__m256i>(indices),
+                            static_cast<__m256>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1668,87 +1670,87 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_ps(
-        __m512{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_ps(__m512{value_type{}},
+                                    static_cast<__mmask16>(mask),
+                                    static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_ps(out, static_cast<__m512i>(indices), static_cast<__m512>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_ps(out, static_cast<__m512i>(indices),
+                       static_cast<__m512>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
-                              static_cast<__m512i>(indices),
-                              static_cast<__m512>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
+                            static_cast<__m512i>(indices),
+                            static_cast<__m512>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2126,87 +2128,95 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm256_mmask_i32gather_epi32(
-        __m256i{value_type{}}, static_cast<__mmask8>(mask), static_cast<__m256i>(indices), in, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm256_mmask_i32gather_epi32(__m256i{value_type{}},
+                                        static_cast<__mmask8>(mask),
+                                        static_cast<__m256i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices), static_cast<__m256i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
+                          static_cast<__m256i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                              static_cast<__m256i>(indices),
-                              static_cast<__m256i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                               static_cast<__m256i>(indices),
+                               static_cast<__m256i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2590,87 +2600,95 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_epi32(
-        __m512i{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_epi32(__m512i{value_type{}},
+                                       static_cast<__mmask16>(mask),
+                                       static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices), static_cast<__m512i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
+                          static_cast<__m512i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                              static_cast<__m512i>(indices),
-                              static_cast<__m512i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                               static_cast<__m512i>(indices),
+                               static_cast<__m512i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3043,87 +3061,96 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in), static_cast<__m256i>(indices), 4));
+  return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in),
+                                  static_cast<__m256i>(indices), 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm256_mmask_i32gather_epi32(
-        __m256i{value_type{}}, static_cast<__mmask8>(mask), static_cast<__m256i>(indices), in, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm256_mmask_i32gather_epi32(__m256i{value_type{}},
+                                        static_cast<__mmask8>(mask),
+                                        static_cast<__m256i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices), static_cast<__m256i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
+                          static_cast<__m256i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                              static_cast<__m256i>(indices),
-                              static_cast<__m256i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
+                               static_cast<__m256i>(indices),
+                               static_cast<__m256i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3507,87 +3534,95 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_epi32(
-        __m512i{value_type{}}, static_cast<__mmask16>(mask), static_cast<__m512i>(indices), in, 4));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_epi32(__m512i{value_type{}},
+                                       static_cast<__mmask16>(mask),
+                                       static_cast<__m512i>(indices), in, 4));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices), static_cast<__m512i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
+                          static_cast<__m512i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                              static_cast<__m512i>(indices),
-                              static_cast<__m512i>(v), 4);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
+                               static_cast<__m512i>(indices),
+                               static_cast<__m512i>(v), 4);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3956,87 +3991,98 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(_mm512_i32gather_epi64(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+  return V(_mm512_i32gather_epi64(
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_epi64(
-        __m512i{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_epi64(
+      __m512i{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_epi64(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512i>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_epi64(out,
+                          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                          static_cast<__m512i>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask),
-                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                              static_cast<__m512i>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_epi64(
+      out, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+      static_cast<__m512i>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -4397,87 +4443,98 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(_mm512_i32gather_epi64(_mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+  return V(_mm512_i32gather_epi64(
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    using value_type = typename V::value_type;
-    return V(_mm512_mask_i32gather_epi64(
-        __m512i{value_type{}}, static_cast<__mmask8>(mask), _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using value_type = typename V::value_type;
+  return V(_mm512_mask_i32gather_epi64(
+      __m512i{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_i32scatter_epi64(out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), static_cast<__m512i>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_i32scatter_epi64(out,
+                          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                          static_cast<__m512i>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask),
-                              _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                              static_cast<__m512i>(v), 8);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  _mm512_mask_i32scatter_epi64(
+      out, static_cast<__mmask8>(mask),
+      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+      static_cast<__m512i>(v), 8);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -700,51 +700,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512d>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    double, simd_abi::avx512_fixed_size<8>, {
-      return V(_mm512_i32gather_pd(
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    double, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_pd(
-          _mm512_set1_pd(value_type{}), static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    double, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    double, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    double, simd_abi::avx512_fixed_size<8>, {
-      _mm512_i32scatter_pd(out,
-                           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                           static_cast<__m512d>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    double, simd_abi::avx512_fixed_size<8>, {
-      _mm512_mask_i32scatter_pd(
-          out, static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-          static_cast<__m512d>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    double, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    double, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& a,
@@ -1142,48 +1097,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                        static_cast<__m256>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    float, simd_abi::avx512_fixed_size<8>,
-    { return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
-      __m256 m         = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
-      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in,
-                                        static_cast<__m256i>(indices), m, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    float, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    float, simd_abi::avx512_fixed_size<8>, {
-      _mm256_i32scatter_ps(out, static_cast<__m256i>(indices),
-                           static_cast<__m256>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<8>, {
-      _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
-                                static_cast<__m256i>(indices),
-                                static_cast<__m256>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    float, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<8>> condition(
@@ -1585,47 +1498,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    float, simd_abi::avx512_fixed_size<16>,
-    { return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<16>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
-                                        static_cast<__mmask16>(mask),
-                                        static_cast<__m512i>(indices), in, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    float, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    float, simd_abi::avx512_fixed_size<16>, {
-      _mm512_i32scatter_ps(out, static_cast<__m512i>(indices),
-                           static_cast<__m512>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<16>, {
-      _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
-                                static_cast<__m512i>(indices),
-                                static_cast<__m512>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    float, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    float, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& a,
@@ -1999,47 +1871,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::avx512_fixed_size<8>,
-    { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm256_mmask_i32gather_epi32(
-          _mm256_set1_epi32(value_type{}), static_cast<__mmask8>(mask),
-          static_cast<__m256i>(indices), in, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int32_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int32_t, simd_abi::avx512_fixed_size<8>, {
-      _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
-                              static_cast<__m256i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<8>, {
-      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                                   static_cast<__m256i>(indices),
-                                   static_cast<__m256i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int32_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -2421,47 +2252,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::avx512_fixed_size<16>,
-    { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<16>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_epi32(
-          _mm512_set1_epi32(value_type{}), static_cast<__mmask16>(mask),
-          static_cast<__m512i>(indices), in, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int32_t, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int32_t, simd_abi::avx512_fixed_size<16>, {
-      _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
-                              static_cast<__m512i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<16>, {
-      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                                   static_cast<__m512i>(indices),
-                                   static_cast<__m512i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int32_t, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& a,
@@ -2830,49 +2620,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                           static_cast<__m256i>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
-      return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in),
-                                      static_cast<__m256i>(indices), 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm256_mmask_i32gather_epi32(
-          _mm256_set1_epi32(value_type{}), static_cast<__mmask8>(mask),
-          static_cast<__m256i>(indices), in, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
-      _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
-                              static_cast<__m256i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
-      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
-                                   static_cast<__m256i>(indices),
-                                   static_cast<__m256i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -3254,47 +3001,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>,
-    { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_epi32(
-          _mm512_set1_epi32(value_type{}), static_cast<__mmask16>(mask),
-          static_cast<__m512i>(indices), in, 4));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
-      _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
-                              static_cast<__m512i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
-      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
-                                   static_cast<__m512i>(indices),
-                                   static_cast<__m512i>(v), 4);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::avx512_fixed_size<16>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
 condition(
@@ -3660,51 +3366,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int64_t, simd_abi::avx512_fixed_size<8>, {
-      return V(_mm512_i32gather_epi64(
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_epi64(
-          _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int64_t, simd_abi::avx512_fixed_size<8>, {
-      _mm512_i32scatter_epi64(
-          out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-          static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::avx512_fixed_size<8>, {
-      _mm512_mask_i32scatter_epi64(
-          out, static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-          static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& a,
@@ -4062,51 +3723,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      return V(_mm512_i32gather_epi64(
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      return V(_mm512_mask_i32gather_epi64(
-          _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      _mm512_i32scatter_epi64(
-          out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-          static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      _mm512_mask_i32scatter_epi64(
-          out, static_cast<__mmask8>(mask),
-          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-          static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& a,
@@ -4320,6 +3936,440 @@ basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const&
         other) noexcept
     : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_i32gather_epi64(idx, in, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
+                                           static_cast<__mmask8>(mask), idx, in,
+                                           8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_i32scatter_epi64(out, idx, static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask), idx,
+                                   static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_i32gather_pd(idx, in, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_mask_i32gather_pd(_mm512_set1_pd(value_type{}),
+                                        static_cast<__mmask8>(mask), idx, in,
+                                        8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_i32scatter_pd(out, idx, static_cast<__m512d>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_mask_i32scatter_pd(out, static_cast<__mmask8>(mask), idx,
+                                static_cast<__m512d>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm256_i32gather_ps(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      __m256 on = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
+      __m256 m  = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
+      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in, idx,
+                                        m, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_i32scatter_ps(out, idx, static_cast<__m256>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask), idx,
+                                static_cast<__m256>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_i32gather_ps(idx, in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      __m512i idx      = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
+                                        static_cast<__mmask16>(mask), idx, in,
+                                        4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_i32scatter_ps(out, idx, static_cast<__m512>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask), idx,
+                                static_cast<__m512>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm256_i32gather_epi32(in, idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
+                                            static_cast<__mmask8>(mask), idx,
+                                            in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_i32scatter_epi32(out, idx, static_cast<__m256i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask), idx,
+                                   static_cast<__m256i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_i32gather_epi32(idx, in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      __m512i idx      = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
+                                           static_cast<__mmask16>(mask), idx,
+                                           in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_i32scatter_epi32(out, idx, static_cast<__m512i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask), idx,
+                                   static_cast<__m512i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(
+          _mm256_i32gather_epi32(reinterpret_cast<const int*>(in), idx, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
+                                            static_cast<__mmask8>(mask), idx,
+                                            in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_i32scatter_epi32(out, idx, static_cast<__m256i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask), idx,
+                                   static_cast<__m256i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_i32gather_epi32(idx, in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      using value_type = typename V::value_type;
+      __m512i idx      = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
+                                           static_cast<__mmask16>(mask), idx,
+                                           in, 4));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_i32scatter_epi32(out, idx, static_cast<__m512i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      __m512i idx = static_cast<__m512i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
+      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask), idx,
+                                   static_cast<__m512i>(v), 4);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_i32gather_epi64(idx, in, 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
+                                           static_cast<__mmask8>(mask), idx, in,
+                                           8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_i32scatter_epi64(out, idx, static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask), idx,
+                                   static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -719,7 +719,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
   return V(_mm512_mask_i32gather_pd(
-      __m512d{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_set1_pd(value_type{}), static_cast<__mmask8>(mask),
       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
@@ -1204,7 +1204,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
   using value_type = typename V::value_type;
   __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
   __m256 m         = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
-  return V(_mm256_mask_i32gather_ps(__m256{value_type{}}, in,
+  return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in,
                                     static_cast<__m256i>(indices), m, 4));
 }
 
@@ -1687,7 +1687,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_ps(__m512{value_type{}},
+  return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
                                     static_cast<__mmask16>(mask),
                                     static_cast<__m512i>(indices), in, 4));
 }
@@ -2147,7 +2147,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm256_mmask_i32gather_epi32(__m256i{value_type{}},
+  return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                         static_cast<__mmask8>(mask),
                                         static_cast<__m256i>(indices), in, 4));
 }
@@ -2619,7 +2619,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi32(__m512i{value_type{}},
+  return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                        static_cast<__mmask16>(mask),
                                        static_cast<__m512i>(indices), in, 4));
 }
@@ -3081,7 +3081,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm256_mmask_i32gather_epi32(__m256i{value_type{}},
+  return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                         static_cast<__mmask8>(mask),
                                         static_cast<__m256i>(indices), in, 4));
 }
@@ -3553,7 +3553,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
-  return V(_mm512_mask_i32gather_epi32(__m512i{value_type{}},
+  return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                        static_cast<__mmask16>(mask),
                                        static_cast<__m512i>(indices), in, 4));
 }
@@ -4012,7 +4012,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
   return V(_mm512_mask_i32gather_epi64(
-      __m512i{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 
@@ -4464,7 +4464,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     simd_flags<Flags...> = simd_flag_default) {
   using value_type = typename V::value_type;
   return V(_mm512_mask_i32gather_epi64(
-      __m512i{value_type{}}, static_cast<__mmask8>(mask),
+      _mm512_set1_epi64(value_type{}), static_cast<__mmask8>(mask),
       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
 }
 

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -3938,58 +3938,10 @@ basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>>::basic_simd(
     : m_value(_mm512_cvtepu32_epi64(static_cast<__m256i>(other))) {}
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      __m256i idx = static_cast<__m256i>(
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_epi64(idx, in, 8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      using value_type = typename V::value_type;
-      __m256i idx      = static_cast<__m256i>(
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
-                                           static_cast<__mmask8>(mask), idx, in,
-                                           8));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      __m256i idx = static_cast<__m256i>(
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_epi64(out, idx, static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
-      __m256i idx = static_cast<__m256i>(
-          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask), idx,
-                                   static_cast<__m512i>(v), 8);
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::avx512_fixed_size<8>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_pd(idx, in, 8));
+      return V(_mm512_i32gather_pd(idx, std::ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3998,8 +3950,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256i idx      = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm512_mask_i32gather_pd(_mm512_set1_pd(value_type{}),
-                                        static_cast<__mmask8>(mask), idx, in,
-                                        8));
+                                        static_cast<__mmask8>(mask), idx,
+                                        std::ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4014,14 +3966,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_pd(out, idx, static_cast<__m512d>(v), 8);
+      _mm512_i32scatter_pd(std::ranges::data(out), idx, static_cast<__m512d>(v),
+                           8);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_pd(out, static_cast<__mmask8>(mask), idx,
+      _mm512_mask_i32scatter_pd(std::ranges::data(out),
+                                static_cast<__mmask8>(mask), idx,
                                 static_cast<__m512d>(v), 8);
     })
 
@@ -4037,7 +3991,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_ps(in, idx, 4));
+      return V(_mm256_i32gather_ps(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4047,8 +4001,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       __m256 on = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
       __m256 m  = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
-      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}), in, idx,
-                                        m, 4));
+      return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}),
+                                        std::ranges::data(in), idx, m, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4063,14 +4017,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_ps(out, idx, static_cast<__m256>(v), 4);
+      _mm256_i32scatter_ps(std::ranges::data(out), idx, static_cast<__m256>(v),
+                           4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask), idx,
+      _mm256_mask_i32scatter_ps(std::ranges::data(out),
+                                static_cast<__mmask8>(mask), idx,
                                 static_cast<__m256>(v), 4);
     })
 
@@ -4086,7 +4042,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_ps(idx, in, 4));
+      return V(_mm512_i32gather_ps(idx, std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4095,8 +4051,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m512i idx      = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
-                                        static_cast<__mmask16>(mask), idx, in,
-                                        4));
+                                        static_cast<__mmask16>(mask), idx,
+                                        std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4111,14 +4067,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_ps(out, idx, static_cast<__m512>(v), 4);
+      _mm512_i32scatter_ps(std::ranges::data(out), idx, static_cast<__m512>(v),
+                           4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask), idx,
+      _mm512_mask_i32scatter_ps(std::ranges::data(out),
+                                static_cast<__mmask16>(mask), idx,
                                 static_cast<__m512>(v), 4);
     })
 
@@ -4134,7 +4092,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_epi32(in, idx, 4));
+      return V(_mm256_i32gather_epi32(std::ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4144,7 +4102,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                             static_cast<__mmask8>(mask), idx,
-                                            in, 4));
+                                            std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4159,14 +4117,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_epi32(out, idx, static_cast<__m256i>(v), 4);
+      _mm256_i32scatter_epi32(std::ranges::data(out), idx,
+                              static_cast<__m256i>(v), 4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask), idx,
+      _mm256_mask_i32scatter_epi32(std::ranges::data(out),
+                                   static_cast<__mmask8>(mask), idx,
                                    static_cast<__m256i>(v), 4);
     })
 
@@ -4182,7 +4142,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_epi32(idx, in, 4));
+      return V(_mm512_i32gather_epi32(idx, std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4192,7 +4152,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                            static_cast<__mmask16>(mask), idx,
-                                           in, 4));
+                                           std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4207,14 +4167,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_epi32(out, idx, static_cast<__m512i>(v), 4);
+      _mm512_i32scatter_epi32(std::ranges::data(out), idx,
+                              static_cast<__m512i>(v), 4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask), idx,
+      _mm512_mask_i32scatter_epi32(std::ranges::data(out),
+                                   static_cast<__mmask16>(mask), idx,
                                    static_cast<__m512i>(v), 4);
     })
 
@@ -4230,8 +4192,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(
-          _mm256_i32gather_epi32(reinterpret_cast<const int*>(in), idx, 4));
+      return V(_mm256_i32gather_epi32(
+          reinterpret_cast<const int*>(std::ranges::data(in)), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4241,7 +4203,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                             static_cast<__mmask8>(mask), idx,
-                                            in, 4));
+                                            std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4256,14 +4218,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_epi32(out, idx, static_cast<__m256i>(v), 4);
+      _mm256_i32scatter_epi32(std::ranges::data(out), idx,
+                              static_cast<__m256i>(v), 4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask), idx,
+      _mm256_mask_i32scatter_epi32(std::ranges::data(out),
+                                   static_cast<__mmask8>(mask), idx,
                                    static_cast<__m256i>(v), 4);
     })
 
@@ -4279,7 +4243,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_epi32(idx, in, 4));
+      return V(_mm512_i32gather_epi32(idx, std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4289,7 +4253,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                            static_cast<__mmask16>(mask), idx,
-                                           in, 4));
+                                           std::ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4304,14 +4268,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_epi32(out, idx, static_cast<__m512i>(v), 4);
+      _mm512_i32scatter_epi32(std::ranges::data(out), idx,
+                              static_cast<__m512i>(v), 4);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask), idx,
+      _mm512_mask_i32scatter_epi32(std::ranges::data(out),
+                                   static_cast<__mmask16>(mask), idx,
                                    static_cast<__m512i>(v), 4);
     })
 
@@ -4327,7 +4293,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_epi64(idx, in, 8));
+      return V(_mm512_i32gather_epi64(idx, std::ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4336,8 +4302,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256i idx      = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
-                                           static_cast<__mmask8>(mask), idx, in,
-                                           8));
+                                           static_cast<__mmask8>(mask), idx,
+                                           std::ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4352,14 +4318,16 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_epi64(out, idx, static_cast<__m512i>(v), 8);
+      _mm512_i32scatter_epi64(std::ranges::data(out), idx,
+                              static_cast<__m512i>(v), 8);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_epi64(out, static_cast<__mmask8>(mask), idx,
+      _mm512_mask_i32scatter_epi64(std::ranges::data(out),
+                                   static_cast<__mmask8>(mask), idx,
                                    static_cast<__m512i>(v), 8);
     })
 
@@ -4369,6 +4337,56 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_i32gather_epi64(idx, std::ranges::data(in), 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      using value_type = typename V::value_type;
+      __m256i idx      = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
+                                           static_cast<__mmask8>(mask), idx,
+                                           std::ranges::data(in), 8));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_i32scatter_epi64(std::ranges::data(out), idx,
+                              static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>, {
+      __m256i idx = static_cast<__m256i>(
+          basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
+      _mm512_mask_i32scatter_epi64(std::ranges::data(out),
+                                   static_cast<__mmask8>(mask), idx,
+                                   static_cast<__m512i>(v), 8);
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -700,12 +700,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512d>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::avx512_fixed_size<8>, {
-  return V(_mm512_i32gather_pd(
-      _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::avx512_fixed_size<8>, {
+      return V(_mm512_i32gather_pd(
+          _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
+    })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     double, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_pd(
@@ -713,23 +714,22 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::avx512_fixed_size<8>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::avx512_fixed_size<8>, {
-  _mm512_i32scatter_pd(out,
-                       _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
-                       static_cast<__m512d>(v), 8);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::avx512_fixed_size<8>, {
+      _mm512_i32scatter_pd(out,
+                           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
+                           static_cast<__m512d>(v), 8);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     double, simd_abi::avx512_fixed_size<8>, {
       _mm512_mask_i32scatter_pd(
           out, static_cast<__mmask8>(mask),
@@ -737,15 +737,13 @@ MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
           static_cast<__m512d>(v), 8);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::avx512_fixed_size<8>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx512_fixed_size<8>> condition(
@@ -1145,11 +1143,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m256>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx512_fixed_size<8>, {
-  return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<8>,
+    { return V(_mm256_i32gather_ps(in, static_cast<__m256i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       __m256 on        = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
@@ -1158,37 +1156,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                         static_cast<__m256i>(indices), m, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx512_fixed_size<8>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx512_fixed_size<8>, {
-  _mm256_i32scatter_ps(out, static_cast<__m256i>(indices),
-                       static_cast<__m256>(v), 4);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<8>, {
+      _mm256_i32scatter_ps(out, static_cast<__m256i>(indices),
+                           static_cast<__m256>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<8>, {
       _mm256_mask_i32scatter_ps(out, static_cast<__mmask8>(mask),
                                 static_cast<__m256i>(indices),
                                 static_cast<__m256>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx512_fixed_size<8>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<8>> condition(
@@ -1590,11 +1585,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                        static_cast<__m512>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::avx512_fixed_size<16>, {
-  return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4));
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<16>,
+    { return V(_mm512_i32gather_ps(static_cast<__m512i>(indices), in, 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::avx512_fixed_size<16>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
@@ -1602,37 +1597,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
                                         static_cast<__m512i>(indices), in, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::avx512_fixed_size<16>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::avx512_fixed_size<16>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::avx512_fixed_size<16>, {
-  _mm512_i32scatter_ps(out, static_cast<__m512i>(indices),
-                       static_cast<__m512>(v), 4);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<16>, {
+      _mm512_i32scatter_ps(out, static_cast<__m512i>(indices),
+                           static_cast<__m512>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<16>, {
       _mm512_mask_i32scatter_ps(out, static_cast<__mmask16>(mask),
                                 static_cast<__m512i>(indices),
                                 static_cast<__m512>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::avx512_fixed_size<16>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float,
-                                            simd_abi::avx512_fixed_size<16>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx512_fixed_size<16>> condition(
@@ -2008,11 +2000,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<8>,
     { return V(_mm256_i32gather_epi32(in, static_cast<__m256i>(indices), 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm256_mmask_i32gather_epi32(
@@ -2020,43 +2012,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(indices), in, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::avx512_fixed_size<8>,
-                                   {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t,
-                                    simd_abi::avx512_fixed_size<8>, {
-                                      _mm256_i32scatter_epi32(
-                                          out, static_cast<__m256i>(indices),
-                                          static_cast<__m256i>(v), 4);
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<8>, {
+      _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
+                              static_cast<__m256i>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
                                    static_cast<__m256i>(indices),
                                    static_cast<__m256i>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx512_fixed_size<8>,
-                                  {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -2438,11 +2421,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<16>,
     { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_epi32(
@@ -2450,43 +2433,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m512i>(indices), in, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t,
-                                   simd_abi::avx512_fixed_size<16>, {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::avx512_fixed_size<16>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t,
-                                    simd_abi::avx512_fixed_size<16>, {
-                                      _mm512_i32scatter_epi32(
-                                          out, static_cast<__m512i>(indices),
-                                          static_cast<__m512i>(v), 4);
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<16>, {
+      _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
+                              static_cast<__m512i>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
                                    static_cast<__m512i>(indices),
                                    static_cast<__m512i>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::avx512_fixed_size<16>,
-                                  {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::avx512_fixed_size<16>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> condition(
@@ -2857,14 +2831,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m256i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::uint32_t,
-                                     simd_abi::avx512_fixed_size<8>, {
-                                       return V(_mm256_i32gather_epi32(
-                                           reinterpret_cast<const int*>(in),
-                                           static_cast<__m256i>(indices), 4));
-                                     })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      return V(_mm256_i32gather_epi32(reinterpret_cast<const int*>(in),
+                                      static_cast<__m256i>(indices), 4));
+    })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm256_mmask_i32gather_epi32(
@@ -2872,43 +2845,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(indices), in, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint32_t,
-                                   simd_abi::avx512_fixed_size<8>, {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint32_t,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint32_t,
-                                    simd_abi::avx512_fixed_size<8>, {
-                                      _mm256_i32scatter_epi32(
-                                          out, static_cast<__m256i>(indices),
-                                          static_cast<__m256i>(v), 4);
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>, {
+      _mm256_i32scatter_epi32(out, static_cast<__m256i>(indices),
+                              static_cast<__m256i>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       _mm256_mask_i32scatter_epi32(out, static_cast<__mmask8>(mask),
                                    static_cast<__m256i>(indices),
                                    static_cast<__m256i>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint32_t, simd_abi::avx512_fixed_size<8>,
-                                  {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint32_t,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -3290,11 +3254,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   }
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint32_t, simd_abi::avx512_fixed_size<16>,
     { return V(_mm512_i32gather_epi32(static_cast<__m512i>(indices), in, 4)); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_epi32(
@@ -3302,43 +3266,34 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m512i>(indices), in, 4));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint32_t,
-                                   simd_abi::avx512_fixed_size<16>, {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint32_t,
-                                             simd_abi::avx512_fixed_size<16>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint32_t,
-                                    simd_abi::avx512_fixed_size<16>, {
-                                      _mm512_i32scatter_epi32(
-                                          out, static_cast<__m512i>(indices),
-                                          static_cast<__m512i>(v), 4);
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>, {
+      _mm512_i32scatter_epi32(out, static_cast<__m512i>(indices),
+                              static_cast<__m512i>(v), 4);
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       _mm512_mask_i32scatter_epi32(out, static_cast<__mmask16>(mask),
                                    static_cast<__m512i>(indices),
                                    static_cast<__m512i>(v), 4);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint32_t,
-                                  simd_abi::avx512_fixed_size<16>, {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint32_t,
-                                            simd_abi::avx512_fixed_size<16>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::avx512_fixed_size<16>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint32_t, simd_abi::avx512_fixed_size<16>>
@@ -3705,13 +3660,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       return V(_mm512_i32gather_epi64(
           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_epi64(
@@ -3719,26 +3674,22 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::avx512_fixed_size<8>,
-                                   {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       _mm512_i32scatter_epi64(
           out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
           static_cast<__m512i>(v), 8);
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       _mm512_mask_i32scatter_epi64(
           out, static_cast<__mmask8>(mask),
@@ -3746,17 +3697,13 @@ MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
           static_cast<__m512i>(v), 8);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::avx512_fixed_size<8>,
-                                  {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> condition(
@@ -4115,13 +4062,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                           static_cast<__m512i>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       return V(_mm512_i32gather_epi64(
           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       using value_type = typename V::value_type;
       return V(_mm512_mask_i32gather_epi64(
@@ -4129,26 +4076,22 @@ MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)), in, 8));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t,
-                                   simd_abi::avx512_fixed_size<8>, {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
-                                             simd_abi::avx512_fixed_size<8>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       _mm512_i32scatter_epi64(
           out, _mm512_cvtepi64_epi32(static_cast<__m512i>(indices)),
           static_cast<__m512i>(v), 8);
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       _mm512_mask_i32scatter_epi64(
           out, static_cast<__mmask8>(mask),
@@ -4156,17 +4099,13 @@ MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
           static_cast<__m512i>(v), 8);
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::avx512_fixed_size<8>,
-                                  {
-                                    unchecked_scatter_to<V>(v, out, indices,
-                                                            flag);
-                                  })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
-                                            simd_abi::avx512_fixed_size<8>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::avx512_fixed_size<8>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> condition(

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -127,6 +127,15 @@ concept NonScalarAbi = !std::same_as<Abi, simd_abi::scalar>;
 template <typename G, typename R, typename... Args>
 concept InvocableWithReturnType = std::is_invocable_r_v<R, G, Args...>;
 
+template <typename V>
+concept simd_vec_type =
+    std::same_as<V, basic_simd<typename V::value_type, typename V::abi_type>> &&
+    std::is_default_constructible_v<V>;
+
+template <typename V>
+concept simd_integral =
+    simd_vec_type<V> && std::integral<typename V::value_type>;
+
 }  // namespace Impl
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -11,6 +11,7 @@ import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
+#include <impl/Kokkos_SIMD_Impl_Macros.hpp>
 #include <cstdint>
 #include <cstring>
 #include <functional>

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -17,6 +17,7 @@ import kokkos.core_impl;
 #include <functional>
 #include <utility>
 #include <type_traits>
+#include <ranges>
 
 namespace Kokkos {
 

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -130,13 +130,12 @@ template <typename G, typename R, typename... Args>
 concept InvocableWithReturnType = std::is_invocable_r_v<R, G, Args...>;
 
 template <typename V>
-concept simd_vec_type =
+concept SimdVecType =
     std::same_as<V, basic_simd<typename V::value_type, typename V::abi_type>> &&
     std::is_default_constructible_v<V>;
 
 template <typename V>
-concept simd_integral =
-    simd_vec_type<V> && std::integral<typename V::value_type>;
+concept SimdIntegral = SimdVecType<V> && std::integral<typename V::value_type>;
 
 }  // namespace Impl
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -741,85 +741,85 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1169,85 +1169,85 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1605,89 +1605,89 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
-    out[indices[2]] = v[2];
-    out[indices[3]] = v[3];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
+  out[indices[2]] = v[2];
+  out[indices[3]] = v[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
-    if (mask[2]) out[indices[2]] = v[2];
-    if (mask[3]) out[indices[3]] = v[3];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
+  if (mask[2]) out[indices[2]] = v[2];
+  if (mask[3]) out[indices[3]] = v[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2021,85 +2021,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2439,89 +2447,97 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
-    out[indices[2]] = v[2];
-    out[indices[3]] = v[3];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
+  out[indices[2]] = v[2];
+  out[indices[3]] = v[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
-    if (mask[2]) out[indices[2]] = v[2];
-    if (mask[3]) out[indices[3]] = v[3];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
+  if (mask[2]) out[indices[2]] = v[2];
+  if (mask[3]) out[indices[3]] = v[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2854,85 +2870,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3260,85 +3284,93 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V([&](Impl::simd_size_t i) {
+    return mask[i] ? in[indices[i]] : typename V::value_type{};
+  });
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    out[indices[0]] = v[0];
-    out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+  out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    if (mask[0]) out[indices[0]] = v[0];
-    if (mask[1]) out[indices[1]] = v[1];
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  if (mask[0]) out[indices[0]] = v[0];
+  if (mask[1]) out[indices[1]] = v[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V,
+                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -741,87 +741,49 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::neon_fixed_size<2>, {
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::neon_fixed_size<2>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::neon_fixed_size<2>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
+                                             simd_abi::neon_fixed_size<2>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::neon_fixed_size<2>, {
   out[indices[0]] = v[0];
   out[indices[1]] = v[1];
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(double,
+                                              simd_abi::neon_fixed_size<2>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::neon_fixed_size<2>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
+                                            simd_abi::neon_fixed_size<2>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::neon_fixed_size<2>> condition(
@@ -1169,87 +1131,49 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::neon_fixed_size<2>, {
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::neon_fixed_size<2>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::neon_fixed_size<2>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::neon_fixed_size<2>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::neon_fixed_size<2>, {
   out[indices[0]] = v[0];
   out[indices[1]] = v[1];
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
+                                              simd_abi::neon_fixed_size<2>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::neon_fixed_size<2>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::neon_fixed_size<2>,
+                                            {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::neon_fixed_size<2>> condition(
@@ -1605,91 +1529,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::neon_fixed_size<4>, {
   return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::neon_fixed_size<4>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::neon_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
+                                             simd_abi::neon_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::neon_fixed_size<4>, {
   out[indices[0]] = v[0];
   out[indices[1]] = v[1];
   out[indices[2]] = v[2];
   out[indices[3]] = v[3];
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-  if (mask[2]) out[indices[2]] = v[2];
-  if (mask[3]) out[indices[3]] = v[3];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
+                                              simd_abi::neon_fixed_size<4>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                                if (mask[2])
+                                                  out[indices[2]] = v[2];
+                                                if (mask[3])
+                                                  out[indices[3]] = v[3];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::neon_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::neon_fixed_size<4>,
+                                            {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::neon_fixed_size<4>> condition(
@@ -2021,95 +1909,53 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<2>,
+                                     {
+                                       return V([&](Impl::simd_size_t i) {
+                                         return in[indices[i]];
+                                       });
+                                     })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<2>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<2>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::neon_fixed_size<2>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<2>,
+                                    {
+                                      out[indices[0]] = v[0];
+                                      out[indices[1]] = v[1];
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
+                                              simd_abi::neon_fixed_size<2>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<2>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::neon_fixed_size<2>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> condition(
@@ -2447,99 +2293,59 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<4>,
+                                     {
+                                       return V([&](Impl::simd_size_t i) {
+                                         return in[indices[i]];
+                                       });
+                                     })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<4>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<4>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
+                                             simd_abi::neon_fixed_size<4>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-  out[indices[2]] = v[2];
-  out[indices[3]] = v[3];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<4>,
+                                    {
+                                      out[indices[0]] = v[0];
+                                      out[indices[1]] = v[1];
+                                      out[indices[2]] = v[2];
+                                      out[indices[3]] = v[3];
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-  if (mask[2]) out[indices[2]] = v[2];
-  if (mask[3]) out[indices[3]] = v[3];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
+                                              simd_abi::neon_fixed_size<4>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                                if (mask[2])
+                                                  out[indices[2]] = v[2];
+                                                if (mask[3])
+                                                  out[indices[3]] = v[3];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<4>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
+                                            simd_abi::neon_fixed_size<4>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
@@ -2870,95 +2676,53 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int64_t, simd_abi::neon_fixed_size<2>,
+                                     {
+                                       return V([&](Impl::simd_size_t i) {
+                                         return in[indices[i]];
+                                       });
+                                     })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::neon_fixed_size<2>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::neon_fixed_size<2>, {
   return unchecked_gather_from<V>(in, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
+                                             simd_abi::neon_fixed_size<2>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int64_t, simd_abi::neon_fixed_size<2>,
+                                    {
+                                      out[indices[0]] = v[0];
+                                      out[indices[1]] = v[1];
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int64_t,
+                                              simd_abi::neon_fixed_size<2>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::neon_fixed_size<2>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
+                                            simd_abi::neon_fixed_size<2>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
@@ -3284,95 +3048,55 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::uint64_t,
+                                     simd_abi::neon_fixed_size<2>, {
+                                       return V([&](Impl::simd_size_t i) {
+                                         return in[indices[i]];
+                                       });
+                                     })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V([&](Impl::simd_size_t i) {
-    return mask[i] ? in[indices[i]] : typename V::value_type{};
-  });
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::neon_fixed_size<2>, {
+      return V([&](Impl::simd_size_t i) {
+        return mask[i] ? in[indices[i]] : typename V::value_type{};
+      });
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t, simd_abi::neon_fixed_size<2>,
+                                   {
+                                     return unchecked_gather_from<V>(
+                                         in, indices, flag);
+                                   })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
+                                             simd_abi::neon_fixed_size<2>, {
+                                               return unchecked_gather_from<V>(
+                                                   in, mask, indices, flag);
+                                             })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint64_t, simd_abi::neon_fixed_size<2>,
+                                    {
+                                      out[indices[0]] = v[0];
+                                      out[indices[1]] = v[1];
+                                    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  if (mask[0]) out[indices[0]] = v[0];
-  if (mask[1]) out[indices[1]] = v[1];
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::uint64_t,
+                                              simd_abi::neon_fixed_size<2>, {
+                                                if (mask[0])
+                                                  out[indices[0]] = v[0];
+                                                if (mask[1])
+                                                  out[indices[1]] = v[1];
+                                              })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::neon_fixed_size<2>, {
   unchecked_scatter_to<V>(v, out, indices, flag);
-}
+})
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V,
-                        basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
+                                            simd_abi::neon_fixed_size<2>, {
+                                              unchecked_scatter_to<V>(
+                                                  v, out, mask, indices, flag);
+                                            })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -741,6 +741,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::neon_fixed_size<2>> condition(
     basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& a,
@@ -1085,6 +1167,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1441,6 +1605,92 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+    out[indices[2]] = v[2];
+    out[indices[3]] = v[3];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+    if (mask[2]) out[indices[2]] = v[2];
+    if (mask[3]) out[indices[3]] = v[3];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::neon_fixed_size<4>> condition(
     basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& a,
@@ -1769,6 +2019,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2107,6 +2439,92 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+    out[indices[2]] = v[2];
+    out[indices[3]] = v[3];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+    if (mask[2]) out[indices[2]] = v[2];
+    if (mask[3]) out[indices[3]] = v[3];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
     basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& a,
@@ -2436,6 +2854,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
     basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& a,
@@ -2758,6 +3258,88 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+    return V([&](Impl::simd_size_t i) { return mask[i] ? in[indices[i]] : typename V::value_type{}; });
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    out[indices[0]] = v[0];
+    out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    if (mask[0]) out[indices[0]] = v[0];
+    if (mask[1]) out[indices[1]] = v[1];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -741,49 +741,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(double, simd_abi::neon_fixed_size<2>, {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::neon_fixed_size<2>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     double, simd_abi::neon_fixed_size<2>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(double, simd_abi::neon_fixed_size<2>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(double,
-                                             simd_abi::neon_fixed_size<2>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(double, simd_abi::neon_fixed_size<2>, {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::neon_fixed_size<2>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(double,
-                                              simd_abi::neon_fixed_size<2>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::neon_fixed_size<2>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(double, simd_abi::neon_fixed_size<2>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(double,
-                                            simd_abi::neon_fixed_size<2>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::neon_fixed_size<2>> condition(
@@ -1131,49 +1126,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::neon_fixed_size<2>, {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::neon_fixed_size<2>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::neon_fixed_size<2>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::neon_fixed_size<2>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::neon_fixed_size<2>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::neon_fixed_size<2>, {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::neon_fixed_size<2>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
-                                              simd_abi::neon_fixed_size<2>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::neon_fixed_size<2>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::neon_fixed_size<2>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::neon_fixed_size<2>,
-                                            {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::neon_fixed_size<2>> condition(
@@ -1529,55 +1519,48 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(float, simd_abi::neon_fixed_size<4>, {
-  return V([&](Impl::simd_size_t i) { return in[indices[i]]; });
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::neon_fixed_size<4>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::neon_fixed_size<4>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(float, simd_abi::neon_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::neon_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(float,
-                                             simd_abi::neon_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::neon_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(float, simd_abi::neon_fixed_size<4>, {
-  out[indices[0]] = v[0];
-  out[indices[1]] = v[1];
-  out[indices[2]] = v[2];
-  out[indices[3]] = v[3];
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::neon_fixed_size<4>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+      out[indices[2]] = v[2];
+      out[indices[3]] = v[3];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(float,
-                                              simd_abi::neon_fixed_size<4>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                                if (mask[2])
-                                                  out[indices[2]] = v[2];
-                                                if (mask[3])
-                                                  out[indices[3]] = v[3];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::neon_fixed_size<4>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+      if (mask[2]) out[indices[2]] = v[2];
+      if (mask[3]) out[indices[3]] = v[3];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(float, simd_abi::neon_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::neon_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(float, simd_abi::neon_fixed_size<4>,
-                                            {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::neon_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::neon_fixed_size<4>> condition(
@@ -1909,53 +1892,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<2>,
-                                     {
-                                       return V([&](Impl::simd_size_t i) {
-                                         return in[indices[i]];
-                                       });
-                                     })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::neon_fixed_size<2>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::neon_fixed_size<2>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<2>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::neon_fixed_size<2>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<2>,
-                                    {
-                                      out[indices[0]] = v[0];
-                                      out[indices[1]] = v[1];
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::neon_fixed_size<2>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
-                                              simd_abi::neon_fixed_size<2>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<2>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<2>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::neon_fixed_size<2>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> condition(
@@ -2293,59 +2267,48 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[3]) ptr[3] = simd[3];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<4>,
-                                     {
-                                       return V([&](Impl::simd_size_t i) {
-                                         return in[indices[i]];
-                                       });
-                                     })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::neon_fixed_size<4>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::neon_fixed_size<4>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int32_t, simd_abi::neon_fixed_size<4>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::neon_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int32_t,
-                                             simd_abi::neon_fixed_size<4>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<4>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<4>,
-                                    {
-                                      out[indices[0]] = v[0];
-                                      out[indices[1]] = v[1];
-                                      out[indices[2]] = v[2];
-                                      out[indices[3]] = v[3];
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::neon_fixed_size<4>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+      out[indices[2]] = v[2];
+      out[indices[3]] = v[3];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int32_t,
-                                              simd_abi::neon_fixed_size<4>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                                if (mask[2])
-                                                  out[indices[2]] = v[2];
-                                                if (mask[3])
-                                                  out[indices[3]] = v[3];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<4>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+      if (mask[2]) out[indices[2]] = v[2];
+      if (mask[3]) out[indices[3]] = v[3];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int32_t, simd_abi::neon_fixed_size<4>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::neon_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int32_t,
-                                            simd_abi::neon_fixed_size<4>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::neon_fixed_size<4>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> condition(
@@ -2676,53 +2639,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::int64_t, simd_abi::neon_fixed_size<2>,
-                                     {
-                                       return V([&](Impl::simd_size_t i) {
-                                         return in[indices[i]];
-                                       });
-                                     })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::neon_fixed_size<2>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::neon_fixed_size<2>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::int64_t, simd_abi::neon_fixed_size<2>, {
-  return unchecked_gather_from<V>(in, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::int64_t,
-                                             simd_abi::neon_fixed_size<2>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::int64_t, simd_abi::neon_fixed_size<2>,
-                                    {
-                                      out[indices[0]] = v[0];
-                                      out[indices[1]] = v[1];
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::neon_fixed_size<2>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::int64_t,
-                                              simd_abi::neon_fixed_size<2>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::neon_fixed_size<2>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::int64_t, simd_abi::neon_fixed_size<2>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::int64_t,
-                                            simd_abi::neon_fixed_size<2>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> condition(
@@ -3048,55 +3002,44 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   if (mask[1]) ptr[1] = simd[1];
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(std::uint64_t,
-                                     simd_abi::neon_fixed_size<2>, {
-                                       return V([&](Impl::simd_size_t i) {
-                                         return in[indices[i]];
-                                       });
-                                     })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::neon_fixed_size<2>,
+    { return V([&](Impl::simd_size_t i) { return in[indices[i]]; }); })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint64_t, simd_abi::neon_fixed_size<2>, {
       return V([&](Impl::simd_size_t i) {
         return mask[i] ? in[indices[i]] : typename V::value_type{};
       });
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(std::uint64_t, simd_abi::neon_fixed_size<2>,
-                                   {
-                                     return unchecked_gather_from<V>(
-                                         in, indices, flag);
-                                   })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(std::uint64_t,
-                                             simd_abi::neon_fixed_size<2>, {
-                                               return unchecked_gather_from<V>(
-                                                   in, mask, indices, flag);
-                                             })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::neon_fixed_size<2>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(std::uint64_t, simd_abi::neon_fixed_size<2>,
-                                    {
-                                      out[indices[0]] = v[0];
-                                      out[indices[1]] = v[1];
-                                    })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::neon_fixed_size<2>, {
+      out[indices[0]] = v[0];
+      out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(std::uint64_t,
-                                              simd_abi::neon_fixed_size<2>, {
-                                                if (mask[0])
-                                                  out[indices[0]] = v[0];
-                                                if (mask[1])
-                                                  out[indices[1]] = v[1];
-                                              })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::neon_fixed_size<2>, {
+      if (mask[0]) out[indices[0]] = v[0];
+      if (mask[1]) out[indices[1]] = v[1];
+    })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(std::uint64_t, simd_abi::neon_fixed_size<2>, {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-})
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(std::uint64_t,
-                                            simd_abi::neon_fixed_size<2>, {
-                                              unchecked_scatter_to<V>(
-                                                  v, out, mask, indices, flag);
-                                            })
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::neon_fixed_size<2>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> condition(

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -809,83 +809,94 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_float64_t>(svld1_gather_index(svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+  return V(static_cast<vls_float64_t>(svld1_gather_index(
+      svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_float64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_float64_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_float64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                      static_cast<vls_float64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_float64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int64_t>(indices),
+                      static_cast<vls_float64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
+                                                  SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1325,83 +1336,102 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_float32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+  return V(static_cast<vls_float32_t>(svld1_gather_index(
+      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_float32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_float32_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_float32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                      static_cast<vls_float32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_float32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int32_t>(indices),
+                      static_cast<vls_float32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V,
+               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -1900,83 +1930,94 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_int32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+  return V(static_cast<vls_int32_t>(svld1_gather_index(
+      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_int32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_int32_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_int32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                      static_cast<vls_int32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_int32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int32_t>(indices),
+                      static_cast<vls_int32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
+                                                        SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -2467,83 +2508,94 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_uint32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+  return V(static_cast<vls_uint32_t>(svld1_gather_index(
+      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_uint32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_uint32_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_uint32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                      static_cast<vls_uint32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_uint32_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int32_t>(indices),
+                      static_cast<vls_uint32_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
+                                                         SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3040,83 +3092,94 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_int64_t>(svld1_gather_index(svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+  return V(static_cast<vls_int64_t>(svld1_gather_index(
+      svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_int64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_int64_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_int64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                      static_cast<vls_int64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_int64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int64_t>(indices),
+                      static_cast<vls_int64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
+                                                        SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
@@ -3613,83 +3676,104 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_uint64_t>(svld1_gather_index(svptrue_b64(), in, 	svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+  return V(static_cast<vls_uint64_t>(svld1_gather_index(
+      svptrue_b64(), in,
+      svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-
-  return V(static_cast<vls_uint64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, 	svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return V(static_cast<vls_uint64_t>(svld1_gather_index(
+      static_cast<vls_bool_t>(mask), in,
+      svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices, flag);
+  return unchecked_gather_from<V>(in, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-    return unchecked_gather_from<V>(in, mask, indices, flag);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_uint64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                      static_cast<vls_uint64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
-    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_uint64_t>(v));
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                      static_cast<vls_int64_t>(indices),
+                      static_cast<vls_uint64_t>(v));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices, flag);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> flag = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<
+               V, basic_simd<std::uint64_t,
+                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> flag = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -809,96 +809,47 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_float64_t>(svld1_gather_index(
-      svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_float64_t>(svld1_gather_index(
+          svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_float64_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_float64_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
+                             static_cast<vls_int64_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                      static_cast<vls_float64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                          static_cast<vls_float64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int64_t>(indices),
-                      static_cast<vls_float64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int64_t>(indices),
+                          static_cast<vls_float64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<
-                                                  SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
@@ -1336,104 +1287,47 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_float32_t>(svld1_gather_index(
-      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_float32_t>(svld1_gather_index(
+          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_float32_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_float32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
+                             static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                      static_cast<vls_float32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                          static_cast<vls_float32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int32_t>(indices),
-                      static_cast<vls_float32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int32_t>(indices),
+                          static_cast<vls_float32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V,
-               basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
@@ -1930,96 +1824,47 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_int32_t>(svld1_gather_index(
-      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_int32_t>(svld1_gather_index(
+          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_int32_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_int32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
+                             static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                      static_cast<vls_int32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                          static_cast<vls_int32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int32_t>(indices),
-                      static_cast<vls_int32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int32_t>(indices),
+                          static_cast<vls_int32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<
-                                                        SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
@@ -2508,96 +2353,47 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_uint32_t>(svld1_gather_index(
-      svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_uint32_t>(svld1_gather_index(
+          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_uint32_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      return V(static_cast<vls_uint32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
+                             static_cast<vls_int32_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                      static_cast<vls_uint32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
+                          static_cast<vls_uint32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int32_t>(indices),
-                      static_cast<vls_uint32_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int32_t>(indices),
+                          static_cast<vls_uint32_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<
-                                                         SVE_WORDS_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
@@ -3092,96 +2888,47 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_int64_t>(svld1_gather_index(
-      svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_int64_t>(svld1_gather_index(
+          svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_int64_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_int64_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
+                             static_cast<vls_int64_t>(indices))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                      static_cast<vls_int64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                          static_cast<vls_int64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int64_t>(indices),
-                      static_cast<vls_int64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int64_t>(indices),
+                          static_cast<vls_int64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<
-                                                        SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
@@ -3676,106 +3423,48 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_uint64_t>(svld1_gather_index(
-      svptrue_b64(), in,
-      svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_uint64_t>(svld1_gather_index(
+          svptrue_b64(), in,
+          svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  return V(static_cast<vls_uint64_t>(svld1_gather_index(
-      static_cast<vls_bool_t>(mask), in,
-      svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
-}
+MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      return V(static_cast<vls_uint64_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), in,
+          svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return unchecked_gather_from<V>(in, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                      static_cast<vls_uint64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
+                          static_cast<vls_uint64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> = simd_flag_default) {
-  svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                      static_cast<vls_int64_t>(indices),
-                      static_cast<vls_uint64_t>(v));
-}
+MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
+                          static_cast<vls_int64_t>(indices),
+                          static_cast<vls_uint64_t>(v));
+    })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
-           std::same_as<
-               V, basic_simd<std::uint64_t,
-                             simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
-    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  unchecked_scatter_to<V>(v, out, mask, indices, flag);
-}
+MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -809,6 +809,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_float64_t>(svld1_gather_index(svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_float64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_float64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_float64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
@@ -1243,6 +1323,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
         mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_float32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_float32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_float32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_float32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
@@ -1740,6 +1900,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_int32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_int32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_int32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_int32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 condition(
@@ -2225,6 +2465,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_uint32_t>(svld1_gather_index(svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_uint32_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int32_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices), static_cast<vls_uint32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int32_t>(indices), static_cast<vls_uint32_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2720,6 +3040,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_int64_t>(svld1_gather_index(svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_int64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, static_cast<vls_int64_t>(indices))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_int64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_int64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
+}
+
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
@@ -3211,6 +3611,86 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
         mask,
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_uint64_t>(svld1_gather_index(svptrue_b64(), in, 	svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+
+  return V(static_cast<vls_uint64_t>(svld1_gather_index(static_cast<vls_bool_t>(mask), in, 	svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
+    return unchecked_gather_from<V>(in, mask, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices), static_cast<vls_uint64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+    svst1_scatter_index(static_cast<vls_bool_t>(mask), out, static_cast<vls_int64_t>(indices), static_cast<vls_uint64_t>(v));
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices, flag);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<V, basic_simd<std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>>
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> flag = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices, flag);
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -3609,7 +3609,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_float64_t>(
-          svld1_gather_index(svptrue_b64(), in, idx)));
+          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3617,8 +3617,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      return V(static_cast<vls_float64_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+      return V(static_cast<vls_float64_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3634,7 +3634,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), out, idx,
+      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
                           static_cast<vls_float64_t>(v));
     })
 
@@ -3643,8 +3643,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
-                          static_cast<vls_float64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_float64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3661,7 +3661,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_float32_t>(
-          svld1_gather_index(svptrue_b32(), in, idx)));
+          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3669,8 +3669,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      return V(static_cast<vls_float32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+      return V(static_cast<vls_float32_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3686,7 +3686,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), out, idx,
+      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
                           static_cast<vls_float32_t>(v));
     })
 
@@ -3695,8 +3695,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
-                          static_cast<vls_float32_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_float32_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3708,21 +3708,21 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      vls_int32_t idx = static_cast<vls_int32_t>(
-          basic_simd<std::int32_t,
-                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      return V(
-          static_cast<vls_int32_t>(svld1_gather_index(svptrue_b32(), in, idx)));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_int32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_int32_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3738,18 +3738,19 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), out, idx, static_cast<vls_int32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      vls_int32_t idx = static_cast<vls_int32_t>(
-          basic_simd<std::int32_t,
-                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
                           static_cast<vls_int32_t>(v));
     })
 
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_int32_t>(v));
+    })
+
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
@@ -3764,7 +3765,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint32_t>(
-          svld1_gather_index(svptrue_b32(), in, idx)));
+          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3772,8 +3773,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      return V(static_cast<vls_uint32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+      return V(static_cast<vls_uint32_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3789,7 +3790,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), out, idx,
+      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
                           static_cast<vls_uint32_t>(v));
     })
 
@@ -3798,8 +3799,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
-                          static_cast<vls_uint32_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_uint32_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3811,21 +3812,21 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      vls_int64_t idx = static_cast<vls_int64_t>(
-          basic_simd<std::int64_t,
-                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      return V(
-          static_cast<vls_int64_t>(svld1_gather_index(svptrue_b64(), in, idx)));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_int64_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_int64_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3841,7 +3842,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), out, idx, static_cast<vls_int64_t>(v));
+      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
+                          static_cast<vls_int64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
@@ -3849,8 +3851,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
-                          static_cast<vls_int64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_int64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3867,7 +3869,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint64_t>(
-          svld1_gather_index(svptrue_b64(), in, idx)));
+          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3875,8 +3877,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       vls_uint64_t idx = static_cast<vls_uint64_t>(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      return V(static_cast<vls_uint64_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+      return V(static_cast<vls_uint64_t>(svld1_gather_index(
+          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3892,7 +3894,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_uint64_t idx = static_cast<vls_uint64_t>(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), out, idx,
+      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
                           static_cast<vls_uint64_t>(v));
     })
 
@@ -3901,8 +3903,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_uint64_t idx = static_cast<vls_uint64_t>(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
-                          static_cast<vls_uint64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
+                          idx, static_cast<vls_uint64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -809,48 +809,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_float64_t>(svld1_gather_index(
-          svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_float64_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
-                             static_cast<vls_int64_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                          static_cast<vls_float64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int64_t>(indices),
-                          static_cast<vls_float64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
@@ -1286,48 +1244,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_float32_t>(svld1_gather_index(
-          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_float32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
-                             static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                          static_cast<vls_float32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int32_t>(indices),
-                          static_cast<vls_float32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
@@ -1824,48 +1740,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_int32_t>(svld1_gather_index(
-          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_int32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
-                             static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                          static_cast<vls_int32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int32_t>(indices),
-                          static_cast<vls_int32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
 condition(
@@ -2352,48 +2226,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     FlagType) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_uint32_t>(svld1_gather_index(
-          svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      return V(static_cast<vls_uint32_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
-                             static_cast<vls_int32_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
-                          static_cast<vls_uint32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int32_t>(indices),
-                          static_cast<vls_uint32_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>
@@ -2888,48 +2720,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_int64_t>(svld1_gather_index(
-          svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_int64_t>(
-          svld1_gather_index(static_cast<vls_bool_t>(mask), in,
-                             static_cast<vls_int64_t>(indices))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                          static_cast<vls_int64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int64_t>(indices),
-                          static_cast<vls_int64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
@@ -3423,49 +3213,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_uint64_t>(svld1_gather_index(
-          svptrue_b64(), in,
-          svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      return V(static_cast<vls_uint64_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), in,
-          svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { return unchecked_gather_from<V>(in, mask, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
-                          static_cast<vls_uint64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
-                          static_cast<vls_int64_t>(indices),
-                          static_cast<vls_uint64_t>(v));
-    })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, indices, flag); })
-
-KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
-    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
-    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
-
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 condition(
@@ -3855,6 +3602,316 @@ condition(
                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       [=](Impl::simd_size_t i) { return a[i] ? b[i] : c[i]; });
 }
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_float64_t>(
+          svld1_gather_index(svptrue_b64(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_float64_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b64(), out, idx,
+                          static_cast<vls_float64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_float64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_float32_t>(
+          svld1_gather_index(svptrue_b32(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_float32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b32(), out, idx,
+                          static_cast<vls_float32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_float32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(
+          static_cast<vls_int32_t>(svld1_gather_index(svptrue_b32(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_int32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b32(), out, idx, static_cast<vls_int32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_int32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_uint32_t>(
+          svld1_gather_index(svptrue_b32(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      return V(static_cast<vls_uint32_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b32(), out, idx,
+                          static_cast<vls_uint32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
+      vls_int32_t idx = static_cast<vls_int32_t>(
+          basic_simd<std::int32_t,
+                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_uint32_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(
+          static_cast<vls_int64_t>(svld1_gather_index(svptrue_b64(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_int64_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b64(), out, idx, static_cast<vls_int64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_int64_t idx = static_cast<vls_int64_t>(
+          basic_simd<std::int64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_int64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_uint64_t idx = static_cast<vls_uint64_t>(
+          basic_simd<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_uint64_t>(
+          svld1_gather_index(svptrue_b64(), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_uint64_t idx = static_cast<vls_uint64_t>(
+          basic_simd<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      return V(static_cast<vls_uint64_t>(
+          svld1_gather_index(static_cast<vls_bool_t>(mask), in, idx)));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { return unchecked_gather_from<V>(in, mask, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_uint64_t idx = static_cast<vls_uint64_t>(
+          basic_simd<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(svptrue_b64(), out, idx,
+                          static_cast<vls_uint64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
+      vls_uint64_t idx = static_cast<vls_uint64_t>(
+          basic_simd<std::uint64_t,
+                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
+      svst1_scatter_index(static_cast<vls_bool_t>(mask), out, idx,
+                          static_cast<vls_uint64_t>(v));
+    })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, indices, flag); })
+
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+    std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
+    { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -809,45 +809,45 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_float64_t>(svld1_gather_index(
           svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_float64_t>(
           svld1_gather_index(static_cast<vls_bool_t>(mask), in,
                              static_cast<vls_int64_t>(indices))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
                           static_cast<vls_float64_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int64_t>(indices),
                           static_cast<vls_float64_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
@@ -1287,45 +1287,45 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_float32_t>(svld1_gather_index(
           svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_float32_t>(
           svld1_gather_index(static_cast<vls_bool_t>(mask), in,
                              static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
                           static_cast<vls_float32_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int32_t>(indices),
                           static_cast<vls_float32_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
@@ -1824,45 +1824,45 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_int32_t>(svld1_gather_index(
           svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_int32_t>(
           svld1_gather_index(static_cast<vls_bool_t>(mask), in,
                              static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
                           static_cast<vls_int32_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int32_t>(indices),
                           static_cast<vls_int32_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
@@ -2353,45 +2353,45 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_uint32_t>(svld1_gather_index(
           svptrue_b32(), in, static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       return V(static_cast<vls_uint32_t>(
           svld1_gather_index(static_cast<vls_bool_t>(mask), in,
                              static_cast<vls_int32_t>(indices))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b32(), out, static_cast<vls_int32_t>(indices),
                           static_cast<vls_uint32_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int32_t>(indices),
                           static_cast<vls_uint32_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
@@ -2888,45 +2888,45 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_int64_t>(svld1_gather_index(
           svptrue_b64(), in, static_cast<vls_int64_t>(indices))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_int64_t>(
           svld1_gather_index(static_cast<vls_bool_t>(mask), in,
                              static_cast<vls_int64_t>(indices))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
                           static_cast<vls_int64_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int64_t>(indices),
                           static_cast<vls_int64_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 
@@ -3423,46 +3423,46 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_uint64_t>(svld1_gather_index(
           svptrue_b64(), in,
           svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
     })
 
-MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       return V(static_cast<vls_uint64_t>(svld1_gather_index(
           static_cast<vls_bool_t>(mask), in,
           svreinterpret_u64(static_cast<vls_int64_t>(indices)))));
     })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { return unchecked_gather_from<V>(in, mask, indices, flag); })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(svptrue_b64(), out, static_cast<vls_int64_t>(indices),
                           static_cast<vls_uint64_t>(v));
     })
 
-MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>, {
       svst1_scatter_index(static_cast<vls_bool_t>(mask), out,
                           static_cast<vls_int64_t>(indices),
                           static_cast<vls_uint64_t>(v));
     })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, indices, flag); })
 
-MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
+KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(
     std::uint64_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>,
     { unchecked_scatter_to<V>(v, out, mask, indices, flag); })
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -524,8 +524,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
@@ -534,8 +534,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
   return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
@@ -546,8 +546,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
   return basic_simd<T, simd_abi::scalar>(val);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
@@ -555,8 +555,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
   return unchecked_gather_from<V>(in, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
@@ -565,8 +565,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
   return unchecked_gather_from<V>(in, mask, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
@@ -575,8 +575,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
   out[indices[0]] = v[0];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
@@ -585,8 +585,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
   out[indices[0]] = (mask[0]) ? v[0] : typename V::value_type{};
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
@@ -595,8 +595,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
   unchecked_scatter_to<V>(v, out, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
-          Impl::simd_integral I, typename... Flags>
+template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+          Impl::SimdIntegral I, typename... Flags>
   requires std::ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -524,6 +524,87 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
   }
 }
 
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+      using T = V::value_type;
+      return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+      using T = V::value_type;
+      auto val = (mask[0]) ? in[indices[0]] : T{};
+      return basic_simd<T, simd_abi::scalar>(val);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+      return unchecked_gather_from<V>(in, indices);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
+      return unchecked_gather_from<V>(in, mask, indices);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = v[0];
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr void unchecked_scatter_to(const V& v,
+                                    R&& out, const typename I::mask_type& mask,
+                                    const I& indices,
+                                    simd_flags<Flags...> = simd_flag_default) {
+  out[indices[0]] = (mask[0]) ? v[0] : typename V::value_type{};
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R>  && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const I& indices,
+                                  simd_flags<Flags...> = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, indices);
+}
+
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
+          typename... Flags>
+  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr void partial_scatter_to(const V& v,
+                                  R&& out, const typename I::mask_type& mask,
+                                  const I& indices,
+                                  simd_flags<Flags...> = simd_flag_default) {
+  unchecked_scatter_to<V>(v, out, mask, indices);
+}
+
 template <class T>
 KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
     std::type_identity_t<basic_simd_mask<T, simd_abi::scalar>> const& a,

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -530,7 +530,7 @@ template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-  using T = V::value_type;
+  using T = typename V::value_type;
   return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
 }
 
@@ -541,7 +541,7 @@ template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
     simd_flags<Flags...> = simd_flag_default) {
-  using T  = V::value_type;
+  using T  = typename V::value_type;
   auto val = (mask[0]) ? in[indices[0]] : T{};
   return basic_simd<T, simd_abi::scalar>(val);
 }

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -524,84 +524,84 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
   }
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-      using T = V::value_type;
-      return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
+  using T = V::value_type;
+  return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr V unchecked_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-      using T = V::value_type;
-      auto val = (mask[0]) ? in[indices[0]] : T{};
-      return basic_simd<T, simd_abi::scalar>(val);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  using T  = V::value_type;
+  auto val = (mask[0]) ? in[indices[0]] : T{};
+  return basic_simd<T, simd_abi::scalar>(val);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-      return unchecked_gather_from<V>(in, indices);
+  return unchecked_gather_from<V>(in, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr V partial_gather_from(
-    R&& in, const typename I::mask_type& mask, const I& indices, simd_flags<Flags...> = simd_flag_default) {
-      return unchecked_gather_from<V>(in, mask, indices);
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
+    R&& in, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
+  return unchecked_gather_from<V>(in, mask, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   out[indices[0]] = v[0];
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr void unchecked_scatter_to(const V& v,
-                                    R&& out, const typename I::mask_type& mask,
-                                    const I& indices,
-                                    simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   out[indices[0]] = (mask[0]) ? v[0] : typename V::value_type{};
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R>  && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const I& indices,
-                                  simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, indices);
 }
 
-template <Impl::simd_vec_type V, std::ranges::contiguous_range R, Impl::simd_integral I,
-          typename... Flags>
-  requires std::ranges::sized_range<R> && std::same_as<typename V::abi_type, simd_abi::scalar>
-KOKKOS_FORCEINLINE_FUNCTION
-constexpr void partial_scatter_to(const V& v,
-                                  R&& out, const typename I::mask_type& mask,
-                                  const I& indices,
-                                  simd_flags<Flags...> = simd_flag_default) {
+template <Impl::simd_vec_type V, std::ranges::contiguous_range R,
+          Impl::simd_integral I, typename... Flags>
+  requires std::ranges::sized_range<R> &&
+           std::same_as<typename V::abi_type, simd_abi::scalar>
+KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
+    const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
+    simd_flags<Flags...> = simd_flag_default) {
   unchecked_scatter_to<V>(v, out, mask, indices);
 }
 

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -4,7 +4,8 @@
 #ifndef KOKKOS_SIMD_IMPL_MACROS_HPP
 #define KOKKOS_SIMD_IMPL_MACROS_HPP
 
-#define MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE, ABI_TYPE, EXPR)     \
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE,    \
+                                                    ABI_TYPE, EXPR)       \
   template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
             Impl::simd_integral I, typename... Flags>                     \
     requires std::ranges::sized_range<R> &&                               \
@@ -15,14 +16,18 @@
     EXPR                                                                  \
   }
 
-#define MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(DATA_TYPE, ABI_TYPE, EXPR) \
-  MEMORY_PERMUTE_GATHER_FROM(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(DATA_TYPE,      \
+                                                              ABI_TYPE, EXPR) \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(unchecked, DATA_TYPE, ABI_TYPE, \
+                                              EXPR)
 
-#define MEMORY_PERMUTE_PARTIAL_GATHER_FROM(DATA_TYPE, ABI_TYPE, EXPR) \
-  MEMORY_PERMUTE_GATHER_FROM(partial, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(DATA_TYPE,      \
+                                                            ABI_TYPE, EXPR) \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(partial, DATA_TYPE, ABI_TYPE, \
+                                              EXPR)
 
-#define MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(PREFIX, DATA_TYPE, ABI_TYPE, \
-                                             EXPR)                        \
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(            \
+    PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                    \
   template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
             Impl::simd_integral I, typename... Flags>                     \
     requires std::ranges::sized_range<R> &&                               \
@@ -33,15 +38,18 @@
     EXPR                                                                  \
   }
 
-#define MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(DATA_TYPE, ABI_TYPE, \
-                                                       EXPR)                \
-  MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(      \
+    DATA_TYPE, ABI_TYPE, EXPR)                                                \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(unchecked, DATA_TYPE, \
+                                                        ABI_TYPE, EXPR)
 
-#define MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(DATA_TYPE, ABI_TYPE, \
-                                                     EXPR)                \
-  MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(partial, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(      \
+    DATA_TYPE, ABI_TYPE, EXPR)                                              \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(partial, DATA_TYPE, \
+                                                        ABI_TYPE, EXPR)
 
-#define MEMORY_PERMUTE_SCATTER_TO(PREFIX, DATA_TYPE, ABI_TYPE, EXPR)        \
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO(PREFIX, DATA_TYPE,       \
+                                                   ABI_TYPE, EXPR)          \
   template <Impl::simd_vec_type V, std::ranges::contiguous_range R,         \
             Impl::simd_integral I, typename... Flags>                       \
     requires std::ranges::sized_range<R> &&                                 \
@@ -52,29 +60,36 @@
     EXPR                                                                    \
   }
 
-#define MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(DATA_TYPE, ABI_TYPE, EXPR) \
-  MEMORY_PERMUTE_SCATTER_TO(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(DATA_TYPE,      \
+                                                             ABI_TYPE, EXPR) \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO(unchecked, DATA_TYPE, ABI_TYPE, \
+                                             EXPR)
 
-#define MEMORY_PERMUTE_PARTIAL_SCATTER_TO(DATA_TYPE, ABI_TYPE, EXPR) \
-  MEMORY_PERMUTE_SCATTER_TO(partial, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(DATA_TYPE,      \
+                                                           ABI_TYPE, EXPR) \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO(partial, DATA_TYPE, ABI_TYPE, EXPR)
 
-#define MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(PREFIX, DATA_TYPE, ABI_TYPE, EXPR) \
-  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,            \
-            Impl::simd_integral I, typename... Flags>                          \
-    requires std::ranges::sized_range<R> &&                                    \
-             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>                  \
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to(    \
-      const V& v, R&& out, const typename I::mask_type& mask,                  \
-      const I& indices,                                                        \
-      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {        \
-    EXPR                                                                       \
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(               \
+    PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                      \
+  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,         \
+            Impl::simd_integral I, typename... Flags>                       \
+    requires std::ranges::sized_range<R> &&                                 \
+             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
+      const V& v, R&& out, const typename I::mask_type& mask,               \
+      const I& indices,                                                     \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
+    EXPR                                                                    \
   }
 
-#define MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(DATA_TYPE, ABI_TYPE, \
-                                                      EXPR)                \
-  MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(      \
+    DATA_TYPE, ABI_TYPE, EXPR)                                               \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(unchecked, DATA_TYPE, \
+                                                       ABI_TYPE, EXPR)
 
-#define MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(DATA_TYPE, ABI_TYPE, EXPR) \
-  MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(partial, DATA_TYPE, ABI_TYPE, EXPR)
+#define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(      \
+    DATA_TYPE, ABI_TYPE, EXPR)                                             \
+  KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(partial, DATA_TYPE, \
+                                                       ABI_TYPE, EXPR)
 
 #endif

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -6,8 +6,8 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE,    \
                                                     ABI_TYPE, EXPR)       \
-  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
-            Impl::simd_integral I, typename... Flags>                     \
+  template <Impl::SimdVecType V, std::ranges::contiguous_range R,         \
+            Impl::SimdIntegral I, typename... Flags>                      \
     requires std::ranges::sized_range<R> &&                               \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
@@ -28,8 +28,8 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(            \
     PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                    \
-  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
-            Impl::simd_integral I, typename... Flags>                     \
+  template <Impl::SimdVecType V, std::ranges::contiguous_range R,         \
+            Impl::SimdIntegral I, typename... Flags>                      \
     requires std::ranges::sized_range<R> &&                               \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
@@ -50,8 +50,8 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO(PREFIX, DATA_TYPE,       \
                                                    ABI_TYPE, EXPR)          \
-  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,         \
-            Impl::simd_integral I, typename... Flags>                       \
+  template <Impl::SimdVecType V, std::ranges::contiguous_range R,           \
+            Impl::SimdIntegral I, typename... Flags>                        \
     requires std::ranges::sized_range<R> &&                                 \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
@@ -71,8 +71,8 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(               \
     PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                      \
-  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,         \
-            Impl::simd_integral I, typename... Flags>                       \
+  template <Impl::SimdVecType V, std::ranges::contiguous_range R,           \
+            Impl::SimdIntegral I, typename... Flags>                        \
     requires std::ranges::sized_range<R> &&                                 \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_SIMD_IMPL_MACROS_HPP
+#define KOKKOS_SIMD_IMPL_MACROS_HPP
+
+#define MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE, ABI_TYPE, EXPR)     \
+  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
+            Impl::simd_integral I, typename... Flags>                     \
+    requires std::ranges::sized_range<R> &&                               \
+             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
+      R&& in, const I& indices,                                           \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
+    EXPR                                                                  \
+  }
+
+#define MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(DATA_TYPE, ABI_TYPE, EXPR) \
+  MEMORY_PERMUTE_GATHER_FROM(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_PARTIAL_GATHER_FROM(DATA_TYPE, ABI_TYPE, EXPR) \
+  MEMORY_PERMUTE_GATHER_FROM(partial, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(PREFIX, DATA_TYPE, ABI_TYPE, \
+                                             EXPR)                        \
+  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,       \
+            Impl::simd_integral I, typename... Flags>                     \
+    requires std::ranges::sized_range<R> &&                               \
+             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
+      R&& in, const typename I::mask_type& mask, const I& indices,        \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
+    EXPR                                                                  \
+  }
+
+#define MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(DATA_TYPE, ABI_TYPE, \
+                                                       EXPR)                \
+  MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_PARTIAL_GATHER_FROM_WITH_MASK(DATA_TYPE, ABI_TYPE, \
+                                                     EXPR)                \
+  MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(partial, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_SCATTER_TO(PREFIX, DATA_TYPE, ABI_TYPE, EXPR)        \
+  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,         \
+            Impl::simd_integral I, typename... Flags>                       \
+    requires std::ranges::sized_range<R> &&                                 \
+             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
+      const V& v, R&& out, const I& indices,                                \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
+    EXPR                                                                    \
+  }
+
+#define MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(DATA_TYPE, ABI_TYPE, EXPR) \
+  MEMORY_PERMUTE_SCATTER_TO(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_PARTIAL_SCATTER_TO(DATA_TYPE, ABI_TYPE, EXPR) \
+  MEMORY_PERMUTE_SCATTER_TO(partial, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(PREFIX, DATA_TYPE, ABI_TYPE, EXPR) \
+  template <Impl::simd_vec_type V, std::ranges::contiguous_range R,            \
+            Impl::simd_integral I, typename... Flags>                          \
+    requires std::ranges::sized_range<R> &&                                    \
+             std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>                  \
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to(    \
+      const V& v, R&& out, const typename I::mask_type& mask,                  \
+      const I& indices,                                                        \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {        \
+    EXPR                                                                       \
+  }
+
+#define MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(DATA_TYPE, ABI_TYPE, \
+                                                      EXPR)                \
+  MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(unchecked, DATA_TYPE, ABI_TYPE, EXPR)
+
+#define MEMORY_PERMUTE_PARTIAL_SCATTER_TO_WITH_MASK(DATA_TYPE, ABI_TYPE, EXPR) \
+  MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(partial, DATA_TYPE, ABI_TYPE, EXPR)
+
+#endif

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -12,3 +12,4 @@
 #include <TestSIMD_Reductions.hpp>
 #include <TestSIMD_Construction.hpp>
 #include <TestSIMD_LoadStore.hpp>
+#include <TestSIMD_MemoryPermute.hpp>

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -36,21 +36,25 @@ inline void host_test_scatter_to(
     }
   };
 
-  alignas(simd_type::size() * sizeof(DataType)) DataType result[init.size()];
+  alignas(simd_type::size() * sizeof(DataType))
+      DataType result[init.size()] = {};
   {
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
     check_scattered(result);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
                                                flag);
     check_scattered(result, mask);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
     check_scattered(result);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
     check_scattered(result, mask);
   }
@@ -189,21 +193,26 @@ KOKKOS_INLINE_FUNCTION void device_test_scatter_to(
     }
   };
 
-  alignas(simd_type::size() * sizeof(DataType)) DataType result[init.size()];
+  alignas(simd_type::size() * sizeof(DataType))
+      DataType result[init.size()] = {};
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
     check_scattered{}(init, indices, result);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
                                                flag);
     check_scattered{}(init, indices, result, mask);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
     check_scattered{}(init, indices, result);
   }
   {
+    std::fill(std::begin(result), std::end(result), 0);
     Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
     check_scattered{}(init, indices, result, mask);
   }

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -141,10 +141,10 @@ inline void host_check_gather_scatter() {
     host_test_scatter_to(init, mask, reverse,
                         Kokkos::Experimental::simd_flag_aligned);
 
-    // host_test_gather_from(init, mask, reverse,
-    //                       Kokkos::Experimental::simd_flag_default);
-    // host_test_gather_from(init, mask, reverse,
-    //                       Kokkos::Experimental::simd_flag_aligned);
+    host_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_default);
+    host_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_aligned);
     }
 }
 

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_SIMD_MEMORY_PERMUTE_HPP
+#define KOKKOS_TEST_SIMD_MEMORY_PERMUTE_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+import kokkos.simd_impl;
+#else
+#include <Kokkos_SIMD.hpp>
+#endif
+#include <SIMDTesting_Utilities.hpp>
+
+template <typename Abi, typename DataType, typename Flag>
+inline void host_test_scatter_to(
+    Kokkos::Experimental::basic_simd<DataType, Abi> init,
+    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
+    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+  using mask_type = decltype(mask);
+
+  auto check_scattered = [&](DataType(&arr)[init.size()], mask_type m = mask_type{true}) {
+    gtest_checker checker;
+    for (size_type i = 0; i < init.size(); ++i) {
+      auto expected = (m[i]) ? init[i] : arr[indices[i]];
+      auto found    = arr[indices[i]];
+      checker.equality(expected, found);
+    }
+  };
+
+  DataType result[init.size()];
+  {
+    Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
+    check_scattered(result);
+  }
+  {
+    Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
+                                               flag);
+    check_scattered(result, mask);
+  }
+  {
+    Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
+    check_scattered(result);
+  }
+  {
+    Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
+    check_scattered(result, mask);
+  }
+}
+
+template <typename Abi, typename DataType, typename Flag>
+inline void host_test_gather_from(
+    Kokkos::Experimental::basic_simd<DataType, Abi> init,
+    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
+    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+  using mask_type = decltype(mask);
+
+  auto check_gathered = [&](DataType(&arr)[init.size()], simd_type& result, mask_type m = mask_type{true}) {
+    gtest_checker checker;
+    for (size_type i = 0; i < result.size(); ++i) {
+      auto expected = (m[i]) ? arr[indices[i]] : DataType{};
+      auto found    = result[i];
+      checker.equality(expected, found);
+    }
+  };
+
+  simd_type result;
+  DataType arr[init.size()];
+  Kokkos::Experimental::simd_unchecked_store(init, arr, flag);
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+          Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
+    } else {
+      result =
+          Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, indices, flag);
+    }
+    check_gathered(arr, result);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+          Kokkos::Experimental::unchecked_gather_from(arr, mask, indices, flag);
+    } else {
+      result =
+          Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, mask, indices, flag);
+    }
+    check_gathered(arr, result, mask);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+          Kokkos::Experimental::partial_gather_from(arr, indices, flag);
+    } else {
+      result =
+          Kokkos::Experimental::partial_gather_from<simd_type>(arr, indices, flag);
+    }
+    check_gathered(arr, result);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+          Kokkos::Experimental::partial_gather_from(arr, mask, indices, flag);
+    } else {
+      result =
+          Kokkos::Experimental::partial_gather_from<simd_type>(arr, mask, indices, flag);
+    }
+    check_gathered(arr, result, mask);
+  }
+}
+
+template <class Abi, typename DataType>
+inline void host_check_gather_scatter() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<int, Abi>;
+    using mask_type  = typename index_type::mask_type;
+
+    simd_type init([=](std::size_t i) { return (i + 1) * 11; });
+    mask_type mask([=](std::size_t i) { return i % 2 == 0; });
+    index_type reverse(
+        [=](std::size_t i) { return (simd_type::size() - 1) - i; });
+
+    host_test_scatter_to(init, mask, reverse,
+                        Kokkos::Experimental::simd_flag_default);
+    host_test_scatter_to(init, mask, reverse,
+                        Kokkos::Experimental::simd_flag_aligned);
+
+    host_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_default);
+    host_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_aligned);
+    }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_memory_permute_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_gather_scatter<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_memory_permute_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_memory_permute_all_types<Abis>(DataTypes()), ...);
+}
+
+template <typename Abi, typename DataType, typename Flag>
+KOKKOS_INLINE_FUNCTION
+void device_test_scatter_to(
+    Kokkos::Experimental::basic_simd<DataType, Abi> init,
+    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
+    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+  using mask_type = decltype(mask);
+
+  auto check_scattered = KOKKOS_LAMBDA(DataType(&arr)[init.size()], mask_type m = mask_type{true}) {
+    kokkos_checker checker;
+    for (size_type i = 0; i < init.size(); ++i) {
+      auto expected = (m[i]) ? init[i] : arr[indices[i]];
+      auto found    = arr[indices[i]];
+      checker.equality(expected, found);
+    }
+  };
+
+  DataType result[init.size()];
+  {
+    Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
+    check_scattered(result);
+  }
+  {
+    Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
+                                               flag);
+    check_scattered(result, mask);
+  }
+  {
+    Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
+    check_scattered(result);
+  }
+  {
+    Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
+    check_scattered(result, mask);
+  }
+}
+
+template <typename Abi, typename DataType, typename Flag>
+KOKKOS_INLINE_FUNCTION
+void device_test_gather_from(
+    Kokkos::Experimental::basic_simd<DataType, Abi> init,
+    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
+    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+  using mask_type = decltype(mask);
+
+  auto check_gathered = KOKKOS_LAMBDA(DataType(&arr)[init.size()], simd_type& result, mask_type m = mask_type{true}) {
+    kokkos_checker checker;
+    for (size_type i = 0; i < result.size(); ++i) {
+      auto expected = (m[i]) ? arr[indices[i]] : DataType{};
+      auto found    = result[i];
+      checker.equality(expected, found);
+    }
+  };
+
+  simd_type result;
+  DataType arr[init.size()];
+  Kokkos::Experimental::simd_unchecked_store(init, arr, flag);
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+    result =
+        Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
+    } else {
+    result =
+        Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, indices, flag);
+    }
+    check_gathered(arr, result);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+        Kokkos::Experimental::unchecked_gather_from(arr, mask, indices, flag);
+    } else {
+      result =
+        Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, mask, indices, flag);
+    }
+    check_gathered(arr, result, mask);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+        Kokkos::Experimental::partial_gather_from(arr, indices, flag);
+    } else {
+      result =
+        Kokkos::Experimental::partial_gather_from<simd_type>(arr, indices, flag);
+    }
+    check_gathered(arr, result);
+  }
+  {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<DataType>,
+                                 Abi>) {
+      result =
+          Kokkos::Experimental::partial_gather_from(arr, mask, indices, flag);
+    } else {
+      result =
+          Kokkos::Experimental::partial_gather_from<simd_type>(arr, mask, indices, flag);
+    }
+    check_gathered(arr, result, mask);
+  }
+}
+
+template <class Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_memory_permute() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<int, Abi>;
+    using mask_type  = typename index_type::mask_type;
+
+    simd_type init(KOKKOS_LAMBDA(std::size_t i) { return (i + 1) * 11; });
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i % 2 == 0; });
+    index_type reverse(
+        KOKKOS_LAMBDA(std::size_t i) { return (simd_type::size() - 1) - i; });
+
+    device_test_scatter_to(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_default);
+    device_test_scatter_to(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_aligned);
+    device_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_default);
+    device_test_gather_from(init, mask, reverse,
+                          Kokkos::Experimental::simd_flag_aligned);
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_memory_permute_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_memory_permute<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void device_check_memory_permute_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_memory_permute_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_memory_permute_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_memory_permute_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set{});
+  }
+};
+
+TEST(simd, host_memory_permuete) {
+  host_check_memory_permute_all_abis(
+      Kokkos::Experimental::Impl::host_abi_set{});
+}
+
+TEST(simd, device_memory_permute) {
+  Kokkos::parallel_for(1, simd_device_memory_permute_functor{});
+  Kokkos::fence();
+}
+
+#endif

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -13,11 +13,14 @@ import kokkos.simd_impl;
 #endif
 #include <SIMDTesting_Utilities.hpp>
 
+template <typename T>
+using simd_index_type = std::conditional_t<(sizeof(T) == 8), std::int64_t, std::int32_t>;
+
 template <typename Abi, typename DataType, typename Flag>
 inline void host_test_scatter_to(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
-    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
-    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
@@ -53,8 +56,8 @@ inline void host_test_scatter_to(
 template <typename Abi, typename DataType, typename Flag>
 inline void host_test_gather_from(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
-    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
-    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
@@ -125,7 +128,7 @@ template <class Abi, typename DataType>
 inline void host_check_gather_scatter() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::basic_simd<int, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
     using mask_type  = typename index_type::mask_type;
 
     simd_type init([=](std::size_t i) { return (i + 1) * 11; });
@@ -138,10 +141,10 @@ inline void host_check_gather_scatter() {
     host_test_scatter_to(init, mask, reverse,
                         Kokkos::Experimental::simd_flag_aligned);
 
-    host_test_gather_from(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_default);
-    host_test_gather_from(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_aligned);
+    // host_test_gather_from(init, mask, reverse,
+    //                       Kokkos::Experimental::simd_flag_default);
+    // host_test_gather_from(init, mask, reverse,
+    //                       Kokkos::Experimental::simd_flag_aligned);
     }
 }
 
@@ -162,8 +165,8 @@ template <typename Abi, typename DataType, typename Flag>
 KOKKOS_INLINE_FUNCTION
 void device_test_scatter_to(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
-    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
-    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
@@ -200,8 +203,8 @@ template <typename Abi, typename DataType, typename Flag>
 KOKKOS_INLINE_FUNCTION
 void device_test_gather_from(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
-    Kokkos::Experimental::basic_simd_mask<int, Abi> mask,
-    Kokkos::Experimental::basic_simd<int, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
@@ -272,7 +275,7 @@ template <class Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_memory_permute() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
     using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::basic_simd<int, Abi>;
+    using index_type = Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
     using mask_type  = typename index_type::mask_type;
 
     simd_type init(KOKKOS_LAMBDA(std::size_t i) { return (i + 1) * 11; });

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -26,8 +26,7 @@ inline void host_test_scatter_to(
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_scattered = [&](DataType(&arr)[init.size()],
-                             mask_type m = mask_type{true}) {
+  auto check_scattered = [&](DataType* arr, mask_type m = mask_type{true}) {
     gtest_checker checker;
     for (size_type i = 0; i < init.size(); ++i) {
       auto expected = (m[i]) ? init[i] : arr[indices[i]];
@@ -66,7 +65,7 @@ inline void host_test_gather_from(
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_gathered = [&](DataType(&arr)[init.size()], simd_type& result,
+  auto check_gathered = [&](DataType* arr, simd_type& result,
                             mask_type m = mask_type{true}) {
     gtest_checker checker;
     for (size_type i = 0; i < result.size(); ++i) {
@@ -135,10 +134,10 @@ inline void host_check_gather_scatter() {
         Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
     using mask_type = typename index_type::mask_type;
 
-    simd_type init([=](std::size_t i) { return (i + 1) * 11; });
-    mask_type mask([=](std::size_t i) { return i % 2 == 0; });
-    index_type reverse(
-        [=](std::size_t i) { return (simd_type::size() - 1) - i; });
+    constexpr auto size = simd_type::size();
+    simd_type init(KOKKOS_LAMBDA(std::size_t i) { return (i + 1) * 11; });
+    mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i % 2 == 0; });
+    index_type reverse(KOKKOS_LAMBDA(std::size_t i) { return (size - 1) - i; });
 
     host_test_scatter_to(init, mask, reverse,
                          Kokkos::Experimental::simd_flag_default);
@@ -171,36 +170,41 @@ KOKKOS_INLINE_FUNCTION void device_test_scatter_to(
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
     Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
     Flag flag) {
-  using size_type = Kokkos::Experimental::Impl::simd_size_t;
-  using mask_type = decltype(mask);
+  using size_type  = Kokkos::Experimental::Impl::simd_size_t;
+  using simd_type  = decltype(init);
+  using mask_type  = decltype(mask);
+  using index_type = decltype(indices);
 
-  auto check_scattered = KOKKOS_LAMBDA(DataType(&arr)[init.size()],
-                                       mask_type m = mask_type{true}) {
-    kokkos_checker checker;
-    for (size_type i = 0; i < init.size(); ++i) {
-      auto expected = (m[i]) ? init[i] : arr[indices[i]];
-      auto found    = arr[indices[i]];
-      checker.equality(expected, found);
+  struct check_scattered {
+    KOKKOS_INLINE_FUNCTION
+    void operator()(simd_type const& arg_init, index_type const& arg_indices,
+                    DataType* arr, mask_type m = mask_type{true}) const {
+      kokkos_checker checker;
+      for (size_type i = 0; i < arg_init.size(); ++i) {
+        auto expected = (m[i]) ? arg_init[i] : arr[arg_indices[i]];
+        auto found    = arr[arg_indices[i]];
+        checker.equality(expected, found);
+      }
     }
   };
 
   DataType result[init.size()];
   {
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
-    check_scattered(result);
+    check_scattered{}(init, indices, result);
   }
   {
     Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
                                                flag);
-    check_scattered(result, mask);
+    check_scattered{}(init, indices, result, mask);
   }
   {
     Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
-    check_scattered(result);
+    check_scattered{}(init, indices, result);
   }
   {
     Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
-    check_scattered(result, mask);
+    check_scattered{}(init, indices, result, mask);
   }
 }
 
@@ -210,18 +214,21 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
     Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
     Flag flag) {
-  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
-  using size_type = Kokkos::Experimental::Impl::simd_size_t;
-  using mask_type = decltype(mask);
+  using size_type  = Kokkos::Experimental::Impl::simd_size_t;
+  using simd_type  = decltype(init);
+  using mask_type  = decltype(mask);
+  using index_type = decltype(indices);
 
-  auto check_gathered =
-      KOKKOS_LAMBDA(DataType(&arr)[init.size()], simd_type & result,
-                    mask_type m = mask_type{true}) {
-    kokkos_checker checker;
-    for (size_type i = 0; i < result.size(); ++i) {
-      auto expected = (m[i]) ? arr[indices[i]] : DataType{};
-      auto found    = result[i];
-      checker.equality(expected, found);
+  struct check_gathered {
+    KOKKOS_INLINE_FUNCTION
+    void operator()(index_type const& arg_indices, DataType* arr,
+                    simd_type& result, mask_type m = mask_type{true}) const {
+      kokkos_checker checker;
+      for (size_type i = 0; i < result.size(); ++i) {
+        auto expected = (m[i]) ? arr[arg_indices[i]] : DataType{};
+        auto found    = result[i];
+        checker.equality(expected, found);
+      }
     }
   };
 
@@ -237,7 +244,7 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
       result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
           arr, indices, flag);
     }
-    check_gathered(arr, result);
+    check_gathered{}(indices, arr, result);
   }
   {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -249,7 +256,7 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
       result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
           arr, mask, indices, flag);
     }
-    check_gathered(arr, result, mask);
+    check_gathered{}(indices, arr, result, mask);
   }
   {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -260,7 +267,7 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
       result = Kokkos::Experimental::partial_gather_from<simd_type>(
           arr, indices, flag);
     }
-    check_gathered(arr, result);
+    check_gathered{}(indices, arr, result);
   }
   {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -272,7 +279,7 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
       result = Kokkos::Experimental::partial_gather_from<simd_type>(
           arr, mask, indices, flag);
     }
-    check_gathered(arr, result, mask);
+    check_gathered{}(indices, arr, result, mask);
   }
 }
 

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -23,6 +23,7 @@ inline void host_test_scatter_to(
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
     Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
     Flag flag) {
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
@@ -35,7 +36,7 @@ inline void host_test_scatter_to(
     }
   };
 
-  DataType result[init.size()];
+  alignas(simd_type::size() * sizeof(DataType)) DataType result[init.size()];
   {
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
     check_scattered(result);
@@ -76,7 +77,7 @@ inline void host_test_gather_from(
   };
 
   simd_type result;
-  DataType arr[init.size()];
+  alignas(simd_type::size() * sizeof(DataType)) DataType arr[init.size()];
   Kokkos::Experimental::simd_unchecked_store(init, arr, flag);
   {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -188,7 +189,7 @@ KOKKOS_INLINE_FUNCTION void device_test_scatter_to(
     }
   };
 
-  DataType result[init.size()];
+  alignas(simd_type::size() * sizeof(DataType)) DataType result[init.size()];
   {
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
     check_scattered{}(init, indices, result);
@@ -233,7 +234,7 @@ KOKKOS_INLINE_FUNCTION void device_test_gather_from(
   };
 
   simd_type result;
-  DataType arr[init.size()];
+  alignas(simd_type::size() * sizeof(DataType)) DataType arr[init.size()];
   Kokkos::Experimental::simd_unchecked_store(init, arr, flag);
   {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -328,7 +328,7 @@ class simd_device_memory_permute_functor {
   }
 };
 
-TEST(simd, host_memory_permuete) {
+TEST(simd, host_memory_permute) {
   host_check_memory_permute_all_abis(
       Kokkos::Experimental::Impl::host_abi_set{});
 }

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -193,26 +193,30 @@ KOKKOS_INLINE_FUNCTION void device_test_scatter_to(
     }
   };
 
+  auto reset_array = KOKKOS_LAMBDA(DataType * arr, size_type len) {
+    for (size_type i = 0; i < len; ++i) arr[i] = 0;
+  };
+
   alignas(simd_type::size() * sizeof(DataType))
       DataType result[init.size()] = {};
   {
-    std::fill(std::begin(result), std::end(result), 0);
+    reset_array(result, init.size());
     Kokkos::Experimental::unchecked_scatter_to(init, result, indices, flag);
     check_scattered{}(init, indices, result);
   }
   {
-    std::fill(std::begin(result), std::end(result), 0);
+    reset_array(result, init.size());
     Kokkos::Experimental::unchecked_scatter_to(init, result, mask, indices,
                                                flag);
     check_scattered{}(init, indices, result, mask);
   }
   {
-    std::fill(std::begin(result), std::end(result), 0);
+    reset_array(result, init.size());
     Kokkos::Experimental::partial_scatter_to(init, result, indices, flag);
     check_scattered{}(init, indices, result);
   }
   {
-    std::fill(std::begin(result), std::end(result), 0);
+    reset_array(result, init.size());
     Kokkos::Experimental::partial_scatter_to(init, result, mask, indices, flag);
     check_scattered{}(init, indices, result, mask);
   }

--- a/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
+++ b/simd/unit_tests/include/TestSIMD_MemoryPermute.hpp
@@ -14,17 +14,20 @@ import kokkos.simd_impl;
 #include <SIMDTesting_Utilities.hpp>
 
 template <typename T>
-using simd_index_type = std::conditional_t<(sizeof(T) == 8), std::int64_t, std::int32_t>;
+using simd_index_type =
+    std::conditional_t<(sizeof(T) == 8), std::int64_t, std::int32_t>;
 
 template <typename Abi, typename DataType, typename Flag>
 inline void host_test_scatter_to(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
-    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
+    Flag flag) {
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_scattered = [&](DataType(&arr)[init.size()], mask_type m = mask_type{true}) {
+  auto check_scattered = [&](DataType(&arr)[init.size()],
+                             mask_type m = mask_type{true}) {
     gtest_checker checker;
     for (size_type i = 0; i < init.size(); ++i) {
       auto expected = (m[i]) ? init[i] : arr[indices[i]];
@@ -57,12 +60,14 @@ template <typename Abi, typename DataType, typename Flag>
 inline void host_test_gather_from(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
-    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
+    Flag flag) {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_gathered = [&](DataType(&arr)[init.size()], simd_type& result, mask_type m = mask_type{true}) {
+  auto check_gathered = [&](DataType(&arr)[init.size()], simd_type& result,
+                            mask_type m = mask_type{true}) {
     gtest_checker checker;
     for (size_type i = 0; i < result.size(); ++i) {
       auto expected = (m[i]) ? arr[indices[i]] : DataType{};
@@ -78,11 +83,10 @@ inline void host_test_gather_from(
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
                                      host_fixed_native<DataType>,
                                  Abi>) {
-      result =
-          Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
     } else {
-      result =
-          Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
+          arr, indices, flag);
     }
     check_gathered(arr, result);
   }
@@ -93,8 +97,8 @@ inline void host_test_gather_from(
       result =
           Kokkos::Experimental::unchecked_gather_from(arr, mask, indices, flag);
     } else {
-      result =
-          Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, mask, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
+          arr, mask, indices, flag);
     }
     check_gathered(arr, result, mask);
   }
@@ -102,11 +106,10 @@ inline void host_test_gather_from(
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
                                      host_fixed_native<DataType>,
                                  Abi>) {
-      result =
-          Kokkos::Experimental::partial_gather_from(arr, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from(arr, indices, flag);
     } else {
-      result =
-          Kokkos::Experimental::partial_gather_from<simd_type>(arr, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from<simd_type>(
+          arr, indices, flag);
     }
     check_gathered(arr, result);
   }
@@ -117,8 +120,8 @@ inline void host_test_gather_from(
       result =
           Kokkos::Experimental::partial_gather_from(arr, mask, indices, flag);
     } else {
-      result =
-          Kokkos::Experimental::partial_gather_from<simd_type>(arr, mask, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from<simd_type>(
+          arr, mask, indices, flag);
     }
     check_gathered(arr, result, mask);
   }
@@ -127,9 +130,10 @@ inline void host_test_gather_from(
 template <class Abi, typename DataType>
 inline void host_check_gather_scatter() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
-    using mask_type  = typename index_type::mask_type;
+    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type =
+        Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
+    using mask_type = typename index_type::mask_type;
 
     simd_type init([=](std::size_t i) { return (i + 1) * 11; });
     mask_type mask([=](std::size_t i) { return i % 2 == 0; });
@@ -137,15 +141,15 @@ inline void host_check_gather_scatter() {
         [=](std::size_t i) { return (simd_type::size() - 1) - i; });
 
     host_test_scatter_to(init, mask, reverse,
-                        Kokkos::Experimental::simd_flag_default);
+                         Kokkos::Experimental::simd_flag_default);
     host_test_scatter_to(init, mask, reverse,
-                        Kokkos::Experimental::simd_flag_aligned);
+                         Kokkos::Experimental::simd_flag_aligned);
 
     host_test_gather_from(init, mask, reverse,
                           Kokkos::Experimental::simd_flag_default);
     host_test_gather_from(init, mask, reverse,
                           Kokkos::Experimental::simd_flag_aligned);
-    }
+  }
 }
 
 template <typename Abi, typename... DataTypes>
@@ -162,15 +166,16 @@ inline void host_check_memory_permute_all_abis(
 }
 
 template <typename Abi, typename DataType, typename Flag>
-KOKKOS_INLINE_FUNCTION
-void device_test_scatter_to(
+KOKKOS_INLINE_FUNCTION void device_test_scatter_to(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
-    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
+    Flag flag) {
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_scattered = KOKKOS_LAMBDA(DataType(&arr)[init.size()], mask_type m = mask_type{true}) {
+  auto check_scattered = KOKKOS_LAMBDA(DataType(&arr)[init.size()],
+                                       mask_type m = mask_type{true}) {
     kokkos_checker checker;
     for (size_type i = 0; i < init.size(); ++i) {
       auto expected = (m[i]) ? init[i] : arr[indices[i]];
@@ -200,16 +205,18 @@ void device_test_scatter_to(
 }
 
 template <typename Abi, typename DataType, typename Flag>
-KOKKOS_INLINE_FUNCTION
-void device_test_gather_from(
+KOKKOS_INLINE_FUNCTION void device_test_gather_from(
     Kokkos::Experimental::basic_simd<DataType, Abi> init,
     Kokkos::Experimental::basic_simd_mask<simd_index_type<DataType>, Abi> mask,
-    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices, Flag flag) {
+    Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi> indices,
+    Flag flag) {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
   using size_type = Kokkos::Experimental::Impl::simd_size_t;
   using mask_type = decltype(mask);
 
-  auto check_gathered = KOKKOS_LAMBDA(DataType(&arr)[init.size()], simd_type& result, mask_type m = mask_type{true}) {
+  auto check_gathered =
+      KOKKOS_LAMBDA(DataType(&arr)[init.size()], simd_type & result,
+                    mask_type m = mask_type{true}) {
     kokkos_checker checker;
     for (size_type i = 0; i < result.size(); ++i) {
       auto expected = (m[i]) ? arr[indices[i]] : DataType{};
@@ -225,11 +232,10 @@ void device_test_gather_from(
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
                                      host_fixed_native<DataType>,
                                  Abi>) {
-    result =
-        Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from(arr, indices, flag);
     } else {
-    result =
-        Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
+          arr, indices, flag);
     }
     check_gathered(arr, result);
   }
@@ -238,10 +244,10 @@ void device_test_gather_from(
                                      host_fixed_native<DataType>,
                                  Abi>) {
       result =
-        Kokkos::Experimental::unchecked_gather_from(arr, mask, indices, flag);
+          Kokkos::Experimental::unchecked_gather_from(arr, mask, indices, flag);
     } else {
-      result =
-        Kokkos::Experimental::unchecked_gather_from<simd_type>(arr, mask, indices, flag);
+      result = Kokkos::Experimental::unchecked_gather_from<simd_type>(
+          arr, mask, indices, flag);
     }
     check_gathered(arr, result, mask);
   }
@@ -249,11 +255,10 @@ void device_test_gather_from(
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
                                      host_fixed_native<DataType>,
                                  Abi>) {
-      result =
-        Kokkos::Experimental::partial_gather_from(arr, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from(arr, indices, flag);
     } else {
-      result =
-        Kokkos::Experimental::partial_gather_from<simd_type>(arr, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from<simd_type>(
+          arr, indices, flag);
     }
     check_gathered(arr, result);
   }
@@ -264,8 +269,8 @@ void device_test_gather_from(
       result =
           Kokkos::Experimental::partial_gather_from(arr, mask, indices, flag);
     } else {
-      result =
-          Kokkos::Experimental::partial_gather_from<simd_type>(arr, mask, indices, flag);
+      result = Kokkos::Experimental::partial_gather_from<simd_type>(
+          arr, mask, indices, flag);
     }
     check_gathered(arr, result, mask);
   }
@@ -274,9 +279,10 @@ void device_test_gather_from(
 template <class Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_memory_permute() {
   if constexpr (is_simd_avail_v<DataType, Abi>) {
-    using simd_type  = Kokkos::Experimental::basic_simd<DataType, Abi>;
-    using index_type = Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
-    using mask_type  = typename index_type::mask_type;
+    using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+    using index_type =
+        Kokkos::Experimental::basic_simd<simd_index_type<DataType>, Abi>;
+    using mask_type = typename index_type::mask_type;
 
     simd_type init(KOKKOS_LAMBDA(std::size_t i) { return (i + 1) * 11; });
     mask_type mask(KOKKOS_LAMBDA(std::size_t i) { return i % 2 == 0; });
@@ -284,13 +290,13 @@ KOKKOS_INLINE_FUNCTION void device_check_memory_permute() {
         KOKKOS_LAMBDA(std::size_t i) { return (simd_type::size() - 1) - i; });
 
     device_test_scatter_to(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_default);
+                           Kokkos::Experimental::simd_flag_default);
     device_test_scatter_to(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_aligned);
+                           Kokkos::Experimental::simd_flag_aligned);
     device_test_gather_from(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_default);
+                            Kokkos::Experimental::simd_flag_default);
     device_test_gather_from(init, mask, reverse,
-                          Kokkos::Experimental::simd_flag_aligned);
+                            Kokkos::Experimental::simd_flag_aligned);
   }
 }
 


### PR DESCRIPTION
This PR reintroduces `gather_from` and `scatter_to` functionalities that were deprecated as part of `where_expression` deprecation in #7960 

Added functions for `[unchcked|partial]_gather_from`:
```c++
template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr V unchecked_gather_from(R&& in, const I& indices, simd_flags<Flags...> f = simd_flag_default);

template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr V unchecked_gather_from(R&& in, const typename I::mask_type& mask,
                                    const I& indices, simd_flags<Flags...> f = simd_flag_default);


template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr V partial_gather_from(R&& in, const I& indices, simd_flags<Flags...> f = simd_flag_default);

template<Impl::simd_vec_type, ranges::contiguous_range R, simd-integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr V partial_gather_from(R&& in, const typename I::mask_type& mask,
                                  const I& indices, simd_flags<Flags...> f = simd_flag_default);
```

Added functions for `[unchcked|partial]_scatter_to`:
```c++
template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr void unchecked_scatter_to(const V& v, R&& out, const I& indices,
                                      simd_flags<Flags...> f = simd_flag_default);
template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr void unchecked_scatter_to(const V& v, R&& out, const typename I::mask_type& mask,
                                      const I& indices, simd_flags<Flags...> f = simd_flag_default);

template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr void
  partial_scatter_to(const V& v, R&& out, const I& indices, simd_flags<Flags...> f = simd_flag_default);

template<Impl::simd_vec_type V, ranges::contiguous_range R, Impl::simd_integral I, typename... Flags>
  requires ranges::sized_range<R>
  constexpr void partial_scatter_to(const V& v, R&& out, const typename I::mask_type& mask,
                                    const I& indices, simd_flags<Flags...> f = simd_flag_default);
```