### PR TITLE
Revert workaround for mdspan with CUDA 12.9

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -160,15 +160,7 @@ mark_as_advanced(Kokkos_ENABLE_MDSPAN_EXTERNAL)
 mark_as_advanced(IMPL_CHECK_POSSIBLY_BREAKING_LAYOUTS)
 
 if(Kokkos_ENABLE_IMPL_MDSPAN)
-  # CUDA 12.9 has a bug that causes it to segfault when mdspan-based view is used:
-  #   see https://github.com/kokkos/kokkos/issues/8126
-  if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND KOKKOS_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9
-     AND KOKKOS_CXX_COMPILER_VERSION VERSION_LESS 13
-  )
-    set(VIEW_LEGACY_DEFAULT ON)
-  else()
-    set(VIEW_LEGACY_DEFAULT OFF)
-  endif()
+  set(VIEW_LEGACY_DEFAULT OFF)
 else()
   set(VIEW_LEGACY_DEFAULT ON)
 endif()

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -237,6 +237,7 @@ class View : public ViewTraits<DataType, Properties...> {
  public:
   //----------------------------------------
   /** \brief  Compatible view of data type */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   using type = std::conditional_t<
       has_hooks_policy,
       View<typename traits::scalar_array_type, typename traits::array_layout,
@@ -244,6 +245,15 @@ class View : public ViewTraits<DataType, Properties...> {
            typename traits::memory_traits>,
       View<typename traits::scalar_array_type, typename traits::array_layout,
            typename traits::device_type, typename traits::memory_traits>>;
+#else
+  using type = std::conditional_t<
+      has_hooks_policy,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::hooks_policy,
+           typename traits::memory_traits>,
+      View<typename traits::data_type, typename traits::array_layout,
+           typename traits::device_type, typename traits::memory_traits>>;
+#endif
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   /** \brief  Compatible view of array of data types */

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -488,7 +488,8 @@ struct ViewTraits {
  public:
   //------------------------------------
   // Data type traits:
-#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+#if defined(KOKKOS_ENABLE_IMPL_VIEW_LEGACY) && \
+    defined(KOKKOS_ENABLE_DEPRECATED_CODE_5)
   using data_type           = typename data_analysis::type;
   using const_data_type     = typename data_analysis::const_type;
   using non_const_data_type = typename data_analysis::non_const_type;


### PR DESCRIPTION
Compiling Kokkos with `cmake -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_DEPRECATED_CODE_5=OFF -B build-cuda` and CUDA 12.9 results in the following error
```
 21%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Core.cpp.o
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
/home/TP026749/kokkos/core/src/View/Kokkos_ViewTraits.hpp(492): error: class "Kokkos::Impl::ViewDataAnalysis<uint32_t *, Kokkos::Cuda::array_layout, uint32_t>" has no member "type"
    using data_type = typename data_analysis::type;
                                              ^
          detected during:
            instantiation of class "Kokkos::ViewTraits<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 214 of /home/TP026749/kokkos/core/src/View/Kokkos_ViewLegacy.hpp
            instantiation of class "Kokkos::View<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 28 of /home/TP026749/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp

/home/TP026749/kokkos/core/src/View/Kokkos_ViewTraits.hpp(493): error: class "Kokkos::Impl::ViewDataAnalysis<uint32_t *, Kokkos::Cuda::array_layout, uint32_t>" has no member "const_type"
    using const_data_type = typename data_analysis::const_type;
                                                    ^
          detected during:
            instantiation of class "Kokkos::ViewTraits<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 214 of /home/TP026749/kokkos/core/src/View/Kokkos_ViewLegacy.hpp
            instantiation of class "Kokkos::View<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 28 of /home/TP026749/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp

/home/TP026749/kokkos/core/src/View/Kokkos_ViewTraits.hpp(494): error: class "Kokkos::Impl::ViewDataAnalysis<uint32_t *, Kokkos::Cuda::array_layout, uint32_t>" has no member "non_const_type"
    using non_const_data_type = typename data_analysis::non_const_type;
                                                        ^
          detected during:
            instantiation of class "Kokkos::ViewTraits<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 214 of /home/TP026749/kokkos/core/src/View/Kokkos_ViewLegacy.hpp
            instantiation of class "Kokkos::View<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 28 of /home/TP026749/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp

/home/TP026749/kokkos/core/src/View/Kokkos_ViewLegacy.hpp(242): error: class "Kokkos::ViewTraits<uint32_t *, Kokkos::CudaSpace>" has no member "scalar_array_type"
        View<typename traits::scalar_array_type, typename traits::array_layout,
                              ^
          detected during instantiation of class "Kokkos::View<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 28 of /home/TP026749/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp

/home/TP026749/kokkos/core/src/View/Kokkos_ViewLegacy.hpp(245): error: class "Kokkos::ViewTraits<uint32_t *, Kokkos::CudaSpace>" has no member "scalar_array_type"
        View<typename traits::scalar_array_type, typename traits::array_layout,
                              ^
          detected during instantiation of class "Kokkos::View<DataType, Properties...> [with DataType=uint32_t *, Properties=<Kokkos::CudaSpace>]" at line 28 of /home/TP026749/kokkos/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp

5 errors detected in the compilation of "/home/TP026749/kokkos/core/src/impl/Kokkos_Core.cpp".
gmake[2]: *** [core/src/CMakeFiles/kokkoscore.dir/build.make:121: core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Core.cpp.o] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:1289: core/src/CMakeFiles/kokkoscore.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

In this PR I suggest to revert the workaround introduced in https://github.com/kokkos/kokkos/pull/8169 because there is a workaround available in mdspan to handle CUDA >=12.9, see https://github.com/kokkos/kokkos/pull/8615 and https://github.com/kokkos/kokkos/pull/8562.

The changes in `core/src/View/Kokkos_ViewTraits.hpp` and `core/src/View/Kokkos_ViewLegacy.hpp` make it possible to compile with `Kokkos_ENABLE_DEPRECATED_CODE_5=OFF` and `Kokkos_ENABLE_IMPL_VIEW_LEGACY=ON`.