### PR TITLE
[ci skip] Add ROCm 7.2 to nightly testing in jenkins

### DIFF
--- a/.jenkins/nightly.groovy
+++ b/.jenkins/nightly.groovy
@@ -153,7 +153,7 @@ pipeline {
                         dockerfile {
                             filename 'Dockerfile.hipcc'
                             dir 'scripts/docker'
-                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:7.0-complete --build-arg CMAKE_VERSION=3.31.3'
+                            additionalBuildArgs '--build-arg BASE=rocm/dev-ubuntu-24.04:7.2-complete --build-arg CMAKE_VERSION=3.31.3'
                             label 'rocm-docker && AMD_Radeon_Instinct_MI210'
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
                         }

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -695,7 +695,11 @@ class TestDynViewAPI {
   }
 
   static void run_operator_test_rank67() {
+    // FIXME_HIP The test triggers an internal compiler error in hipcc
+#if !(defined(KOKKOS_ENABLE_HIP) || \
+      (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 2))
     TestViewOperator_LeftAndRight<int, device, 7>::testit(2, 3, 4, 2, 3, 4, 2);
+#endif
     TestViewOperator_LeftAndRight<int, device, 6>::testit(2, 3, 4, 2, 3, 4);
   }
 


### PR DESCRIPTION
Add ROCm 7.2 to the nightly testing. 

We hit an ICE in `containers/unit_tests/TestDynViewAPI.hpp` for `DynRankView` of rank 7.

cc: @khuck-amd