### PR TITLE
Update nvcc_wrapper for c++20

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -315,7 +315,7 @@ do
     ;;
   # End of Werror handling
   #Handle unsupported standard flags
-  --std=c++1y|-std=c++1y|--std=gnu++1y|-std=gnu++1y|--std=c++1z|-std=c++1z|--std=gnu++1z|-std=gnu++1z|--std=c++2a|-std=c++2a)
+  --std=c++1y|-std=c++1y|--std=gnu++1y|-std=gnu++1y|--std=c++1z|-std=c++1z|--std=gnu++1z|-std=gnu++1z|--std=c++2a|-std=c++2a|--std=c++2b|-std=c++2b|--std=c++2c|-std=c++2c)
     fallback_std_flag="-std=c++20"
     # this is hopefully just occurring in a downstream project during CMake feature tests
     # we really have no choice here but to accept the flag and change  to an accepted C++ standard

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -316,10 +316,10 @@ do
   # End of Werror handling
   #Handle unsupported standard flags
   --std=c++1y|-std=c++1y|--std=gnu++1y|-std=gnu++1y|--std=c++1z|-std=c++1z|--std=gnu++1z|-std=gnu++1z|--std=c++2a|-std=c++2a)
-    fallback_std_flag="-std=c++17"
+    fallback_std_flag="-std=c++20"
     # this is hopefully just occurring in a downstream project during CMake feature tests
     # we really have no choice here but to accept the flag and change  to an accepted C++ standard
-    echo "nvcc_wrapper does not accept standard flags $1 since partial standard flags and standards after C++17 are not supported. nvcc_wrapper will use $fallback_std_flag instead. It is undefined behavior to use this flag. This should only be occurring during CMake configuration."
+    echo "nvcc_wrapper does not accept standard flags $1 since partial standard flags and standards after C++20 are not supported. nvcc_wrapper will use $fallback_std_flag instead. It is undefined behavior to use this flag. This should only be occurring during CMake configuration."
     if [ -n "$std_flag" ]; then
        warn_std_flag
        shared_args=${shared_args/ $std_flag/}
@@ -337,25 +337,7 @@ do
     std_flag=$corrected_std_flag
     shared_args="$shared_args $std_flag"
     ;;
-  --std=c++20|-std=c++20)
-    if [ -n "$std_flag" ]; then
-      warn_std_flag
-      shared_args=${shared_args/ $std_flag/}
-    fi
-    # NVCC only has C++20 from version 12 on
-    cuda_main_version=$([[ $(${nvcc_compiler} --version) =~ V([0-9]+) ]] && echo ${BASH_REMATCH[1]})
-    if [ ${cuda_main_version} -lt 12 ]; then
-      fallback_std_flag="-std=c++17"
-      # this is hopefully just occurring in a downstream project during CMake feature tests
-      # we really have no choice here but to accept the flag and change  to an accepted C++ standard
-      echo "nvcc_wrapper does not accept standard flags $1 since partial standard flags and standards after C++17 are not supported. nvcc_wrapper will use $fallback_std_flag instead. It is undefined behavior to use this flag. This should only be occurring during CMake configuration."
-      std_flag=$fallback_std_flag
-    else
-      std_flag=$1
-    fi
-    shared_args="$shared_args $std_flag"
-    ;;
-  --std=c++11|-std=c++11|--std=c++14|-std=c++14|--std=c++17|-std=c++17)
+  --std=c++11|-std=c++11|--std=c++14|-std=c++14|--std=c++17|-std=c++17|--std=c++20|-std=c++20)
     if [ -n "$std_flag" ]; then
        warn_std_flag
        shared_args=${shared_args/ $std_flag/}
@@ -365,7 +347,7 @@ do
     ;;
 
   #convert PGI standard flags to something nvcc can handle
-  --c++11|--c++14|--c++17)
+  --c++11|--c++14|--c++17|--c++20)
     if [ -n "$std_flag" ]; then
        warn_std_flag
        shared_args=${shared_args/ $std_flag/}


### PR DESCRIPTION
The fallback `--std` flag was still `--std=c++17` and there was also an obsolete branch for cuda<12