### PR TITLE
Implement StaticBatchSize for HIP and use it in ViewFill

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -18,9 +18,10 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
   using Policy = Kokkos::RangePolicy<Traits...>;
 
  private:
-  using Member       = typename Policy::member_type;
-  using WorkTag      = typename Policy::work_tag;
-  using LaunchBounds = typename Policy::launch_bounds;
+  using Member          = typename Policy::member_type;
+  using WorkTag         = typename Policy::work_tag;
+  using LaunchBounds    = typename Policy::launch_bounds;
+  using StaticBatchSize = typename Policy::static_batch_size;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -45,21 +46,33 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
   ParallelFor& operator=(ParallelFor const&) = delete;
 
   inline __device__ void operator()() const {
-    const auto work_stride = Member(blockDim.y) * gridDim.x;
-    const Member work_end  = m_policy.end();
+    constexpr auto batch_size = Member(StaticBatchSize::batch_size);
+    const auto work_stride    = Member(blockDim.y) * gridDim.x;
+    const Member work_end     = m_policy.end();
 
     for (Member iwork = m_policy.begin() + threadIdx.y +
                         static_cast<Member>(blockDim.y) * blockIdx.x;
          iwork < work_end;
-         iwork = iwork < static_cast<Member>(work_end - work_stride)
-                     ? iwork + work_stride
-                     : work_end) {
-      this->template exec_range<WorkTag>(iwork);
+         iwork =
+             iwork < static_cast<Member>(work_end - work_stride * batch_size)
+                 ? iwork + work_stride * batch_size
+                 : work_end) {
+      for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
+                         i < work_end - iwork;
+           i = (i < static_cast<Member>(work_end - work_stride - iwork))
+                   ? i + work_stride
+                   : work_end - iwork) {
+        this->template exec_range<WorkTag>(iwork + i);
+      }
     }
   }
 
   inline void execute() const {
-    const typename Policy::index_type nwork = m_policy.end() - m_policy.begin();
+    constexpr typename Policy::index_type batch_size =
+        StaticBatchSize::batch_size;
+    const typename Policy::index_type nwork =
+        (m_policy.end() - m_policy.begin()) / batch_size +
+        ((m_policy.end() - m_policy.begin()) % batch_size == 0 ? 0 : 1);
 
     using DriverType = ParallelFor<FunctorType, Policy, Kokkos::HIP>;
     const int block_size =

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -69,20 +69,20 @@ struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
 // Increasing the number of elements per thread improves throughput for
 // configurations that support StaticBatchSize. The values were found
 // empirically.
-template <class ExecutionSpace>
+template <class ExecutionSpace, int size>
 struct ViewFillStaticBatchSize {
   static constexpr int value = 1;
 };
 #ifdef KOKKOS_ENABLE_CUDA
-template <>
-struct ViewFillStaticBatchSize<Kokkos::Cuda> {
+template <int size>
+struct ViewFillStaticBatchSize<Kokkos::Cuda, size> {
   static constexpr int value = 16;
 };
 #endif
 #ifdef KOKKOS_ENABLE_HIP
-template <>
-struct ViewFillStaticBatchSize<Kokkos::HIP> {
-  static constexpr int value = 4;
+template <int size>
+struct ViewFillStaticBatchSize<Kokkos::HIP, size> {
+  static constexpr int value = size < 4 ? 8 : 4;
 };
 #endif
 
@@ -90,10 +90,10 @@ template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 1, iType> {
   ViewType a;
   typename ViewType::const_value_type val;
-  using policy_type =
-      Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
-                          Kokkos::Experimental::StaticBatchSize<
-                              ViewFillStaticBatchSize<ExecSpace>::value>>;
+  using policy_type = Kokkos::RangePolicy<
+      ExecSpace, Kokkos::IndexType<iType>,
+      Kokkos::Experimental::StaticBatchSize<ViewFillStaticBatchSize<
+          ExecSpace, sizeof(typename ViewType::value_type)>::value>>;
 
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -70,12 +70,20 @@ template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 1, iType> {
   ViewType a;
   typename ViewType::const_value_type val;
-  // It was found empirically that increasing the number of elements per thread
-  // by a factor of 16 gives good results for configurations that support
-  // StaticBatchSize.
+  // Increasing the number of elements per thread improves throughput for
+  // configurations that support StaticBatchSize. The values were found
+  // empirically.
+#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   using policy_type =
       Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
                           Kokkos::Experimental::StaticBatchSize<16>>;
+#elif defined(KOKKOS_ARCH_AMD_GPU)
+  using policy_type =
+      Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
+                          Kokkos::Experimental::StaticBatchSize<4>>;
+#else
+  using policy_type = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
+#endif
 
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -66,24 +66,34 @@ struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
   void operator()(const iType&) const { a() = val; }
 };
 
+// Increasing the number of elements per thread improves throughput for
+// configurations that support StaticBatchSize. The values were found
+// empirically.
+template <Kokkos::ExecutionSpace>
+struct ViewFillStaticBatchSize {
+  static constexpr int value = 1;
+};
+#ifdef KOKKOS_ENABLE_CUDA
+template <>
+struct ViewFillStaticBatchSize<Kokkos::Cuda> {
+  static constexpr int value = 16;
+};
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+template <>
+struct ViewFillStaticBatchSize<Kokkos::HIP> {
+  static constexpr int value = 4;
+};
+#endif
+
 template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 1, iType> {
   ViewType a;
   typename ViewType::const_value_type val;
-  // Increasing the number of elements per thread improves throughput for
-  // configurations that support StaticBatchSize. The values were found
-  // empirically.
-#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
   using policy_type =
       Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
-                          Kokkos::Experimental::StaticBatchSize<16>>;
-#elif defined(KOKKOS_ARCH_AMD_GPU)
-  using policy_type =
-      Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>,
-                          Kokkos::Experimental::StaticBatchSize<4>>;
-#else
-  using policy_type = Kokkos::RangePolicy<ExecSpace, Kokkos::IndexType<iType>>;
-#endif
+                          Kokkos::Experimental::StaticBatchSize<
+                              ViewFillStaticBatchSize<ExecSpace>::value>>;
 
   ViewFill(const ViewType& a_, typename ViewType::const_value_type& val_,
            const ExecSpace& space)

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -69,7 +69,7 @@ struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
 // Increasing the number of elements per thread improves throughput for
 // configurations that support StaticBatchSize. The values were found
 // empirically.
-template <Kokkos::ExecutionSpace>
+template <class ExecutionSpace>
 struct ViewFillStaticBatchSize {
   static constexpr int value = 1;
 };


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/8795.

Using
```C++
#include<Kokkos_Core.hpp>

template <int UR, typename View>
double execute(View v, typename View::value_type V)
{
  Kokkos::Timer timer;
  int N = v.size();
  int NUR = N/UR;
  Kokkos::parallel_for(NUR, KOKKOS_LAMBDA(int i) {
      for (int j=0; j<UR; ++j)
        v(i + j*NUR) = V;
  });
  Kokkos::fence();
  return ((double)N)*sizeof(typename View::value_type) / timer.seconds();
}

template <typename T>
void test(int N, T V) {
    Kokkos::View<T*> a("A", N);

    std::vector<double> unrolled;
    unrolled.push_back(execute<1>(a, V));
    unrolled.push_back(execute<2>(a, V));
    unrolled.push_back(execute<4>(a, V));
    unrolled.push_back(execute<8>(a, V));
    unrolled.push_back(execute<16>(a, V));
    unrolled.push_back(execute<32>(a, V));
    unrolled.push_back(execute<64>(a, V));
    unrolled.push_back(execute<128>(a, V));

    Kokkos::Timer timer;
    Kokkos::deep_copy(a,V);
    double time_dc = timer.seconds();
    double bw_dc = ((double)N)*sizeof(T) / time_dc;

    printf("%lu | %d | %d | %d | %d | %d | %d | %d | %d\n", sizeof(T), 
		    int(unrolled[0] * 1.e-9), int(unrolled[1] * 1.e-9), int(unrolled[2] * 1.e-9), int(unrolled[3] * 1.e-9),
		    int(unrolled[4] * 1.e-9), int(unrolled[5] * 1.e-9), int(unrolled[6] * 1.e-9), int(unrolled[7] * 1.e-9));
  }

int main(int argc, char* argv[]) {
  Kokkos::initialize(argc, argv);
  {
    int N = argc > 1 ? atoi(argv[1]) : 1000000000;
    int V = argc > 2 ? atoi(argv[2]) : 0;
    
    test<char>(N,V);
    test<short>(N,V);
    test<int>(N,V);
    test<long>(N,V);
    test<Kokkos::complex<double>>(N,V);
  }
    Kokkos::finalize();
}
```
MI250X shows
| sizeof(T) | 1  |  2 |  4 |  8 | 16 | 32 | 64 | 128 |
| --            | -- | -- | -- | -- | -- | -- | -- | -- |
| 1 | 28 | 380 | 710 | 1045 | 883 | 727 | 466 | 325 |
| 2 | 399 | 773 | 1200 | 1098 | 968 | 790 | 482 | 340 |
| 4 | 795 | 1345 | 1301 | 1113 | 1012 | 913 | 585 | 448 |
| 8 | 1399 | 1398 | 1384 | 1365 | 1086 | 988 | 873 | 639 |
| 16 | 368 | 1317 | 1237 | 1157 | 1100 | 1019 | 1041 | 1025 |

and MI300
| sizeof(T) | 1  |  2 |  4 |  8 | 16 | 32 | 64 | 128 |
| --            | -- | -- | -- | -- | -- | -- | -- | -- |
| 1 | 187 | 1456 | 2807 | 3973 | 3660 | 3232 | 2751 | 2334 |
| 2 | 1452 | 2896 | 4064 | 4019 | 4052 | 3782 | 3564 | 3333 |
| 4 | 2896 | 4029 | 4128 | 4132 | 4114 | 4127 | 3829 | 3610 |
| 8 | 4129 | 4163 | 4157 | 4175 | 4164 | 4168 | 4111 | 3655 |
| 16 | 4139 | 4143 | 4154 | 4153 | 4151 | 4153 | 4147 | 4142 |

The actual values using `ViewFill` differ slightly and using `StaticBatchSize<4>` seems to be a good compromise if we don't want to specialize for every size.