### PR TITLE
Nightly CI spack: Verbose install kokkos

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -35,7 +35,7 @@ pipeline {
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
-                          spack install --only=dependencies kokkos@develop+tests && \
+                          spack install -v --only=dependencies kokkos@develop+tests && \
                           spack install -v --only=package ${CDASH_ARGS} kokkos@develop+tests cxxstd=20 && \
                           spack load cmake && \
                           spack test run ${CDASH_ARGS} kokkos && \
@@ -67,7 +67,7 @@ pipeline {
                           rm -rf spack && \
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
-                          spack install --only=dependencies kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
+                          spack install -v --only=dependencies kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
                           spack install -v --only=package ${CDASH_ARGS} kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
                           spack load cmake  && \
                           spack load kokkos-nvcc-wrapper && \

--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -36,7 +36,7 @@ pipeline {
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=dependencies kokkos@develop+tests && \
-                          spack install --only=package ${CDASH_ARGS} kokkos@develop+tests cxxstd=20 && \
+                          spack install -v --only=package ${CDASH_ARGS} kokkos@develop+tests cxxstd=20 && \
                           spack load cmake && \
                           spack test run ${CDASH_ARGS} kokkos && \
                           spack test results -l
@@ -68,7 +68,7 @@ pipeline {
                           git clone https://github.com/spack/spack.git && \
                           . ./spack/share/spack/setup-env.sh && \
                           spack install --only=dependencies kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
-                          spack install --only=package ${CDASH_ARGS} kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
+                          spack install -v --only=package ${CDASH_ARGS} kokkos@develop+cuda+wrapper+tests cuda_arch=80 ^cuda@12.9.0 && \
                           spack load cmake  && \
                           spack load kokkos-nvcc-wrapper && \
                           spack load cuda && \


### PR DESCRIPTION
We don't get enough information if `spack install` fails. Asking for verbose information should help.