### PR TITLE
Drop workaround to use unqualified math functions on CUDA with ancient GCC host compiler

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -66,12 +66,7 @@ using promote_3_t = typename promote_3<T, U, V>::type;
 #if defined(KOKKOS_ENABLE_SYCL)
 #define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE sycl
 #else
-#if (defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC)) && \
-    defined(__GNUC__) && (__GNUC__ < 6) && !defined(__clang__)
-#define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE
-#else
 #define KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE std
-#endif
 #endif
 
 #define KOKKOS_IMPL_MATH_UNARY_FUNCTION(FUNC)                                  \


### PR DESCRIPTION
Our minimum requirements is GCC 10+