### PR TITLE
View with mdspan Arguments

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3139,7 +3139,10 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
     if constexpr (std::is_constructible_v<
                       typename dst_type::accessor_type,
                       typename Kokkos::View<T, P...>::accessor_type>)
-      return dst_type(prop_copy, src.mapping(), src.accessor());
+      return dst_type(
+          prop_copy,
+          static_cast<typename dst_type::mapping_type>(src.mapping()),
+          static_cast<typename dst_type::accessor_type>(src.accessor()));
     else
       return dst_type(prop_copy, src.layout());
 #else

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3125,7 +3125,10 @@ inline auto create_mirror(const Kokkos::View<T, P...>& src,
     if constexpr (std::is_constructible_v<
                       typename dst_type::accessor_type,
                       typename Kokkos::View<T, P...>::accessor_type>)
-      return dst_type(prop_copy, src.mapping(), src.accessor());
+      return dst_type(
+          prop_copy,
+          static_cast<typename dst_type::mapping_type>(src.mapping()),
+          static_cast<typename dst_type::accessor_type>(src.accessor()));
     else
       return dst_type(prop_copy, src.layout());
 #else

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -128,6 +128,7 @@ export {
   using ::Kokkos::ViewTraits;
   using ::Kokkos::WithoutInitializing;
   namespace Experimental {
+  using ::Kokkos::Experimental::Accessor;
   using ::Kokkos::Experimental::AppendExtent;
   using ::Kokkos::Experimental::Extents;
   using ::Kokkos::Experimental::is_hooks_policy;

--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -27,6 +27,7 @@ export {
   using ::Kokkos::Impl::append_formatted_multidimensional_index;
   using ::Kokkos::Impl::ApplyToViewOfStaticRank;
   using ::Kokkos::Impl::are_integral;
+  using ::Kokkos::Impl::ArrayLayoutFromLayout;
   using ::Kokkos::Impl::as_view_of_rank_n;
   using ::Kokkos::Impl::AtomicAccessorRelaxed;
   using ::Kokkos::Impl::check_view_ctor_args_create_mirror;
@@ -45,6 +46,7 @@ export {
   using ::Kokkos::Impl::is_view_ctor_property;
   using ::Kokkos::Impl::is_view_label;
   using ::Kokkos::Impl::LabelTag;
+  using ::Kokkos::Impl::LayoutFromArrayLayout;
   using ::Kokkos::Impl::MDSpanViewTraits;
   using ::Kokkos::Impl::MirrorViewType;
   using ::Kokkos::Impl::ParseViewExtents;

--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -47,6 +47,7 @@ export {
   using ::Kokkos::Impl::LabelTag;
   using ::Kokkos::Impl::LayoutFromArrayLayout;
   using ::Kokkos::Impl::MDSpanViewTraits;
+  using ::Kokkos::Impl::MemoryTraitsFromAccessor;
   using ::Kokkos::Impl::MirrorViewType;
   using ::Kokkos::Impl::ParseViewExtents;
   using ::Kokkos::Impl::rank_dynamic;

--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -27,7 +27,6 @@ export {
   using ::Kokkos::Impl::append_formatted_multidimensional_index;
   using ::Kokkos::Impl::ApplyToViewOfStaticRank;
   using ::Kokkos::Impl::are_integral;
-  using ::Kokkos::Impl::ArrayLayoutFromLayout;
   using ::Kokkos::Impl::as_view_of_rank_n;
   using ::Kokkos::Impl::AtomicAccessorRelaxed;
   using ::Kokkos::Impl::check_view_ctor_args_create_mirror;

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -162,17 +162,35 @@ constexpr bool is_assignable(DstView&, const SrcView&) {
 }
 
 namespace Impl {
-template <class... Properties>
+template <class DataType, class... Properties>
 struct BasicViewFromTraits {
-  using view_traits        = ViewTraits<Properties...>;
+  using view_traits        = ViewTraits<DataType, Properties...>;
   using mdspan_view_traits = MDSpanViewTraits<view_traits>;
   using element_type       = typename view_traits::value_type;
   using extents_type       = typename mdspan_view_traits::extents_type;
   using layout_type        = typename mdspan_view_traits::mdspan_layout_type;
   using accessor_type      = typename mdspan_view_traits::accessor_type;
-
+  using data_type          = DataType;
   using type =
       BV::BasicView<element_type, extents_type, layout_type, accessor_type>;
+};
+
+template <class ElementType, class IndexType, size_t... Extents,
+          class... Properties>
+struct BasicViewFromTraits<ElementType, extents<IndexType, Extents...>,
+                           Properties...> {
+  using type =
+      BV::BasicView<ElementType, extents<IndexType, Extents...>, Properties...>;
+  using element_type  = typename type::element_type;
+  using extents_type  = typename type::extents_type;
+  using layout_type   = typename type::mdspan_type::layout_type;
+  using accessor_type = typename type::accessor_type;
+  using data_type =
+      typename DataTypeFromExtents<element_type, extents_type>::type;
+  using view_traits =
+      ViewTraits<data_type, typename ArrayLayoutFromLayout<layout_type>::type,
+                 typename accessor_type::memory_space>;
+  using mdspan_view_traits = MDSpanViewTraits<view_traits>;
 };
 
 // Helper function to deal with cases where the data handle is
@@ -202,8 +220,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_extents_impl(
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
 
-template <class DataType, class... Properties>
-class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
+template <class FirstArg, class... Properties>
+class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
   // We are deriving from BasicView, but need a helper to translate
   // View template parameters to BasicView template parameters
  private:
@@ -212,8 +230,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   template <typename V>
   friend struct Kokkos::Impl::ViewTracker;
 
-  using base_t =
-      typename Impl::BasicViewFromTraits<DataType, Properties...>::type;
+  using basic_view_from_traits_t =
+      Impl::BasicViewFromTraits<FirstArg, Properties...>;
+  using base_t = typename basic_view_from_traits_t::type;
 
   using base_t::m_acc;
   using base_t::m_map;
@@ -223,19 +242,21 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   using base_t::base_t;
 
   // typedefs originally from ViewTraits
-  using traits               = ViewTraits<DataType, Properties...>;
+  using traits = typename basic_view_from_traits_t::view_traits;
+
   using const_value_type     = typename traits::const_value_type;
   using non_const_value_type = typename traits::non_const_value_type;
-  using data_type            = DataType;
-  using const_data_type      = typename traits::const_data_type;
-  using non_const_data_type  = typename traits::non_const_data_type;
-  using view_tracker_type    = Impl::ViewTracker<View>;
-  using array_layout         = typename traits::array_layout;
-  using device_type          = typename traits::device_type;
-  using execution_space      = typename traits::execution_space;
-  using memory_space         = typename traits::memory_space;
-  using memory_traits        = typename traits::memory_traits;
-  using host_mirror_space    = typename traits::host_mirror_space;
+  using data_type            = typename basic_view_from_traits_t::data_type;
+
+  using const_data_type     = typename traits::const_data_type;
+  using non_const_data_type = typename traits::non_const_data_type;
+  using view_tracker_type   = Impl::ViewTracker<View>;
+  using array_layout        = typename traits::array_layout;
+  using device_type         = typename traits::device_type;
+  using execution_space     = typename traits::execution_space;
+  using memory_space        = typename traits::memory_space;
+  using memory_traits       = typename traits::memory_traits;
+  using host_mirror_space   = typename traits::host_mirror_space;
   using typename base_t::index_type;
 
   // aliases from BasicView
@@ -251,9 +272,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
       std::declval<typename base_t::data_handle_type>()));
 
  private:
-  using raw_allocation_value_type = std::remove_pointer_t<pointer_type>;
-  using hooks_policy =
-      typename Impl::ViewHooksFromTraits<DataType, Properties...>::type;
+  using raw_allocation_value_type        = std::remove_pointer_t<pointer_type>;
+  using hooks_policy                     = typename traits::hooks_policy;
   static constexpr bool has_hooks_policy = !std::is_void_v<hooks_policy>;
 
  public:

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -256,16 +256,15 @@ class View
   using const_value_type     = typename traits::const_value_type;
   using non_const_value_type = typename traits::non_const_value_type;
   using data_type            = typename basic_view_from_traits::data_type;
-
-  using const_data_type     = typename traits::const_data_type;
-  using non_const_data_type = typename traits::non_const_data_type;
-  using view_tracker_type   = Impl::ViewTracker<View>;
-  using array_layout        = typename traits::array_layout;
-  using device_type         = typename traits::device_type;
-  using execution_space     = typename traits::execution_space;
-  using memory_space        = typename traits::memory_space;
-  using memory_traits       = typename traits::memory_traits;
-  using host_mirror_space   = typename traits::host_mirror_space;
+  using const_data_type      = typename traits::const_data_type;
+  using non_const_data_type  = typename traits::non_const_data_type;
+  using view_tracker_type    = Impl::ViewTracker<View>;
+  using array_layout         = typename traits::array_layout;
+  using device_type          = typename traits::device_type;
+  using execution_space      = typename traits::execution_space;
+  using memory_space         = typename traits::memory_space;
+  using memory_traits        = typename traits::memory_traits;
+  using host_mirror_space    = typename traits::host_mirror_space;
   using typename base_t::index_type;
 
   // aliases from BasicView

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -173,14 +173,15 @@ struct BasicViewFromTraits {
   using data_type          = DataType;
   using type =
       BV::BasicView<element_type, extents_type, layout_type, accessor_type>;
+  static constexpr bool mdspan_style_args = false;
 };
 
 template <class ElementType, class IndexType, size_t... Extents,
-          class... Properties>
+          class LayoutType, class Accessor>
 struct BasicViewFromTraits<ElementType, extents<IndexType, Extents...>,
-                           Properties...> {
-  using type =
-      BV::BasicView<ElementType, extents<IndexType, Extents...>, Properties...>;
+                           LayoutType, Accessor> {
+  using type = BV::BasicView<ElementType, extents<IndexType, Extents...>,
+                             LayoutType, Accessor>;
   using element_type  = typename type::element_type;
   using extents_type  = typename type::extents_type;
   using layout_type   = typename type::mdspan_type::layout_type;
@@ -191,7 +192,8 @@ struct BasicViewFromTraits<ElementType, extents<IndexType, Extents...>,
       ViewTraits<data_type, typename ArrayLayoutFromLayout<layout_type>::type,
                  typename accessor_type::memory_space,
                  MemoryTraitsFromAccessor<accessor_type> >;
-  using mdspan_view_traits = MDSpanViewTraits<view_traits>;
+  using mdspan_view_traits                = MDSpanViewTraits<view_traits>;
+  static constexpr bool mdspan_style_args = true;
 };
 
 // Helper function to deal with cases where the data handle is
@@ -565,7 +567,15 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
 
  public:
   template <class... OtherIndexTypes>
+    requires(basic_view_from_traits_t::mdspan_style_args)
+  KOKKOS_FUNCTION constexpr reference_type operator()(
+      OtherIndexTypes... idx) const {
+    return base_t::operator()(idx...);
+  }
+
+  template <class... OtherIndexTypes>
     requires(
+        !basic_view_from_traits_t::mdspan_style_args &&
         (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
         (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...) &&
         (sizeof...(OtherIndexTypes) == rank()) &&
@@ -584,6 +594,7 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
 
   template <class... OtherIndexTypes>
     requires(
+        !basic_view_from_traits_t::mdspan_style_args &&
         (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
         (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...) &&
         (sizeof...(OtherIndexTypes) == rank()) &&

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -189,7 +189,8 @@ struct BasicViewFromTraits<ElementType, extents<IndexType, Extents...>,
       typename DataTypeFromExtents<element_type, extents_type>::type;
   using view_traits =
       ViewTraits<data_type, typename ArrayLayoutFromLayout<layout_type>::type,
-                 typename accessor_type::memory_space>;
+                 typename accessor_type::memory_space,
+                 MemoryTraitsFromAccessor<accessor_type> >;
   using mdspan_view_traits = MDSpanViewTraits<view_traits>;
 };
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1585,6 +1585,17 @@ KOKKOS_INLINE_FUNCTION bool operator!=(const View<LT, LP...>& lhs,
 
 } /* namespace Kokkos */
 
+// ViewTraits handling if the arguments are mdspan style args
+// This is not circular: View will translate mdspan style args to original style
+// before creating its internal ViewTraits typedef
+// The reason we need this is that in certain places we create ViewTraits from
+// the template arguments of passed in Views (like in deep_copy).
+namespace Kokkos {
+template <class T, class IndexType, size_t... Extents, class... Prop>
+struct ViewTraits<T, extents<IndexType, Extents...>, Prop...>
+    : public View<T, extents<IndexType, Extents...>, Prop...>::traits {};
+}  // namespace Kokkos
+
 // FIXME: https://github.com/kokkos/kokkos/issues/7736 We may want to move these
 // out
 #include <View/Kokkos_ViewCommonType.hpp>
@@ -1594,5 +1605,5 @@ KOKKOS_INLINE_FUNCTION bool operator!=(const View<LT, LP...>& lhs,
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
-#endif /* KOKKOS_ENABLE_IMPL_VIEW_LEGACY */
+#endif /* !KOKKOS_ENABLE_IMPL_VIEW_LEGACY */
 #endif /* #ifndef KOKKOS_VIEW_HPP */

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -162,6 +162,7 @@ constexpr bool is_assignable(DstView&, const SrcView&) {
 }
 
 namespace Impl {
+// primary template handles traditional View template arguments
 template <class DataType, class... Properties>
 struct BasicViewFromTraits {
   using view_traits        = ViewTraits<DataType, Properties...>;
@@ -176,6 +177,7 @@ struct BasicViewFromTraits {
   static constexpr bool mdspan_style_args = false;
 };
 
+// specialization handles mdspan style View template arguments
 template <class ElementType, class IndexType, size_t... Extents,
           class LayoutType, class Accessor>
 struct BasicViewFromTraits<ElementType, extents<IndexType, Extents...>,
@@ -223,8 +225,12 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_extents_impl(
 #pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
 
-template <class FirstArg, class... Properties>
-class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
+// DataOrElementType can be either the classic Kokkos DataType including the
+// rank information or the mdspan compatible element type if mdspan style
+// arguments are used.
+template <class DataOrElementType, class... Properties>
+class View
+    : public Impl::BasicViewFromTraits<DataOrElementType, Properties...>::type {
   // We are deriving from BasicView, but need a helper to translate
   // View template parameters to BasicView template parameters
  private:
@@ -233,9 +239,9 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
   template <typename V>
   friend struct Kokkos::Impl::ViewTracker;
 
-  using basic_view_from_traits_t =
-      Impl::BasicViewFromTraits<FirstArg, Properties...>;
-  using base_t = typename basic_view_from_traits_t::type;
+  using basic_view_from_traits =
+      Impl::BasicViewFromTraits<DataOrElementType, Properties...>;
+  using base_t = typename basic_view_from_traits::type;
 
   using base_t::m_acc;
   using base_t::m_map;
@@ -245,11 +251,11 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
   using base_t::base_t;
 
   // typedefs originally from ViewTraits
-  using traits = typename basic_view_from_traits_t::view_traits;
+  using traits = typename basic_view_from_traits::view_traits;
 
   using const_value_type     = typename traits::const_value_type;
   using non_const_value_type = typename traits::non_const_value_type;
-  using data_type            = typename basic_view_from_traits_t::data_type;
+  using data_type            = typename basic_view_from_traits::data_type;
 
   using const_data_type     = typename traits::const_data_type;
   using non_const_data_type = typename traits::non_const_data_type;
@@ -567,7 +573,7 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
 
  public:
   template <class... OtherIndexTypes>
-    requires(basic_view_from_traits_t::mdspan_style_args)
+    requires(basic_view_from_traits::mdspan_style_args)
   KOKKOS_FUNCTION constexpr reference_type operator()(
       OtherIndexTypes... idx) const {
     return base_t::operator()(idx...);
@@ -575,7 +581,7 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
 
   template <class... OtherIndexTypes>
     requires(
-        !basic_view_from_traits_t::mdspan_style_args &&
+        !basic_view_from_traits::mdspan_style_args &&
         (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
         (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...) &&
         (sizeof...(OtherIndexTypes) == rank()) &&
@@ -594,7 +600,7 @@ class View : public Impl::BasicViewFromTraits<FirstArg, Properties...>::type {
 
   template <class... OtherIndexTypes>
     requires(
-        !basic_view_from_traits_t::mdspan_style_args &&
+        !basic_view_from_traits::mdspan_style_args &&
         (std::is_convertible_v<OtherIndexTypes, index_type> && ...) &&
         (std::is_nothrow_constructible_v<index_type, OtherIndexTypes> && ...) &&
         (sizeof...(OtherIndexTypes) == rank()) &&
@@ -1602,9 +1608,14 @@ KOKKOS_INLINE_FUNCTION bool operator!=(const View<LT, LP...>& lhs,
 // The reason we need this is that in certain places we create ViewTraits from
 // the template arguments of passed in Views (like in deep_copy).
 namespace Kokkos {
-template <class T, class IndexType, size_t... Extents, class... Prop>
-struct ViewTraits<T, extents<IndexType, Extents...>, Prop...>
-    : public View<T, extents<IndexType, Extents...>, Prop...>::traits {};
+template <class ElementType, class IndexType, size_t... Extents, class... Prop>
+struct ViewTraits<ElementType, extents<IndexType, Extents...>, Prop...>
+    : public View<ElementType, extents<IndexType, Extents...>,
+                  Prop...>::traits {
+  static_assert(sizeof...(Prop) == 2,
+                "When using mdspan arguments in View, both Layout and Accessor "
+                "must be specified explicitly.");
+};
 }  // namespace Kokkos
 
 // FIXME: https://github.com/kokkos/kokkos/issues/7736 We may want to move these

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -35,6 +35,19 @@ struct SpaceAwareAccessor {
 
   static_assert(is_memory_space_v<memory_space>);
 
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(!requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    return MemoryTraits<Unmanaged>();
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    return nested_accessor_type::impl_memory_traits();
+  }
+
   KOKKOS_DEFAULTED_FUNCTION
   constexpr SpaceAwareAccessor() = default;
 
@@ -118,6 +131,19 @@ struct SpaceAwareAccessor<AnonymousSpace, NestedAccessor> {
   using memory_space         = AnonymousSpace;
   using nested_accessor_type = NestedAccessor;
 
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(!requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    return MemoryTraits<Unmanaged>();
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    return nested_accessor_type::impl_memory_traits();
+  }
+
   KOKKOS_DEFAULTED_FUNCTION
   constexpr SpaceAwareAccessor() = default;
 
@@ -190,6 +216,11 @@ struct AtomicAccessorRelaxed {
       desul::AtomicRef<ElementType, desul::MemoryOrderRelaxed, MemoryScope>;
   using data_handle_type = ElementType*;
   using offset_policy    = AtomicAccessorRelaxed;
+
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits() {
+    return MemoryTraits<Unmanaged | Atomic>();
+  }
 
   KOKKOS_DEFAULTED_FUNCTION
   AtomicAccessorRelaxed() = default;
@@ -376,7 +407,27 @@ class ReferenceCountedAccessor {
   using offset_policy =
       ReferenceCountedAccessor<ElementType, MemorySpace,
                                typename NestedAccessor::offset_policy>;
-  using memory_space = MemorySpace;
+  using memory_space         = MemorySpace;
+  using nested_accessor_type = NestedAccessor;
+
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(!requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    return MemoryTraits<>();
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr auto impl_memory_traits()
+    requires(requires { nested_accessor_type::impl_memory_traits(); })
+  {
+    using mt = decltype(nested_accessor_type::impl_memory_traits());
+    // we need to add Managed, which means we need to remove Unmanaged but
+    // maintain all others
+    return MemoryTraits<(mt::is_random_access ? RandomAccess : 0) |
+                        (mt::is_atomic ? Atomic : 0) |
+                        (mt::is_restrict ? Restrict : 0) |
+                        (mt::is_aligned ? Kokkos::Aligned : 0)>();
+  }
 
   KOKKOS_DEFAULTED_FUNCTION
   constexpr ReferenceCountedAccessor() noexcept = default;
@@ -468,7 +519,77 @@ using CheckedReferenceCountedRelaxedAtomicAccessor = SpaceAwareAccessor<
     MemorySpace, ReferenceCountedAccessor<ElementType, MemorySpace,
                                           AtomicAccessorRelaxed<ElementType>>>;
 
+// Implements the deduction of accessors from ElementType, Space, and MemTraits
+template <class ElementType, class Space, class MemTraits>
+struct ImplAccessor {
+ private:
+  using memory_space = typename Space::memory_space;
+
+  KOKKOS_FUNCTION
+  constexpr static auto impl_type()
+    requires(!MemTraits::is_unmanaged && !MemTraits::is_atomic)
+  {
+    return std::type_identity<
+        CheckedReferenceCountedAccessor<ElementType, memory_space>>();
+  }
+
+  KOKKOS_FUNCTION
+  constexpr static auto impl_type()
+    requires(!MemTraits::is_unmanaged && MemTraits::is_atomic)
+  {
+    return std::type_identity<CheckedReferenceCountedRelaxedAtomicAccessor<
+        ElementType, memory_space>>();
+  }
+
+  KOKKOS_FUNCTION
+  constexpr static auto impl_type()
+    requires(MemTraits::is_unmanaged && !MemTraits::is_atomic)
+  {
+    return std::type_identity<
+        SpaceAwareAccessor<memory_space, default_accessor<ElementType>>>();
+  }
+
+  KOKKOS_FUNCTION
+  constexpr static auto impl_type()
+    requires(MemTraits::is_unmanaged && MemTraits::is_atomic)
+  {
+    return std::type_identity<
+        CheckedRelaxedAtomicAccessor<ElementType, memory_space>>();
+  }
+
+ public:
+  using type = typename decltype(impl_type())::type;
+};
 }  // namespace Impl
+
+// Public Accessor alias for our internal ones, deduced from classic template
+// arguments
+namespace Experimental {
+template <class ElementType, class Space = DefaultExecutionSpace,
+          class MemTraits = MemoryTraits<>>
+using Accessor =
+    typename Kokkos::Impl::ImplAccessor<ElementType, Space, MemTraits>::type;
+}  // namespace Experimental
+
+namespace Impl {
+template <class Accessor>
+  requires(!requires { Accessor::impl_memory_traits(); })
+KOKKOS_FUNCTION constexpr auto memory_traits_from_accessor() {
+  return MemoryTraits<Unmanaged>();
+}
+
+template <class Accessor>
+  requires(requires { Accessor::impl_memory_traits(); })
+KOKKOS_FUNCTION constexpr auto memory_traits_from_accessor() {
+  return Accessor::impl_memory_traits();
+}
+
+template <class Accessor>
+using MemoryTraitsFromAccessor =
+    decltype(memory_traits_from_accessor<Accessor>());
+
+}  // namespace Impl
+
 }  // namespace Kokkos
 
 #endif

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -521,7 +521,7 @@ using CheckedReferenceCountedRelaxedAtomicAccessor = SpaceAwareAccessor<
 
 // Implements the deduction of accessors from ElementType, Space, and MemTraits
 template <class ElementType, class Space, class MemTraits>
-struct ImplAccessor {
+struct ViewArgsToAccessor {
  private:
   using memory_space = typename Space::memory_space;
 
@@ -567,8 +567,8 @@ struct ImplAccessor {
 namespace Experimental {
 template <class ElementType, class Space = DefaultExecutionSpace,
           class MemTraits = MemoryTraits<>>
-using Accessor =
-    typename Kokkos::Impl::ImplAccessor<ElementType, Space, MemTraits>::type;
+using Accessor = typename Kokkos::Impl::ViewArgsToAccessor<ElementType, Space,
+                                                           MemTraits>::type;
 }  // namespace Experimental
 
 namespace Impl {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -426,7 +426,7 @@ class ReferenceCountedAccessor {
     return MemoryTraits<(mt::is_random_access ? RandomAccess : 0) |
                         (mt::is_atomic ? Atomic : 0) |
                         (mt::is_restrict ? Restrict : 0) |
-                        (mt::is_aligned ? Kokkos::Aligned : 0)>();
+                        (mt::is_aligned ? Aligned : 0)>();
   }
 
   KOKKOS_DEFAULTED_FUNCTION

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -423,10 +423,7 @@ class ReferenceCountedAccessor {
     using mt = decltype(nested_accessor_type::impl_memory_traits());
     // we need to add Managed, which means we need to remove Unmanaged but
     // maintain all others
-    return MemoryTraits<(mt::is_random_access ? RandomAccess : 0) |
-                        (mt::is_atomic ? Atomic : 0) |
-                        (mt::is_restrict ? Restrict : 0) |
-                        (mt::is_aligned ? Aligned : 0)>();
+    return MemoryTraits<mt::impl_value & ~Kokkos::Unmanaged>{};
   }
 
   KOKKOS_DEFAULTED_FUNCTION

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -57,6 +57,38 @@ struct LayoutFromArrayLayout<LayoutStride> {
   using type = layout_stride;
 };
 
+template <class Layout>
+struct ArrayLayoutFromLayout {
+  using type = void;
+};
+
+template <>
+struct ArrayLayoutFromLayout<layout_left> {
+  using type = LayoutLeft;
+};
+
+template <size_t Padding>
+struct ArrayLayoutFromLayout<
+    Kokkos::Experimental::layout_left_padded<Padding>> {
+  using type = LayoutLeft;
+};
+
+template <>
+struct ArrayLayoutFromLayout<layout_right> {
+  using type = LayoutRight;
+};
+
+template <size_t Padding>
+struct ArrayLayoutFromLayout<
+    Kokkos::Experimental::layout_right_padded<Padding>> {
+  using type = LayoutRight;
+};
+
+template <>
+struct ArrayLayoutFromLayout<layout_stride> {
+  using type = LayoutStride;
+};
+
 template <class ArrayLayout, class MDSpanType>
 KOKKOS_INLINE_FUNCTION auto array_layout_from_mapping(
     const typename MDSpanType::mapping_type &mapping) {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -58,9 +58,7 @@ struct LayoutFromArrayLayout<LayoutStride> {
 };
 
 template <class Layout>
-struct ArrayLayoutFromLayout {
-  using type = void;
-};
+struct ArrayLayoutFromLayout;
 
 template <>
 struct ArrayLayoutFromLayout<layout_left> {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -361,7 +361,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       )
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_OPENACC)
         list(APPEND BV_TestNames ViewCustomizationAccessorArg ViewCustomizationAllocationType
-             ViewCustomizationAccessorFromMapping
+             ViewCustomizationAccessorFromMapping MinimalViewMDSpanTemplateArgumentViability
         )
       endif()
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -75,7 +75,7 @@ if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
 endif()
 
 if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR Kokkos_ENABLE_IMPL_VIEW_LEGACY)
-  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestAccessorFromMemoryTraits.cpp.cpp)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestAccessorFromMemoryTraits.cpp)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewCustomization.cpp)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewMDSpanTemplateArgumentEquivalence.cpp)
 endif()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(COMPILE_ONLY_SOURCES
     TestTeamPolicyCTAD.cpp
     TestTeamMDRangePolicyCTAD.cpp
     TestNestedReducerCTAD.cpp
+    view/TestAccessorFromMemoryTraits.cpp
     view/TestBasicViewMDSpanConversion.cpp
     view/TestViewCustomization.cpp
     view/TestExtentsDatatypeConversion.cpp

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(COMPILE_ONLY_SOURCES
     view/TestExtentsDatatypeConversion.cpp
     view/TestConversionFromPointer.cpp
     view/TestMemoryTraitTypes.cpp
+    view/TestViewMDSpanTemplateArgumentEquivalence.cpp
 )
 
 # FIXME_NEXTSILICON: whitelisted tests
@@ -74,7 +75,9 @@ if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
 endif()
 
 if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR Kokkos_ENABLE_IMPL_VIEW_LEGACY)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestAccessorFromMemoryTraits.cpp.cpp)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewCustomization.cpp)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewMDSpanTemplateArgumentEquivalence.cpp)
 endif()
 
 #testing if windows.h and Kokkos_Core.hpp can be included

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -14,6 +14,34 @@ import kokkos.core;
 
 namespace Test {
 
-TEST(defaultdevicetype, development_test) {}
+template <class D, class... Properties>
+struct Compare {
+  using old_view_t = Kokkos::View<D, Properties...>;
+  using mdspan_t   = typename old_view_t::mdspan_type;
+  using new_view_t = Kokkos::View<
+      typename mdspan_t::element_type, typename mdspan_t::extents_type,
+      typename mdspan_t::layout_type, typename mdspan_t::accessor_type>;
+  static_assert(std::is_same_v<typename new_view_t::mdspan_type,
+                               typename old_view_t::mdspan_type>);
+  template <class... Args>
+  Compare(Args... args) {
+    new_view_t a(args...);
+  }
+};
+
+TEST(defaultdevicetype, development_test) {
+  int* data = new int[12];
+  {
+    Compare<int**> c0("A", 1, 2);
+    Compare<const int*, Kokkos::LayoutLeft> c1(data, 12);
+    Compare<const int* [3][4], Kokkos::HostSpace> c2(data, 1, 3, 4);
+    Compare<int*** [1], Kokkos::LayoutLeft, Kokkos::HostSpace,
+            Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+        c3(data, 1, 2, 3);
+    Compare<const int******, Kokkos::MemoryTraits<Kokkos::Unmanaged>> c4(
+        data, 1, 2, 2, 3, 1, 1);
+  }
+  delete[] data;
+}
 
 }  // namespace Test

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -14,62 +14,6 @@ import kokkos.core;
 
 namespace Test {
 
-template <class D, class... Properties>
-struct Compare {
-  using old_view_t = Kokkos::View<D, Properties...>;
-  using mdspan_t   = typename old_view_t::mdspan_type;
-  using new_view_t = Kokkos::View<
-      typename mdspan_t::element_type, typename mdspan_t::extents_type,
-      typename mdspan_t::layout_type, typename mdspan_t::accessor_type>;
-  static_assert(std::is_same_v<typename new_view_t::mdspan_type,
-                               typename old_view_t::mdspan_type>);
-  template <class... Args>
-  Compare(Args... args) {
-    new_view_t a(args...);
-  }
-};
-
-template <class MemoryTraits>
-struct CheckAccessor {
-  using acc_t = typename Kokkos::Impl::ImplAccessor<int, Kokkos::HostSpace,
-                                                    MemoryTraits>::type;
-  static_assert(
-      std::is_same_v<MemoryTraits, decltype(acc_t::impl_memory_traits())>);
-};
-
-TEST(defaultdevicetype, development_test) {
-  int* data = new int[12];
-  {
-    Compare<int**> c0("A", 1, 2);
-    Compare<const int*, Kokkos::LayoutLeft> c1(data, 12);
-    Compare<const int* [3][4], Kokkos::HostSpace> c2(data, 1, 3, 4);
-    Compare<int*** [1], Kokkos::LayoutLeft, Kokkos::HostSpace,
-            Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-        c3(data, 1, 2, 3);
-    Compare<const int******, Kokkos::MemoryTraits<Kokkos::Unmanaged>> c4(
-        data, 1, 2, 2, 3, 1, 1);
-  }
-  {
-    CheckAccessor<Kokkos::MemoryTraits<>> a0;
-    (void)a0;
-    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Unmanaged>> a1;
-    (void)a1;
-    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Atomic>> a2;
-    (void)a2;
-    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>> a3;
-    (void)a3;
-  }
-  {
-    using new_view_t =
-        Kokkos::View<float, Kokkos::dextents<unsigned, 7>, Kokkos::layout_right,
-                     Kokkos::Experimental::Accessor<float>>;
-    using old_view_t = Kokkos::View<float*******, Kokkos::LayoutRight>;
-    static_assert(std::is_same_v<typename new_view_t::index_type, unsigned>);
-    static_assert(std::is_same_v<typename old_view_t::index_type, size_t>);
-    static_assert(sizeof(new_view_t) == 4 * 7 + 4 + 16);
-    static_assert(sizeof(old_view_t) == 8 * 7 + 8 + 16);
-  }
-  delete[] data;
-}
+TEST(defaultdevicetype, development_test) {}
 
 }  // namespace Test

--- a/core/unit_test/default/TestDefaultDeviceDevelop.cpp
+++ b/core/unit_test/default/TestDefaultDeviceDevelop.cpp
@@ -29,6 +29,14 @@ struct Compare {
   }
 };
 
+template <class MemoryTraits>
+struct CheckAccessor {
+  using acc_t = typename Kokkos::Impl::ImplAccessor<int, Kokkos::HostSpace,
+                                                    MemoryTraits>::type;
+  static_assert(
+      std::is_same_v<MemoryTraits, decltype(acc_t::impl_memory_traits())>);
+};
+
 TEST(defaultdevicetype, development_test) {
   int* data = new int[12];
   {
@@ -40,6 +48,26 @@ TEST(defaultdevicetype, development_test) {
         c3(data, 1, 2, 3);
     Compare<const int******, Kokkos::MemoryTraits<Kokkos::Unmanaged>> c4(
         data, 1, 2, 2, 3, 1, 1);
+  }
+  {
+    CheckAccessor<Kokkos::MemoryTraits<>> a0;
+    (void)a0;
+    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Unmanaged>> a1;
+    (void)a1;
+    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Atomic>> a2;
+    (void)a2;
+    CheckAccessor<Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>> a3;
+    (void)a3;
+  }
+  {
+    using new_view_t =
+        Kokkos::View<float, Kokkos::dextents<unsigned, 7>, Kokkos::layout_right,
+                     Kokkos::Experimental::Accessor<float>>;
+    using old_view_t = Kokkos::View<float*******, Kokkos::LayoutRight>;
+    static_assert(std::is_same_v<typename new_view_t::index_type, unsigned>);
+    static_assert(std::is_same_v<typename old_view_t::index_type, size_t>);
+    static_assert(sizeof(new_view_t) == 4 * 7 + 4 + 16);
+    static_assert(sizeof(old_view_t) == 8 * 7 + 8 + 16);
   }
   delete[] data;
 }

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -4,6 +4,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <type_traits>
+
+// Checking requirement of explict type conversion to View
+
+namespace {
+
+template <class T, class Space>
+constexpr bool test_equivalence() {
+  // Checking that the aliases lead to expected accessor
+  static_assert(
+      std::is_same_v<
+          Kokkos::Experimental::Accessor<T, Space, Kokkos::MemoryTraits<>>,
+          Kokkos::Impl::CheckedReferenceCountedAccessor<
+              T, typename Space::memory_space>>);
+  static_assert(std::is_same_v<
+                Kokkos::Experimental::Accessor<
+                    T, Space,
+                    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>,
+                Kokkos::Impl::CheckedRelaxedAtomicAccessor<
+                    T, typename Space::memory_space>>);
+  static_assert(
+      std::is_same_v<Kokkos::Experimental::Accessor<
+                         T, Space, Kokkos::MemoryTraits<Kokkos::Atomic>>,
+                     Kokkos::Impl::CheckedReferenceCountedRelaxedAtomicAccessor<
+                         T, typename Space::memory_space>>);
+  static_assert(std::is_same_v<
+                Kokkos::Experimental::Accessor<
+                    T, Space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>,
+                Kokkos::Impl::SpaceAwareAccessor<typename Space::memory_space,
+                                                 Kokkos::default_accessor<T>>>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Experimental::Accessor<
+              T, Space,
+              Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>,
+          Kokkos::Impl::CheckedReferenceCountedRelaxedAtomicAccessor<
+              T, typename Space::memory_space>>);
+
+  // Checking MemoryTraits behavior of our accessors
+  // Default ones should stay default
+  static_assert(
+      std::is_same_v<
+          decltype(Kokkos::Experimental::Accessor<
+                   T, Space, Kokkos::MemoryTraits<>>::impl_memory_traits()),
+          Kokkos::MemoryTraits<>>);
+  // Unmanaged and Atomic are propagated now
+  static_assert(std::is_same_v<
+                decltype(Kokkos::Experimental::Accessor<
+                         T, Space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>::
+                             impl_memory_traits()),
+                Kokkos::MemoryTraits<Kokkos::Unmanaged>>);
+  static_assert(
+      std::is_same_v<decltype(Kokkos::Experimental::Accessor<
+                              T, Space, Kokkos::MemoryTraits<Kokkos::Atomic>>::
+                                  impl_memory_traits()),
+                     Kokkos::MemoryTraits<Kokkos::Atomic>>);
+  // RandomAccess is dropped, since no accessor currently implements this
+  static_assert(
+      std::is_same_v<decltype(Kokkos::Experimental::Accessor<
+                              T, Space,
+                              Kokkos::MemoryTraits<Kokkos::Atomic |
+                                                   Kokkos::RandomAccess>>::
+                                  impl_memory_traits()),
+                     Kokkos::MemoryTraits<Kokkos::Atomic>>);
+  return true;
+}
+
+static_assert(test_equivalence<float, Kokkos::DefaultExecutionSpace>());
+static_assert(
+    test_equivalence<const float, Kokkos::DefaultHostExecutionSpace>());
+static_assert(test_equivalence<Kokkos::complex<float>, Kokkos::HostSpace>());
+}  // namespace

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -18,6 +18,13 @@ namespace {
 template <class T, class Space>
 constexpr bool test_equivalence() {
   // Checking that the aliases lead to expected accessor
+  static_assert(std::is_same_v<
+                Kokkos::Experimental::Accessor<T>,
+                Kokkos::Impl::CheckedReferenceCountedAccessor<
+                    T, typename Kokkos::DefaultExecutionSpace::memory_space>>);
+  static_assert(std::is_same_v<Kokkos::Experimental::Accessor<T, Space>,
+                               Kokkos::Impl::CheckedReferenceCountedAccessor<
+                                   T, typename Space::memory_space>>);
   static_assert(
       std::is_same_v<
           Kokkos::Experimental::Accessor<T, Space, Kokkos::MemoryTraits<>>,
@@ -51,28 +58,27 @@ constexpr bool test_equivalence() {
   // Default ones should stay default
   static_assert(
       std::is_same_v<
-          decltype(Kokkos::Experimental::Accessor<
-                   T, Space, Kokkos::MemoryTraits<>>::impl_memory_traits()),
+          Kokkos::Impl::MemoryTraitsFromAccessor<
+              Kokkos::Experimental::Accessor<T, Space, Kokkos::MemoryTraits<>>>,
           Kokkos::MemoryTraits<>>);
   // Unmanaged and Atomic are propagated now
-  static_assert(std::is_same_v<
-                decltype(Kokkos::Experimental::Accessor<
-                         T, Space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>::
-                             impl_memory_traits()),
-                Kokkos::MemoryTraits<Kokkos::Unmanaged>>);
   static_assert(
-      std::is_same_v<decltype(Kokkos::Experimental::Accessor<
-                              T, Space, Kokkos::MemoryTraits<Kokkos::Atomic>>::
-                                  impl_memory_traits()),
-                     Kokkos::MemoryTraits<Kokkos::Atomic>>);
+      std::is_same_v<
+          Kokkos::Impl::MemoryTraitsFromAccessor<Kokkos::Experimental::Accessor<
+              T, Space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>>,
+          Kokkos::MemoryTraits<Kokkos::Unmanaged>>);
+  static_assert(
+      std::is_same_v<
+          Kokkos::Impl::MemoryTraitsFromAccessor<Kokkos::Experimental::Accessor<
+              T, Space, Kokkos::MemoryTraits<Kokkos::Atomic>>>,
+          Kokkos::MemoryTraits<Kokkos::Atomic>>);
   // RandomAccess is dropped, since no accessor currently implements this
   static_assert(
-      std::is_same_v<decltype(Kokkos::Experimental::Accessor<
-                              T, Space,
-                              Kokkos::MemoryTraits<Kokkos::Atomic |
-                                                   Kokkos::RandomAccess>>::
-                                  impl_memory_traits()),
-                     Kokkos::MemoryTraits<Kokkos::Atomic>>);
+      std::is_same_v<
+          Kokkos::Impl::MemoryTraitsFromAccessor<Kokkos::Experimental::Accessor<
+              T, Space,
+              Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>>,
+          Kokkos::MemoryTraits<Kokkos::Atomic>>);
   return true;
 }
 

--- a/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
+++ b/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
@@ -4,6 +4,7 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -44,7 +44,9 @@ struct ViewTestHarness {
     Kokkos::parallel_reduce(
         p,
         KOKKOS_LAMBDA(Extents... idx, size_t & lerr) {
-          if (a(idx...) != (idx + ... + extra_val)) lerr++;
+          if (a(idx...) != static_cast<typename ViewT::element_type>(
+                               (idx + ... + extra_val)))
+            lerr++;
         },
         errors);
     return errors;
@@ -151,8 +153,8 @@ struct ViewTestHarness {
 };
 
 TEST(TEST_CATEGORY, view_minimal_mdspan_args_access) {
-  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::access(3, 7);
-  ViewTestHarness<float, Kokkos::extents<int, Kokkos::dynamic_extent,
+  ViewTestHarness<int, Kokkos::extents<unsigned, 3, 7>>::access(3, 7);
+  ViewTestHarness<float, Kokkos::extents<unsigned, Kokkos::dynamic_extent,
                                          Kokkos::dynamic_extent, 7>>::access(3,
                                                                              5,
                                                                              7);
@@ -162,9 +164,9 @@ TEST(TEST_CATEGORY, view_minimal_mdspan_args_access) {
 }
 
 TEST(TEST_CATEGORY, view_minimal_mdspan_args_deep_copy) {
-  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::deep_copy(3, 7);
+  ViewTestHarness<int, Kokkos::extents<unsigned, 3, 7>>::deep_copy(3, 7);
   ViewTestHarness<float,
-                  Kokkos::extents<int, Kokkos::dynamic_extent,
+                  Kokkos::extents<unsigned, Kokkos::dynamic_extent,
                                   Kokkos::dynamic_extent, 7>>::deep_copy(3, 5,
                                                                          7);
   ViewTestHarness<int, Kokkos::dextents<size_t, 6>,
@@ -173,9 +175,9 @@ TEST(TEST_CATEGORY, view_minimal_mdspan_args_deep_copy) {
 }
 
 TEST(TEST_CATEGORY, view_minimal_mdspan_args_create_mirror) {
-  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::create_mirror(3, 7);
+  ViewTestHarness<int, Kokkos::extents<unsigned, 3, 7>>::create_mirror(3, 7);
   ViewTestHarness<float,
-                  Kokkos::extents<int, Kokkos::dynamic_extent,
+                  Kokkos::extents<unsigned, Kokkos::dynamic_extent,
                                   Kokkos::dynamic_extent, 7>>::create_mirror(3,
                                                                              5,
                                                                              7);

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -146,6 +146,18 @@ struct ViewTestHarness {
       ASSERT_EQ(a.extents(), h_a.extents());
     }
     {
+      auto h_a     = Kokkos::create_mirror(Kokkos::HostSpace(), a);
+      using h_type = decltype(h_a);
+      // since create_mirror still uses old-style template args
+      // the extents type isn't necessarily the same index_type
+      static_assert(
+          std::is_same_v<typename h_type::memory_space, Kokkos::HostSpace>);
+      static_assert(std::is_same_v<typename h_type::element_type,
+                                   typename new_view_t::element_type>);
+
+      ASSERT_EQ(a.extents(), h_a.extents());
+    }
+    {
       auto h_a = Kokkos::create_mirror_view(a);
       ASSERT_EQ(a.extents(), h_a.extents());
     }

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -25,11 +25,18 @@ struct ViewTestHarness {
   using rank_indicies =
       decltype(std::make_index_sequence<new_view_t::rank()>());
 
+  // function to get zeros in a fold expression
+  // , operator and ternary result in warnings
+  template <class T>
+  static long unsigned make_zero(const T&) {
+    return 0lu;
+  }
+
   template <class ViewT, class... Extents>
   static void init_view(ViewT a, size_t extra_val, Extents... extents) {
     using exec_t = typename ViewT::execution_space;
     auto p = Kokkos::MDRangePolicy<exec_t, Kokkos::Rank<new_view_t::rank()>>(
-        {(extents ? 0lu : 0lu)...}, {static_cast<long unsigned>(extents)...});
+        {(make_zero(extents))...}, {static_cast<long unsigned>(extents)...});
     Kokkos::parallel_for(
         p,
         KOKKOS_LAMBDA(Extents... idx) { a(idx...) = (idx + ... + extra_val); });
@@ -39,7 +46,7 @@ struct ViewTestHarness {
   static size_t check_view(ViewT a, size_t extra_val, Extents... extents) {
     using exec_t = typename ViewT::execution_space;
     auto p = Kokkos::MDRangePolicy<exec_t, Kokkos::Rank<new_view_t::rank()>>(
-        {(extents ? 0lu : 0lu)...}, {static_cast<long unsigned>(extents)...});
+        {(make_zero(extents))...}, {static_cast<long unsigned>(extents)...});
     size_t errors = 0;
     Kokkos::parallel_reduce(
         p,

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -12,6 +12,18 @@ import kokkos.core_impl;
 #endif
 #include <cstddef>
 
+using view_t_64bit_idx =
+    Kokkos::View<int, Kokkos::dextents<int64_t, 4>, Kokkos::layout_left,
+                 Kokkos::Experimental::Accessor<int, Kokkos::HostSpace>>;
+using view_t_32bit_idx =
+    Kokkos::View<int, Kokkos::dextents<int32_t, 4>, Kokkos::layout_left,
+                 Kokkos::Experimental::Accessor<int, Kokkos::HostSpace>>;
+
+// Just a minimal check that the object storage actually changes
+// Doing exact numbers would require a bunch of compiler ifdefs
+// due to missing full support of no-unique-address in some cases
+static_assert(sizeof(view_t_64bit_idx) > sizeof(view_t_32bit_idx));
+
 template <class ElementType, class Exts,
           class LayoutType = typename Kokkos::View<int>::layout_type>
 struct ViewTestHarness {

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+#include <cstddef>
+
+template <class ElementType, class Exts,
+          class LayoutType = typename Kokkos::View<int>::layout_type>
+struct ViewTestHarness {
+  // using the default accessor type
+  using accessor_type = typename Kokkos::View<ElementType>::accessor_type;
+  using new_view_t = Kokkos::View<ElementType, Exts, LayoutType, accessor_type>;
+
+  using old_view_t = Kokkos::View<
+      typename new_view_t::data_type, typename new_view_t::array_layout,
+      typename new_view_t::device_type, typename new_view_t::memory_traits>;
+  using rank_indicies =
+      decltype(std::make_index_sequence<new_view_t::rank()>());
+
+  template <class ViewT, class... Extents>
+  static void init_view(ViewT a, size_t extra_val, Extents... extents) {
+    using exec_t = typename ViewT::execution_space;
+    auto p = Kokkos::MDRangePolicy<exec_t, Kokkos::Rank<new_view_t::rank()>>(
+        {(extents ? 0lu : 0lu)...}, {static_cast<long unsigned>(extents)...});
+    Kokkos::parallel_for(
+        p,
+        KOKKOS_LAMBDA(Extents... idx) { a(idx...) = (idx + ... + extra_val); });
+  }
+
+  template <class ViewT, class... Extents>
+  static size_t check_view(ViewT a, size_t extra_val, Extents... extents) {
+    using exec_t = typename ViewT::execution_space;
+    auto p = Kokkos::MDRangePolicy<exec_t, Kokkos::Rank<new_view_t::rank()>>(
+        {(extents ? 0lu : 0lu)...}, {static_cast<long unsigned>(extents)...});
+    size_t errors = 0;
+    Kokkos::parallel_reduce(
+        p,
+        KOKKOS_LAMBDA(Extents... idx, size_t & lerr) {
+          if (a(idx...) != (idx + ... + extra_val)) lerr++;
+        },
+        errors);
+    return errors;
+  }
+
+  template <class... Extents>
+  static void access(Extents... extents) {
+    new_view_t a("A", extents...);
+
+    old_view_t b(a);
+
+    ASSERT_EQ(a.data(), b.data());
+    ASSERT_EQ(a.extents(), b.extents());
+
+    init_view(a, 1, extents...);
+    size_t errors = check_view(b, 1, extents...);
+    ASSERT_EQ(errors, 0lu);
+  }
+
+  template <class... Extents>
+  static void deep_copy(Extents... extents) {
+    new_view_t a("A", extents...);
+
+    // New View to new View
+    {
+      new_view_t b("B", extents...);
+
+      init_view(a, 1, extents...);
+      Kokkos::deep_copy(b, a);
+      size_t errors = check_view(b, 1, extents...);
+      ASSERT_EQ(errors, 0lu);
+    }
+
+    // New View to old View
+    {
+      old_view_t b("B", extents...);
+
+      init_view(a, 1, extents...);
+      Kokkos::deep_copy(b, a);
+      size_t errors_to = check_view(b, 1, extents...);
+      ASSERT_EQ(errors_to, 0lu);
+
+      init_view(b, 2, extents...);
+      Kokkos::deep_copy(a, b);
+      size_t errors_from = check_view(a, 2, extents...);
+      ASSERT_EQ(errors_from, 0lu);
+    }
+
+    // New View to new View::host_mirror_type
+    {
+      typename new_view_t::host_mirror_type b("B", extents...);
+
+      init_view(a, 1, extents...);
+      Kokkos::deep_copy(b, a);
+      size_t errors_to = check_view(b, 1, extents...);
+      ASSERT_EQ(errors_to, 0lu);
+
+      init_view(b, 2, extents...);
+      Kokkos::deep_copy(a, b);
+      size_t errors_from = check_view(a, 2, extents...);
+      ASSERT_EQ(errors_from, 0lu);
+    }
+
+    // New View to old View::host_mirror_type
+    {
+      typename old_view_t::host_mirror_type b("B", extents...);
+
+      init_view(a, 1, extents...);
+      Kokkos::deep_copy(b, a);
+      size_t errors_to = check_view(b, 1, extents...);
+      ASSERT_EQ(errors_to, 0lu);
+
+      init_view(b, 2, extents...);
+      Kokkos::deep_copy(a, b);
+      size_t errors_from = check_view(a, 2, extents...);
+      ASSERT_EQ(errors_from, 0lu);
+    }
+  }
+
+  template <class... Extents>
+  static void create_mirror(Extents... extents) {
+    new_view_t a("A", extents...);
+    static_assert(
+        std::is_same_v<typename new_view_t::host_mirror_type::index_type,
+                       size_t>);
+    {
+      auto h_a = Kokkos::create_mirror(a);
+      static_assert(
+          std::is_same_v<decltype(h_a), typename new_view_t::host_mirror_type>);
+      ASSERT_EQ(a.extents(), h_a.extents());
+    }
+    {
+      auto h_a = Kokkos::create_mirror_view(a);
+      ASSERT_EQ(a.extents(), h_a.extents());
+    }
+    {
+      init_view(a, 1, extents...);
+      auto h_a = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), a);
+      ASSERT_EQ(a.extents(), h_a.extents());
+      size_t errors = check_view(h_a, 1, extents...);
+      ASSERT_EQ(errors, 0lu);
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, view_minimal_mdspan_args_access) {
+  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::access(3, 7);
+  ViewTestHarness<float, Kokkos::extents<int, Kokkos::dynamic_extent,
+                                         Kokkos::dynamic_extent, 7>>::access(3,
+                                                                             5,
+                                                                             7);
+  ViewTestHarness<int, Kokkos::dextents<size_t, 6>,
+                  Kokkos::Experimental::layout_right_padded<
+                      Kokkos::dynamic_extent>>::access(3, 5lu, 7, 9, 2, 1);
+}
+
+TEST(TEST_CATEGORY, view_minimal_mdspan_args_deep_copy) {
+  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::deep_copy(3, 7);
+  ViewTestHarness<float,
+                  Kokkos::extents<int, Kokkos::dynamic_extent,
+                                  Kokkos::dynamic_extent, 7>>::deep_copy(3, 5,
+                                                                         7);
+  ViewTestHarness<int, Kokkos::dextents<size_t, 6>,
+                  Kokkos::Experimental::layout_right_padded<
+                      Kokkos::dynamic_extent>>::deep_copy(3, 5lu, 7, 9, 2, 1);
+}
+
+TEST(TEST_CATEGORY, view_minimal_mdspan_args_create_mirror) {
+  ViewTestHarness<int, Kokkos::extents<int, 3, 7>>::create_mirror(3, 7);
+  ViewTestHarness<float,
+                  Kokkos::extents<int, Kokkos::dynamic_extent,
+                                  Kokkos::dynamic_extent, 7>>::create_mirror(3,
+                                                                             5,
+                                                                             7);
+  ViewTestHarness<int, Kokkos::dextents<size_t, 6>,
+                  Kokkos::Experimental::layout_right_padded<
+                      Kokkos::dynamic_extent>>::create_mirror(3, 5lu, 7, 9, 2,
+                                                              1);
+}

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
@@ -4,10 +4,12 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <cstdlib>
 #include <type_traits>
 
 namespace {

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <type_traits>
+
+namespace {
+
+#define CHECK_SAME(type) \
+  static_assert(         \
+      std::is_same_v<typename new_view_t::type, typename old_view_t::type>)
+
+template <class T, class Extents, class DataType, class ArrayLayout,
+          class Space, class MemTraits>
+constexpr bool test_equivalence() {
+  using layout_type =
+      typename Kokkos::Impl::LayoutFromArrayLayout<ArrayLayout>::type;
+  using new_view_t =
+      Kokkos::View<T, Extents, layout_type,
+                   Kokkos::Experimental::Accessor<
+                       T, typename Space::memory_space, MemTraits>>;
+  using old_view_t = Kokkos::View<DataType, ArrayLayout, Space, MemTraits>;
+
+  // Primary test: this is equivalent to checking that they derive from the same
+  // BasicView implementation, since mdspan_type comes from BasicView and uses
+  // directly the template args of BasicView
+  CHECK_SAME(mdspan_type);
+
+  // Checking typedefs which come from ViewTraits and not from BasicView
+  // Not currently the same
+  // CHECK_SAME(traits);
+  CHECK_SAME(value_type);
+  CHECK_SAME(const_value_type);
+  CHECK_SAME(non_const_value_type);
+  CHECK_SAME(data_type);
+  CHECK_SAME(const_data_type);
+  CHECK_SAME(non_const_data_type);
+  // Not currently the same
+  // CHECK_SAME(view_tracker_type);
+  CHECK_SAME(array_layout);
+  CHECK_SAME(device_type);
+  CHECK_SAME(execution_space);
+  CHECK_SAME(memory_space);
+  // Not currently the same
+  // CHECK_SAME(memory_traits);
+  CHECK_SAME(host_mirror_space);
+
+  return true;
+}
+
+using LL           = Kokkos::LayoutLeft;
+using LR           = Kokkos::LayoutRight;
+using LS           = Kokkos::LayoutStride;
+using ED           = Kokkos::DefaultExecutionSpace;
+using EH           = Kokkos::DefaultHostExecutionSpace;
+using SH           = Kokkos::HostSpace;
+using SD           = typename Kokkos::DefaultExecutionSpace::memory_space;
+using DD           = typename Kokkos::DefaultExecutionSpace::device_type;
+using f            = float;
+using cf           = const float;
+constexpr size_t d = Kokkos::dynamic_extent;
+
+// clang-format off
+
+static_assert(test_equivalence<f,  Kokkos::dextents<size_t, 0>,         f,          LL, ED, Kokkos::MemoryTraits<>>());
+static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 2>,         cf**,       LS, EH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
+static_assert(test_equivalence<f,  Kokkos::extents<size_t, 2, 3>,       f[2][3],    LR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
+static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 8>,         cf********, LS, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
+static_assert(test_equivalence<f,  Kokkos::extents<size_t, d, d, 2, 3>, f**[2][3],  LR, DD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+// This can't give the same
+//static_assert(test_equivalence<f,  Kokkos::extents<size_t, 3, d, 2, 3>, f**[2][3],     LR, HS, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+
+// clang-format on
+
+}  // namespace


### PR DESCRIPTION
Initial support for `View` with `mdspan` template arguments.
    
This supports instantiating View as
```c++
View<ElementType, ExtentsType, LayoutType, AccessorType>
```
 
### Why we are doing this

- General principle of greater alignment with the ISO C++ standard i.e. `std::mdspan`
- This will enable specifying index type other than `size_t` leading to smaller size of the `View` object, and potentially higher performance in particular for high rank `Views` when using 32bit indexing
- Opens the path to having arbitrarily mixed static and dynamic dimensions (not in this PR though)
- Opens natural path to arbitrary rank `View` (i.e. > 8) (not in this PR though)

### Current Limitation

All four arguments must be provided and they must be compatible with BasicView, e.g. AccessorType must be one of Kokkos's accessor types for Views such as `SpaceAwareAccessor`.

### Status of this PR

This is a draft to gather implementation strategy feedback.

The changes to the Develop test just illustrate that this produces the intended behavior.

Where I want to end up is the following
- `T` is an element type
- `E` some instance of `extents`
- `L` an `mdspan` compatible layout
- `Space` is a execution or memory space or `Kokkos::Device`
- `MemTraits` is `Kokkos::MemoryTraits<...>` with some args
- `A` is a potentially user provided accessor

- [x] Must have: `Kokkos::View<T, E, L, A>`
- [x] Must have: `Kokkos::View<T, E, L, Kokkos::Accessor<T, Space, MemTraits>>`
- [ ] Deferred: `Kokkos::View<T, E, L>`  and `Kokkos::View<T, E, Kokkos::Accessor<T, Space, MemTraits>>`
- [ ] Deferred: `Kokkos::View<T, E, L, Kokkos::AccessorPolicy<Space, MemTraits>>`  and `View<T, E, Kokkos::AccessorPolicy<Space, MemTraits>>`

The `AccessorPolicy` works like layouts in `mdspan` i.e. `AccessorPolicy<Space, MemTraits>::accessor<T>` is `Accessor<T, Space, MemTraits>`.

I would start out both in Experimental.

## Issues

I want to handle this in follow ons. 

- `MemoryTraits` is not preserving: `std::is_same_v<View<T, E, L, M>::memory_traits, M>` might be false. Only values in memory traits that are implemented by the accessors actually are preserved right now.
- The nested typedefs for uniform view types are using old style arguments
  - but making them use the new ones means it could break stuff like KokkosKernels where the implementation converts everything to the uniform types and then expects that the second argument for example is a layout.
  - When mixing static and dynamic dimensions arbitrarily we wouldn't be able to give old style unified types etc.
- `host_mirror_type` does not preserve the new style args (in particular the index_type)