### PR TITLE
Use StaticBatchSize in ViewFill

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -70,7 +70,12 @@ template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 1, iType> {
   ViewType a;
   typename ViewType::const_value_type val;
-  using policy_type = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
+  // It was found empirically that increasing the number of elements per thread
+  // by a factor of 16 gives good results for configurations that support
+  // StaticBatchSize.
+  using policy_type =
+      Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
+                          Kokkos::Experimental::StaticBatchSize<16>>;
 
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8033.

Using
```C++
#include<Kokkos_Core.hpp>

template <int UR, typename View>
double execute(View v, typename View::value_type V)
{
  Kokkos::Timer timer;
  int N = v.size();
  int NUR = N/UR;
  Kokkos::parallel_for(NUR, KOKKOS_LAMBDA(int i) {
      for (int j=0; j<UR; ++j)
        v(i + j*NUR) = V;
  });
  Kokkos::fence();
  return ((double)N)*sizeof(typename View::value_type) / timer.seconds();
}

template <typename T>
void test(int N, T V) {
    Kokkos::View<T*> a("A", N);

    std::vector<double> unrolled;
    unrolled.push_back(execute<1>(a, V));
    unrolled.push_back(execute<2>(a, V));
    unrolled.push_back(execute<4>(a, V));
    unrolled.push_back(execute<8>(a, V));
    unrolled.push_back(execute<16>(a, V));
    unrolled.push_back(execute<32>(a, V));
    unrolled.push_back(execute<64>(a, V));
    unrolled.push_back(execute<128>(a, V));

    Kokkos::Timer timer;
    Kokkos::deep_copy(a,V);
    double time_dc = timer.seconds();
    double bw_dc = ((double)N)*sizeof(T) / time_dc;

    printf("%lu | %d | %d | %d | %d | %d | %d | %d | %d\n", sizeof(T), 
		    int(unrolled[0] * 1.e-9), int(unrolled[1] * 1.e-9), int(unrolled[2] * 1.e-9), int(unrolled[3] * 1.e-9),
		    int(unrolled[4] * 1.e-9), int(unrolled[5] * 1.e-9), int(unrolled[6] * 1.e-9), int(unrolled[7] * 1.e-9));
  }

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  {
    int N = argc > 1 ? atoi(argv[1]) : 1000000000;
    int V = argc > 2 ? atoi(argv[2]) : 0;
    
    test<char>(N,V);
    test<short>(N,V);
    test<int>(N,V);
    test<long>(N,V);
    test<Kokkos::complex<double>>(N,V);
  }
    Kokkos::finalize();
}
```
on an A100, I'm seeing (results in GB/s)
| sizeof(T) | 1  |  2 |  4 |  8 | 16 | 32 | 64 | 128 |
| --            | -- | -- | -- | -- | -- | -- | -- | -- |
| 1 | 120 | 341 | 676 | 1330 | 1765 | 946 | 723 | 622 |
| 2 | 343 | 683 | 1356 | 1752 | 1651 | 1616 | 1101 | 777 |
| 4 | 687 | 1367 | 1717 | 1675 | 1631 | 1592 | 1524 | 998 |
| 8 | 1373 | 1725 | 1682 | 1669 | 1632 | 1622 | 1580 | 1541 |
| 16 | 1728 | 1716 | 1694 | 1679 | 1645 | 1621 | 1627 | 1607 |

and on GH200:
| sizeof(T) | 1  |  2 |  4 |  8 | 16 | 32 | 64 | 128 |
| --            | -- | -- | -- | -- | -- | -- | -- | -- |
| 1 | 172 | 422 | 839 | 1655 | 3204 | 1778 | 1167 | 1094 |
| 2 | 423 | 844 | 1664 | 3300 | 3754 | 3675 | 2012 | 1455 |
| 4 | 845 | 1684 | 3344 | 3786 | 3728 | 3721 | 3638 | 2217 |
| 8 | 1681 | 3374 | 3868 | 3829 | 3786 | 3769 | 3690 | 3614 |
| 16 | 3389 | 3928 | 3912 | 3882 | 3815 | 3741 | 3747 | 3703 |

