### PR TITLE
Skip exec thread safety tests when ATOMICS_BYPASS is enabled

### DIFF
--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -21,6 +21,29 @@ namespace {
 #define THREAD_SAFETY_TEST_UNREACHABLE() static_assert(true)
 #endif
 
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+#define KOKKOS_TEST_SKIP_IF_OPENACC()                                       \
+  GTEST_SKIP()                                                              \
+      << "skipping OpenACC test since unsupported host-side atomics cause " \
+         "race conditions during shared allocation reference counting";     \
+  THREAD_SAFETY_TEST_UNREACHABLE();
+#else
+#define KOKKOS_TEST_SKIP_IF_OPENACC()
+#endif
+
+#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
+#define KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES() \
+  GTEST_SKIP()                                         \
+      << "skipping since tests are known to fail with out-of-order queues";
+#else
+#define KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES()
+#endif
+
+#define KOKKOS_TEST_SKIP_IF_NEEDED()             \
+  KOKKOS_TEST_SKIP_IF_OPENACC()                  \
+  KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES() \
+  static_assert(true, "no-op to require trailing semicolon")
+
 #ifdef KOKKOS_ENABLE_OPENMP
 template <class Lambda1, class Lambda2>
 void run_threaded_test(const Lambda1 l1, const Lambda2 l2) {
@@ -94,16 +117,7 @@ void run_exec_space_thread_safety_range() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_range();
 }
 
@@ -137,16 +151,7 @@ void run_exec_space_thread_safety_mdrange() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_mdrange();
 }
 
@@ -182,16 +187,7 @@ void run_exec_space_thread_safety_team_policy() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_team_policy();
 }
 
@@ -225,16 +221,7 @@ void run_exec_space_thread_safety_range_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_reduce) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_range_reduce();
 }
 
@@ -269,16 +256,7 @@ void run_exec_space_thread_safety_mdrange_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_mdrange_reduce) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_mdrange_reduce();
 }
 
@@ -314,20 +292,11 @@ void run_exec_space_thread_safety_team_policy_reduce() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_team_policy_reduce) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   // FIXME_SYCL
 #if defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   if (std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>)
     GTEST_SKIP() << "skipping since test is know to fail with SYCL+Cuda";
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
 #endif
   run_exec_space_thread_safety_team_policy_reduce();
 }
@@ -364,17 +333,12 @@ void run_exec_space_thread_safety_range_scan() {
 }
 
 TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
-#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
-  GTEST_SKIP()
-      << "skipping OpenACC test since unsupported host-side atomics cause "
-         "race conditions during shared allocation reference counting";
-  THREAD_SAFETY_TEST_UNREACHABLE();
-#endif
-#ifdef KOKKOS_ENABLE_IMPL_SYCL_OUT_OF_ORDER_QUEUES  // FIXME_SYCL
-  GTEST_SKIP()
-      << "skipping since tests are known to fail with out-of-order queues";
-#endif
+  KOKKOS_TEST_SKIP_IF_NEEDED();
   run_exec_space_thread_safety_range_scan();
 }
+
+#undef KOKKOS_TEST_SKIP_IF_NEEDED
+#undef KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES
+#undef KOKKOS_TEST_SKIP_IF_OPENACC
 
 }  // namespace

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -39,9 +39,17 @@ namespace {
 #define KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES()
 #endif
 
+#ifdef KOKKOS_ENABLE_ATOMICS_BYPASS
+#define KOKKOS_TEST_SKIP_IF_ATOMICS_BYPASS() \
+  GTEST_SKIP() << "since bypassing atomics";
+#else
+#define KOKKOS_TEST_SKIP_IF_ATOMICS_BYPASS()
+#endif
+
 #define KOKKOS_TEST_SKIP_IF_NEEDED()             \
   KOKKOS_TEST_SKIP_IF_OPENACC()                  \
   KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES() \
+  KOKKOS_TEST_SKIP_IF_ATOMICS_BYPASS()           \
   static_assert(true, "no-op to require trailing semicolon")
 
 #ifdef KOKKOS_ENABLE_OPENMP
@@ -338,6 +346,7 @@ TEST(TEST_CATEGORY, exec_space_thread_safety_range_scan) {
 }
 
 #undef KOKKOS_TEST_SKIP_IF_NEEDED
+#undef KOKKOS_TEST_SKIP_IF_ATOMICS_BYPASS
 #undef KOKKOS_TEST_SKIP_IF_SYCL_OUT_OF_ORDER_QUEUES
 #undef KOKKOS_TEST_SKIP_IF_OPENACC
 


### PR DESCRIPTION
An attempt to address https://github.com/trilinos/Trilinos/pull/14868#issuecomment-3755124597

We will also need to address coverage in the CI/nightlies