### PR TITLE
core(view): `noexcept` move constructor

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -611,7 +611,7 @@ union SharedAllocationTracker {
   // Move:
 
   KOKKOS_FORCEINLINE_FUNCTION
-  SharedAllocationTracker(SharedAllocationTracker&& rhs)
+  SharedAllocationTracker(SharedAllocationTracker&& rhs) noexcept
       : m_record_bits(rhs.m_record_bits) {
     rhs.m_record_bits = DO_NOT_DEREF_FLAG;
   }

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -165,9 +165,14 @@ TEST(TEST_CATEGORY, view_moved_from) {
 #if !(defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
       (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)))
 constexpr bool test_view_is_nothrow_move_constructible() {
-  using view_t = Kokkos::View<int*, TEST_EXECSPACE>;
-
-  static_assert(std::is_nothrow_move_constructible_v<view_t>);
+  static_assert(
+      std::is_nothrow_move_constructible_v<Kokkos::View<int*, TEST_EXECSPACE>>);
+  static_assert(
+      std::is_nothrow_move_constructible_v<Kokkos::View<
+          int*, TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Unmanaged>>>);
+  static_assert(
+      std::is_nothrow_move_constructible_v<Kokkos::View<
+          int*, TEST_EXECSPACE, Kokkos::MemoryTraits<Kokkos::Atomic>>>);
 
   return true;
 }

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -163,7 +163,7 @@ TEST(TEST_CATEGORY, view_moved_from) {
 }
 
 #if !(defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
-    (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)))
+      (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)))
 constexpr bool test_view_is_nothrow_move_constructible() {
   using view_t = Kokkos::View<int*, TEST_EXECSPACE>;
 

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -162,12 +162,8 @@ TEST(TEST_CATEGORY, view_moved_from) {
       v2.data(), v2.extent(0), v2.extent(1)));
 }
 
-#if defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
-    (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA))
-#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND 1
-#endif
-
-#if !defined(KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND)
+#if !(defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
+    (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)))
 constexpr bool test_view_is_nothrow_move_constructible() {
   using view_t = Kokkos::View<int*, TEST_EXECSPACE>;
 

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -162,4 +162,20 @@ TEST(TEST_CATEGORY, view_moved_from) {
       v2.data(), v2.extent(0), v2.extent(1)));
 }
 
+#if defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
+    (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA))
+#define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND 1
+#endif
+
+#if !defined(KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND)
+constexpr bool test_view_is_nothrow_move_constructible() {
+  using view_t = Kokkos::View<int*, TEST_EXECSPACE>;
+
+  static_assert(std::is_nothrow_move_constructible_v<view_t>);
+
+  return true;
+}
+static_assert(test_view_is_nothrow_move_constructible());
+#endif
+
 }  // namespace


### PR DESCRIPTION
This PR adds `noexcept` specifiers so that `Kokkos::View` satisfies `std::is_nothrow_move_constructible`.

The main motivation is that the `std::execution` sender/receiver framework (P2300) mandates receivers must be nothrow-movable.
