### PR TITLE
Enable the [[deprecated]] attribute with nvcc

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -583,7 +583,11 @@ static_assert(
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
 #endif
 
-#if defined(__NVCC__) && defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+// FIXME NVCC <13: using the deprecation warnings push/pop mechanism with nvcc
+// and nvc++ as host compiler leads to bugs where some of the _Pragma are not
+// taken into account.
+#if defined(__NVCC__) && defined(__NVCC_DIAG_PRAGMA_SUPPORT__) && \
+    (!defined(__NVCOMPILER) || (KOKKOS_COMPILER_NVCC >= 1300))
   #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
     KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
     _Pragma("nv_diagnostic push") \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -531,10 +531,7 @@ static_assert(
 
 #define KOKKOS_IMPL_CTOR_DEFAULT_ARG KOKKOS_INVALID_INDEX
 
-// Guard intel compiler version 19 and older
-// intel error #2651: attribute does not apply to any entity
-// using <deprecated_type> KOKKOS_DEPRECATED = ...
-#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS) && !defined(__NVCC__)
+#if defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
 #define KOKKOS_DEPRECATED [[deprecated]]
 #define KOKKOS_DEPRECATED_WITH_COMMENT(comment) [[deprecated(comment)]]
 #else

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -554,33 +554,48 @@ static_assert(
 
 // clang-format off
 #if defined(__NVCOMPILER)
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
     _Pragma("diag_suppress 1216") \
     _Pragma("diag_suppress deprecated_entity_with_custom_message")
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_() \
     _Pragma("diag_default 1216") \
-    _Pragma("diag_suppress deprecated_entity_with_custom_message")
+    _Pragma("diag_default deprecated_entity_with_custom_message")
 #elif defined(__EDG__)
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
     _Pragma("warning push")                              \
     _Pragma("warning disable 1478")
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_() \
     _Pragma("warning pop")
 #elif defined(__GNUC__) || defined(__clang__)
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
     _Pragma("GCC diagnostic push")                       \
     _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_() \
     _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
     _Pragma("warning(push)")                             \
     _Pragma("warning(disable: 4996)")
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_() \
     _Pragma("warning(pop)")
 #else
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
-  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_()
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
+#endif
+
+#if defined(__NVCC__) && defined(__NVCC_DIAG_PRAGMA_SUPPORT__)
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
+    _Pragma("nv_diagnostic push") \
+    _Pragma("nv_diag_suppress 1215,1444")
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    _Pragma("nv_diagnostic pop") \
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
+#else
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_()
+  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
+    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
 #endif
 
 #if defined(__NVCOMPILER)


### PR DESCRIPTION
https://github.com/kokkos/kokkos/pull/4229 guarded against `KOKKOS_DEPRECATED` being defined to `[[deprecated]]` because it would generate some "attribute does not apply to any entity" warnings with cuda 10, but it seems that this was fixed in cuda 11 (https://godbolt.org/z/hjj8K93xa), so I guess we can remove this guard since we use cuda 12.2+.

The `KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH/POP` macros were not handling nvcc deprecation warnings, I renamed the macros to `KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_()/POP_()`, and replaced them with this 
```
#if defined(__NVCC__) && defined(__NVCC_DIAG_PRAGMA_SUPPORT__) \
    (!defined(__NVCOMPILER) || (KOKKOS_COMPILER_NVCC >= 1300))
  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_() \
    _Pragma("nv_diagnostic push") \
    _Pragma("nv_diag_suppress 1215,1444")
  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
    _Pragma("nv_diagnostic pop") \
    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
#else
  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH() \
    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH_()
  #define KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP() \
    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP_()
#endif
```
1215 and 1444 are for deprecated attributes and deprecated functions respectively, see https://godbolt.org/z/E5YqdPzoM

I guard for cuda < 13 with nvhpc as host since I encountered a bug where some of the `_Pragma`s would not be taken into account, leading to warnings like this `warning #3185-D: no '#pragma diagnostic push' was found to match this 'diagnostic pop'` (see [here](https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8796/3/pipeline-overview/?start-byte=0&selected-node=427#log-427-165) for example). I tested inside a cuda 13.0.2 container and didn't encounter this issue.