### PR TITLE
Fix performance issue in subview

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -597,6 +597,9 @@ class BasicView {
     m_map = mapping_type(sub_mapping_result.mapping);
     m_acc = sub_accessor_t(src_view.m_acc);
 
+    // Kokkos View precondition checks happen in release builds
+    check_basic_view_constructibility(sub_mapping_result.mapping);
+
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
     bool valid = subview_extents_valid(
         src_view, std::make_index_sequence<sizeof...(SliceSpecifiers)>{},

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -575,16 +575,28 @@ class BasicView {
 #endif
 
  protected:
+  // Optimized subview constructor that calls submdspan_mapping directly
+  // and initializes members in the constructor body
   template <class OtherElementType, class OtherExtents, class OtherLayoutPolicy,
             class OtherAccessorPolicy, class... SliceSpecifiers>
   KOKKOS_INLINE_FUNCTION BasicView(
       Impl::SubViewCtorTag,
       const BasicView<OtherElementType, OtherExtents, OtherLayoutPolicy,
                       OtherAccessorPolicy> &src_view,
-      SliceSpecifiers... slices)
-      : BasicView(submdspan(
-            src_view.to_mdspan(),
-            Impl::transform_kokkos_slice_to_mdspan_slice(slices)...)) {
+      SliceSpecifiers... slices) {
+    // Get submdspan_mapping result directly from source mapping
+    const auto sub_mapping_result = submdspan_mapping(
+        src_view.m_map,
+        Impl::transform_kokkos_slice_to_mdspan_slice(slices)...);
+
+    // Initialize members directly from the mapping result
+    // Explicit cast is needed because submdspan_mapping may return a different
+    // layout type
+    using sub_accessor_t = typename OtherAccessorPolicy::offset_policy;
+    m_ptr = src_view.m_acc.offset(src_view.m_ptr, sub_mapping_result.offset);
+    m_map = mapping_type(sub_mapping_result.mapping);
+    m_acc = sub_accessor_t(src_view.m_acc);
+
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
     bool valid = subview_extents_valid(
         src_view, std::make_index_sequence<sizeof...(SliceSpecifiers)>{},

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -584,17 +584,18 @@ class BasicView {
       const BasicView<OtherElementType, OtherExtents, OtherLayoutPolicy,
                       OtherAccessorPolicy> &src_view,
       SliceSpecifiers... slices) {
-    // Get submdspan_mapping result directly from source mapping
+    // Avoid calling submdspan to not create temporary mdspan objects.
+    // Instead do what submdspan does: calling submdspan_mapping.
     const auto sub_mapping_result = submdspan_mapping(
         src_view.m_map,
         Impl::transform_kokkos_slice_to_mdspan_slice(slices)...);
 
-    // Kokkos View precondition should happen in release builds
+    // Kokkos View precondition should happen in release build,
+    // and before any checks happen inside mdspan mapping ctor itself.
     check_basic_view_constructibility(sub_mapping_result.mapping);
 
-    // Initialize members directly from the mapping result
     // Explicit cast is needed because submdspan_mapping may return a different
-    // layout type
+    // layout type.
     using sub_accessor_t = typename OtherAccessorPolicy::offset_policy;
     m_ptr = src_view.m_acc.offset(src_view.m_ptr, sub_mapping_result.offset);
     m_map = mapping_type(sub_mapping_result.mapping);


### PR DESCRIPTION
This fixes a performance issue that was first indirectly reported from Tpetra. 

The problem in that BasicView ctor was that it created first and mdspan to pass to submdspan, and then constructed a BasicView from an mdspan. For reference counted Views that amounts to three calls to increment and two to decrement.

Simple reproducer was something like this: 

```c++
  int N = 100000;
  int M = 1000;
  Kokkos::View<int*, Kokkos::HostSpace> a("A",M+1);
  Kokkos::Timer timer;

  for(int i=0; i<N; i++) {
    auto sub = Kokkos::subview(a, Kokkos::pair<int,int>(i%M, i%M + 1));
    sub(0) += i;
  }
  double time = timer.seconds();
  
  timer.reset();
  Kokkos::View<int*, Kokkos::HostSpace> aum(a.data(), M+1);
  for(int i=0; i<N; i++) {
    auto sub = Kokkos::subview(aum, Kokkos::pair<int,int>(i%M, i%M + 1));
    sub(0) += i;
  }
  double time2 = timer.seconds();
  printf("%e %e %i\n",time, time2, a(0));
 ```

Producing timings like this:
```
5.0.1:  5.419963e-03 6.490440e-04 9900000
+fix:   1.658971e-03 6.827100e-05 9900000
Legacy: 1.658479e-03 6.826900e-05 9900000
```

I found this myself first, but then decided to see what CoPilot does, and if it can fix the problem. It actually came up pretty quickly with the same solution. In both cases however where was an oversight. While `subview` always worked, calling the subview ctor of View didn't if you didn't use the actual expected output type. 

For example:

```c++
  Kokkos::View<int[4][7]> a("A");
  Kokkos::View<int[7]> b(a, 0, Kokkos::pair{0,7});
```

This wouldn't work, because the `m_map = sub_map.mapping` assignment didn't work implicitly. The sub mapping created has a runtime dimension because the extent specifier (pair{0,7} is runtime. An explicit cast is wherefore necessary. That tripped copilot up pretty bad and I had to basically tell it to just do it. 

Anyway I think this was pretty instructive. The code now is correct and does what I think it needs to do.  