### PR TITLE
Add suffixed rcp{f,l} non-standard math functions

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -548,6 +548,8 @@ export {
   using ::Kokkos::powf;
   using ::Kokkos::powl;
   using ::Kokkos::rcp;
+  using ::Kokkos::rcpf;
+  using ::Kokkos::rcpl;
   using ::Kokkos::remainder;
   using ::Kokkos::remainderf;
   using ::Kokkos::remainderl;

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -761,6 +761,8 @@ KOKKOS_INLINE_FUNCTION double rcp(double val) {
 #endif
 }
 inline long double rcp(long double val) { return 1.0l / val; }
+KOKKOS_INLINE_FUNCTION float rcpf(float val) { return Kokkos::rcp(val); }
+inline long double rcpl(long double val) { return Kokkos::rcp(val); }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, double> rcp(
     T x) {


### PR DESCRIPTION
For consistency with `rsqrt`.

Following up on #8778 
I realized they were missing when I wrote that note in the wiki (which is not accurate as we do provide `sqrt{f,l}`) 
https://github.com/kokkos/kokkos-core-wiki/pull/795/changes#diff-d047ee76e7ab75df86293baca6ec0137762f79c86d3e176d14eaa259d2589748R550-R552