### PR TITLE
Add binary predicate math comparison functions

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -491,7 +491,6 @@ export {
   using ::Kokkos::ilogb;
   using ::Kokkos::ilogbf;
   using ::Kokkos::ilogbl;
-  using ::Kokkos::isequal;
   using ::Kokkos::isfinite;
   using ::Kokkos::isgreater;
   using ::Kokkos::isgreaterequal;

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -491,10 +491,17 @@ export {
   using ::Kokkos::ilogb;
   using ::Kokkos::ilogbf;
   using ::Kokkos::ilogbl;
+  using ::Kokkos::isequal;
   using ::Kokkos::isfinite;
+  using ::Kokkos::isgreater;
+  using ::Kokkos::isgreaterequal;
   using ::Kokkos::isinf;
+  using ::Kokkos::isless;
+  using ::Kokkos::islessequal;
+  using ::Kokkos::islessgreater;
   using ::Kokkos::isnan;
   using ::Kokkos::isnormal;
+  using ::Kokkos::isunordered;
   using ::Kokkos::lgamma;
   using ::Kokkos::lgammaf;
   using ::Kokkos::lgammal;

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -18,6 +18,12 @@
 #include <sycl/sycl.hpp>
 #endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12090
+#include <cuda/std/cmath>
+#endif
+#endif
+
 namespace Kokkos {
 
 namespace Impl {
@@ -237,13 +243,13 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     return FUNC(static_cast<double>(x), y);                                    \
   }
 
-#define KOKKOS_IMPL_MATH_BINARY_PREDICATE(FUNC)                                \
+#define KOKKOS_IMPL_MATH_BINARY_PREDICATE(FUNC, NAMESPACE)                     \
   KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) {                         \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    using NAMESPACE::FUNC;                                                     \
     return FUNC(x, y);                                                         \
   }                                                                            \
   KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) {                       \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    using NAMESPACE::FUNC;                                                     \
     return FUNC(x, y);                                                         \
   }                                                                            \
   inline bool FUNC(long double x, long double y) {                             \
@@ -258,7 +264,7 @@ using promote_3_t = typename promote_3<T, U, V>::type;
                        bool>                                                   \
       FUNC(T1 x, T2 y) {                                                       \
     using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
-    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    using NAMESPACE::FUNC;                                                     \
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
   }                                                                            \
   template <class T1, class T2>                                                \
@@ -613,20 +619,34 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> isnormal(
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnormal)
 #endif
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(signbit)
-#if defined CUDA_VERSION && CUDA_VERSION < 12090
+#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12090
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater, cuda::std)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreaterequal, cuda::std)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isless, cuda::std)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal, cuda::std)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater, cuda::std)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered, cuda::std)
+#else
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreater, x > y)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreaterequal, x >= y)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isless, x < y)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessequal, x <= y)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessgreater, x<y || x> y)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isunordered, isnan(x) || isnan(y))
+#endif
 #else
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreaterequal)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(isless)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater,
+                                  KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreaterequal,
+                                  KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isless, KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal,
+                                  KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater,
+                                  KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered,
+                                  KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE)
 #endif
 
 #undef KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -274,6 +274,38 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
   }
 
+#define KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(FUNC, OP)                   \
+  KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) { return OP; }            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) { return OP; }          \
+  inline bool FUNC(long double x, long double y) {                             \
+    using std::FUNC;                                                           \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  KOKKOS_INLINE_FUNCTION                                                       \
+      std::enable_if_t<std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> && \
+                           !std::is_same_v<T1, long double> &&                 \
+                           !std::is_same_v<T2, long double>,                   \
+                       bool>                                                   \
+      FUNC(T1 a, T2 b) {                                                       \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    auto x         = static_cast<Promoted>(a);                                 \
+    auto y         = static_cast<Promoted>(b);                                 \
+    return OP;                                                                 \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  inline std::enable_if_t<std::is_arithmetic_v<T1> &&                          \
+                              std::is_arithmetic_v<T2> &&                      \
+                              (std::is_same_v<T1, long double> ||              \
+                               std::is_same_v<T2, long double>),               \
+                          bool>                                                \
+  FUNC(T1 x, T2 y) {                                                           \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    static_assert(std::is_same_v<Promoted, long double>);                      \
+    using std::FUNC;                                                           \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
+  }
+
 #define KOKKOS_IMPL_MATH_TERNARY_INT_PTR_FUNCTION(FUNC)                        \
   KOKKOS_INLINE_FUNCTION float FUNC(float x, float y, int* z) {                \
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
@@ -581,12 +613,21 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> isnormal(
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnormal)
 #endif
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(signbit)
+#if defined CUDA_VERSION && CUDA_VERSION < 12090
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreater, x > y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreaterequal, x >= y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isless, x < y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessequal, x <= y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessgreater, x<y || x> y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isunordered, isnan(x) || isnan(y))
+#else
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreaterequal)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isless)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered)
+#endif
 
 #undef KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE
 #undef KOKKOS_IMPL_MATH_UNARY_FUNCTION
@@ -595,6 +636,7 @@ KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered)
 #undef KOKKOS_IMPL_MATH_BINARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_BINARY_PTR_FUNCTION
 #undef KOKKOS_IMPL_MATH_BINARY_PREDICATE
+#undef KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK
 #undef KOKKOS_IMPL_MATH_TERNARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_TERNARY_INT_PTR_FUNCTION
 

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -237,6 +237,43 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     return FUNC(static_cast<double>(x), y);                                    \
   }
 
+#define KOKKOS_IMPL_MATH_BINARY_PREDICATE(FUNC)                                \
+  KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) {                         \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) {                       \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  inline bool FUNC(long double x, long double y) {                             \
+    using std::FUNC;                                                           \
+    return FUNC(x, y);                                                         \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  KOKKOS_INLINE_FUNCTION                                                       \
+      std::enable_if_t<std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2> && \
+                           !std::is_same_v<T1, long double> &&                 \
+                           !std::is_same_v<T2, long double>,                   \
+                       bool>                                                   \
+      FUNC(T1 x, T2 y) {                                                       \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
+  }                                                                            \
+  template <class T1, class T2>                                                \
+  inline std::enable_if_t<std::is_arithmetic_v<T1> &&                          \
+                              std::is_arithmetic_v<T2> &&                      \
+                              (std::is_same_v<T1, long double> ||              \
+                               std::is_same_v<T2, long double>),               \
+                          bool>                                                \
+  FUNC(T1 x, T2 y) {                                                           \
+    using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
+    static_assert(std::is_same_v<Promoted, long double>);                      \
+    using std::FUNC;                                                           \
+    return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
+  }
+
 #define KOKKOS_IMPL_MATH_TERNARY_INT_PTR_FUNCTION(FUNC)                        \
   KOKKOS_INLINE_FUNCTION float FUNC(float x, float y, int* z) {                \
     using KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE::FUNC;                          \
@@ -544,12 +581,12 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> isnormal(
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnormal)
 #endif
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(signbit)
-// isgreater
-// isgreaterequal
-// isless
-// islessequal
-// islessgreater
-// isunordered
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreaterequal)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isless)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered)
 
 #undef KOKKOS_IMPL_MATH_FUNCTIONS_NAMESPACE
 #undef KOKKOS_IMPL_MATH_UNARY_FUNCTION
@@ -557,6 +594,7 @@ KOKKOS_IMPL_MATH_UNARY_PREDICATE(signbit)
 #undef KOKKOS_IMPL_MATH_UNARY_PREDICATE
 #undef KOKKOS_IMPL_MATH_BINARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_BINARY_PTR_FUNCTION
+#undef KOKKOS_IMPL_MATH_BINARY_PREDICATE
 #undef KOKKOS_IMPL_MATH_TERNARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_TERNARY_INT_PTR_FUNCTION
 

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -280,9 +280,15 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     return FUNC(static_cast<Promoted>(x), static_cast<Promoted>(y));           \
   }
 
-#define KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(FUNC, OP)                   \
-  KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) { return OP; }            \
-  KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) { return OP; }          \
+#define KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(FUNC, OP)            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) {                         \
+    KOKKOS_IF_ON_DEVICE(return OP;)                                            \
+    KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
+  }                                                                            \
+  KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) {                       \
+    KOKKOS_IF_ON_DEVICE(return OP;)                                            \
+    KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
+  }                                                                            \
   inline bool FUNC(long double x, long double y) {                             \
     using std::FUNC;                                                           \
     return FUNC(x, y);                                                         \
@@ -297,7 +303,8 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     using Promoted = Kokkos::Impl::promote_2_t<T1, T2>;                        \
     auto x         = static_cast<Promoted>(a);                                 \
     auto y         = static_cast<Promoted>(b);                                 \
-    return OP;                                                                 \
+    KOKKOS_IF_ON_DEVICE(return OP;)                                            \
+    KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
   }                                                                            \
   template <class T1, class T2>                                                \
   inline std::enable_if_t<std::is_arithmetic_v<T1> &&                          \
@@ -628,12 +635,13 @@ KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessequal, cuda::std)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(islessgreater, cuda::std)
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered, cuda::std)
 #else
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreater, x > y)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isgreaterequal, x >= y)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isless, x < y)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessequal, x <= y)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(islessgreater, x<y || x> y)
-KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK(isunordered, isnan(x) || isnan(y))
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(isgreater, x > y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(isgreaterequal, x >= y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(isless, x < y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(islessequal, x <= y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(islessgreater, x<y || x> y)
+KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK(isunordered,
+                                                  isnan(x) || isnan(y))
 #endif
 #else
 KOKKOS_IMPL_MATH_BINARY_PREDICATE(isgreater,
@@ -656,7 +664,7 @@ KOKKOS_IMPL_MATH_BINARY_PREDICATE(isunordered,
 #undef KOKKOS_IMPL_MATH_BINARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_BINARY_PTR_FUNCTION
 #undef KOKKOS_IMPL_MATH_BINARY_PREDICATE
-#undef KOKKOS_IMPL_MATH_BINARY_PREDICATE_FALLBACK
+#undef KOKKOS_IMPL_MATH_BINARY_PREDICATE_DEVICE_FALLBACK
 #undef KOKKOS_IMPL_MATH_TERNARY_FUNCTION
 #undef KOKKOS_IMPL_MATH_TERNARY_INT_PTR_FUNCTION
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -517,6 +517,37 @@ DEFINE_BINARY_FUNCTION_EVAL(fmin, 0);
 
 #undef DEFINE_BINARY_FUNCTION_EVAL
 
+#define DEFINE_BINARY_PREDICATE_EVAL(FUNC)                                     \
+  struct MathBinaryPredicate_##FUNC {                                          \
+    template <typename T, typename U>                                          \
+    static KOKKOS_FUNCTION auto eval(T x, U y) {                               \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0, (U)0)), bool>); \
+      return Kokkos::FUNC(x, y);                                               \
+    }                                                                          \
+    template <typename T, typename U>                                          \
+    static auto eval_std(T x, U y) {                                           \
+      using std::FUNC;                                                         \
+      return FUNC(x, y);                                                       \
+    }                                                                          \
+  };                                                                           \
+  using kk_##FUNC = MathBinaryPredicate_##FUNC;                                \
+  template <>                                                                  \
+  struct math_function_name<MathBinaryPredicate_##FUNC> {                      \
+    static constexpr char name[] = #FUNC;                                      \
+  };                                                                           \
+  constexpr char math_function_name<MathBinaryPredicate_##FUNC>::name[]
+
+#ifndef KOKKOS_MATHEMATICAL_FUNCTIONS_SKIP_2
+DEFINE_BINARY_PREDICATE_EVAL(isgreater);
+DEFINE_BINARY_PREDICATE_EVAL(isgreaterequal);
+DEFINE_BINARY_PREDICATE_EVAL(isless);
+DEFINE_BINARY_PREDICATE_EVAL(islessequal);
+DEFINE_BINARY_PREDICATE_EVAL(islessgreater);
+DEFINE_BINARY_PREDICATE_EVAL(isunordered);
+#endif
+
+#undef DEFINE_BINARY_PREDICATE_EVAL
+
 #define DEFINE_BINARY_PTR_FUNCTION_EVAL(FUNC, ULP_FACTOR)          \
   struct MathBinaryPtrFunction_##FUNC {                            \
     template <typename T, typename U>                              \
@@ -783,6 +814,12 @@ struct TestMathBinaryFunction : FloatingPointComparison {
   }
 };
 
+template <class Space, class... Func, class Arg1, class Arg2>
+void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
+  (void)std::initializer_list<int>{
+      (TestMathBinaryFunction<Space, Func, Arg1, Arg2>(arg1, arg2), 0)...};
+}
+
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathBinaryPtrFunction : FloatingPointComparison {
@@ -827,10 +864,39 @@ void do_test_math_binary_ptr_function(Arg x) {
   }
 }
 
+template <class Space, class Func, class Arg1, class Arg2>
+struct TestMathBinaryPredicate {
+  Arg1 val1_;
+  Arg2 val2_;
+  bool res_;
+  TestMathBinaryPredicate(Arg1 val1, Arg2 val2)
+      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
+    run();
+  }
+  void run() {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0) << "Failed check no error for "
+                         << math_function_name<Func>::name << "("
+                         << type_helper<Arg1>::name() << ", "
+                         << type_helper<Arg2>::name() << ")";
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    bool ar = Func::eval(val1_, val2_) == res_;
+    if (!ar) {
+      ++e;
+      Kokkos::printf("value at %f, %f which is %s was expected to be %s\n",
+                     (double)val1_, (double)val2_,
+                     Func::eval(val1_, val2_) ? "true" : "false",
+                     res_ ? "true" : "false");
+    }
+  }
+};
+
 template <class Space, class... Func, class Arg1, class Arg2>
-void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
+void do_test_math_binary_predicate(Arg1 arg1, Arg2 arg2) {
   (void)std::initializer_list<int>{
-      (TestMathBinaryFunction<Space, Func, Arg1, Arg2>(arg1, arg2), 0)...};
+      (TestMathBinaryPredicate<Space, Func, Arg1, Arg2>(arg1, arg2), 0)...};
 }
 
 template <class Space, class Func, class Arg1, class Arg2,
@@ -2430,6 +2496,24 @@ TEST(TEST_CATEGORY, mathematical_functions_signbit) {
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
   TestSignbit<TEST_EXECSPACE>();
+}
+
+TEST(TEST_CATEGORY, mathematical_functions_binary_predicates) {
+  auto test_all_predicates = [](auto x, auto y) {
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_isgreater>(x, y);
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_isgreaterequal>(x, y);
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_isless>(x, y);
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_islessequal>(x, y);
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_islessgreater>(x, y);
+    do_test_math_binary_predicate<TEST_EXECSPACE, kk_isunordered>(x, y);
+  };
+
+  test_all_predicates(2.f, 3.f);
+  test_all_predicates(2., 3.);
+  test_all_predicates(2, 3.f);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  test_all_predicates(2.l, 3.l);
+#endif
 }
 
 KE::half_t ref_test_fallback_half(KE::half_t) {


### PR DESCRIPTION
Implement missing functions under "Classification and comparison"
* `isgreater`
* `sgreaterequal`
* `isless`
* `islessequal`
* `islessgreater`
* `isunordered`