### PR TITLE
NextSilicon: add no-op CI environment

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -298,7 +298,7 @@ jobs:
       # Let nextsystemd try to initialize everything for 20s and see what happens
       - name: Initialize Hardware
         run: |
-          nextsystemd &
+          nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!
           sleep 20
           kill $NEXTSYSTEMD_PID

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -295,10 +295,13 @@ jobs:
           nextcli --version
           nextcxx --version
           cmake --version
-      # Let nextsystemd try to initialize everything for 20s and see what happens
+      # Give nextsystemd 20s to get going and check that everything is up
       - name: Initialize Hardware
         run: |
           nextsystemd --ui-collector-address none &
-          NEXTSYSTEMD_PID=$!
           sleep 20
-          kill $NEXTSYSTEMD_PID
+          nextcli system status
+          nextcli system status | grep "Service: UP"
+          nextcli system status | grep "Maverick 2"
+          nextcli system status | grep "Status: OK"
+          nextcli system terminate

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -283,8 +283,8 @@ jobs:
         working-directory: kokkos/build
         run: KOKKOS_NUM_THREADS=64 ctest --output-on-failure --timeout 3600
 
-  NS_1_0_0:
-    name: SNL_NS_1_0_0
+  NextSilicon_1_0_0:
+    name: SNL_NextSilicon_1_0_0
     runs-on: [ns-1.0.0]
     # no NextSilicon backend yet, so okay if this job fails
     continue-on-error: true

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -286,7 +286,6 @@ jobs:
   NextSilicon_1_0_0:
     name: SNL_NextSilicon_1_0_0
     runs-on: [ns-1.0.0]
-    # no NextSilicon backend yet, so okay if this job fails
     continue-on-error: true
 
     steps:

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -282,3 +282,21 @@ jobs:
       - name: test_kokkos
         working-directory: kokkos/build
         run: KOKKOS_NUM_THREADS=64 ctest --output-on-failure --timeout 3600
+
+  NS_1_0_0:
+    name: SNL_NS_1_0_0
+    runs-on: [ns-1.0.0]
+    # no NextSilicon backend yet, so okay if this job fails
+    continue-on-error: true
+
+    steps:
+      - name: Environment Information
+        run: |
+          nextcli --version
+          nextcxx --version
+          cmake --version
+      # Let nextsystemd try to initialize everything for 20s and see what happens
+      - name: Initialize Hardware
+        run: |
+          nextsystemd &
+          sleep 20

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -299,4 +299,6 @@ jobs:
       - name: Initialize Hardware
         run: |
           nextsystemd &
+          NEXTSYSTEMD_PID=$!
           sleep 20
+          kill $NEXTSYSTEMD_PID


### PR DESCRIPTION
This CI environment runs NextSilicon's 1.0.0 software release on Lambda at Sandia National Laboratories. It prints some environment info and then tries to initialize the Maverick-2 accelerator.