### PR TITLE
core(exec): allow execution space instances to be moved around

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,7 @@ Checks: >
   -bugprone-suspicious-include,
   cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-rvalue-reference-param-not-moved,
+  cppcoreguidelines-special-member-functions,
   modernize-type-traits,
   modernize-use-nullptr,
   modernize-use-using,

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -145,6 +145,9 @@ class Cuda {
 
   Cuda(const Cuda&)            = default;
   Cuda& operator=(const Cuda&) = default;
+  Cuda(Cuda&&)                 = default;
+  Cuda& operator=(Cuda&&)      = default;
+
   ~Cuda();
   Cuda();
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -36,6 +36,9 @@ class HIP {
 
   HIP(const HIP&)            = default;
   HIP& operator=(const HIP&) = default;
+  HIP(HIP&&)                 = default;
+  HIP& operator=(HIP&&)      = default;
+
   ~HIP();
   HIP();
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -199,8 +199,10 @@ class HPX {
       : HPX(std::move(sender)) {}
 #endif
 
-  HPX(const HPX &other)       = default;
+  HPX(const HPX &)            = default;
   HPX &operator=(const HPX &) = default;
+  HPX(HPX &&)                 = default;
+  HPX &operator=(HPX &&)      = default;
 
   void print_configuration(std::ostream &os, bool /*verbose*/ = false) const;
   instance_data &impl_get_instance_data() const noexcept {

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -64,6 +64,9 @@ class OpenACC {
 
   OpenACC(const OpenACC&)            = default;
   OpenACC& operator=(const OpenACC&) = default;
+  OpenACC(OpenACC&&)                 = default;
+  OpenACC& operator=(OpenACC&&)      = default;
+
   ~OpenACC();
   OpenACC();
 

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -53,6 +53,9 @@ class OpenMP {
 
   OpenMP(const OpenMP&)            = default;
   OpenMP& operator=(const OpenMP&) = default;
+  OpenMP(OpenMP&&)                 = default;
+  OpenMP& operator=(OpenMP&&)      = default;
+
   ~OpenMP();
   OpenMP();
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -45,6 +45,9 @@ class SYCL {
 
   SYCL(const SYCL&)            = default;
   SYCL& operator=(const SYCL&) = default;
+  SYCL(SYCL&&)                 = default;
+  SYCL& operator=(SYCL&&)      = default;
+
   ~SYCL();
   SYCL();
   explicit SYCL(const sycl::queue&);

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -98,6 +98,9 @@ class Serial {
 
   Serial(const Serial&)            = default;
   Serial& operator=(const Serial&) = default;
+  Serial(Serial&&)                 = default;
+  Serial& operator=(Serial&&)      = default;
+
   ~Serial();
   Serial();
 

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -113,6 +113,8 @@ class Threads {
 
   Threads(const Threads&)            = default;
   Threads& operator=(const Threads&) = default;
+  Threads(Threads&&)                 = default;
+  Threads& operator=(Threads&&)      = default;
 
   ~Threads() { Impl::check_execution_space_destructor_precondition(name()); }
 


### PR DESCRIPTION
### Motivation

Currently, execution space instances define custom constructors, destructor, and copy operations but do not explicitly define move constructor and move assignment operator. 

This violates the rule of five and results in implicitly-deleted move operations, forcing unnecessary copies in move contexts.

Since execution space instances hold resources (like a shared pointer to their internal implementation), copying them involves work (like atomic reference count operations).
While not catastrophic, these copies are more expensive than moves and can impact performance in scenarios where execution spaces are passed around frequently (such as in `std::execution` sender/receiver chains).

### To move or not to move

If you don't agree that execution space instances can be moved, and that copy is the behavior we want, we should still define the move constructor and assignment operator as `delete`d to make this intent clear (though I don't see why we'd want such a behavior).

### Drive-by :car: 

I've added the `cppcoreguidelines-special-member-functions` check to `clang-tidy`, which I feel may flag a lot of issues, so it can also be removed from this PR if needed.

### Risks

I don't think this would break any downstream code. Relying on the always-copied behavior feels like a code smell.