### PR TITLE
Riscv stream fix

### DIFF
--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -102,7 +102,7 @@ int validate_array(V& a_dev, typename V::const_value_type expected) {
 
 template <unsigned MemTraits>
 static void StreamSet(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 8);
+  const size_t N8                 = std::pow(state.range(0), 7);
   static constexpr int DATA_RATIO = 1;
 
   StreamView<MemTraits> a(Kokkos::view_alloc(Kokkos::WithoutInitializing, "a"),
@@ -121,7 +121,7 @@ static void StreamSet(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamCopy(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 8);
+  const size_t N8                 = std::pow(state.range(0), 7);
   static constexpr int DATA_RATIO = 2;
 
   StreamView<MemTraits> a("a", N8), b("b", N8);
@@ -141,7 +141,7 @@ static void StreamCopy(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamScale(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 8);
+  const size_t N8                 = std::pow(state.range(0), 7);
   static constexpr int DATA_RATIO = 2;
 
   StreamView<MemTraits> a("a", N8), b("b", N8);
@@ -161,7 +161,7 @@ static void StreamScale(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamAdd(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 8);
+  const size_t N8                 = std::pow(state.range(0), 7);
   static constexpr int DATA_RATIO = 3;
 
   StreamView<MemTraits> a("a", N8), b("b", N8), c("c", N8);
@@ -183,7 +183,7 @@ static void StreamAdd(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamTriad(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 8);
+  const size_t N8                 = std::pow(state.range(0), 7);
   static constexpr int DATA_RATIO = 3;
 
   StreamView<MemTraits> a("a", N8), b("b", N8), c("c", N8);

--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -213,21 +213,17 @@ static void or_skip(benchmark::State& state) {
   }
 }
 
-// As of May 2025, 10^8 doubles is larger than caches, but not so large as
-// to be inconvenient. Also run 11^8 for a quick check of convergence.
-// This value is only used if the available memory is > 6GB, so the test defaults
-// to a low-memory mode using 9^8 and 10^8 elements.
-#ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS
-constexpr static int base_val = 10;
-#else
-constexpr static int base_val = 9;
-#endif
+// We choose the case of 9^8 doubles to test with (which allocates ~1 GB), as
+// well as a quick test with 10^8 doubles (~2.4 GB) for checking convergence. As
+// of January 2026, This value is higher than caches but reasonable enough
+// to be safely allocated, even on low-memory devices. This needs to be
+// (potentially) periodically revisited.
 
 #define STREAM_ARGS(label)            \
   Name(label)                         \
       ->ArgName("N")                  \
-      ->Arg(base_val)                 \
-      ->Arg(base_val + 1)             \
+      ->Arg(9)                        \
+      ->Arg(10)                       \
       ->Unit(benchmark::kMillisecond) \
       ->UseManualTime()
 

--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -213,13 +213,21 @@ static void or_skip(benchmark::State& state) {
   }
 }
 
-// As of Jan 2026, 9^8 doubles is larger than caches, but not so large as
-// to be inconvenient. Also run 10^8 for a quick check of convergence.
+// As of May 2025, 10^8 doubles is larger than caches, but not so large as
+// to be inconvenient. Also run 11^8 for a quick check of convergence.
+// This value is only used if the available memory is > 6G, so the test defaults
+// to a low-memory mode
+#ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS
+constexpr static int base_val = 10;
+#else
+constexpr static int base_val = 9;
+#endif
+
 #define STREAM_ARGS(label)            \
   Name(label)                         \
       ->ArgName("N")                  \
-      ->Arg(9)                        \
-      ->Arg(10)                       \
+      ->Arg(base_val)                 \
+      ->Arg(base_val + 1)             \
       ->Unit(benchmark::kMillisecond) \
       ->UseManualTime()
 

--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -102,7 +102,7 @@ int validate_array(V& a_dev, typename V::const_value_type expected) {
 
 template <unsigned MemTraits>
 static void StreamSet(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 7);
+  const size_t N8                 = std::pow(state.range(0), 8);
   static constexpr int DATA_RATIO = 1;
 
   StreamView<MemTraits> a(Kokkos::view_alloc(Kokkos::WithoutInitializing, "a"),
@@ -121,7 +121,7 @@ static void StreamSet(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamCopy(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 7);
+  const size_t N8                 = std::pow(state.range(0), 8);
   static constexpr int DATA_RATIO = 2;
 
   StreamView<MemTraits> a("a", N8), b("b", N8);
@@ -141,7 +141,7 @@ static void StreamCopy(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamScale(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 7);
+  const size_t N8                 = std::pow(state.range(0), 8);
   static constexpr int DATA_RATIO = 2;
 
   StreamView<MemTraits> a("a", N8), b("b", N8);
@@ -161,7 +161,7 @@ static void StreamScale(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamAdd(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 7);
+  const size_t N8                 = std::pow(state.range(0), 8);
   static constexpr int DATA_RATIO = 3;
 
   StreamView<MemTraits> a("a", N8), b("b", N8), c("c", N8);
@@ -183,7 +183,7 @@ static void StreamAdd(benchmark::State& state) {
 
 template <unsigned MemTraits>
 static void StreamTriad(benchmark::State& state) {
-  const size_t N8                 = std::pow(state.range(0), 7);
+  const size_t N8                 = std::pow(state.range(0), 8);
   static constexpr int DATA_RATIO = 3;
 
   StreamView<MemTraits> a("a", N8), b("b", N8), c("c", N8);
@@ -213,13 +213,13 @@ static void or_skip(benchmark::State& state) {
   }
 }
 
-// As of May 2025, 10^8 doubles is larger than caches, but not so large as
-// to be inconvenient. Also run 11^8 for a quick check of convergence.
+// As of Jan 2026, 9^8 doubles is larger than caches, but not so large as
+// to be inconvenient. Also run 10^8 for a quick check of convergence.
 #define STREAM_ARGS(label)            \
   Name(label)                         \
       ->ArgName("N")                  \
+      ->Arg(9)                        \
       ->Arg(10)                       \
-      ->Arg(11)                       \
       ->Unit(benchmark::kMillisecond) \
       ->UseManualTime()
 

--- a/core/perf_test/PerfTest_Stream.cpp
+++ b/core/perf_test/PerfTest_Stream.cpp
@@ -215,8 +215,8 @@ static void or_skip(benchmark::State& state) {
 
 // As of May 2025, 10^8 doubles is larger than caches, but not so large as
 // to be inconvenient. Also run 11^8 for a quick check of convergence.
-// This value is only used if the available memory is > 6G, so the test defaults
-// to a low-memory mode
+// This value is only used if the available memory is > 6GB, so the test defaults
+// to a low-memory mode using 9^8 and 10^8 elements.
 #ifdef KOKKOS_ENABLE_LARGE_MEM_TESTS
 constexpr static int base_val = 10;
 #else


### PR DESCRIPTION
The stream benchmark (part of Perf tests) gets OOM-killed on low-memory devices. This PR keeps the original version if the `KOKKOS_ENABLE_LARGE_MEM_TESTS` option  is specified at compile time, else it defaults to a lower memory version.


Fixes #8799.