### PR TITLE
simd: add some missing comparison operators on AVX2 and NEON

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -3176,11 +3176,11 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
+    return !(lhs < rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
+    return !(lhs > rhs);
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -3174,6 +3174,35 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs > rhs) || (lhs == rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return (lhs < rhs) || (lhs == rhs);
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    // We use the following bit trick to compute the unsigned comparison from
+    // the signed values since there is no intrinsic for unsigned int comparison
+    // in AVX2: (a < 0) ^ (b < 0) ^ (a > b)
+    // If a and b have the same sign, the signed and unsigned comparison will
+    // give the same result. In this case:
+    //  (a < 0) == (b < 0) => (a < 0) ^ (b < 0) = 0, and 0 ^ (a > b) == (a > b)
+    // If they have different signs, the signed and unsigned comparisons will
+    // give opposite results (negative values are higher than positive values
+    // when interpreting them as unsigned). In that case:
+    //  (a < 0) != (b < 0) => (a < 0) ^ (b < 0) = 1, and 1 ^ (a > b) == !(a > b)
+    basic_simd<std::int64_t, abi_type> signed_lhs{static_cast<__m256i>(lhs)};
+    basic_simd<std::int64_t, abi_type> signed_rhs{static_cast<__m256i>(rhs)};
+    return static_cast<mask_type>((signed_lhs < 0) ^ (signed_rhs < 0) ^
+                                  (signed_lhs > signed_rhs));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return rhs > lhs;
+  }
 };
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -440,8 +440,8 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
-                                        static_cast<__m512d>(lhs), _CMP_GE_OS));
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_GE_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
@@ -450,8 +450,8 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(rhs),
-                                        static_cast<__m512d>(lhs), _CMP_GT_OS));
+    return mask_type(_mm512_cmp_pd_mask(static_cast<__m512d>(lhs),
+                                        static_cast<__m512d>(rhs), _CMP_GT_OS));
   }
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
       basic_simd const& lhs, basic_simd const& rhs) noexcept {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -2615,6 +2615,26 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
       basic_simd const& lhs, basic_simd const& rhs) noexcept {
     return !(lhs == rhs);
   }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        vcgeq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        vcleq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        vcgtq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
+      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+    return mask_type(
+        vcltq_u64(static_cast<uint64x2_t>(lhs), static_cast<uint64x2_t>(rhs)));
+  }
 };
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -6,6 +6,7 @@
 #include <TestSIMD_Conversions.hpp>
 #include <TestSIMD_ShiftOps.hpp>
 #include <TestSIMD_BitwiseOps.hpp>
+#include <TestSIMD_ComparisonOps.hpp>
 #include <TestSIMD_Condition.hpp>
 #include <TestSIMD_GeneratorCtors.hpp>
 #include <TestSIMD_Reductions.hpp>

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -816,4 +816,76 @@ class ternary_hypot_op {
 KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
 #endif
 
+class equal {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a == b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a == b;
+  }
+};
+
+class not_equal {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a != b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a != b;
+  }
+};
+
+class less_than {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a < b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a < b;
+  }
+};
+
+class less_equal {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a <= b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a <= b;
+  }
+};
+
+class greater_than {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a > b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a > b;
+  }
+};
+
+class greater_equal {
+ public:
+  template <typename T>
+  auto on_host(T const& a, T const& b) const {
+    return a >= b;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, T const& b) const {
+    return a >= b;
+  }
+};
+
 #endif

--- a/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_SIMD_COMPARISON_OPS_HPP
+#define KOKKOS_TEST_SIMD_COMPARISON_OPS_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
+#include <Kokkos_SIMD.hpp>
+#endif
+#include <SIMDTesting_Utilities.hpp>
+
+template <class Abi, class Loader, class BinaryOp, class T>
+void host_check_comparison_op_one_loader(
+    BinaryOp binary_op, Kokkos::Experimental::Impl::simd_size_t n,
+    T const* first_args, T const* second_args) {
+  Loader loader;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+  using mask_type = typename simd_type::mask_type;
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+
+  constexpr size_type width = simd_type::size();
+  for (size_type i = 0; i < n; i += width) {
+    size_type const nremaining = n - i;
+    size_type const nlanes     = Kokkos::min(nremaining, width);
+
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.host_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.host_load(second_args + i, nlanes, second_arg);
+    if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    bool expected_val[width];
+    for (size_type lane = 0; lane < width; ++lane) {
+      expected_val[lane] =
+          binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
+    }
+
+    mask_type const expected_result([&](auto i) { return expected_val[i]; });
+    mask_type const computed_result = binary_op.on_host(first_arg, second_arg);
+    host_check_mask_equality(expected_result, computed_result, nlanes);
+  }
+}
+
+template <class Abi, class Op, class T>
+inline void host_check_comparison_op_all_loaders(
+    Op op, Kokkos::Experimental::Impl::simd_size_t n, T const* first_args,
+    T const* second_args) {
+  host_check_comparison_op_one_loader<Abi, load_element_aligned>(
+      op, n, first_args, second_args);
+  host_check_comparison_op_one_loader<Abi, load_masked>(op, n, first_args,
+                                                        second_args);
+  host_check_comparison_op_one_loader<Abi, load_as_scalars>(op, n, first_args,
+                                                            second_args);
+  host_check_comparison_op_one_loader<Abi, load_vector_aligned>(
+      op, n, first_args, second_args);
+}
+
+template <typename Abi, typename DataType,
+          Kokkos::Experimental::Impl::simd_size_t n>
+inline void host_check_all_comparison_ops(const DataType (&first_args)[n],
+                                          const DataType (&second_args)[n]) {
+  host_check_comparison_op_all_loaders<Abi>(equal(), n, first_args,
+                                            second_args);
+  host_check_comparison_op_all_loaders<Abi>(not_equal(), n, first_args,
+                                            second_args);
+  host_check_comparison_op_all_loaders<Abi>(less_than(), n, first_args,
+                                            second_args);
+  host_check_comparison_op_all_loaders<Abi>(less_equal(), n, first_args,
+                                            second_args);
+  host_check_comparison_op_all_loaders<Abi>(greater_than(), n, first_args,
+                                            second_args);
+  host_check_comparison_op_all_loaders<Abi>(greater_equal(), n, first_args,
+                                            second_args);
+}
+
+template <typename Abi, typename DataType>
+inline void host_check_comparison_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi> &&
+                std::is_integral_v<DataType>) {
+    constexpr size_t alignment =
+        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        sizeof(DataType);
+
+    if constexpr (!std::is_integral_v<DataType>) {
+      alignas(alignment) DataType const first_args[] = {
+          0.1, 0.4, 0.5,  0.7, 1.0, 1.5,  -2.0, 10.0,
+          0.0, 1.2, -2.8, 3.0, 4.0, -0.1, 5.0,  -0.2};
+      alignas(alignment) DataType const second_args[] = {
+          1.0,  0.2,  1.1,  1.8, -0.1,  -3.0, -2.4, 1.0,
+          13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2, -0.2};
+      host_check_all_comparison_ops<Abi>(first_args, second_args);
+    } else {
+      if constexpr (std::is_signed_v<DataType>) {
+        alignas(alignment) DataType const first_args[] = {
+            1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2, -3, 7, 4, -9, -15};
+        alignas(alignment) DataType const second_args[] = {
+            1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2, 10, -15, 7, 2, -10};
+        host_check_all_comparison_ops<Abi>(first_args, second_args);
+      } else {
+        alignas(alignment) DataType const first_args[] = {
+            1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2, 11, 5, 8, 2, 14};
+        alignas(alignment) DataType const second_args[] = {
+            1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2, 3, 6, 20, 5, 14};
+        host_check_all_comparison_ops<Abi>(first_args, second_args);
+      }
+    }
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_comparison_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_comparison_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_comparison_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_comparison_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+template <class Abi, class Loader, class BinaryOp, class T>
+KOKKOS_INLINE_FUNCTION void device_check_comparison_op_one_loader(
+    BinaryOp binary_op, Kokkos::Experimental::Impl::simd_size_t n,
+    T const* first_args, T const* second_args) {
+  Loader loader;
+  using simd_type = Kokkos::Experimental::basic_simd<T, Abi>;
+  using mask_type = typename simd_type::mask_type;
+  using size_type = Kokkos::Experimental::Impl::simd_size_t;
+
+  constexpr size_type width = simd_type::size();
+  for (size_type i = 0; i < n; i += width) {
+    size_type const nremaining = n - i;
+    size_type const nlanes     = Kokkos::min(nremaining, width);
+
+    simd_type first_arg;
+    bool const loaded_first_arg =
+        loader.device_load(first_args + i, nlanes, first_arg);
+    simd_type second_arg;
+    bool const loaded_second_arg =
+        loader.device_load(second_args + i, nlanes, second_arg);
+    if (!(loaded_first_arg && loaded_second_arg)) continue;
+
+    T expected_val[width];
+    for (size_type lane = 0; lane < width; ++lane) {
+      expected_val[lane] =
+          binary_op.on_device(T(first_arg[lane]), T(second_arg[lane]));
+    }
+
+    mask_type const expected_result([&](auto i) { return expected_val[i]; });
+    mask_type const computed_result =
+        binary_op.on_device(first_arg, second_arg);
+    device_check_mask_equality(expected_result, computed_result, nlanes);
+  }
+}
+
+template <class Abi, class Op, class T>
+KOKKOS_INLINE_FUNCTION void device_check_comparison_op_all_loaders(
+    Op op, Kokkos::Experimental::Impl::simd_size_t n, T const* first_args,
+    T const* second_args) {
+  device_check_comparison_op_one_loader<Abi, load_element_aligned>(
+      op, n, first_args, second_args);
+  device_check_comparison_op_one_loader<Abi, load_masked>(op, n, first_args,
+                                                          second_args);
+  device_check_comparison_op_one_loader<Abi, load_as_scalars>(op, n, first_args,
+                                                              second_args);
+  device_check_comparison_op_one_loader<Abi, load_vector_aligned>(
+      op, n, first_args, second_args);
+}
+
+template <typename Abi, typename DataType,
+          Kokkos::Experimental::Impl::simd_size_t n>
+KOKKOS_INLINE_FUNCTION void device_check_all_comparison_ops(
+    const DataType (&first_args)[n], const DataType (&second_args)[n]) {
+  device_check_comparison_op_all_loaders<Abi>(equal(), n, first_args,
+                                              second_args);
+  device_check_comparison_op_all_loaders<Abi>(not_equal(), n, first_args,
+                                              second_args);
+  device_check_comparison_op_all_loaders<Abi>(less_than(), n, first_args,
+                                              second_args);
+  device_check_comparison_op_all_loaders<Abi>(less_equal(), n, first_args,
+                                              second_args);
+  device_check_comparison_op_all_loaders<Abi>(greater_than(), n, first_args,
+                                              second_args);
+  device_check_comparison_op_all_loaders<Abi>(greater_equal(), n, first_args,
+                                              second_args);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_comparison_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi> &&
+                std::is_integral_v<DataType>) {
+    constexpr size_t alignment =
+        Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
+        sizeof(DataType);
+
+    if constexpr (!std::is_integral_v<DataType>) {
+      alignas(alignment) DataType const first_args[] = {
+          0.1, 0.4, 0.5,  0.7, 1.0, 1.5,  -2.0, 10.0,
+          0.0, 1.2, -2.8, 3.0, 4.0, -0.1, 5.0,  -0.2};
+      alignas(alignment) DataType const second_args[] = {
+          1.0,  0.2,  1.1,  1.8, -0.1,  -3.0, -2.4, 1.0,
+          13.0, -3.2, -2.1, 3.0, -15.0, -0.5, -0.2, -0.2};
+      device_check_all_comparison_ops<Abi>(first_args, second_args);
+    } else {
+      if constexpr (std::is_signed_v<DataType>) {
+        alignas(alignment) DataType const first_args[] = {
+            1, 2, -1, 10, 0, 1, -2, 10, 0, 1, -2, -3, 7, 4, -9, -15};
+        alignas(alignment) DataType const second_args[] = {
+            1, 2, 1, 1, 1, -3, -2, 1, 13, -3, -2, 10, -15, 7, 2, -10};
+        device_check_all_comparison_ops<Abi>(first_args, second_args);
+      } else {
+        alignas(alignment) DataType const first_args[] = {
+            1, 2, 1, 10, 0, 1, 2, 10, 0, 1, 2, 11, 5, 8, 2, 14};
+        alignas(alignment) DataType const second_args[] = {
+            1, 2, 1, 1, 1, 3, 2, 1, 13, 3, 2, 3, 6, 20, 5, 14};
+        device_check_all_comparison_ops<Abi>(first_args, second_args);
+      }
+    }
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_comparison_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_comparison_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void device_check_comparison_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_comparison_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_comparison_ops_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_comparison_ops_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set());
+  }
+};
+
+template <typename Abi, typename DataType>
+inline void host_check_mask_comparison_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+    using size_type = Kokkos::Experimental::Impl::simd_size_t;
+
+    using Kokkos::Experimental::all_of;
+    using Kokkos::Experimental::none_of;
+
+    constexpr size_type width = mask_type::size();
+
+    mask_type const all(true);
+    mask_type const none(false);
+
+    gtest_checker checker;
+
+    checker.truth(all_of(all == all));
+    checker.truth(none_of(all != all));
+    checker.truth(all_of(none == none));
+    checker.truth(none_of(none != none));
+
+    if constexpr (!std::is_same_v<Abi,
+                                  Kokkos::Experimental::simd_abi::scalar>) {
+      mask_type const hi([=](std::size_t const i) { return i >= width / 2; });
+      mask_type const lo([=](std::size_t const i) { return i < width / 2; });
+      mask_type const even([=](std::size_t const i) { return i % 2 == 0; });
+      mask_type const odd([=](std::size_t const i) { return i % 2 == 1; });
+
+      checker.truth(all_of(hi == hi));
+      checker.truth(none_of(hi != hi));
+      checker.truth(all_of(lo == lo));
+      checker.truth(none_of(lo != lo));
+      checker.truth(none_of(hi == lo));
+      checker.truth(all_of(hi != lo));
+
+      checker.truth(all_of(even == even));
+      checker.truth(none_of(even != even));
+      checker.truth(all_of(odd == odd));
+      checker.truth(none_of(odd != odd));
+      checker.truth(none_of(even == odd));
+      checker.truth(all_of(even != odd));
+    }
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+inline void host_check_mask_comparison_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (host_check_mask_comparison_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+inline void host_check_mask_comparison_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (host_check_mask_comparison_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void device_check_mask_comparison_ops() {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+
+    using Kokkos::Experimental::all_of;
+    using Kokkos::Experimental::none_of;
+
+    mask_type const all(true);
+    mask_type const none(false);
+
+    kokkos_checker checker;
+
+    checker.truth(all_of(all == all));
+    checker.truth(none_of(all != all));
+    checker.truth(all_of(none == none));
+    checker.truth(none_of(none != none));
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void device_check_mask_comparison_ops_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (device_check_mask_comparison_ops<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void device_check_mask_comparison_ops_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (device_check_mask_comparison_ops_all_types<Abis>(DataTypes()), ...);
+}
+
+class simd_device_mask_comparison_ops_functor {
+ public:
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    device_check_mask_comparison_ops_all_abis(
+        Kokkos::Experimental::Impl::device_abi_set());
+  }
+};
+
+TEST(simd, host_comparison_ops) {
+  host_check_comparison_ops_all_abis(
+      Kokkos::Experimental::Impl::host_abi_set());
+}
+
+TEST(simd, host_mask_comparison_ops) {
+  host_check_mask_comparison_ops_all_abis(
+      Kokkos::Experimental::Impl::host_abi_set());
+}
+
+TEST(simd, device_comparison_ops) {
+  Kokkos::parallel_for(1, simd_device_comparison_ops_functor());
+  Kokkos::fence();
+}
+
+TEST(simd, device_mask_comparison_ops) {
+  Kokkos::parallel_for(1, simd_device_mask_comparison_ops_functor());
+  Kokkos::fence();
+}
+
+#endif

--- a/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
@@ -41,7 +41,7 @@ void host_check_comparison_op_one_loader(
     }
 
     mask_type const expected_result(
-        [&](auto idx) { return expected_val[idx]; });
+        KOKKOS_LAMBDA(size_type idx) { return expected_val[idx]; });
     mask_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_mask_equality(expected_result, computed_result, nlanes);
   }
@@ -155,7 +155,7 @@ KOKKOS_INLINE_FUNCTION void device_check_comparison_op_one_loader(
     }
 
     mask_type const expected_result(
-        [&](auto idx) { return expected_val[idx]; });
+        KOKKOS_LAMBDA(size_type idx) { return expected_val[idx]; });
     mask_type const computed_result =
         binary_op.on_device(first_arg, second_arg);
     device_check_mask_equality(expected_result, computed_result, nlanes);

--- a/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
@@ -40,7 +40,8 @@ void host_check_comparison_op_one_loader(
           binary_op.on_host(T(first_arg[lane]), T(second_arg[lane]));
     }
 
-    mask_type const expected_result([&](auto i) { return expected_val[i]; });
+    mask_type const expected_result(
+        [&](auto idx) { return expected_val[idx]; });
     mask_type const computed_result = binary_op.on_host(first_arg, second_arg);
     host_check_mask_equality(expected_result, computed_result, nlanes);
   }
@@ -153,7 +154,8 @@ KOKKOS_INLINE_FUNCTION void device_check_comparison_op_one_loader(
           binary_op.on_device(T(first_arg[lane]), T(second_arg[lane]));
     }
 
-    mask_type const expected_result([&](auto i) { return expected_val[i]; });
+    mask_type const expected_result(
+        [&](auto idx) { return expected_val[idx]; });
     mask_type const computed_result =
         binary_op.on_device(first_arg, second_arg);
     device_check_mask_equality(expected_result, computed_result, nlanes);

--- a/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_ComparisonOps.hpp
@@ -81,8 +81,7 @@ inline void host_check_all_comparison_ops(const DataType (&first_args)[n],
 
 template <typename Abi, typename DataType>
 inline void host_check_comparison_ops() {
-  if constexpr (is_simd_avail_v<DataType, Abi> &&
-                std::is_integral_v<DataType>) {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
     constexpr size_t alignment =
         Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
         sizeof(DataType);
@@ -196,8 +195,7 @@ KOKKOS_INLINE_FUNCTION void device_check_all_comparison_ops(
 
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_check_comparison_ops() {
-  if constexpr (is_simd_avail_v<DataType, Abi> &&
-                std::is_integral_v<DataType>) {
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
     constexpr size_t alignment =
         Kokkos::Experimental::basic_simd<DataType, Abi>::size() *
         sizeof(DataType);


### PR DESCRIPTION
This PR implements the `<`, `<=`, `>` and `>=` operators for `simd<uint64_t>` on the AVX2 and NEON backends. I also added tests for the comparison operations.

This also fixes a bug where `a > b` and `a >= b` would return `b > a` and `b >= a` for `simd<double>` on avx512