### PR TITLE
Fix `abs(half_t)` with clang + cuda

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
@@ -72,8 +72,15 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
   KOKKOS_CUDA_BHALF_UNARY_PREDICATE_IMPL(OP, CUDA_NAME)
 
 // Basic operations
+// FIXME_CLANG+CUDA: __habs ICEs clang 17 for special values with half_t
+#if defined KOKKOS_COMPILER_CLANG && KOKKOS_COMPILER_CLANG >= 1700 && \
+    KOKKOS_COMPILER_CLANG < 1800
+KOKKOS_CUDA_BHALF_UNARY_FUNCTION_IMPL(abs, __habs)
+KOKKOS_CUDA_BHALF_UNARY_FUNCTION_IMPL(fabs, __habs)
+#else
 KOKKOS_CUDA_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(abs, __habs)
 KOKKOS_CUDA_HALF_AND_BHALF_UNARY_FUNCTION_IMPL(fabs, __habs)
+#endif
 // fmod
 // remainder
 #if KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -1673,12 +1673,32 @@ struct TestAbsoluteValueFunction {
       Kokkos::printf("failed abs(float)\n");
     }
     if (abs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
-        abs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
+        abs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f) ||
+        abs(KE::quiet_NaN<KE::half_t>::value) ==
+            abs(KE::quiet_NaN<KE::half_t>::value) ||
+        abs(KE::signaling_NaN<KE::half_t>::value) ==
+            abs(KE::signaling_NaN<KE::half_t>::value) ||
+        abs(KE::infinity<KE::half_t>::value) !=
+            abs(KE::infinity<KE::half_t>::value) ||
+        abs(KE::denorm_min<KE::half_t>::value) !=
+            abs(KE::denorm_min<KE::half_t>::value) ||
+        abs(KE::norm_min<KE::half_t>::value) !=
+            abs(KE::norm_min<KE::half_t>::value)) {
       ++e;
       Kokkos::printf("failed abs(KE::half_t)\n");
     }
     if (abs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
-        abs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
+        abs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f) ||
+        abs(KE::quiet_NaN<KE::bhalf_t>::value) ==
+            abs(KE::quiet_NaN<KE::bhalf_t>::value) ||
+        abs(KE::signaling_NaN<KE::bhalf_t>::value) ==
+            abs(KE::signaling_NaN<KE::bhalf_t>::value) ||
+        abs(KE::infinity<KE::bhalf_t>::value) !=
+            abs(KE::infinity<KE::bhalf_t>::value) ||
+        abs(KE::denorm_min<KE::bhalf_t>::value) !=
+            abs(KE::denorm_min<KE::bhalf_t>::value) ||
+        abs(KE::norm_min<KE::bhalf_t>::value) !=
+            abs(KE::norm_min<KE::bhalf_t>::value)) {
       ++e;
       Kokkos::printf("failed abs(KE::bhalf_t)\n");
     }


### PR DESCRIPTION
Clang 17 + cuda created an ICE for special values of `half_t` in the `abs` function.
This pr proposes excluding these functions for this particular combination of compiler and backend and using the `float` versions instead. Interestingly the problem does not occur for `bhalf_t`.
This came up in https://github.com/kokkos/kokkos/pull/8712

Things I did not look at:
- Does it also produce problems at runtime? We know the special values produce problems when inserted to `abs` at compile time
- What happens with other Clang and Cuda version combinations.

Alternatives:
- make `isnormal` not use `abs` as proposed in https://github.com/kokkos/kokkos/pull/8712#discussion_r2672257322