### PR TITLE
Test with Kokkos_ENABLE_ROCTHRUST=OFF

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -154,6 +154,7 @@ pipeline {
                                 -DKokkos_ENABLE_DEPRECATED_CODE_4=ON \
                                 -DKokkos_ENABLE_TESTS=ON \
                                 -DKokkos_ENABLE_HIP=ON \
+                                -DKokkos_ENABLE_ROCTHRUST=OFF \
                                 -DKokkos_ENABLE_MULTIPLE_CMAKE_LANGUAGES=ON \
                                 -DCMAKE_INSTALL_PREFIX=${PWD}/../install \
                               .. && \


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8793. https://github.com/kokkos/kokkos/pull/8787 fixed an issue when disabling `rocThrust` support but didn't add a build exposing the problem.
After https://github.com/kokkos/kokkos/pull/8808, we have more (HIP) builds testing with examples so we can use the initially proposed jenkins build to test this configuration.