### PR TITLE
[5.0.2] Fix a View::layout() bug for LayoutRight and in DynRankView (#8838)

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -104,13 +104,10 @@ struct DynRankDimTraits {
         layout.dimension[7] != unspecified ? layout.dimension[7] : unspecified);
 
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
-    // In order to have a valid LayoutRight stride when Sacado passes through
-    // extra integer arguments, we need to set it to the dimension[6] for the
-    // rank-7 view coming out of here. Only if the original layout was already
-    // rank-7 we can preserve the stride.
-    // FIXME_SACADO
-    if constexpr (!std::is_same_v<Specialize, void> &&
-                  std::is_same_v<Layout, Kokkos::LayoutRight>) {
+    // In order to have a valid LayoutRight stride we need to set it to the
+    // dimension[6] for the rank-7 view coming out of here. Only if the original
+    // layout was already rank-7 we can preserve the stride.
+    if constexpr (std::is_same_v<Layout, Kokkos::LayoutRight>) {
       if (layout.dimension[6] == unspecified) {
         new_layout.stride = unspecified;
       } else {

--- a/containers/unit_tests/TestDynRankView_LayoutMember.hpp
+++ b/containers/unit_tests/TestDynRankView_LayoutMember.hpp
@@ -9,7 +9,7 @@ namespace {
 
 template <class Layout>
 void test_dyn_rank_view_layout_member() {
-  bool is_ll = std::is_same_v<Layout, Kokkos::LayoutLeft>;
+  constexpr bool is_ll = std::is_same_v<Layout, Kokkos::LayoutLeft>;
   {
     Kokkos::DynRankView<int, Layout> a(
         Kokkos::View<int***, Layout>("A", 11, 7, 5));
@@ -17,16 +17,22 @@ void test_dyn_rank_view_layout_member() {
     ASSERT_EQ(l.dimension[0], 11lu);
     ASSERT_EQ(l.dimension[1], 7lu);
     ASSERT_EQ(l.dimension[2], 5lu);
-    ASSERT_TRUE(
-        (l.stride == is_ll ? 11lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_TRUE((l.stride == is_ll ? 11lu : KOKKOS_INVALID_INDEX));
+#else
+    ASSERT_TRUE((l.stride == is_ll ? 11lu : 5lu));
+#endif
   }
   {
     Kokkos::DynRankView<int, Layout> a(Kokkos::View<int**, Layout>("A", 7, 5));
     auto l = a.layout();
     ASSERT_EQ(l.dimension[0], 7lu);
     ASSERT_EQ(l.dimension[1], 5lu);
-    ASSERT_TRUE(
-        (l.stride == is_ll ? 7lu : 5lu || l.stride == KOKKOS_INVALID_INDEX));
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_TRUE((l.stride == is_ll ? 7lu : KOKKOS_INVALID_INDEX));
+#else
+    ASSERT_TRUE((l.stride == is_ll ? 7lu : 5lu));
+#endif
   }
 }
 
@@ -35,4 +41,13 @@ void test_dyn_rank_view_layout_member() {
 TEST(TEST_CATEGORY, dyn_rank_view_layout_member) {
   test_dyn_rank_view_layout_member<Kokkos::LayoutRight>();
   test_dyn_rank_view_layout_member<Kokkos::LayoutLeft>();
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_layout_bug) {
+  Kokkos::DynRankView<double, Kokkos::LayoutRight> a("A", 10, 11);
+  // The following call failed with an error with legacy View off
+  Kokkos::DynRankView<double, Kokkos::LayoutRight> b("B", a.layout());
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  ASSERT_EQ(a.mapping(), b.mapping());
+#endif
 }

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -107,6 +107,10 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
     if constexpr (std::is_same_v<typename mapping_type::layout_type,
                                  Kokkos::Experimental::layout_right_padded<
                                      dynamic_extent>>) {
+// Legacy LayoutRight actually padded the left most dimension, not like
+// layout_right_padded the right most dimension. Thus if the stride wasn't
+// matching the appropriate extent this conversion doesn't work.
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
       if constexpr (rank == 2) {
         layout.stride = mapping.stride(0);
       }
@@ -115,6 +119,14 @@ KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
           Kokkos::abort(
               "Invalid conversion from layout_right_padded to LayoutRight");
       }
+#else
+      if constexpr (rank > 1) {
+        layout.stride = mapping.stride(rank - 2);
+      } else {
+        // Just setting the stride to 1 for rank 0/1
+        layout.stride = 1;
+      }
+#endif
     }
     return layout;
   }

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -354,7 +354,9 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenMPTarget;OpenACC;HIP;SYCL)
     # ViewSupport should eventually contain the new implementation
     # detail tests for the mdspan based View
     if(Kokkos_ENABLE_IMPL_MDSPAN)
-      set(BV_TestNames BasicView ReferenceCountedAccessor ReferenceCountedDataHandle AllocationAndSpanSize)
+      set(BV_TestNames BasicView ReferenceCountedAccessor ReferenceCountedDataHandle AllocationAndSpanSize
+                       LegacyLayoutFunction
+      )
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_OPENACC)
         list(APPEND BV_TestNames ViewCustomizationAccessorArg ViewCustomizationAllocationType
              ViewCustomizationAccessorFromMapping

--- a/core/unit_test/view/TestLegacyLayoutFunction.hpp
+++ b/core/unit_test/view/TestLegacyLayoutFunction.hpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <gtest/gtest.h>
+
+template <class ViewT, class Exts>
+void test_layout_single_rank_impl(ViewT a, Exts exts, int stride) {
+  // Avoid warning for pointless comparison of unsigned with 0
+  if constexpr (ViewT::rank() > 0) {
+    for (unsigned r = 0; r < ViewT::rank(); r++) {
+      ASSERT_EQ(a.extent(r), exts.extent(r));
+      ASSERT_EQ(a.layout().dimension[r], exts.extent(r));
+    }
+  }
+  if constexpr (ViewT::rank() > 1) {
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    // In Legacy View the stride wasn't propagated correctly
+    ASSERT_EQ(a.layout().stride, stride);
+    int actual_stride =
+        std::is_same_v<typename ViewT::array_layout, Kokkos::LayoutLeft>
+            ? a.stride(1)
+            : a.stride(ViewT::rank() - 2);
+#else
+    // In Legacy View the padded dimension was always the leftmost
+    int actual_stride =
+        std::is_same_v<typename ViewT::array_layout, Kokkos::LayoutLeft>
+            ? a.stride(1)
+            : a.stride(0);
+#endif
+    ASSERT_EQ(actual_stride, stride);
+  }
+  {
+    ViewT b("B", a.layout());
+    ASSERT_EQ(a.layout(), b.layout());
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(a.mapping(), b.mapping());
+#endif
+  }
+  {
+    ViewT b(a.data(), a.layout());
+    ASSERT_EQ(a.layout(), b.layout());
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(a.mapping(), b.mapping());
+#endif
+  }
+  {
+    ViewT b(Kokkos::view_alloc("B"), a.layout());
+    ASSERT_EQ(a.layout(), b.layout());
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(a.mapping(), b.mapping());
+#endif
+  }
+  {
+    ViewT b(Kokkos::view_wrap(a.data()), a.layout());
+    ASSERT_EQ(a.layout(), b.layout());
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+    ASSERT_EQ(a.mapping(), b.mapping());
+#endif
+  }
+}
+
+template <class ViewT, std::integral... Sizes>
+void test_layout_single_rank(Sizes... sizes) {
+#ifdef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  using extents_type =
+      typename decltype(std::declval<ViewT>().to_mdspan())::extents_type;
+  using mapping_type =
+      typename decltype(std::declval<ViewT>().to_mdspan())::mapping_type;
+#else
+  using extents_type = typename ViewT::extents_type;
+  using mapping_type = typename ViewT::mapping_type;
+#endif
+  extents_type exts{sizes...};
+
+  int padded_extent = 1;
+
+  if (ViewT::rank() > 0) {
+    padded_extent =
+        std::is_same_v<typename ViewT::array_layout, Kokkos::LayoutLeft>
+            ?
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+            exts.extent(0)
+            : exts.extent(ViewT::rank() - 1);
+#else
+            exts.extent(0)
+            : ((sizes * ... * 1)) / exts.extent(0);
+#endif
+  }
+  // Test with no padding
+  test_layout_single_rank_impl(ViewT("A", sizes...), exts, padded_extent);
+  // using array_layout because I need LayoutLeft/Right, not
+  // layout_left/right_padded
+  using Layout = typename ViewT::array_layout;
+  Layout l;
+  // Avoid warning for pointless comparison with 0
+  if constexpr (ViewT::rank() > 0)
+    for (size_t r = 0; r < ViewT::rank(); r++) l.dimension[r] = exts.extent(r);
+  test_layout_single_rank_impl(ViewT("A", l), exts, padded_extent);
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  test_layout_single_rank_impl(ViewT("A", mapping_type(exts)), exts,
+                               padded_extent);
+#endif
+
+  // Test with padding
+  padded_extent += 3;
+
+  l.stride = padded_extent;
+  test_layout_single_rank_impl(ViewT("A", l), exts, padded_extent);
+
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
+  test_layout_single_rank_impl(ViewT("A", mapping_type(exts, padded_extent)),
+                               exts, padded_extent);
+#endif
+}
+
+template <class Layout>
+void test_layout() {
+  test_layout_single_rank<Kokkos::View<double, Layout, TEST_EXECSPACE>>();
+  test_layout_single_rank<Kokkos::View<double*, Layout, TEST_EXECSPACE>>(7);
+  test_layout_single_rank<Kokkos::View<double[7], Layout, TEST_EXECSPACE>>(7);
+
+  test_layout_single_rank<Kokkos::View<double**, Layout, TEST_EXECSPACE>>(7,
+                                                                          11);
+  test_layout_single_rank<Kokkos::View<double* [11], Layout, TEST_EXECSPACE>>(
+      7, 11);
+  test_layout_single_rank<Kokkos::View<double*******, Layout, TEST_EXECSPACE>>(
+      7, 11, 13, 17, 19, 2, 3);
+  test_layout_single_rank<
+      Kokkos::View<double***** [2][3], Layout, TEST_EXECSPACE>>(7, 11, 13, 17,
+                                                                19, 2, 3);
+}
+
+TEST(TEST_CATEGORY, view_legacy_layout_member) {
+  test_layout<Kokkos::LayoutLeft>();
+  test_layout<Kokkos::LayoutRight>();
+}


### PR DESCRIPTION
Cherry Pick of #8838 
We had an abort in there for layout_right_padded to LayoutRight which only actually applies to LegacyView since they were different layouts. With the new View implementation they are the same.

A second bug was in DynRankView where something I thought only applies to Sacado, actually applies always. We just didn't test the case where we ran into trouble.

I added testing for all of this - with the test also demonstrating the change in behavior from Legacy to new view.