### PR TITLE
Add `hip` as a dependency for `Kokkos_ENABLE_HIP=ON`

### DIFF
--- a/cmake/Modules/FindTPLROCM.cmake
+++ b/cmake/Modules/FindTPLROCM.cmake
@@ -1,3 +1,4 @@
 find_package(hip REQUIRED PATHS ${ROCM_PATH} $ENV{ROCM_PATH})
 
 kokkos_create_imported_tpl(ROCM INTERFACE LINK_LIBRARIES hip::device)
+kokkos_export_cmake_tpl(hip REQUIRED)


### PR DESCRIPTION
fixes #8776

if we build the HIP backend with `-DKokkos_ENABLE_ROCTHRUST=OFF` we do not get CMake to properly propagate the dependency on `hip`.
Previously our tpl was called `ROCM` and we switched the internals to `find_package(hip)` instead of doing our own logic in #8747

This PR renames the tpl which fixed the issue for me (tested on MI300A, rocm 6.3.4 building Kokkos-kernels, as described in #8776)

@yasahi-hpc could you please verify this fixes the issue for you?