### PR TITLE
Fix GH200 HPSF CI build

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -1,5 +1,8 @@
 .common-setup:
   stage: test
+  variables:
+    OMP_PLACES: "threads"
+    OMP_PROC_BIND: "spread"
   before_script:
     - if [ ${CI_PIPELINE_SOURCE} == "schedule" ]; then
         export CDASH_MODEL="Nightly";
@@ -68,7 +71,6 @@ NVIDIA-GH200:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_LARGE_MEM_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_LIBDL=OFF"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_BENCHMARKS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON"
     - export CTEST_BUILD_NAME="NVIDIA-GH200"
     - ctest -VV

--- a/core/unit_test/cuda/TestCuda_DebugPinUVMSpace.cpp
+++ b/core/unit_test/cuda/TestCuda_DebugPinUVMSpace.cpp
@@ -34,8 +34,8 @@ struct CopyFunctor {
 };
 
 TEST(cuda, debug_pin_um_to_host) {
-#if defined(KOKKOS_ARCH_AMPERE87) || defined(KOKKOS_ARCH_HOPPER90)
-  GTEST_SKIP() << "skipping for devices that have integrated memory";
+#ifdef KOKKOS_ARCH_AMPERE87
+  GTEST_SKIP() << "skipping for Jetson devices that have integrated memory";
 #endif
   double time_cuda_space;
   double time_cuda_host_pinned_space;

--- a/core/unit_test/cuda/TestCuda_DebugPinUVMSpace.cpp
+++ b/core/unit_test/cuda/TestCuda_DebugPinUVMSpace.cpp
@@ -34,8 +34,8 @@ struct CopyFunctor {
 };
 
 TEST(cuda, debug_pin_um_to_host) {
-#ifdef KOKKOS_ARCH_AMPERE87
-  GTEST_SKIP() << "skipping for Jetson devices that have integrated memory";
+#if defined(KOKKOS_ARCH_AMPERE87) || defined(KOKKOS_ARCH_HOPPER90)
+  GTEST_SKIP() << "skipping for devices that have integrated memory";
 #endif
   double time_cuda_space;
   double time_cuda_host_pinned_space;


### PR DESCRIPTION
We are frequently seeing the GH200 build failing, mostly when running in `Debug` mode. This pull request should address the 3 failing tests:
- Kokkos_CoreUnitTest_OpenMP by setting `OMP_PLACES` and `OMP_PROC_BIND`
- Kokkos_PerformanceTest_Benchmark by not running benchmarks
- ~~Kokkos_CoreUnitTest_CudaTimingBased by skipping a test that we already skipped for `KOKKOS_ARCH_AMPERE87`~~