### PR TITLE
Complex operators improved

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -63,7 +63,6 @@ class
   /// This constructor cannot be called in a CUDA device function,
   /// because std::complex's methods and nonmember functions are not
   /// marked as CUDA device functions.
-  KOKKOS_INLINE_FUNCTION
   complex(const std::complex<RealType>& src) noexcept
       // We can use this aspect of the standard to avoid calling
       // non-device-marked functions `std::real` and `std::imag`: "For any
@@ -149,12 +148,12 @@ class
     return *this;
   }
 
-  KOKKOS_FUNCTION friend constexpr complex& operator+=(
-      complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex& operator+=(complex& lhs,
+                                       const std::complex<RealType>& rhs) {
     return lhs = lhs + rhs;
   }
 
-  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator+=(
+  friend constexpr std::complex<RealType>& operator+=(
       std::complex<RealType>& lhs, const complex& rhs) {
     return lhs = lhs + rhs;
   }
@@ -172,12 +171,12 @@ class
     return *this;
   }
 
-  KOKKOS_FUNCTION friend constexpr complex& operator-=(
-      complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex& operator-=(complex& lhs,
+                                       const std::complex<RealType>& rhs) {
     return lhs = lhs - rhs;
   }
 
-  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator-=(
+  friend constexpr std::complex<RealType>& operator-=(
       std::complex<RealType>& lhs, const complex& rhs) {
     return lhs = lhs - rhs;
   }
@@ -198,12 +197,12 @@ class
     return *this;
   }
 
-  KOKKOS_FUNCTION friend constexpr complex& operator*=(
-      complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex& operator*=(complex& lhs,
+                                       const std::complex<RealType>& rhs) {
     return lhs = lhs * rhs;
   }
 
-  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator*=(
+  friend constexpr std::complex<RealType>& operator*=(
       std::complex<RealType>& lhs, const complex& rhs) {
     return lhs = lhs * rhs;
   }
@@ -235,9 +234,8 @@ class
     return *this;
   }
 
-  constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
-      const std::complex<RealType>& y) noexcept(noexcept(RealType{} /
-                                                         RealType{})) {
+  constexpr complex& operator/=(const std::complex<RealType>& y) noexcept(
+      noexcept(RealType{} / RealType{})) {
     // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
     // If the real part is +/-Inf and the imaginary part is -/+Inf,
     // this won't change the result.
@@ -261,7 +259,7 @@ class
     return *this;
   }
 
-  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator/=(
+  friend constexpr std::complex<RealType>& operator/=(
       std::complex<RealType>& lhs, const complex& rhs) {
     return lhs = lhs / rhs;
   }
@@ -284,65 +282,65 @@ class
   // These can be hidden friends because they are not specified by the C++
   // standard.
 
-  KOKKOS_FUNCTION friend constexpr complex operator+(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex operator+(const complex& lhs,
+                                     const std::complex<RealType>& rhs) {
     return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator+(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr complex operator+(const std::complex<RealType>& lhs,
+                                     const complex& rhs) {
     return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator-(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex operator-(const complex& lhs,
+                                     const std::complex<RealType>& rhs) {
     return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator-(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr complex operator-(const std::complex<RealType>& lhs,
+                                     const complex& rhs) {
     return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator*(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex operator*(const complex& lhs,
+                                     const std::complex<RealType>& rhs) {
     return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator*(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr complex operator*(const std::complex<RealType>& lhs,
+                                     const complex& rhs) {
     return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator/(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr complex operator/(const complex& lhs,
+                                     const std::complex<RealType>& rhs) {
     return lhs / complex(rhs);
   }
 
-  KOKKOS_FUNCTION friend constexpr complex operator/(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr complex operator/(const std::complex<RealType>& lhs,
+                                     const complex& rhs) {
     return complex(lhs) / rhs;
   }
 
-  KOKKOS_FUNCTION friend constexpr bool operator==(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr bool operator==(const complex& lhs,
+                                   const std::complex<RealType>& rhs) {
     return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
   }
 
-  KOKKOS_FUNCTION friend constexpr bool operator==(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr bool operator==(const std::complex<RealType>& lhs,
+                                   const complex& rhs) {
     return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
   }
 
-  KOKKOS_FUNCTION friend constexpr bool operator!=(
-      const complex& lhs, const std::complex<RealType>& rhs) {
+  friend constexpr bool operator!=(const complex& lhs,
+                                   const std::complex<RealType>& rhs) {
     return !(lhs == rhs);
   }
 
-  KOKKOS_FUNCTION friend constexpr bool operator!=(
-      const std::complex<RealType>& lhs, const complex& rhs) {
+  friend constexpr bool operator!=(const std::complex<RealType>& lhs,
+                                   const complex& rhs) {
     return !(lhs == rhs);
   }
 

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -64,14 +64,9 @@ class
   /// because std::complex's methods and nonmember functions are not
   /// marked as CUDA device functions.
   complex(const std::complex<RealType>& src) noexcept
-      // We can use this aspect of the standard to avoid calling
-      // non-device-marked functions `std::real` and `std::imag`: "For any
-      // object z of type complex<T>, reinterpret_cast<T(&)[2]>(z)[0] is the
-      // real part of z and reinterpret_cast<T(&)[2]>(z)[1] is the imaginary
-      // part of z." Now we don't have to provide a whole bunch of the overloads
-      // of things taking either Kokkos::complex or std::complex
-      : re_(reinterpret_cast<const RealType (&)[2]>(src)[0]),
-        im_(reinterpret_cast<const RealType (&)[2]>(src)[1]) {}
+      // Because this constructor is host-only, we can call .real() and .imag()
+      // instead of reinterpret_cast
+      : re_(src.real()), im_(src.imag()) {}
 
   /// \brief Conversion operator to std::complex.
   ///

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -12,6 +12,7 @@
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
 #include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_Utilities.hpp>
 #include <complex>
 #include <type_traits>
 #include <iosfwd>
@@ -32,8 +33,7 @@ class
     alignas(2 * sizeof(RealType))
 #endif
         complex {
-  static_assert(std::is_floating_point_v<RealType> &&
-                    std::is_same_v<RealType, std::remove_cv_t<RealType>>,
+  static_assert(Impl::is_noncv_floating_point_v<RealType>,
                 "Kokkos::complex can only be instantiated for a cv-unqualified "
                 "floating point type");
 
@@ -149,6 +149,16 @@ class
     return *this;
   }
 
+  KOKKOS_FUNCTION friend constexpr complex& operator+=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs + rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator+=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs + rhs;
+  }
+
   constexpr KOKKOS_INLINE_FUNCTION complex& operator-=(
       const complex<RealType>& src) noexcept {
     re_ -= src.re_;
@@ -160,6 +170,16 @@ class
       const RealType& src) noexcept {
     re_ -= src;
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex& operator-=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs - rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator-=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs - rhs;
   }
 
   constexpr KOKKOS_INLINE_FUNCTION complex& operator*=(
@@ -176,6 +196,16 @@ class
     re_ *= src;
     im_ *= src;
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex& operator*=(
+      complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs = lhs * rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator*=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs * rhs;
   }
 
   // Conditional noexcept, just in case RType throws on divide-by-zero
@@ -221,7 +251,7 @@ class
       this->im_ /= s;
     } else {
       const complex x_scaled(this->re_ / s, this->im_ / s);
-      const complex y_conj_scaled(y.re_ / s, -(y.im_) / s);
+      const complex y_conj_scaled(y.real() / s, -(y.imag()) / s);
       const RealType y_scaled_abs =
           y_conj_scaled.re_ * y_conj_scaled.re_ +
           y_conj_scaled.im_ * y_conj_scaled.im_;  // abs(y) == abs(conj(y))
@@ -229,6 +259,11 @@ class
       *this /= y_scaled_abs;
     }
     return *this;
+  }
+
+  KOKKOS_FUNCTION friend constexpr std::complex<RealType>& operator/=(
+      std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs = lhs / rhs;
   }
 
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
@@ -243,6 +278,74 @@ class
 
   template <size_t I, typename RT>
   friend constexpr const RT&& get(const complex<RT>&&) noexcept;
+
+  // Operators for mixed operations involving std::complex and Kokkos::complex
+  //
+  // These can be hidden friends because they are not specified by the C++
+  // standard.
+
+  KOKKOS_FUNCTION friend constexpr complex operator+(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator+(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator-(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator-(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator*(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                   lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator*(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                   lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator/(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs / complex(rhs);
+  }
+
+  KOKKOS_FUNCTION friend constexpr complex operator/(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return complex(lhs) / rhs;
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator==(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator==(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator!=(
+      const complex& lhs, const std::complex<RealType>& rhs) {
+    return !(lhs == rhs);
+  }
+
+  KOKKOS_FUNCTION friend constexpr bool operator!=(
+      const std::complex<RealType>& lhs, const complex& rhs) {
+    return !(lhs == rhs);
+  }
+
 };
 
 }  // namespace Kokkos
@@ -310,8 +413,28 @@ KOKKOS_FUNCTION constexpr const RealType&& get(
 // to do it this way now.
 
 //! Binary == operator for complex complex.
+//      Returns: complex(lhs).real() == complex(rhs).real() &&
+//      complex(lhs).imag() == complex(rhs).imag()
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  return lhs.real() == rhs.real() && lhs.imag() == rhs.imag();
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const complex<T>& lhs, const T& rhs) {
+  return lhs.real() == rhs && lhs.imag() == T();
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator==(const T& lhs, const complex<T>& rhs) {
+  return lhs == rhs.real() && T() == rhs.imag();
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+//! Binary == operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(
     complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
@@ -322,7 +445,7 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator==(
 //      and do the comparison in a device-marked function
 //! Binary == operator for std::complex complex.
 template <class RealType1, class RealType2>
-inline bool operator==(std::complex<RealType1> const& x,
+KOKKOS_DEPRECATED bool operator==(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
@@ -331,7 +454,7 @@ inline bool operator==(std::complex<RealType1> const& x,
 
 //! Binary == operator for complex std::complex.
 template <class RealType1, class RealType2>
-inline bool operator==(complex<RealType1> const& x,
+KOKKOS_DEPRECATED bool operator==(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y.real()) &&
@@ -343,7 +466,7 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(complex<RealType1> const& x,
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(complex<RealType1> const& x,
                                                  RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) == common_type(y) &&
@@ -355,16 +478,36 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator==(
     RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) == common_type(y.real()) &&
          common_type(0) == common_type(y.imag());
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 //! Binary != operator for complex complex.
+//      Returns: !(lhs == rhs)
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const complex<T>& lhs,
+                                          const complex<T>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const complex<T>& lhs, const T& rhs) {
+  return !(lhs == rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr bool operator!=(const T& lhs, const complex<T>& rhs) {
+  return !(lhs == rhs);
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+//! Binary != operator for complex complex.
 template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(
     complex<RealType1> const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
@@ -373,7 +516,7 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
 
 //! Binary != operator for std::complex complex.
 template <class RealType1, class RealType2>
-inline bool operator!=(std::complex<RealType1> const& x,
+KOKKOS_DEPRECATED bool operator!=(std::complex<RealType1> const& x,
                        complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
@@ -382,7 +525,7 @@ inline bool operator!=(std::complex<RealType1> const& x,
 
 //! Binary != operator for complex std::complex.
 template <class RealType1, class RealType2>
-inline bool operator!=(complex<RealType1> const& x,
+KOKKOS_DEPRECATED bool operator!=(complex<RealType1> const& x,
                        std::complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y.real()) ||
@@ -394,7 +537,7 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType2, RealType1>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(complex<RealType1> const& x,
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(complex<RealType1> const& x,
                                                  RealType2 const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x.real()) != common_type(y) ||
@@ -406,39 +549,73 @@ template <
     class RealType1, class RealType2,
     // Constraints to avoid participation in oparator==() for every possible RHS
     std::enable_if_t<std::is_convertible_v<RealType1, RealType2>, int> = 0>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+KOKKOS_DEPRECATED KOKKOS_FUNCTION bool operator!=(
     RealType1 const& x, complex<RealType2> const& y) noexcept {
   using common_type = std::common_type_t<RealType1, RealType2>;
   return common_type(x) != common_type(y.real()) ||
          common_type(0) != common_type(y.imag());
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 // </editor-fold> end Equality and inequality }}}1
 //==============================================================================
 
 //! Binary + operator for complex complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) += rhs
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs.real() + rhs.real(), lhs.imag() + rhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(lhs.real() + rhs, lhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator+(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs + rhs.real(), rhs.imag());
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+//! Binary + operator for complex complex.
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y.real(),
                                                            x.imag() + y.imag());
 }
 
 //! Binary + operator for complex scalar.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() + y,
                                                            x.imag());
 }
 
 //! Binary + operator for scalar complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator+(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x + y.real(),
                                                            y.imag());
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 //! Unary + operator for complex.
 template <class RealType>
@@ -448,28 +625,60 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator+(
 }
 
 //! Binary - operator for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) -= rhs
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs.real() - rhs.real(), lhs.imag() - rhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(lhs.real() - rhs, lhs.imag());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator-(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs - rhs.real(), -rhs.imag());
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+//! Binary - operator for complex.
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y.real(),
                                                            x.imag() - y.imag());
 }
 
 //! Binary - operator for complex scalar.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const complex<RealType1>& x, const RealType2& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x.real() - y,
                                                            x.imag());
 }
 
 //! Binary - operator for scalar complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator-(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x - y.real(),
                                                            -y.imag());
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 //! Unary - operator for complex.
 template <class RealType>
@@ -479,9 +688,34 @@ KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
 }
 
 //! Binary * operator for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
+//      Returns: complex<T>(lhs) *= rhs.
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs.real() * rhs.real() - lhs.imag() * rhs.imag(),
+                    lhs.real() * rhs.imag() + lhs.imag() * rhs.real());
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator*(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(lhs.real() * rhs, lhs.imag() * rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator*(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs * rhs.real(), lhs * rhs.imag());
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const complex<RealType1>& x,
+              const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
       x.real() * y.imag() + x.imag() * y.real());
@@ -495,8 +729,10 @@ operator*(const complex<RealType1>& x, const complex<RealType2>& y) noexcept {
 /// This function cannot be called in a CUDA device function, because
 /// std::complex's methods and nonmember functions are not marked as
 /// CUDA device functions.
-template <class RealType1, class RealType2>
-inline complex<std::common_type_t<RealType1, RealType2>> operator*(
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED complex<std::common_type_t<RealType1, RealType2>> operator*(
     const std::complex<RealType1>& x, const complex<RealType2>& y) {
   return complex<std::common_type_t<RealType1, RealType2>>(
       x.real() * y.real() - x.imag() * y.imag(),
@@ -507,9 +743,12 @@ inline complex<std::common_type_t<RealType1, RealType2>> operator*(
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
                                                            x * y.imag());
 }
@@ -518,12 +757,16 @@ operator*(const RealType1& x, const complex<RealType2>& y) noexcept {
 ///
 /// This function exists because the compiler doesn't know that
 /// RealType and complex<RealType> commute with respect to operator*.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
   return complex<std::common_type_t<RealType1, RealType2>>(x * y.real(),
                                                            x * y.imag());
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 //! Imaginary part of a complex number.
 template <class RealType>
@@ -795,19 +1038,69 @@ inline complex<RealType> exp(const std::complex<RealType>& c) {
                            std::exp(c.real()) * std::sin(c.imag()));
 }
 
+//! Binary operator / for complex.
+//      Returns: complex<T>(lhs) /= rhs
+//
+//  Note: not constexpr until C++23 (because fabs is not constexpr until C++23)
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const complex<T>& lhs,
+                                               const complex<T>& rhs) {
+  // Scale (by the "1-norm" of rhs) to avoid unwarranted overflow.
+  // If the real part is +/-Inf and the imaginary part is -/+Inf,
+  // this won't change the result.
+  const T s = fabs(real(rhs)) + fabs(imag(rhs));
+
+  // If s is 0, then rhs is zero, so lhs/rhs == real(lhs)/0 + i*imag(lhs)/0.
+  // In that case, the relation lhs/rhs == (lhs/s) / (rhs/s) doesn't hold,
+  // because rhs/s is NaN.
+  if (s == 0.0) {
+    return complex<T>(real(lhs) / s, imag(lhs) / s);
+  } else {
+    const complex<T> lhs_scaled(real(lhs) / s, imag(lhs) / s);
+    const complex<T> rhs_conj_scaled(real(rhs) / s, -imag(rhs) / s);
+    const T rhs_scaled_abs =
+        real(rhs_conj_scaled) * real(rhs_conj_scaled) +
+        imag(rhs_conj_scaled) *
+            imag(rhs_conj_scaled);  // abs(rhs) == abs(conj(rhs))
+    complex<T> result = lhs_scaled * rhs_conj_scaled;
+    result /= rhs_scaled_abs;
+    return result;
+  }
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const complex<T>& lhs,
+                                               const T& rhs) {
+  return complex<T>(real(lhs) / rhs, imag(lhs) / rhs);
+}
+
+template <class T>
+KOKKOS_FUNCTION constexpr complex<T> operator/(const T& lhs,
+                                               const complex<T>& rhs) {
+  return complex<T>(lhs) / rhs;
+}
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const complex<RealType1>& x,
-          const RealType2& y) noexcept(noexcept(RealType1{} / RealType2{})) {
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const complex<RealType1>& x,
+              const RealType2& y) noexcept(noexcept(RealType1{} /
+                                                    RealType2{})) {
   return complex<std::common_type_t<RealType1, RealType2>>(real(x) / y,
                                                            imag(x) / y);
 }
 
 //! Binary operator / for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const complex<RealType1>& x,
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const complex<RealType1>& x,
           const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
                                                          RealType2{})) {
   // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
@@ -834,13 +1127,17 @@ operator/(const complex<RealType1>& x,
 }
 
 //! Binary operator / for complex and real numbers
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const RealType1& x,
+template <class RealType1, class RealType2,
+          class = std::enable_if_t<Impl::is_noncv_floating_point_v<
+              std::common_type_t<RealType1, RealType2>>>>
+KOKKOS_DEPRECATED KOKKOS_FUNCTION
+    complex<std::common_type_t<RealType1, RealType2>>
+    operator/(const RealType1& x,
           const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
                                                          RealType2{})) {
   return complex<std::common_type_t<RealType1, RealType2>>(x) / y;
 }
+#endif  // KOKKOS_ENABLE_DEPRECATED_CODE_5
 
 template <class RealType>
 std::ostream& operator<<(std::ostream& os, const complex<RealType>& x) {

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -617,9 +617,9 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 
 //! Unary + operator for complex.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION complex<RealType> operator+(
+KOKKOS_FUNCTION constexpr complex<RealType> operator+(
     const complex<RealType>& x) noexcept {
-  return complex<RealType>{+x.real(), +x.imag()};
+  return x;
 }
 
 //! Binary - operator for complex.
@@ -680,7 +680,7 @@ KOKKOS_DEPRECATED KOKKOS_FUNCTION
 
 //! Unary - operator for complex.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION complex<RealType> operator-(
+KOKKOS_FUNCTION constexpr complex<RealType> operator-(
     const complex<RealType>& x) noexcept {
   return complex<RealType>(-x.real(), -x.imag());
 }

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -70,6 +70,15 @@ template <typename E>
 inline constexpr bool is_scoped_enum_v = is_scoped_enum<E>::value;
 #endif
 
+template <typename F>
+struct is_noncv_floating_point
+    : std::bool_constant<std::is_floating_point_v<F> &&
+                         std::is_same_v<F, std::remove_cv_t<F>>> {};
+
+template <typename F>
+inline constexpr bool is_noncv_floating_point_v =
+    is_noncv_floating_point<F>::value;
+
 //==============================================================================
 // <editor-fold desc="is_specialization_of"> {{{1
 

--- a/core/unit_test/TestAtomicOperations_complexdouble.hpp
+++ b/core/unit_test/TestAtomicOperations_complexdouble.hpp
@@ -28,7 +28,7 @@ TEST(TEST_CATEGORY, atomic_operations_complexdouble) {
     // FIXME_32BIT disable division test for 32bit where we have accuracy issues
     // with division atomics still compile it though
     if (sizeof(void*) == 8) {
-      ASSERT_TRUE((update != 0
+      ASSERT_TRUE((update != 0.
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE>(
                              old_val, update)
                        : true));

--- a/core/unit_test/TestAtomicOperations_complexfloat.hpp
+++ b/core/unit_test/TestAtomicOperations_complexfloat.hpp
@@ -23,7 +23,7 @@ TEST(TEST_CATEGORY, atomic_operations_complexfloat) {
     // FIXME_32BIT disable division test for 32bit where we have accuracy issues
     // with division atomics still compile it though
     if (sizeof(void*) == 8) {
-      ASSERT_TRUE((update != 0
+      ASSERT_TRUE((update != 0.f
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE>(
                              old_val, update)
                        : true));

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -673,6 +673,347 @@ constexpr bool comparison_in_constant_expression() {
 
 static_assert(comparison_in_constant_expression());
 
+struct TestStdComplexOperators {
+  static void testit() {
+    using fp_t       = double;
+    using kcomplex_t = Kokkos::complex<fp_t>;
+    using scomplex_t = std::complex<fp_t>;
+
+    // These values have exact floating point representations
+    // For addition, subtraction and multiplication, the result
+    // also has an exact floating point representation.
+    constexpr kcomplex_t k(.5, .25);
+    constexpr scomplex_t s(.125, .0625);
+
+    // Division involving Kokkos::complex numbers with exact
+    // floating point representations is inexact because of the way we perform
+    // it, so we need to check results against an epsilon.
+    constexpr fp_t epsilon = std::numeric_limits<fp_t>::epsilon();
+
+    // operator +=
+    kcomplex_t k0 = k;
+    k0 += s;
+    ASSERT_FLOAT_EQ(k0.real(), .625);
+    ASSERT_FLOAT_EQ(k0.imag(), .3125);
+
+    scomplex_t s1 = s;
+    s1 += k;
+    ASSERT_FLOAT_EQ(s1.real(), .625);
+    ASSERT_FLOAT_EQ(s1.imag(), .3125);
+
+    kcomplex_t k2 = k;
+    k2 -= s;
+    ASSERT_FLOAT_EQ(k2.real(), .375);
+    ASSERT_FLOAT_EQ(k2.imag(), .1875);
+
+    scomplex_t s3 = s;
+    s3 -= k;
+    ASSERT_FLOAT_EQ(s3.real(), -.375);
+    ASSERT_FLOAT_EQ(s3.imag(), -.1875);
+
+    kcomplex_t k4 = k;
+    k4 *= s;
+    ASSERT_FLOAT_EQ(k4.real(), .046875);
+    ASSERT_FLOAT_EQ(k4.imag(), .0625);
+
+    scomplex_t s5 = s;
+    s5 *= k;
+    ASSERT_FLOAT_EQ(s5.real(), .046875);
+    ASSERT_FLOAT_EQ(s5.imag(), .0625);
+
+    kcomplex_t k6 = k;
+    k6 /= s;
+    ASSERT_FLOAT_EQ(k6.real(), 4.);
+    ASSERT_NEAR(k6.imag(), 0., epsilon);
+
+    scomplex_t s7 = s;
+    s7 /= k;
+    ASSERT_FLOAT_EQ(s7.real(), .25);
+    ASSERT_NEAR(s7.imag(), 0., epsilon);
+
+    kcomplex_t k8 = k + s;
+    ASSERT_FLOAT_EQ(k8.real(), .625);
+    ASSERT_FLOAT_EQ(k8.imag(), .3125);
+
+    kcomplex_t s9 = s + k;
+    ASSERT_FLOAT_EQ(s9.real(), .625);
+    ASSERT_FLOAT_EQ(s9.imag(), .3125);
+
+    kcomplex_t k10 = k - s;
+    ASSERT_FLOAT_EQ(k10.real(), .375);
+    ASSERT_FLOAT_EQ(k10.imag(), .1875);
+
+    kcomplex_t k11 = s - k;
+    ASSERT_FLOAT_EQ(k11.real(), -.375);
+    ASSERT_FLOAT_EQ(k11.imag(), -.1875);
+
+    kcomplex_t k12 = k * s;
+    ASSERT_FLOAT_EQ(k12.real(), .046875);
+    ASSERT_FLOAT_EQ(k12.imag(), .0625);
+
+    kcomplex_t k13 = s * k;
+    ASSERT_FLOAT_EQ(k13.real(), .046875);
+    ASSERT_FLOAT_EQ(k13.imag(), .0625);
+
+    kcomplex_t k14 = k / s;
+    ASSERT_FLOAT_EQ(k14.real(), 4.);
+    ASSERT_NEAR(k14.imag(), 0., epsilon);
+
+    kcomplex_t k15 = s / k;
+    ASSERT_FLOAT_EQ(k15.real(), .25);
+    ASSERT_NEAR(k15.imag(), 0., epsilon);
+
+    bool b16 = (k == s);
+    ASSERT_FALSE(b16);
+
+    bool b17 = (s == k);
+    ASSERT_FALSE(b17);
+
+    bool b18 = (k != s);
+    ASSERT_TRUE(b18);
+
+    bool b19 = (s != k);
+    ASSERT_TRUE(b19);
+
+    bool b20 = (k == k);
+    ASSERT_TRUE(b20);
+
+    bool b21 = (k == epsilon);
+    ASSERT_FALSE(b21);
+
+    bool b22 = (epsilon == k);
+    ASSERT_FALSE(b22);
+
+    bool b23 = (k != k);
+    ASSERT_FALSE(b23);
+
+    bool b24 = (k != epsilon);
+    ASSERT_TRUE(b24);
+
+    bool b25 = (epsilon != k);
+    ASSERT_TRUE(b25);
+  }
+};
+
+TEST(TEST_CATEGORY, std_complex_operators) {
+  TestStdComplexOperators test;
+  test.testit();
+}
+
+template <class ExecSpace>
+struct TestComplexOperators {
+  using exec_space          = ExecSpace;
+  using floating_point_type = double;
+  using complex_type        = Kokkos::complex<double>;
+  using device_view_type    = Kokkos::View<complex_type *, exec_space>;
+  using host_view_type      = typename device_view_type::host_mirror_type;
+
+  device_view_type d_results;
+  host_view_type h_results;
+
+  KOKKOS_FUNCTION
+  void operator()(int) const {
+    {
+      // These values have exact floating point representations.
+      // For addition, subtraction and multiplication, the result
+      // also has an exact floating point representation.
+      constexpr complex_type zl{.5, .25};
+      constexpr complex_type zr{.125, .0625};
+
+      constexpr floating_point_type f{.03125};
+      constexpr complex_type zf{f};
+
+      bool b0      = (zl == zl);
+      d_results[0] = complex_type(b0);
+
+      bool b1      = (zl == zr);
+      d_results[1] = complex_type(b1);
+
+      bool b2      = (zf == f);
+      d_results[2] = complex_type(b2);
+
+      bool b3      = (zl == f);
+      d_results[3] = complex_type(b3);
+
+      bool b4      = (f == zf);
+      d_results[4] = complex_type(b4);
+
+      bool b5      = (f == zr);
+      d_results[5] = complex_type(b5);
+
+      bool b6      = (zl != zl);
+      d_results[6] = complex_type(b6);
+
+      bool b7      = (zl != zr);
+      d_results[7] = complex_type(b7);
+
+      bool b8      = (zf != f);
+      d_results[8] = complex_type(b8);
+
+      bool b9      = (zl != f);
+      d_results[9] = complex_type(b9);
+
+      bool b10      = (f != zf);
+      d_results[10] = complex_type(b10);
+
+      bool b11      = (f != zr);
+      d_results[11] = complex_type(b11);
+
+      complex_type z12 = zl + zr;
+      d_results[12]    = z12;
+
+      complex_type z13 = zl + f;
+      d_results[13]    = z13;
+
+      complex_type z14 = f + zr;
+      d_results[14]    = z14;
+
+      complex_type z15 = zl - zr;
+      d_results[15]    = z15;
+
+      complex_type z16 = zl - f;
+      d_results[16]    = z16;
+
+      complex_type z17 = f - zr;
+      d_results[17]    = z17;
+
+      complex_type z18 = zl * zr;
+      d_results[18]    = z18;
+
+      complex_type z19 = zl * f;
+      d_results[19]    = z19;
+
+      complex_type z20 = f * zr;
+      d_results[20]    = z20;
+
+      complex_type z21 = zl / zr;
+      d_results[21]    = z21;
+
+      complex_type z22 = zl / f;
+      d_results[22]    = z22;
+
+      complex_type z23 = f / zr;
+      d_results[23]    = z23;
+    }
+  }
+
+  void testit() {
+    d_results = device_view_type("TestComplexOperators", 24);
+    h_results = Kokkos::create_mirror_view(d_results);
+
+    Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), *this);
+    Kokkos::fence();
+    Kokkos::deep_copy(h_results, d_results);
+
+    // l == l
+    ASSERT_FLOAT_EQ(h_results[0].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[0].imag(), 0.);
+
+    // l == r
+    ASSERT_FLOAT_EQ(h_results[1].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[1].imag(), 0.);
+
+    // zf == f
+    ASSERT_FLOAT_EQ(h_results[2].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[2].imag(), 0.);
+
+    // zl == f
+    ASSERT_FLOAT_EQ(h_results[3].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[3].imag(), 0.);
+
+    // f == zf
+    ASSERT_FLOAT_EQ(h_results[4].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[4].imag(), 0.);
+
+    // f == zr
+    ASSERT_FLOAT_EQ(h_results[5].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[5].imag(), 0.);
+
+    // l != l
+    ASSERT_FLOAT_EQ(h_results[6].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[6].imag(), 0.);
+
+    // l != r
+    ASSERT_FLOAT_EQ(h_results[7].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[7].imag(), 0.);
+
+    // zf != f
+    ASSERT_FLOAT_EQ(h_results[8].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[8].imag(), 0.);
+
+    // zl != f
+    ASSERT_FLOAT_EQ(h_results[9].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[9].imag(), 0.);
+
+    // f != zf
+    ASSERT_FLOAT_EQ(h_results[10].real(), 0.);
+    ASSERT_FLOAT_EQ(h_results[10].imag(), 0.);
+
+    // f != zr
+    ASSERT_FLOAT_EQ(h_results[11].real(), 1.);
+    ASSERT_FLOAT_EQ(h_results[11].imag(), 0.);
+
+    // zl + zr
+    ASSERT_FLOAT_EQ(h_results[12].real(), .625);
+    ASSERT_FLOAT_EQ(h_results[12].imag(), .3125);
+
+    // zl + f
+    ASSERT_FLOAT_EQ(h_results[13].real(), .53125);
+    ASSERT_FLOAT_EQ(h_results[13].imag(), .25);
+
+    // f + zr
+    ASSERT_FLOAT_EQ(h_results[14].real(), .15625);
+    ASSERT_FLOAT_EQ(h_results[14].imag(), .0625);
+
+    // zl - zr
+    ASSERT_FLOAT_EQ(h_results[15].real(), .375);
+    ASSERT_FLOAT_EQ(h_results[15].imag(), .1875);
+
+    // zl - f
+    ASSERT_FLOAT_EQ(h_results[16].real(), .46875);
+    ASSERT_FLOAT_EQ(h_results[16].imag(), .25);
+
+    // f - zr
+    ASSERT_FLOAT_EQ(h_results[17].real(), -.09375);
+    ASSERT_FLOAT_EQ(h_results[17].imag(), -.0625);
+
+    // zl * zr
+    ASSERT_FLOAT_EQ(h_results[18].real(), .046875);
+    ASSERT_FLOAT_EQ(h_results[18].imag(), .0625);
+
+    // zl * f
+    ASSERT_FLOAT_EQ(h_results[19].real(), .015625);
+    ASSERT_FLOAT_EQ(h_results[19].imag(), .0078125);
+
+    // f * zr
+    ASSERT_FLOAT_EQ(h_results[20].real(), .00390625);
+    ASSERT_FLOAT_EQ(h_results[20].imag(), .001953125);
+
+    // Division involving Kokkos::complex numbers with exact
+    // floating point representations is inexact because of the way we perform
+    // it, so we need to check results against an epsilon.
+    constexpr floating_point_type epsilon{
+        std::numeric_limits<floating_point_type>::epsilon()};
+
+    // z1 / zr
+    ASSERT_FLOAT_EQ(h_results[21].real(), 4.);
+    ASSERT_NEAR(h_results[21].imag(), 0., epsilon);
+
+    // zl / f
+    ASSERT_FLOAT_EQ(h_results[22].real(), 16.);
+    ASSERT_FLOAT_EQ(h_results[22].imag(), 8.);
+
+    // f / zr
+    ASSERT_FLOAT_EQ(h_results[23].real(), .2);
+    ASSERT_FLOAT_EQ(h_results[23].imag(), -.1);
+  }
+};
+
+TEST(TEST_CATEGORY, complex_operators) {
+  TestComplexOperators<TEST_EXECSPACE> test;
+  test.testit();
+}
+
 constexpr bool test_complex_norm() {
   return Kokkos::norm(Kokkos::complex<double>{4., 2.}) == 20.;
 }
@@ -703,6 +1044,7 @@ constexpr bool test_complex_conj() {
   return true;
 }
 static_assert(test_complex_conj());
+
 
 }  // namespace Test
 

--- a/core/unit_test/TestUtilities.hpp
+++ b/core/unit_test/TestUtilities.hpp
@@ -121,4 +121,53 @@ void test_is_scoped_enum() {
                                       is_scoped_enum<ScopedEnumShort>>);
 }
 
+void test_is_non_cv_floating_point() {
+  using Kokkos::Impl::is_noncv_floating_point;
+  using Kokkos::Impl::is_noncv_floating_point_v;
+
+  static_assert(!is_noncv_floating_point<int>::value);                 // NOLINT
+  static_assert(!is_noncv_floating_point<const int>::value);           // NOLINT
+  static_assert(!is_noncv_floating_point<volatile int>::value);        // NOLINT
+  static_assert(!is_noncv_floating_point<const volatile int>::value);  // NOLINT
+
+  static_assert(!is_noncv_floating_point_v<int>);
+  static_assert(!is_noncv_floating_point_v<const int>);
+  static_assert(!is_noncv_floating_point_v<volatile int>);
+  static_assert(!is_noncv_floating_point_v<const volatile int>);
+
+  static_assert(is_noncv_floating_point<float>::value);            // NOLINT
+  static_assert(!is_noncv_floating_point<const float>::value);     // NOLINT
+  static_assert(!is_noncv_floating_point<volatile float>::value);  // NOLINT
+  static_assert(
+      !is_noncv_floating_point<const volatile float>::value);  // NOLINT
+
+  static_assert(is_noncv_floating_point_v<float>);
+  static_assert(!is_noncv_floating_point_v<const float>);
+  static_assert(!is_noncv_floating_point_v<volatile float>);
+  static_assert(!is_noncv_floating_point_v<const volatile float>);
+
+  static_assert(is_noncv_floating_point<double>::value);            // NOLINT
+  static_assert(!is_noncv_floating_point<const double>::value);     // NOLINT
+  static_assert(!is_noncv_floating_point<volatile double>::value);  // NOLINT
+  static_assert(
+      !is_noncv_floating_point<const volatile double>::value);  // NOLINT
+
+  static_assert(is_noncv_floating_point_v<double>);
+  static_assert(!is_noncv_floating_point_v<const double>);
+  static_assert(!is_noncv_floating_point_v<volatile double>);
+  static_assert(!is_noncv_floating_point_v<const volatile double>);
+
+  static_assert(is_noncv_floating_point<long double>::value);         // NOLINT
+  static_assert(!is_noncv_floating_point<const long double>::value);  // NOLINT
+  static_assert(
+      !is_noncv_floating_point<volatile long double>::value);  // NOLINT
+  static_assert(
+      !is_noncv_floating_point<const volatile long double>::value);  // NOLINT
+
+  static_assert(is_noncv_floating_point_v<long double>);
+  static_assert(!is_noncv_floating_point_v<const long double>);
+  static_assert(!is_noncv_floating_point_v<volatile long double>);
+  static_assert(!is_noncv_floating_point_v<const volatile long double>);
+}
+
 }  // namespace Test


### PR DESCRIPTION
Fixed compilation bug and added a unit test for:
```c++
Kokkos::complex /= std::complex
```

Added the following operators and unit tests:
```c++
Kokkos::complex<T> += std::complex<T>
std::complex<T> += Kokkos::complex<T>

Kokkos::complex<T> -= std::complex<T>
std::complex<T> -= Kokkos::complex<T>

Kokkos::complex<T> *= std::complex<T>
std::complex<T> *= Kokkos::complex<T>

std::complex<T> /= Kokkos::complex<T>


Kokkos::complex<T> + std::complex<T>
std::complex<T> + Kokkos::complex<T>

Kokkos::complex<T> - std::complex<T>
std::complex<T> - Kokkos::complex<T>

Kokkos::complex<T> * std::complex<T>
std::complex<T> * Kokkos::complex<T>

Kokkos::complex<T> / std::complex<T>
std::complex<T> / Kokkos::complex<T>

Kokkos::complex<T> == Kokkos::complex<T>
Kokkos::complex<T> == T
T == Kokkos::complex<T>

Kokkos::complex<T> == std::complex<T>
std::complex<T> == Kokkos::complex<T>

Kokkos::complex<T> == std::complex<T>
std::complex<T> == Kokkos::complex<T>

Kokkos::complex<T> == std::complex<T>
std::complex<T> == Kokkos::complex<T>

Kokkos::complex<T> == std::complex<T>
std::complex<T> == Kokkos::complex<T>


Kokkos::complex<T> != Kokkos::complex<T>
Kokkos::complex<T> != T
T != Kokkos::complex<T>

Kokkos::complex<T> != std::complex<T>
std::complex<T> != Kokkos::complex<T>

Kokkos::complex<T> != std::complex<T>
std::complex<T> != Kokkos::complex<T>

Kokkos::complex<T> != std::complex<T>
std::complex<T> != Kokkos::complex<T>

Kokkos::complex<T> != std::complex<T>
std::complex<T> != Kokkos::complex<T>

Kokkos::complex<T> + Kokkos::complex<T>
Kokkos::complex<T> + T
T + Kokkos::complex<T>

Kokkos::complex<T> - Kokkos::complex<T>
Kokkos::complex<T> - T
T - Kokkos::complex<T>

Kokkos::complex<T> * Kokkos::complex<T>
Kokkos::complex<T> * T
T * Kokkos::complex<T>

Kokkos::complex<T> / Kokkos::complex<T>
Kokkos::complex<T> / T
T / Kokkos::complex<T>
```

Added a new trait and unit tests:
```c++
is_non_cv_floating_point
```

Deprecated the following operators (when `T` and `U` are different types):
```c++
Kokkos::complex<T> == Kokkos::complex<U>
std::complex<T> == Kokkos::complex<U>
Kokkos::complex<T> == std::complex<U>
Kokkos::complex<T> == U
T == Kokkos::complex<U>

Kokkos::complex<T> != Kokkos::complex<U>
std::complex<T> != Kokkos::complex<U>
Kokkos::complex<T> != std::complex<U>
Kokkos::complex<T> != U
T != Kokkos::complex<U>
```

Deprecated and constrained (to `is_floating_point<common_type<T, U>>` so that `complex<common_type<T, U>>` is valid) the following operators (when `T` and `U` are different types):
```c++
Kokkos::complex<T> + Kokkos::complex<U>
Kokkos::complex<T> + U
T + Kokkos::complex<U>

Kokkos::complex<T> - Kokkos::complex<U>
Kokkos::complex<T> - U
T - Kokkos::complex<U>

Kokkos::complex<T> * Kokkos::complex<U>
Kokkos::complex<T> * U
T * Kokkos::complex<U>
Kokkos::complex<T> * std::complex<U>

Kokkos::complex<T> / U
Kokkos::complex<T> / Kokkos::complex<U>
T / Kokkos::complex<U>
```

Removed `KOKKOS_FUNCTION` and `KOKKOS_INLINE_FUNCTION` from all operations involving `std::complex`, since they cannot be on device code on CUDA (this was inconsistent before).