### PR TITLE
Fix `isnormal` overload in the CUDA workaround

### DIFF
--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -609,13 +609,18 @@ KOKKOS_IMPL_MATH_UNARY_PREDICATE(isfinite)
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isinf)
 KOKKOS_IMPL_MATH_UNARY_PREDICATE(isnan)
 #if defined(KOKKOS_ENABLE_CUDA)
-template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_floating_point_v<T>, bool>
-isnormal(T x) {
-  const T abs = Kokkos::abs(x);
-  return (abs >= Kokkos::Experimental::norm_min_v<T>)&&(
-      abs <= Kokkos::Experimental::finite_max_v<T>);
-}
+#define KOKKOS_IMPL_MATH_ISNORMAL(SPECIFIER, TYPE)            \
+  SPECIFIER bool isnormal(TYPE x) {                           \
+    auto const abs = Kokkos::abs(x);                          \
+    return (abs >= Kokkos::Experimental::norm_min_v<TYPE>)&&( \
+        abs <= Kokkos::Experimental::finite_max_v<TYPE>);     \
+  }
+
+KOKKOS_IMPL_MATH_ISNORMAL(KOKKOS_INLINE_FUNCTION, float)
+KOKKOS_IMPL_MATH_ISNORMAL(KOKKOS_INLINE_FUNCTION, double)
+KOKKOS_IMPL_MATH_ISNORMAL(inline, long double)
+
+#undef KOKKOS_IMPL_MATH_ISNORMAL
 
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, bool> isnormal(

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -317,35 +317,50 @@ struct IntegerComparison {
   }
 };
 
+template <class Floating>
+struct ConvertibleTo {
+  operator Floating() const;
+};
+
 template <class>
 struct math_function_name;
 
-#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                         \
-  struct MathUnaryFunction_##FUNC {                                          \
-    template <typename T>                                                    \
-    static KOKKOS_FUNCTION auto eval(T x) {                                  \
-      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),             \
-                                   math_unary_function_return_type_t<T>>);   \
-      return Kokkos::FUNC(x);                                                \
-    }                                                                        \
-    template <typename T>                                                    \
-    static auto eval_std(T x) {                                              \
-      if constexpr (std::is_same_v<T, KE::half_t> ||                         \
-                    std::is_same_v<T, KE::bhalf_t>) {                        \
-        return std::FUNC(static_cast<float>(x));                             \
-      } else {                                                               \
-        static_assert(std::is_same_v<decltype(std::FUNC((T)0)),              \
-                                     math_unary_function_return_type_t<T>>); \
-        return std::FUNC(x);                                                 \
-      }                                                                      \
-    }                                                                        \
-    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }           \
-  };                                                                         \
-  using kk_##FUNC = MathUnaryFunction_##FUNC;                                \
-  template <>                                                                \
-  struct math_function_name<MathUnaryFunction_##FUNC> {                      \
-    static constexpr char name[] = #FUNC;                                    \
-  };                                                                         \
+#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                           \
+  struct MathUnaryFunction_##FUNC {                                            \
+    template <typename T>                                                      \
+    static KOKKOS_FUNCTION auto eval(T x) {                                    \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),               \
+                                   math_unary_function_return_type_t<T>>);     \
+      if constexpr (std::is_floating_point_v<T>) {                             \
+        static_assert(std::is_same_v<decltype(Kokkos::FUNC(                    \
+                                         std::declval<ConvertibleTo<T>>())),   \
+                                     math_unary_function_return_type_t<T>>);   \
+      }                                                                        \
+      return Kokkos::FUNC(x);                                                  \
+    }                                                                          \
+    template <typename T>                                                      \
+    static auto eval_std(T x) {                                                \
+      if constexpr (std::is_same_v<T, KE::half_t> ||                           \
+                    std::is_same_v<T, KE::bhalf_t>) {                          \
+        return std::FUNC(static_cast<float>(x));                               \
+      } else {                                                                 \
+        static_assert(std::is_same_v<decltype(std::FUNC((T)0)),                \
+                                     math_unary_function_return_type_t<T>>);   \
+        if constexpr (std::is_floating_point_v<T>) {                           \
+          static_assert(std::is_same_v<decltype(std::FUNC(                     \
+                                           std::declval<ConvertibleTo<T>>())), \
+                                       math_unary_function_return_type_t<T>>); \
+        }                                                                      \
+        return std::FUNC(x);                                                   \
+      }                                                                        \
+    }                                                                          \
+    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }             \
+  };                                                                           \
+  using kk_##FUNC = MathUnaryFunction_##FUNC;                                  \
+  template <>                                                                  \
+  struct math_function_name<MathUnaryFunction_##FUNC> {                        \
+    static constexpr char name[] = #FUNC;                                      \
+  };                                                                           \
   constexpr char math_function_name<MathUnaryFunction_##FUNC>::name[]
 
 #define DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(FUNC, ULP_FACTOR, REF_FUNC)        \
@@ -354,6 +369,11 @@ struct math_function_name;
     static KOKKOS_FUNCTION auto eval(T x) {                                  \
       static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),             \
                                    math_unary_function_return_type_t<T>>);   \
+      if constexpr (std::is_floating_point_v<T>) {                           \
+        static_assert(std::is_same_v<decltype(Kokkos::FUNC(                  \
+                                         std::declval<ConvertibleTo<T>>())), \
+                                     math_unary_function_return_type_t<T>>); \
+      }                                                                      \
       return Kokkos::FUNC(x);                                                \
     }                                                                        \
     template <typename T>                                                    \
@@ -383,6 +403,10 @@ struct math_function_name;
     template <typename T>                                              \
     static KOKKOS_FUNCTION auto eval(T x) {                            \
       static_assert(std::is_integral_v<decltype(Kokkos::FUNC((T)0))>); \
+      if constexpr (std::is_floating_point_v<T>) {                     \
+        static_assert(std::is_integral_v<decltype(Kokkos::FUNC(        \
+                          std::declval<ConvertibleTo<T>>()))>);        \
+      }                                                                \
       return Kokkos::FUNC(x);                                          \
     }                                                                  \
     template <typename T>                                              \
@@ -392,6 +416,10 @@ struct math_function_name;
         return std::FUNC(static_cast<float>(x));                       \
       } else {                                                         \
         static_assert(std::is_integral_v<decltype(std::FUNC((T)0))>);  \
+        if constexpr (std::is_floating_point_v<T>) {                   \
+          static_assert(std::is_integral_v<decltype(std::FUNC(         \
+                            std::declval<ConvertibleTo<T>>()))>);      \
+        }                                                              \
         return std::FUNC(x);                                           \
       }                                                                \
     }                                                                  \
@@ -2065,6 +2093,11 @@ TEST(TEST_CATEGORY, mathematical_functions_ieee_remainder_function) {
 #define KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #endif
 
+#define KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(FUNC, FP_TYPE)             \
+  static_assert(std::is_same_v<decltype(Kokkos::FUNC(                        \
+                                   std::declval<ConvertibleTo<FP_TYPE>>())), \
+                               bool>)
+
 template <class Space>
 struct TestIsFinite {
   TestIsFinite() { run(); }
@@ -2131,6 +2164,12 @@ struct TestIsFinite {
     KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isfinite(4.l)), bool>);
+#endif
+
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, float);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, double);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, long double);
 #endif
   }
 };
@@ -2208,6 +2247,12 @@ struct TestIsInf {
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isinf(4.l)), bool>);
 #endif
+
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, float);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, double);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, long double);
+#endif
   }
 };
 
@@ -2283,6 +2328,12 @@ struct TestIsNaN {
     KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isnan(4.l)), bool>);
+#endif
+
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, float);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, double);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, long double);
 #endif
   }
 };
@@ -2396,6 +2447,12 @@ struct TestIsNormal {
     KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isnormal(4.l)), bool>);
+#endif
+
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, float);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, double);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, long double);
 #endif
   }
 };
@@ -2528,6 +2585,12 @@ struct TestSignbit {
     KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(signbit(4.l)), bool>);
+#endif
+
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, float);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, double);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, long double);
 #endif
   }
 };

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -322,45 +322,48 @@ struct ConvertibleTo {
   operator Floating() const;
 };
 
+#define KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(FUNC, FP_TYPE, RET_TYPE)   \
+  static_assert(                                                             \
+      std::is_same_v<decltype(FUNC(std::declval<ConvertibleTo<FP_TYPE>>())), \
+                     RET_TYPE>)
+
 template <class>
 struct math_function_name;
 
-#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                           \
-  struct MathUnaryFunction_##FUNC {                                            \
-    template <typename T>                                                      \
-    static KOKKOS_FUNCTION auto eval(T x) {                                    \
-      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),               \
-                                   math_unary_function_return_type_t<T>>);     \
-      if constexpr (std::is_floating_point_v<T>) {                             \
-        static_assert(std::is_same_v<decltype(Kokkos::FUNC(                    \
-                                         std::declval<ConvertibleTo<T>>())),   \
-                                     math_unary_function_return_type_t<T>>);   \
-      }                                                                        \
-      return Kokkos::FUNC(x);                                                  \
-    }                                                                          \
-    template <typename T>                                                      \
-    static auto eval_std(T x) {                                                \
-      if constexpr (std::is_same_v<T, KE::half_t> ||                           \
-                    std::is_same_v<T, KE::bhalf_t>) {                          \
-        return std::FUNC(static_cast<float>(x));                               \
-      } else {                                                                 \
-        static_assert(std::is_same_v<decltype(std::FUNC((T)0)),                \
-                                     math_unary_function_return_type_t<T>>);   \
-        if constexpr (std::is_floating_point_v<T>) {                           \
-          static_assert(std::is_same_v<decltype(std::FUNC(                     \
-                                           std::declval<ConvertibleTo<T>>())), \
-                                       math_unary_function_return_type_t<T>>); \
-        }                                                                      \
-        return std::FUNC(x);                                                   \
-      }                                                                        \
-    }                                                                          \
-    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }             \
-  };                                                                           \
-  using kk_##FUNC = MathUnaryFunction_##FUNC;                                  \
-  template <>                                                                  \
-  struct math_function_name<MathUnaryFunction_##FUNC> {                        \
-    static constexpr char name[] = #FUNC;                                      \
-  };                                                                           \
+#define DEFINE_UNARY_FUNCTION_EVAL(FUNC, ULP_FACTOR)                         \
+  struct MathUnaryFunction_##FUNC {                                          \
+    template <typename T>                                                    \
+    static KOKKOS_FUNCTION auto eval(T x) {                                  \
+      static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),             \
+                                   math_unary_function_return_type_t<T>>);   \
+      if constexpr (std::is_floating_point_v<T>) {                           \
+        KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(                           \
+            Kokkos::FUNC, T, math_unary_function_return_type_t<T>);          \
+      }                                                                      \
+      return Kokkos::FUNC(x);                                                \
+    }                                                                        \
+    template <typename T>                                                    \
+    static auto eval_std(T x) {                                              \
+      if constexpr (std::is_same_v<T, KE::half_t> ||                         \
+                    std::is_same_v<T, KE::bhalf_t>) {                        \
+        return std::FUNC(static_cast<float>(x));                             \
+      } else {                                                               \
+        static_assert(std::is_same_v<decltype(std::FUNC((T)0)),              \
+                                     math_unary_function_return_type_t<T>>); \
+        if constexpr (std::is_floating_point_v<T>) {                         \
+          KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(                         \
+              std::FUNC, T, math_unary_function_return_type_t<T>);           \
+        }                                                                    \
+        return std::FUNC(x);                                                 \
+      }                                                                      \
+    }                                                                        \
+    static KOKKOS_FUNCTION int ulp_factor() { return ULP_FACTOR; }           \
+  };                                                                         \
+  using kk_##FUNC = MathUnaryFunction_##FUNC;                                \
+  template <>                                                                \
+  struct math_function_name<MathUnaryFunction_##FUNC> {                      \
+    static constexpr char name[] = #FUNC;                                    \
+  };                                                                         \
   constexpr char math_function_name<MathUnaryFunction_##FUNC>::name[]
 
 #define DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(FUNC, ULP_FACTOR, REF_FUNC)        \
@@ -370,9 +373,8 @@ struct math_function_name;
       static_assert(std::is_same_v<decltype(Kokkos::FUNC((T)0)),             \
                                    math_unary_function_return_type_t<T>>);   \
       if constexpr (std::is_floating_point_v<T>) {                           \
-        static_assert(std::is_same_v<decltype(Kokkos::FUNC(                  \
-                                         std::declval<ConvertibleTo<T>>())), \
-                                     math_unary_function_return_type_t<T>>); \
+        KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(                           \
+            Kokkos::FUNC, T, math_unary_function_return_type_t<T>);          \
       }                                                                      \
       return Kokkos::FUNC(x);                                                \
     }                                                                        \
@@ -2093,11 +2095,6 @@ TEST(TEST_CATEGORY, mathematical_functions_ieee_remainder_function) {
 #define KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #endif
 
-#define KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(FUNC, FP_TYPE)             \
-  static_assert(std::is_same_v<decltype(Kokkos::FUNC(                        \
-                                   std::declval<ConvertibleTo<FP_TYPE>>())), \
-                               bool>)
-
 template <class Space>
 struct TestIsFinite {
   TestIsFinite() { run(); }
@@ -2161,16 +2158,17 @@ struct TestIsFinite {
     static_assert(std::is_same_v<decltype(isfinite(1)), bool>);
     static_assert(std::is_same_v<decltype(isfinite(2.f)), bool>);
     static_assert(std::is_same_v<decltype(isfinite(3.)), bool>);
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isfinite(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, float);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, float, bool);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, double, bool);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isfinite, long double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, long double,
+                                              bool);
 #endif
+    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
   }
 };
 
@@ -2243,16 +2241,16 @@ struct TestIsInf {
     static_assert(std::is_same_v<decltype(isinf(1)), bool>);
     static_assert(std::is_same_v<decltype(isinf(2.f)), bool>);
     static_assert(std::is_same_v<decltype(isinf(3.)), bool>);
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isinf(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, float);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, float, bool);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, double, bool);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isinf, long double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, long double, bool);
 #endif
+    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
   }
 };
 
@@ -2325,16 +2323,16 @@ struct TestIsNaN {
     static_assert(std::is_same_v<decltype(isnan(1)), bool>);
     static_assert(std::is_same_v<decltype(isnan(2.f)), bool>);
     static_assert(std::is_same_v<decltype(isnan(3.)), bool>);
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isnan(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, float);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, float, bool);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, double, bool);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnan, long double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, long double, bool);
 #endif
+    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
   }
 };
 
@@ -2444,16 +2442,17 @@ struct TestIsNormal {
     static_assert(std::is_same_v<decltype(isnormal(1)), bool>);
     static_assert(std::is_same_v<decltype(isnormal(2.f)), bool>);
     static_assert(std::is_same_v<decltype(isnormal(3.)), bool>);
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(isnormal(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, float);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, float, bool);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, double, bool);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(isnormal, long double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, long double,
+                                              bool);
 #endif
+    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
   }
 };
 
@@ -2582,16 +2581,17 @@ struct TestSignbit {
     static_assert(std::is_same_v<decltype(signbit(1)), bool>);
     static_assert(std::is_same_v<decltype(signbit(2.f)), bool>);
     static_assert(std::is_same_v<decltype(signbit(3.)), bool>);
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
     static_assert(std::is_same_v<decltype(signbit(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, float);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, float, bool);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, double, bool);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(signbit, long double);
+    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, long double,
+                                              bool);
 #endif
+    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
   }
 };
 


### PR DESCRIPTION
See https://eel.is/c++draft/c.math#cmath.syn-2

> For each function with at least one parameter of type
> `floating-point-type`, the implementation provides an overload for
> each cv-unqualified floating-point type ([basic.fundamental]) where
> all uses of `floating-point-type` in the function signature are
> replaced with that floating-point type.


I added some test coverage.  I did not bother with binary functions.