### PR TITLE
Fix skipping ARM and SVE detection with compiler wrapper

### DIFF
--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -276,18 +276,6 @@ function(kokkos_use_neon_if_compiler_allows_it)
   endif()
 
   unset(KOKKOS_COMPILER_HAS_ARM_NEON CACHE)
-  check_source_compiles(
-    ${KOKKOS_COMPILE_LANGUAGE}
-    "
-    #include <arm_neon.h>
-    int main() {
-        float32x2_t a;
-        a = vadd_f32(a, a);
-    }
-    "
-    KOKKOS_COMPILER_HAS_ARM_NEON
-  )
-
   #FIXME_Kokkos_launch_compiler
   get_property(kokkos_global_rule_compile GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
   if("${kokkos_global_rule_compile}" MATCHES "kokkos_launch_compiler")
@@ -295,10 +283,19 @@ function(kokkos_use_neon_if_compiler_allows_it)
                     "You can force the use of NEON by using the Kokkos_ARCH_* flag specific to your target "
                     "processor instead of Kokkos_ARCH_NATIVE."
     )
-    set(KOKKOS_COMPILER_HAS_ARM_NEON OFF)
+  else()
+    check_source_compiles(
+      ${KOKKOS_COMPILE_LANGUAGE}
+      "
+      #include <arm_neon.h>
+      int main() {
+          float32x2_t a;
+          a = vadd_f32(a, a);
+      }
+      "
+      KOKKOS_COMPILER_HAS_ARM_NEON
+    )
   endif()
-
-  set(KOKKOS_ARCH_ARM_NEON ${KOKKOS_COMPILER_HAS_ARM_NEON} PARENT_SCOPE)
 endfunction()
 
 function(kokkos_use_sve_if_compiler_allows_it)
@@ -312,18 +309,6 @@ function(kokkos_use_sve_if_compiler_allows_it)
   endif()
 
   unset(KOKKOS_COMPILER_HAS_ARM_SVE CACHE)
-  check_source_compiles(
-    ${KOKKOS_COMPILE_LANGUAGE}
-    "
-    #include <arm_sve.h>
-    int main() {
-    auto a = svcntb();
-    return 0;
-    }
-    "
-    KOKKOS_COMPILER_HAS_ARM_SVE
-  )
-
   #FIXME_Kokkos_launch_compiler
   get_property(kokkos_global_rule_compile GLOBAL PROPERTY RULE_LAUNCH_COMPILE)
   if("${kokkos_global_rule_compile}" MATCHES "kokkos_launch_compiler")
@@ -331,10 +316,19 @@ function(kokkos_use_sve_if_compiler_allows_it)
                     "You can force the use of SVE by using the Kokkos_ARCH_* flag specific to your target "
                     "processor instead of Kokkos_ARCH_NATIVE."
     )
-    set(KOKKOS_COMPILER_HAS_ARM_SVE OFF)
+  else()
+    check_source_compiles(
+      ${KOKKOS_COMPILE_LANGUAGE}
+      "
+      #include <arm_sve.h>
+      int main() {
+      auto a = svcntb();
+      return 0;
+      }
+      "
+      KOKKOS_COMPILER_HAS_ARM_SVE
+    )
   endif()
-
-  set(KOKKOS_ARCH_ARM_SVE ${KOKKOS_COMPILER_HAS_ARM_SVE} PARENT_SCOPE)
 endfunction()
 
 if(KOKKOS_ARCH_ARMV80)


### PR DESCRIPTION
On GH200, I was still seeing
```
$ cmake -DKokkos_ARCH_NATIVE=ON -DKokkos_ENABLE_CUDA=ON  -DKokkos_ENABLE_TESTS=ON .. &&  make -j64 Kokkos_UnitTest_SIMD
-- Setting default Kokkos CXX standard to 20
-- The CXX compiler identification is GNU 11.4.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'RelWithDebInfo' as none was specified.
-- Kokkos version: 5.0.99
-- The project name is: Kokkos
-- Using bundled GoogleTest version
-- Configured git information in /home/users/darndt/kokkos/build/generated/Kokkos_Version_Info.cpp
-- kokkos_launch_compiler (/home/users/darndt/kokkos/bin/kokkos_launch_compiler) is enabled...
-- Kokkos is configured for CMake languages CXX compilation (using NVIDIA version 13.0.48)
-- SERIAL backend is being turned on to ensure there is at least one Host space. To change this, you must enable another host execution space and configure with -DKokkos_ENABLE_SERIAL=OFF.
-- Using -std=c++20 for C++20 standard as feature
CMake Warning at cmake/kokkos_arch.cmake:330 (message):
  The use of 'kokkos_launch_compiler' prevents reliable SVE detection.
  Disabling SVE.

  You can force the use of SVE by using the Kokkos_ARCH_* flag specific to
  your target processor instead of Kokkos_ARCH_NATIVE.
Call Stack (most recent call first):
  cmake/kokkos_arch.cmake:827 (kokkos_use_sve_if_compiler_allows_it)
  cmake/kokkos_tribits.cmake:175 (include)
  CMakeLists.txt:216 (kokkos_setup_build_environment)


CMake Warning at cmake/kokkos_arch.cmake:294 (message):
  The use of 'kokkos_launch_compiler' prevents reliable NEON detection.
  Disabling NEON.

  You can force the use of NEON by using the Kokkos_ARCH_* flag specific to
  your target processor instead of Kokkos_ARCH_NATIVE.
Call Stack (most recent call first):
  cmake/kokkos_arch.cmake:828 (kokkos_use_neon_if_compiler_allows_it)
  cmake/kokkos_tribits.cmake:175 (include)
  CMakeLists.txt:216 (kokkos_setup_build_environment)


-- SIMD: ARM_SVE detected
-- Performing Test GET_SVE_HW_VL = 128 -- success
-- CUDA auto-detection of architecture failed with /usr/bin/c++. Enabling CUDA language ONLY to auto-detect architecture...
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - /packages/cuda/13.0.0/bin/nvcc
-- The CUDA compiler identification is NVIDIA 13.0.48
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /packages/cuda/13.0.0/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Detected CUDA Compute Capability 90
-- Setting Kokkos_ARCH_HOPPER90=ON
-- Built-in Execution Spaces:
--     Device Parallel: Kokkos::Cuda
--     Host Parallel: NoTypeDefined
--       Host Serial: SERIAL
-- 
-- Architectures:
--  NATIVE
--  HOPPER90
-- Found CUDAToolkit: /packages/cuda/13.0.0/include (found version "13.0.48") 
-- Found Threads: TRUE  
-- Using bundled desul_atomics copy (desul/desul@79f928075837ffb5d302aae188e0ec7b7a79ae94)
-- Using bundled mdspan copy (kokkos/mdspan@546d4dd63697c6a331554adb6fe650e09b690812)
-- Found Python3: /usr/bin/python3.11 (found version "3.11.7") found components: Interpreter 
-- Sources TestCuda.cpp
-- Looking for C++ include arm_neon_sve_bridge.h
-- Looking for C++ include arm_neon_sve_bridge.h - not found
CMake Warning at simd/src/CMakeLists.txt:54 (message):
  You are using a compiler without NEON-SVE bridge header
  (arm_neon_sve_bridge.h).  Kokkos will use its own implementation of these
  functions, which could be slower than native ones from a more recent SVE
  compiler.  It is recommended to upgrade your compiler.

  NOTE: It was also observed that, in some LLVM versions (14, 15), despite
  the macro __ARM_NEON_SVE_BRIDGE was defined, the header
  arm_neon_sve_bridge.h is still not available (see
  https://godbolt.org/z/7jqWvzvWY ).


-- Kokkos Backends: SERIAL;CUDA
-- Configuring done (7.0s)
-- Generating done (0.9s)
-- Build files have been written to: /home/users/darndt/kokkos/build
[  0%] Building CXX object _deps/googletest-build/CMakeFiles/gtest.dir/gtest/gtest-all.cc.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Abort.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_CPUDiscovery.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Command_Line_Parsing.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Core.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Error.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_ExecPolicy.cpp.o
[  0%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostBarrier.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostSpace_deepcopy.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostSpace.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_HostThreadTeam.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_MemoryPool.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Profiling.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_SharedAlloc.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_Stacktrace.cpp.o
[ 20%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/impl/Kokkos_hwloc.cpp.o
[ 40%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/Cuda/Kokkos_Cuda_Instance.cpp.o
[ 40%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/Cuda/Kokkos_CudaSpace.cpp.o
[ 40%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/__/__/tpls/desul/src/Lock_Array_CUDA.cpp.o
[ 40%] Building CXX object core/src/CMakeFiles/kokkoscore.dir/Serial/Kokkos_Serial.cpp.o
[ 40%] Linking CXX static library libgtest.a
[ 40%] Built target gtest
[ 40%] Linking CXX static library libkokkoscore.a
[ 40%] Built target kokkoscore
[ 40%] Building CXX object simd/src/CMakeFiles/kokkossimd.dir/Kokkos_SIMD_dummy.cpp.o
[ 40%] Building CXX object algorithms/src/CMakeFiles/kokkosalgorithms.dir/KokkosAlgorithms_dummy.cpp.o
[ 60%] Building CXX object containers/src/CMakeFiles/kokkoscontainers.dir/impl/Kokkos_UnorderedMap_impl.cpp.o
[ 80%] Linking CXX static library libkokkosalgorithms.a
[ 80%] Linking CXX static library libkokkossimd.a
[ 80%] Built target kokkosalgorithms
[ 80%] Built target kokkossimd
[ 80%] Linking CXX static library libkokkoscontainers.a
[ 80%] Built target kokkoscontainers
[100%] Building CXX object simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/UnitTestMain.cpp.o
[100%] Building CXX object simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/TestSIMD.cpp.o
/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(18): error: identifier "svuint64_t" is undefined
      svuint64_t z) {
      ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(21): error: identifier "svbool_t" is undefined
    svbool_t pg0 = svpfirst(svptrue_b64(), svpfalse());
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(21): error: identifier "svptrue_b64" is undefined
    svbool_t pg0 = svpfirst(svptrue_b64(), svpfalse());
                            ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(21): error: identifier "svpfalse" is undefined
    svbool_t pg0 = svpfirst(svptrue_b64(), svpfalse());
                                           ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(21): error: identifier "svpfirst" is undefined
    svbool_t pg0 = svpfirst(svptrue_b64(), svpfalse());
                   ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(22): error: identifier "svbool_t" is undefined
    svbool_t pg1 = svpnext_b64(pg0, pg0);
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(22): error: identifier "svpnext_b64" is undefined
    svbool_t pg1 = svpnext_b64(pg0, pg0);
                   ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(24): error: identifier "svlastb" is undefined
    res[0] = svlastb(pg0, z);
             ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(31): error: identifier "svint32_t" is undefined
      svint32_t z) {
      ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(34): error: identifier "svbool_t" is undefined
    svbool_t pg0 = svpfirst(svptrue_b32(), svpfalse());
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(34): error: identifier "svptrue_b32" is undefined
    svbool_t pg0 = svpfirst(svptrue_b32(), svpfalse());
                            ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(34): error: identifier "svpfalse" is undefined
    svbool_t pg0 = svpfirst(svptrue_b32(), svpfalse());
                                           ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(34): error: identifier "svpfirst" is undefined
    svbool_t pg0 = svpfirst(svptrue_b32(), svpfalse());
                   ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(35): error: identifier "svbool_t" is undefined
    svbool_t pg1 = svpnext_b32(pg0, pg0);
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(35): error: identifier "svpnext_b32" is undefined
    svbool_t pg1 = svpnext_b32(pg0, pg0);
                   ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(36): error: identifier "svbool_t" is undefined
    svbool_t pg2 = svpnext_b32(pg1, pg1);
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(37): error: identifier "svbool_t" is undefined
    svbool_t pg3 = svpnext_b32(pg2, pg2);
    ^

/home/users/darndt/kokkos/simd/src/impl/Kokkos_Neon_SVE_bridge.hpp(39): error: identifier "svlastb" is undefined
    res[0] = svlastb(pg0, z);
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(35): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svint32_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(35): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svint32_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(37): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svuint32_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(37): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svuint32_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(39): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svfloat32_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(39): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svfloat32_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(41): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svint64_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(41): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svint64_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(43): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svuint64_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(43): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svuint64_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(45): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svfloat64_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(45): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svfloat64_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(47): error: explicit type is missing ("int" assumed)
      __attribute__((arm_sve_vector_bits(128))) svbool_t;
      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(47): error: expected a ";"
      __attribute__((arm_sve_vector_bits(128))) svbool_t;
                                                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(59): error: identifier "svint32_t" is undefined
      std::is_same_v<T, std::int32_t>, svint32_t,
                                       ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(61): error: identifier "svuint32_t" is undefined
          std::is_same_v<T, std::uint32_t>, svuint32_t,
                                            ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(63): error: identifier "svfloat32_t" is undefined
              std::is_same_v<T, float>, svfloat32_t,
                                        ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(65): error: identifier "svint64_t" is undefined
                  std::is_same_v<T, std::int64_t>, svint64_t,
                                                   ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(67): error: identifier "svuint64_t" is undefined
                      std::is_same_v<T, std::uint64_t>, svuint64_t,
                                                        ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(69): error: identifier "svfloat64_t" is undefined
                          std::is_same_v<T, double>, svfloat64_t,
                                                     ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(70): error: identifier "svbool_t" is undefined
                          std::conditional_t<std::is_same_v<T, bool>, svbool_t,
                                                                      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(95): error: identifier "svwhilele_b8" is undefined
      return svwhilele_b8(0, static_cast<std::int32_t>(lane));
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(97): error: identifier "svwhilele_b16" is undefined
      return svwhilele_b16(0, static_cast<std::int32_t>(lane));
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(99): error: identifier "svwhilele_b32" is undefined
      return svwhilele_b32(0, static_cast<std::int32_t>(lane));
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(101): error: identifier "svwhilele_b64" is undefined
      return svwhilele_b64(0, static_cast<std::int32_t>(lane));
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(124): error: identifier "svdup_b64" is undefined
        : m_value(svdup_b64(value)) {}
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(133): error: identifier "svdupq_b64" is undefined
      m_value = svdupq_b64(
                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(178): error: identifier "svptest_last" is undefined
      return svptest_last(Impl::get_pred<64>(i), m_value);
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(187): error: identifier "svptrue_b64" is undefined
          static_cast<implementation_type>(svnot_z(svptrue_b64(), m_value)));
                                                   ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(187): error: identifier "svnot_z" is undefined
          static_cast<implementation_type>(svnot_z(svptrue_b64(), m_value)));
                                           ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(201): error: identifier "svptrue_b64" is undefined
          svand_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(201): error: identifier "svand_z" is undefined
          svand_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(206): error: identifier "svptrue_b64" is undefined
          svorr_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(206): error: identifier "svorr_z" is undefined
          svorr_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(211): error: identifier "svptrue_b64" is undefined
          sveor_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(211): error: identifier "sveor_z" is undefined
          sveor_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(216): error: identifier "svptrue_b64" is undefined
          sveor_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(216): error: identifier "sveor_z" is undefined
          sveor_z(svptrue_b64(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(241): error: identifier "svdup_b32" is undefined
        : m_value(svdup_b32(value)) {}
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(250): error: identifier "svdupq_b32" is undefined
      m_value = svdupq_b32(
                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(309): error: identifier "svptest_last" is undefined
      return svptest_last(Impl::get_pred<32>(i), m_value);
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(318): error: identifier "svptrue_b32" is undefined
          static_cast<implementation_type>(svnot_z(svptrue_b32(), m_value)));
                                                   ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(318): error: identifier "svnot_z" is undefined
          static_cast<implementation_type>(svnot_z(svptrue_b32(), m_value)));
                                           ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(332): error: identifier "svptrue_b32" is undefined
          svand_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(332): error: identifier "svand_z" is undefined
          svand_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(337): error: identifier "svptrue_b32" is undefined
          svorr_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(337): error: identifier "svorr_z" is undefined
          svorr_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(342): error: identifier "svptrue_b32" is undefined
          sveor_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(342): error: identifier "sveor_z" is undefined
          sveor_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(347): error: identifier "svptrue_b32" is undefined
          sveor_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(347): error: identifier "sveor_z" is undefined
          sveor_z(svptrue_b32(), lhs.m_value, rhs.m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(431): error: identifier "svdup_f64" is undefined
        : m_value(svdup_f64(value_type(value))) {}
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(478): error: identifier "svptrue_b64" is undefined
      m_value = svld1(svptrue_b64(), temp);
                      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(478): error: identifier "svld1" is undefined
      m_value = svld1(svptrue_b64(), temp);
                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(484): error: identifier "svptrue_b64" is undefined
      m_value = svld1(svptrue_b64(), ptr);
                      ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(484): error: identifier "svld1" is undefined
      m_value = svld1(svptrue_b64(), ptr);
                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(489): error: identifier "svld1" is undefined
      m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
                ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(494): error: identifier "svlastb" is undefined
      return svlastb(Impl::get_pred<64>(i), m_value);
             ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(526): error: identifier "svptrue_b64" is undefined
          svneg_m(m_value, svptrue_b64(), m_value)));
                           ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(526): error: identifier "svneg_m" is undefined
          svneg_m(m_value, svptrue_b64(), m_value)));
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(532): error: identifier "svptrue_b64" is undefined
          svmul_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(532): error: identifier "svmul_m" is undefined
          svmul_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(539): error: identifier "svptrue_b64" is undefined
          svdiv_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(539): error: identifier "svdiv_m" is undefined
          svdiv_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(545): error: identifier "svptrue_b64" is undefined
          svadd_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(545): error: identifier "svadd_m" is undefined
          svadd_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(551): error: identifier "svptrue_b64" is undefined
          svsub_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(551): error: identifier "svsub_m" is undefined
          svsub_m(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(558): error: identifier "svptrue_b64" is undefined
          svcmplt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(558): error: identifier "svcmplt" is undefined
          svcmplt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(564): error: identifier "svptrue_b64" is undefined
          svcmpgt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(564): error: identifier "svcmpgt" is undefined
          svcmpgt(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(570): error: identifier "svptrue_b64" is undefined
          svcmple(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(570): error: identifier "svcmple" is undefined
          svcmple(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(576): error: identifier "svptrue_b64" is undefined
          svcmpge(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(576): error: identifier "svcmpge" is undefined
          svcmpge(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(582): error: identifier "svptrue_b64" is undefined
          svcmpeq(svptrue_b64(), static_cast<vls_float64_t>(lhs),
                  ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(582): error: identifier "svcmpeq" is undefined
          svcmpeq(svptrue_b64(), static_cast<vls_float64_t>(lhs),
          ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(600): error: identifier "svptrue_b64" is undefined
        static_cast<vls_float64_t>(svabs_m(aa, svptrue_b64(), aa)));
                                               ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(600): error: identifier "svabs_m" is undefined
        static_cast<vls_float64_t>(svabs_m(aa, svptrue_b64(), aa)));
                                   ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(610): error: identifier "svptrue_b64" is undefined
        static_cast<vls_float64_t>(svrintm_m(aa, svptrue_b64(), aa)));
                                                 ^

/home/users/darndt/kokkos/simd/src/Kokkos_SIMD_SVE.hpp(610): error: identifier "svrintm_m" is undefined
        static_cast<vls_float64_t>(svrintm_m(aa, svptrue_b64(), aa)));
                                   ^

Error limit reached.
100 errors detected in the compilation of "/home/users/darndt/kokkos/simd/unit_tests/TestSIMD.cpp".
Compilation terminated.
make[3]: *** [simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/build.make:90: simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/TestSIMD.cpp.o] Error 4
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/Makefile2:5072: simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:5079: simd/unit_tests/CMakeFiles/Kokkos_UnitTest_SIMD.dir/rule] Error 2
make: *** [Makefile:2194: Kokkos_UnitTest_SIMD] Error 2
```
and in particular
```
-- SIMD: ARM_SVE detected
```
.

```
set(KOKKOS_COMPILER_HAS_ARM_SVE OFF)
```
sets a local variable and didn't have any effect for the parent scope. Also, we don't need to set `KOKKOS_ARCH_ARM_SVE`. That variable will be set based on `KOKKOS_COMPILER_HAS_ARM_SVE` anyway.

Thus, this pull request just skips even trying to call `check_source_compiles` ensuring that the test result is empty.