### PR TITLE
Add nexttoward

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -550,6 +550,9 @@ export {
   using ::Kokkos::nextafter;
   using ::Kokkos::nextafterf;
   using ::Kokkos::nextafterl;
+  using ::Kokkos::nexttoward;
+  using ::Kokkos::nexttowardf;
+  using ::Kokkos::nexttowardl;
   using ::Kokkos::pow;
   using ::Kokkos::powf;
   using ::Kokkos::powl;

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -663,7 +663,32 @@ KOKKOS_IMPL_MATH_BINARY_INT_FUNCTION(scalbn, ldexp, int)
 KOKKOS_IMPL_MATH_UNARY_INT_FUNCTION(ilogb)
 KOKKOS_IMPL_MATH_UNARY_FUNCTION(logb)
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(nextafter)
-// nexttoward
+inline float nexttoward(float from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+inline float nexttowardf(float from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+inline double nexttoward(double from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+inline long double nexttoward(long double from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+inline long double nexttowardl(long double from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+template <class Integer>
+inline std::enable_if_t<std::is_integral_v<Integer>, double> nexttoward(
+    Integer from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
 KOKKOS_IMPL_MATH_BINARY_FUNCTION(copysign)
 // Classification and comparison
 // fpclassify not available on Cuda and SYCL
@@ -831,28 +856,6 @@ template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, double> rcp(
     T x) {
   return Kokkos::rcp(static_cast<double>(x));
-}
-
-inline float nexttoward(float from, long double to) {
-  using std::nexttoward;
-  return nexttoward(from, to);
-}
-
-inline double nexttoward(double from, long double to) {
-  using std::nexttoward;
-  return nexttoward(from, to);
-}
-
-inline long double nexttoward(long double from, long double to) {
-  using std::nexttoward;
-  return nexttoward(from, to);
-}
-
-template <class Integer>
-inline std::enable_if_t<std::is_integral_v<Integer>, double> nexttoward(
-    Integer from, long double to) {
-  using std::nexttoward;
-  return nexttoward(from, to);
 }
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -833,6 +833,28 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_integral_v<T>, double> rcp(
   return Kokkos::rcp(static_cast<double>(x));
 }
 
+inline float nexttoward(float from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+
+inline double nexttoward(double from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+
+inline long double nexttoward(long double from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+
+template <class Integer>
+inline std::enable_if_t<std::is_integral_v<Integer>, double> nexttoward(
+    Integer from, long double to) {
+  using std::nexttoward;
+  return nexttoward(from, to);
+}
+
 }  // namespace Kokkos
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_MATHFUNCTIONS

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -465,6 +465,36 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_helper(fp16_t from, fp16_t to) {
    // }
    return bit_cast<fp16_t>(uint_result);
 }
+
+template <typename fp16_t>
+inline fp16_t nexttoward_half_helper(fp16_t from, long double to) {
+  static_assert((std::is_same_v<fp16_t, Kokkos::Experimental::half_t> ||
+                 std::is_same_v<fp16_t, Kokkos::Experimental::bhalf_t>)
+                 && sizeof(fp16_t) == 2, "nexttoward_half_impl only supports half_t and bhalf_t");
+  // Handle Nans
+  if (isnan(from) || std::isnan(to)) {
+    return Kokkos::Experimental::quiet_NaN<fp16_t>::value;
+  }
+
+  // Since we cannot cast half to long double directly,
+  // we cast from to float first.
+  float from_as_float = static_cast<float>(from);
+
+  // Handle equality
+  if (from_as_float == to) return static_cast<fp16_t>(static_cast<float>(to));
+
+  // Determine direction
+  if (from_as_float < to) {
+    // Moving toward positive infinity
+    const fp16_t pos_inf = Kokkos::Experimental::infinity<fp16_t>::value;
+    return nextafter_half_helper(from, pos_inf);
+  } else {
+    // Moving toward negative infinity
+    const fp16_t neg_inf =
+       -static_cast<fp16_t>(Kokkos::Experimental::infinity<fp16_t>::value);
+    return nextafter_half_helper(from, neg_inf);
+  }
+}
 } // namespace Impl
 
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
@@ -472,12 +502,20 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t nextafter(Kokkos::Experiment
                                                               Kokkos::Experimental::half_t to) {
   return Impl::nextafter_half_helper(from, to);
 }
+inline Kokkos::Experimental::half_t nexttoward(Kokkos::Experimental::half_t from,
+                                               long double to) {
+  return Impl::nexttoward_half_helper(from, to);
+}
 #endif
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimental::bhalf_t from,
                                                                Kokkos::Experimental::bhalf_t to) {
   return Impl::nextafter_half_helper(from, to);
+}
+inline Kokkos::Experimental::bhalf_t nexttoward(Kokkos::Experimental::bhalf_t from,
+                                                long double to) {
+  return Impl::nexttoward_half_helper(from, to);
 }
 #endif
 #endif  // !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3091,6 +3091,409 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
 #endif
 #endif
 }
+
+template <class Space, class FP>
+struct TestNextToward {
+  TestNextToward() { run(); }
+  void run() const {
+    int errors = 0;
+    if constexpr ((std::is_same_v<FP, Kokkos::Experimental::half_t> ||
+                   std::is_same_v<FP,
+                                  Kokkos::Experimental::bhalf_t>)&&sizeof(FP) ==
+                  2) {
+      test_half(errors);
+    } else if constexpr (std::is_integral_v<FP>) {
+      test_integral(errors);
+    } else {
+      test_float(errors);
+    }
+    ASSERT_EQ(errors, 0);
+  }
+  KOKKOS_FUNCTION void operator()(int, int& e) const {
+    if constexpr ((std::is_same_v<FP, Kokkos::Experimental::half_t> ||
+                   std::is_same_v<FP,
+                                  Kokkos::Experimental::bhalf_t>)&&sizeof(FP) ==
+                  2) {
+      test_half(e);
+    } else if constexpr (std::is_integral_v<FP>) {
+      test_integral(e);
+    } else {
+      test_float(e);
+    }
+  }
+
+  inline void test_half(int& e) const {
+    using Kokkos::isnan;
+    using Kokkos::nexttoward;
+
+    // Define useful constants
+    const std::uint16_t FP16_POS_ZERO     = 0x0000;
+    const std::uint16_t FP16_NEG_ZERO     = 0x8000;
+    const std::uint16_t FP16_SMALLEST_POS = 0x0001;
+    const std::uint16_t FP16_SMALLEST_NEG = 0x8001;
+
+    const FP pos_one{1.0f}, neg_one{-1.0f};
+    const FP pos_zero     = Kokkos::bit_cast<FP>(FP16_POS_ZERO);
+    const FP neg_zero     = Kokkos::bit_cast<FP>(FP16_NEG_ZERO);
+    const FP pos_smallest = Kokkos::bit_cast<FP>(FP16_SMALLEST_POS);
+    const FP neg_smallest = Kokkos::bit_cast<FP>(FP16_SMALLEST_NEG);
+    const FP pos_max      = Kokkos::Experimental::finite_max<FP>::value;
+    const FP neg_max      = Kokkos::Experimental::finite_min<FP>::value;
+    const FP pos_inf      = Kokkos::Experimental::infinity<FP>::value;
+    const FP neg_inf =
+        -static_cast<FP>(Kokkos::Experimental::infinity<FP>::value);
+
+    long double target_pos_one{1.0l}, target_pos_two{2.0l};
+    long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
+    long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
+    long double target_pos_inf{std::numeric_limits<long double>::infinity()};
+    long double target_neg_inf{-std::numeric_limits<long double>::infinity()};
+
+    // Check return type
+    testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
+                                FP>();
+
+    // NaN Handling
+    if (!isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)) ||
+        !isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)) ||
+        !isnan(nexttoward(pos_one,
+                          std::numeric_limits<long double>::quiet_NaN())) ||
+        !isnan(nexttoward(pos_one,
+                          std::numeric_limits<long double>::signaling_NaN())) ||
+        !isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                          std::numeric_limits<long double>::quiet_NaN())) ||
+        !isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                          std::numeric_limits<long double>::signaling_NaN())) ||
+        !isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                          std::numeric_limits<long double>::quiet_NaN())) ||
+        !isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                          std::numeric_limits<long double>::signaling_NaN()))) {
+      ++e;
+      Kokkos::printf("failed half precision nexttoward(NaN)\n");
+    }
+
+    // Zero Handling ()
+    if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
+        nexttoward(pos_zero, target_neg_one) != neg_smallest ||
+        nexttoward(pos_zero, target_neg_zero) != neg_zero ||
+        nexttoward(neg_zero, target_pos_one) != pos_smallest ||
+        nexttoward(neg_zero, target_neg_one) != neg_smallest ||
+        nexttoward(neg_zero, target_pos_zero) != pos_zero) {
+      ++e;
+      Kokkos::printf("failed half precision nexttoward(zero)\n");
+    }
+
+    // From Negative Non Zero Handling
+    const FP after_neg_one = Kokkos::bit_cast<FP>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
+    const FP before_neg_one = Kokkos::bit_cast<FP>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
+    if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
+        nexttoward(neg_one, target_pos_one) != after_neg_one ||
+        nexttoward(neg_one, target_neg_two) != before_neg_one ||
+        nexttoward(neg_max, target_neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed half precision nexttoward(negative)\n");
+    }
+
+    // From Positive Non Zero Handling
+    const FP after_pos_one = Kokkos::bit_cast<FP>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
+    const FP before_pos_one = Kokkos::bit_cast<FP>(
+        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
+    if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
+        nexttoward(pos_one, target_neg_one) != before_pos_one ||
+        nexttoward(pos_one, target_pos_two) != after_pos_one ||
+        nexttoward(pos_max, target_pos_inf) != pos_inf) {
+      ++e;
+      Kokkos::printf("failed half precision nexttoward(positive)\n");
+    }
+
+    // From Inf Handling
+    // Note: The behavior of nextafter with infinities is
+    // implementation-defined, but in Kokkos it returns the maximum
+    // finite value when moving towards a finite value.
+    if (nexttoward(pos_inf, target_pos_one) != pos_max ||
+        nexttoward(neg_inf, target_neg_one) != neg_max ||
+        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
+        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed half precision nexttoward(inf)\n");
+    }
+  }
+
+  inline void test_integral(int& e) const {
+    using Kokkos::nexttoward;
+
+    // Since FP may be an integral type, we need to declare input constants in
+    // FP type, but reference constants are in FromDataType
+    const FP pos_one{1}, pos_two{2};
+    const FP neg_one{-1}, neg_two{-2};
+    const FP pos_zero{0}, neg_zero{-0};
+
+    const FP pos_max{std::numeric_limits<FP>::max()};
+    const FP neg_max{-std::numeric_limits<FP>::max()};
+
+    const double ref_pos_one{1.0}, ref_pos_two{2.0};
+    const double ref_neg_one{-1.0}, ref_neg_two{-2.0};
+    const double ref_pos_zero{0.0}, ref_neg_zero{-0.0};
+    const double ref_pos_smallest{std::numeric_limits<double>::denorm_min()};
+    const double ref_neg_smallest{-std::numeric_limits<double>::denorm_min()};
+
+    const long double target_pos_one{1.0l}, target_pos_two{2.0l};
+    const long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
+    const long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
+    const long double target_pos_inf{
+        std::numeric_limits<long double>::infinity()};
+    const long double target_neg_inf{
+        -std::numeric_limits<long double>::infinity()};
+
+    // Check return type. For integral types, the return type is double
+    testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
+                                double>();
+
+    // NaN Handling. Normally, integers do not support Nans or Infinity
+    if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
+      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN()))) {
+        ++e;
+        Kokkos::printf("failed int nexttoward(from quiet_NaN)\n");
+      }
+    }
+    if constexpr (std::numeric_limits<FP>::has_signaling_NaN) {
+      if (!std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN()))) {
+        ++e;
+        Kokkos::printf("failed int nexttoward(from signaling_NaN)\n");
+      }
+    }
+    if (!std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::signaling_NaN()))) {
+      ++e;
+      Kokkos::printf("failed int nexttoward(to NaN)\n");
+    }
+
+    // Zero Handling
+    if (nexttoward(pos_zero, target_pos_one) != ref_pos_smallest ||
+        nexttoward(pos_zero, target_neg_one) != ref_neg_smallest ||
+        nexttoward(pos_zero, target_neg_zero) != ref_neg_zero ||
+        nexttoward(neg_zero, target_pos_one) != ref_pos_smallest ||
+        nexttoward(neg_zero, target_neg_one) != ref_neg_smallest ||
+        nexttoward(neg_zero, target_pos_zero) != ref_pos_zero) {
+      ++e;
+      Kokkos::printf("failed int nexttoward(zero)\n");
+    }
+
+    // From Negative Non Zero Handling
+    const double after_neg_one  = std::nextafter(ref_neg_one, ref_pos_one);
+    const double before_neg_one = std::nextafter(ref_neg_one, ref_neg_two);
+    if (nexttoward(neg_one, target_pos_one) != after_neg_one ||
+        nexttoward(neg_one, target_neg_two) != before_neg_one) {
+      ++e;
+      Kokkos::printf("failed int nexttoward(negative)\n");
+    }
+
+    // From Positive Non Zero Handling
+    const double after_pos_one  = std::nextafter(ref_pos_one, ref_pos_two);
+    const double before_pos_one = std::nextafter(ref_pos_one, ref_neg_one);
+    if (nexttoward(pos_one, target_neg_one) != before_pos_one ||
+        nexttoward(pos_one, target_pos_two) != after_pos_one) {
+      ++e;
+      Kokkos::printf("failed int nexttoward(positive)\n");
+    }
+
+    // Special treatments for denorm
+    if constexpr (std::numeric_limits<FP>::has_denorm == std::denorm_present) {
+      const FP pos_smallest{std::numeric_limits<FP>::denorm_min()};
+      const FP neg_smallest{-std::numeric_limits<FP>::denorm_min()};
+      if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
+          nexttoward(pos_smallest, target_neg_zero) != pos_zero) {
+        ++e;
+        Kokkos::printf("failed int nexttoward(denorm)\n");
+      }
+    }
+
+    // Special treatements for max, these should be numbers slightly bigger than
+    // max_val in double
+    double max_as_double = static_cast<double>(pos_max);
+    const double before_neg_max =
+        std::nextafter(-max_as_double, target_neg_inf);
+    const double after_pos_max = std::nextafter(max_as_double, target_pos_inf);
+    if (nexttoward(neg_max, target_neg_inf) != before_neg_max ||
+        nexttoward(pos_max, target_pos_inf) != after_pos_max) {
+      ++e;
+      Kokkos::printf("failed int nexttoward(max)\n");
+    }
+
+    // From Inf Handling
+    // Normally, integers do not support Nans or Infinity
+    if constexpr (std::numeric_limits<FP>::has_infinity) {
+      const FP pos_inf{std::numeric_limits<FP>::infinity()};
+      const FP neg_inf{-std::numeric_limits<FP>::infinity()};
+      const double ref_pos_inf{std::numeric_limits<double>::infinity()};
+      const double ref_neg_inf{-std::numeric_limits<double>::infinity()};
+      const double ref_pos_max{std::numeric_limits<double>::max()};
+      const double ref_neg_max{-std::numeric_limits<double>::max()};
+      if (nexttoward(pos_inf, target_pos_one) != ref_pos_max ||
+          nexttoward(neg_inf, target_neg_one) != ref_neg_max ||
+          nexttoward(pos_inf, target_pos_inf) != ref_pos_inf ||
+          nexttoward(neg_inf, target_neg_inf) != ref_neg_inf) {
+        ++e;
+        Kokkos::printf("failed int nexttoward(inf)\n");
+      }
+    }
+  }
+
+  inline void test_float(int& e) const {
+    using Kokkos::nexttoward;
+
+    // Since FP may be an integral type, we need to declare input constants in
+    // FP type, but reference constants are in FromDataType
+    const FP pos_one{1.0}, pos_two{2.0};
+    const FP neg_one{-1.0}, neg_two{-2.0};
+    const FP pos_zero{0.0}, neg_zero{-0.0};
+    const FP pos_smallest{std::numeric_limits<FP>::denorm_min()};
+    const FP neg_smallest{-std::numeric_limits<FP>::denorm_min()};
+    const FP pos_max{std::numeric_limits<FP>::max()};
+    const FP neg_max{-std::numeric_limits<FP>::max()};
+    const FP pos_inf{std::numeric_limits<FP>::infinity()};
+    const FP neg_inf{-std::numeric_limits<FP>::infinity()};
+
+    const long double target_pos_one{1.0l}, target_pos_two{2.0l};
+    const long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
+    const long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
+    const long double target_pos_inf{
+        std::numeric_limits<long double>::infinity()};
+    const long double target_neg_inf{
+        -std::numeric_limits<long double>::infinity()};
+
+    // Check return type.
+    testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
+                                FP>();
+
+    // NaN Handling
+    if (!std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(), target_pos_one)) ||
+        !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                               target_pos_one)) ||
+        !std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                       std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                       std::numeric_limits<long double>::signaling_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                       std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                       std::numeric_limits<long double>::signaling_NaN()))) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(NaN)\n");
+    }
+
+    // Zero Handling
+    if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
+        nexttoward(pos_zero, target_neg_one) != neg_smallest ||
+        nexttoward(pos_zero, target_neg_zero) != neg_zero ||
+        nexttoward(neg_zero, target_pos_one) != pos_smallest ||
+        nexttoward(neg_zero, target_neg_one) != neg_smallest ||
+        nexttoward(neg_zero, target_pos_zero) != pos_zero) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(zero)\n");
+    }
+
+    // From Negative Non Zero Handling
+    const FP after_neg_one  = std::nextafter(neg_one, pos_one);
+    const FP before_neg_one = std::nextafter(neg_one, neg_two);
+    if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
+        nexttoward(neg_one, target_pos_one) != after_neg_one ||
+        nexttoward(neg_one, target_neg_two) != before_neg_one ||
+        nexttoward(neg_max, target_neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(negative)\n");
+    }
+
+    // From Positive Non Zero Handling
+    const FP after_pos_one  = std::nextafter(pos_one, pos_two);
+    const FP before_pos_one = std::nextafter(pos_one, neg_one);
+    if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
+        nexttoward(pos_one, target_neg_one) != before_pos_one ||
+        nexttoward(pos_one, target_pos_two) != after_pos_one ||
+        nexttoward(pos_max, target_pos_inf) != pos_inf) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(positive)\n");
+    }
+
+    // From Inf Handling
+    // Note: The behavior of nexttoward with infinities is
+    // implementation-defined, but in Kokkos it returns the maximum
+    // finite value when moving towards a finite value.
+    if (nexttoward(pos_inf, target_pos_one) != pos_max ||
+        nexttoward(neg_inf, target_neg_one) != neg_max ||
+        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
+        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(inf)\n");
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, mathematical_functions_nexttoward) {
+  bool skipped = true;
+#if defined(MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS)
+  skipped = false;
+  TestNextToward<TEST_EXECSPACE, int>();
+  TestNextToward<TEST_EXECSPACE, float>();
+  TestNextToward<TEST_EXECSPACE, double>();
+  TestNextToward<TEST_EXECSPACE, long double>();
+#else
+  if constexpr (!std::is_same_v<TEST_EXECSPACE,
+                                Kokkos::DefaultExecutionSpace>) {
+    skipped = false;
+    TestNextToward<TEST_EXECSPACE, int>();
+    TestNextToward<TEST_EXECSPACE, float>();
+    TestNextToward<TEST_EXECSPACE, double>();
+    TestNextToward<TEST_EXECSPACE, long double>();
+#if defined(KOKKOS_ENABLE_CUDA) &&                         \
+    defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
+    defined(KOKKOS_COMPILER_CLANG)
+    GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
+#else
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
+    GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
+                    "not implemented yet";
+#else
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+    TestNextToward<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+#endif
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+    TestNextToward<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+#endif
+#endif
+#endif
+  }
+#endif
+  if (skipped) GTEST_SKIP() << "This function is host only";
+}
 #endif
 
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3092,7 +3092,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
 #endif
 }
 
-template <class Space, class FP>
+template <class FP>
 struct TestNextToward {
   TestNextToward() { run(); }
   void run() const {
@@ -3110,32 +3110,24 @@ struct TestNextToward {
     ASSERT_EQ(errors, 0);
   }
 
-  inline void test_half(int& e) const {
+  void test_half(int& e) const {
     using Kokkos::isnan;
     using Kokkos::nexttoward;
 
-    // Define useful constants
-    const std::uint16_t FP16_POS_ZERO     = 0x0000;
-    const std::uint16_t FP16_NEG_ZERO     = 0x8000;
-    const std::uint16_t FP16_SMALLEST_POS = 0x0001;
-    const std::uint16_t FP16_SMALLEST_NEG = 0x8001;
-
     const FP pos_one{1.0f}, neg_one{-1.0f};
-    const FP pos_zero     = Kokkos::bit_cast<FP>(FP16_POS_ZERO);
-    const FP neg_zero     = Kokkos::bit_cast<FP>(FP16_NEG_ZERO);
-    const FP pos_smallest = Kokkos::bit_cast<FP>(FP16_SMALLEST_POS);
-    const FP neg_smallest = Kokkos::bit_cast<FP>(FP16_SMALLEST_NEG);
-    const FP pos_max      = Kokkos::Experimental::finite_max<FP>::value;
-    const FP neg_max      = Kokkos::Experimental::finite_min<FP>::value;
-    const FP pos_inf      = Kokkos::Experimental::infinity<FP>::value;
-    const FP neg_inf =
-        -static_cast<FP>(Kokkos::Experimental::infinity<FP>::value);
+    const FP pos_zero{0.0f}, neg_zero{-0.0f};
+    const FP pos_smallest = KE::denorm_min<FP>::value;
+    const FP neg_smallest = -static_cast<FP>(KE::denorm_min<FP>::value);
+    const FP pos_max      = KE::finite_max<FP>::value;
+    const FP neg_max      = KE::finite_min<FP>::value;
+    const FP pos_inf      = KE::infinity<FP>::value;
+    const FP neg_inf      = -static_cast<FP>(KE::infinity<FP>::value);
 
     long double target_pos_one{1.0l}, target_pos_two{2.0l};
     long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
     long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
-    long double target_pos_inf{std::numeric_limits<long double>::infinity()};
-    long double target_neg_inf{-std::numeric_limits<long double>::infinity()};
+    long double target_pos_inf{KE::infinity<long double>::value};
+    long double target_neg_inf{-KE::infinity<long double>::value};
 
     // Check return type
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
@@ -3144,18 +3136,16 @@ struct TestNextToward {
     // NaN Handling
     if (!isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)) ||
         !isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)) ||
-        !isnan(nexttoward(pos_one,
-                          std::numeric_limits<long double>::quiet_NaN())) ||
-        !isnan(nexttoward(pos_one,
-                          std::numeric_limits<long double>::signaling_NaN())) ||
+        !isnan(nexttoward(pos_one, KE::quiet_NaN<long double>::value)) ||
+        !isnan(nexttoward(pos_one, KE::signaling_NaN<long double>::value)) ||
         !isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                          std::numeric_limits<long double>::quiet_NaN())) ||
+                          KE::quiet_NaN<long double>::value)) ||
         !isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                          std::numeric_limits<long double>::signaling_NaN())) ||
+                          KE::signaling_NaN<long double>::value)) ||
         !isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                          std::numeric_limits<long double>::quiet_NaN())) ||
+                          KE::quiet_NaN<long double>::value)) ||
         !isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                          std::numeric_limits<long double>::signaling_NaN()))) {
+                          KE::signaling_NaN<long double>::value))) {
       ++e;
       Kokkos::printf("failed half precision nexttoward(NaN)\n");
     }
@@ -3172,10 +3162,8 @@ struct TestNextToward {
     }
 
     // From Negative Non Zero Handling
-    const FP after_neg_one = Kokkos::bit_cast<FP>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
-    const FP before_neg_one = Kokkos::bit_cast<FP>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
+    const FP after_neg_one  = Kokkos::nextafter(neg_one, pos_inf);
+    const FP before_neg_one = Kokkos::nextafter(neg_one, neg_inf);
     if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
         nexttoward(neg_one, target_pos_one) != after_neg_one ||
         nexttoward(neg_one, target_neg_two) != before_neg_one ||
@@ -3185,10 +3173,8 @@ struct TestNextToward {
     }
 
     // From Positive Non Zero Handling
-    const FP after_pos_one = Kokkos::bit_cast<FP>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
-    const FP before_pos_one = Kokkos::bit_cast<FP>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
+    const FP after_pos_one  = Kokkos::nextafter(pos_one, pos_inf);
+    const FP before_pos_one = Kokkos::nextafter(pos_one, neg_inf);
     if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
         nexttoward(pos_one, target_neg_one) != before_pos_one ||
         nexttoward(pos_one, target_pos_two) != after_pos_one ||
@@ -3210,7 +3196,7 @@ struct TestNextToward {
     }
   }
 
-  inline void test_integral(int& e) const {
+  void test_integral(int& e) const {
     using Kokkos::nexttoward;
 
     // Since FP may be an integral type, we need to declare input constants in
@@ -3238,7 +3224,7 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 double>();
 
-    // NaN Handling. Normally, integers do not support Nans or Infinity
+    // NaN Handling. Normally, integers do not support NaNs or Infinity
     if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
       if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
                                  target_pos_one)) ||
@@ -3328,7 +3314,7 @@ struct TestNextToward {
     }
 
     // From Inf Handling
-    // Normally, integers do not support Nans or Infinity
+    // Normally, integers do not support NaNs or Infinity
     if constexpr (std::numeric_limits<FP>::has_infinity) {
       const FP pos_inf{std::numeric_limits<FP>::infinity()};
       const FP neg_inf{-std::numeric_limits<FP>::infinity()};
@@ -3346,7 +3332,7 @@ struct TestNextToward {
     }
   }
 
-  inline void test_float(int& e) const {
+  void test_float(int& e) const {
     using Kokkos::nexttoward;
 
     const FP pos_one{1.0}, pos_two{2.0};
@@ -3371,29 +3357,31 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 FP>();
 
-    // NaN Handling
-    if (!std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(), target_pos_one)) ||
-        !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                               target_pos_one)) ||
-        !std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                       std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                       std::numeric_limits<long double>::signaling_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                       std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                       std::numeric_limits<long double>::signaling_NaN()))) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(NaN)\n");
+    // NaN Handling. If finite-math is enabled, skip this
+    if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
+      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN()))) {
+        ++e;
+        Kokkos::printf("failed float nexttoward(NaN)\n");
+      }
     }
 
     // Zero Handling
@@ -3412,8 +3400,7 @@ struct TestNextToward {
     const FP before_neg_one = std::nextafter(neg_one, neg_two);
     if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
         nexttoward(neg_one, target_pos_one) != after_neg_one ||
-        nexttoward(neg_one, target_neg_two) != before_neg_one ||
-        nexttoward(neg_max, target_neg_inf) != neg_inf) {
+        nexttoward(neg_one, target_neg_two) != before_neg_one) {
       ++e;
       Kokkos::printf("failed float nexttoward(negative)\n");
     }
@@ -3423,65 +3410,49 @@ struct TestNextToward {
     const FP before_pos_one = std::nextafter(pos_one, neg_one);
     if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
         nexttoward(pos_one, target_neg_one) != before_pos_one ||
-        nexttoward(pos_one, target_pos_two) != after_pos_one ||
-        nexttoward(pos_max, target_pos_inf) != pos_inf) {
+        nexttoward(pos_one, target_pos_two) != after_pos_one) {
       ++e;
       Kokkos::printf("failed float nexttoward(positive)\n");
     }
 
-    // From Inf Handling
+    // From Inf Handling. If finite-math is enabled, skip this
     // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
-    if (nexttoward(pos_inf, target_pos_one) != pos_max ||
-        nexttoward(neg_inf, target_neg_one) != neg_max ||
-        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
-        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(inf)\n");
+    if constexpr (std::numeric_limits<FP>::has_infinity) {
+      if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
+          nexttoward(pos_max, target_pos_inf) != pos_inf ||
+          nexttoward(pos_inf, target_pos_one) != pos_max ||
+          nexttoward(neg_inf, target_neg_one) != neg_max ||
+          nexttoward(pos_inf, target_pos_inf) != pos_inf ||
+          nexttoward(neg_inf, target_neg_inf) != neg_inf) {
+        ++e;
+        Kokkos::printf("failed float nexttoward(inf)\n");
+      }
     }
   }
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nexttoward) {
-#if __FINITE_MATH_ONLY__
-  GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
-#endif
-  [[maybe_unused]] bool skipped = true;
-#if defined(MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS)
-  skipped = false;
-  TestNextToward<TEST_EXECSPACE, int>();
-  TestNextToward<TEST_EXECSPACE, float>();
-  TestNextToward<TEST_EXECSPACE, double>();
-  TestNextToward<TEST_EXECSPACE, long double>();
-#else
-  if constexpr (!std::is_same_v<TEST_EXECSPACE,
-                                Kokkos::DefaultExecutionSpace>) {
-    skipped = false;
-    TestNextToward<TEST_EXECSPACE, int>();
-    TestNextToward<TEST_EXECSPACE, float>();
-    TestNextToward<TEST_EXECSPACE, double>();
-    TestNextToward<TEST_EXECSPACE, long double>();
+  TestNextToward<int>();
+  TestNextToward<float>();
+  TestNextToward<double>();
+  TestNextToward<long double>();
 #if defined(KOKKOS_ENABLE_CUDA) &&                         \
     defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
     defined(KOKKOS_COMPILER_CLANG)
-    GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
-#else
-#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
-    GTEST_SKIP() << "FIXME MSVC nexttoward for half precision "
-                    "not implemented yet";
+  GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
+#elif defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
+  GTEST_SKIP() << "FIXME MSVC nexttoward for half precision "
+                  "not implemented yet";
 #else
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-    TestNextToward<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+  TestNextToward<Kokkos::Experimental::half_t>();
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-    TestNextToward<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+  TestNextToward<Kokkos::Experimental::bhalf_t>();
 #endif
 #endif
-#endif
-  }
-#endif
-  if (skipped) GTEST_SKIP() << "This function is host only";
 }
 #endif
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3109,18 +3109,6 @@ struct TestNextToward {
     }
     ASSERT_EQ(errors, 0);
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    if constexpr ((std::is_same_v<FP, Kokkos::Experimental::half_t> ||
-                   std::is_same_v<FP,
-                                  Kokkos::Experimental::bhalf_t>)&&sizeof(FP) ==
-                  2) {
-      test_half(e);
-    } else if constexpr (std::is_integral_v<FP>) {
-      test_integral(e);
-    } else {
-      test_float(e);
-    }
-  }
 
   inline void test_half(int& e) const {
     using Kokkos::isnan;

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3313,7 +3313,7 @@ struct TestNextToward {
       }
     }
 
-    // Special treatements for max, these should be numbers slightly bigger than
+    // Special treatments for max, these should be numbers slightly bigger than
     // max_val in double
     double pos_max_as_double = static_cast<double>(pos_max);
     double neg_max_as_double = static_cast<double>(neg_max);

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3319,7 +3319,8 @@ struct TestNextToward {
     double neg_max_as_double = static_cast<double>(neg_max);
     const double before_neg_max =
         std::nextafter(neg_max_as_double, target_neg_inf);
-    const double after_pos_max = std::nextafter(max_as_double, target_pos_inf);
+    const double after_pos_max =
+        std::nextafter(pos_max_as_double, target_pos_inf);
     if (nexttoward(neg_max, target_neg_inf) != before_neg_max ||
         nexttoward(pos_max, target_pos_inf) != after_pos_max) {
       ++e;

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3198,7 +3198,7 @@ struct TestNextToward {
     }
 
     // From Inf Handling
-    // Note: The behavior of nextafter with infinities is
+    // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
     if (nexttoward(pos_inf, target_pos_one) != pos_max ||
@@ -3214,7 +3214,7 @@ struct TestNextToward {
     using Kokkos::nexttoward;
 
     // Since FP may be an integral type, we need to declare input constants in
-    // FP type, but reference constants are in FromDataType
+    // FP type, but reference constants are in double
     const FP pos_one{1}, neg_one{-1};
     const FP pos_zero{0}, neg_zero{-0};
     const FP pos_max{std::numeric_limits<FP>::max()};
@@ -3349,8 +3349,6 @@ struct TestNextToward {
   inline void test_float(int& e) const {
     using Kokkos::nexttoward;
 
-    // Since FP may be an integral type, we need to declare input constants in
-    // FP type, but reference constants are in FromDataType
     const FP pos_one{1.0}, pos_two{2.0};
     const FP neg_one{-1.0}, neg_two{-2.0};
     const FP pos_zero{0.0}, neg_zero{-0.0};
@@ -3446,7 +3444,10 @@ struct TestNextToward {
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nexttoward) {
-  bool skipped = true;
+#if __FINITE_MATH_ONLY__
+  GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
+#endif
+  [[maybe_unused]] bool skipped = true;
 #if defined(MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS)
   skipped = false;
   TestNextToward<TEST_EXECSPACE, int>();
@@ -3467,7 +3468,7 @@ TEST(TEST_CATEGORY, mathematical_functions_nexttoward) {
     GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
 #else
 #if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
-    GTEST_SKIP() << "FIXME MSVC nextafter for half precision "
+    GTEST_SKIP() << "FIXME MSVC nexttoward for half precision "
                     "not implemented yet";
 #else
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3215,10 +3215,8 @@ struct TestNextToward {
 
     // Since FP may be an integral type, we need to declare input constants in
     // FP type, but reference constants are in FromDataType
-    const FP pos_one{1}, pos_two{2};
-    const FP neg_one{-1}, neg_two{-2};
+    const FP pos_one{1}, neg_one{-1};
     const FP pos_zero{0}, neg_zero{-0};
-
     const FP pos_max{std::numeric_limits<FP>::max()};
     const FP neg_max{-std::numeric_limits<FP>::max()};
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3096,27 +3096,20 @@ template <class FP>
 struct TestNextToward {
   TestNextToward() { run(); }
   void run() const {
-    if constexpr ((std::is_same_v<FP, Kokkos::Experimental::half_t> ||
-                   std::is_same_v<FP,
-                                  Kokkos::Experimental::bhalf_t>)&&sizeof(FP) ==
-                  2) {
-      test_half();
-    } else if constexpr (std::is_integral_v<FP>) {
 #if __FINITE_MATH_ONLY__
-      test_integral<true>();
+    constexpr bool finite_math_only = true;
 #else
-      test_integral<false>();
+    constexpr bool finite_math_only = false;
 #endif
+    if constexpr (std::is_integral_v<FP>) {
+      test_integral<finite_math_only>();
     } else {
-#if __FINITE_MATH_ONLY__
-      test_float<true>();
-#else
-      test_float<false>();
-#endif
+      test_float<finite_math_only>();
     }
   }
 
-  void test_half() const {
+  template <bool finite_math_only>
+  void test_float() const {
     using Kokkos::isnan;
     using Kokkos::nexttoward;
 
@@ -3139,54 +3132,91 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 FP>();
 
-    // NaN Handling
-    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)));
-    EXPECT_TRUE(
-        isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)));
-    EXPECT_TRUE(isnan(nexttoward(pos_one, KE::quiet_NaN<long double>::value)));
-    EXPECT_TRUE(
-        isnan(nexttoward(pos_one, KE::signaling_NaN<long double>::value)));
-    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                                 KE::quiet_NaN<long double>::value)));
-    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                                 KE::signaling_NaN<long double>::value)));
-    EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                                 KE::quiet_NaN<long double>::value)));
-    EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                                 KE::signaling_NaN<long double>::value)));
+    // NaN Handling. If finite-math is enabled, skip this
+    if constexpr (!finite_math_only) {
+      std::string nan_err_msg = "failed ";
+      nan_err_msg += Kokkos::Impl::TypeInfo<FP>::name();
+      nan_err_msg += " precision nexttoward(NaN)";
+      EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)))
+          << nan_err_msg;
+      EXPECT_TRUE(
+          isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)))
+          << nan_err_msg;
+      EXPECT_TRUE(isnan(nexttoward(pos_one, KE::quiet_NaN<long double>::value)))
+          << nan_err_msg;
+      EXPECT_TRUE(
+          isnan(nexttoward(pos_one, KE::signaling_NaN<long double>::value)))
+          << nan_err_msg;
+      EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                                   KE::quiet_NaN<long double>::value)))
+          << nan_err_msg;
+      EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                                   KE::signaling_NaN<long double>::value)))
+          << nan_err_msg;
+      EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                                   KE::quiet_NaN<long double>::value)))
+          << nan_err_msg;
+      EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                                   KE::signaling_NaN<long double>::value)))
+          << nan_err_msg;
+    }
 
     // Zero Handling
-    EXPECT_EQ(nexttoward(pos_zero, target_pos_one), pos_smallest);
-    EXPECT_EQ(nexttoward(pos_zero, target_neg_one), neg_smallest);
-    EXPECT_EQ(nexttoward(pos_zero, target_neg_zero), neg_zero);
-    EXPECT_EQ(nexttoward(neg_zero, target_pos_one), pos_smallest);
-    EXPECT_EQ(nexttoward(neg_zero, target_neg_one), neg_smallest);
-    EXPECT_EQ(nexttoward(neg_zero, target_pos_zero), pos_zero);
+    std::string zero_err_msg = "failed ";
+    zero_err_msg += Kokkos::Impl::TypeInfo<FP>::name();
+    zero_err_msg += " precision nexttoward(zero)";
+    EXPECT_EQ(nexttoward(pos_zero, target_pos_one), pos_smallest)
+        << zero_err_msg;
+    EXPECT_EQ(nexttoward(pos_zero, target_neg_one), neg_smallest)
+        << zero_err_msg;
+    EXPECT_EQ(nexttoward(pos_zero, target_neg_zero), neg_zero) << zero_err_msg;
+    EXPECT_EQ(nexttoward(neg_zero, target_pos_one), pos_smallest)
+        << zero_err_msg;
+    EXPECT_EQ(nexttoward(neg_zero, target_neg_one), neg_smallest)
+        << zero_err_msg;
+    EXPECT_EQ(nexttoward(neg_zero, target_pos_zero), pos_zero) << zero_err_msg;
 
     // From Negative Non Zero Handling
+    std::string negative_err_msg = "failed ";
+    negative_err_msg += Kokkos::Impl::TypeInfo<FP>::name();
+    negative_err_msg += " precision nexttoward(zero)";
     const FP after_neg_one  = Kokkos::nextafter(neg_one, pos_inf);
     const FP before_neg_one = Kokkos::nextafter(neg_one, neg_inf);
-    EXPECT_EQ(nexttoward(neg_smallest, target_pos_zero), neg_zero);
-    EXPECT_EQ(nexttoward(neg_one, target_pos_one), after_neg_one);
-    EXPECT_EQ(nexttoward(neg_one, target_neg_two), before_neg_one);
-    EXPECT_EQ(nexttoward(neg_max, target_neg_inf), neg_inf);
+    EXPECT_EQ(nexttoward(neg_smallest, target_pos_zero), neg_zero)
+        << negative_err_msg;
+    EXPECT_EQ(nexttoward(neg_one, target_pos_one), after_neg_one)
+        << negative_err_msg;
+    EXPECT_EQ(nexttoward(neg_one, target_neg_two), before_neg_one)
+        << negative_err_msg;
 
     // From Positive Non Zero Handling
+    std::string positive_err_msg = "failed ";
+    positive_err_msg += Kokkos::Impl::TypeInfo<FP>::name();
+    positive_err_msg += " precision nexttoward(zero)";
     const FP after_pos_one  = Kokkos::nextafter(pos_one, pos_inf);
     const FP before_pos_one = Kokkos::nextafter(pos_one, neg_inf);
-    EXPECT_EQ(nexttoward(pos_smallest, target_neg_zero), pos_zero);
-    EXPECT_EQ(nexttoward(pos_one, target_neg_one), before_pos_one);
-    EXPECT_EQ(nexttoward(pos_one, target_pos_two), after_pos_one);
-    EXPECT_EQ(nexttoward(pos_max, target_pos_inf), pos_inf);
+    EXPECT_EQ(nexttoward(pos_smallest, target_neg_zero), pos_zero)
+        << positive_err_msg;
+    EXPECT_EQ(nexttoward(pos_one, target_neg_one), before_pos_one)
+        << positive_err_msg;
+    EXPECT_EQ(nexttoward(pos_one, target_pos_two), after_pos_one)
+        << positive_err_msg;
 
-    // From Inf Handling
+    // From Inf Handling. If finite-math is enabled, skip this
     // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
-    EXPECT_EQ(nexttoward(pos_inf, target_pos_one), pos_max);
-    EXPECT_EQ(nexttoward(neg_inf, target_neg_one), neg_max);
-    EXPECT_EQ(nexttoward(pos_inf, target_pos_inf), pos_inf);
-    EXPECT_EQ(nexttoward(neg_inf, target_neg_inf), neg_inf);
+    if constexpr (!finite_math_only) {
+      std::string inf_err_msg = "failed ";
+      inf_err_msg += Kokkos::Impl::TypeInfo<FP>::name();
+      inf_err_msg += " precision nexttoward(inf)";
+      EXPECT_EQ(nexttoward(neg_max, target_neg_inf), neg_inf) << inf_err_msg;
+      EXPECT_EQ(nexttoward(pos_max, target_pos_inf), pos_inf) << inf_err_msg;
+      EXPECT_EQ(nexttoward(pos_inf, target_pos_one), pos_max) << inf_err_msg;
+      EXPECT_EQ(nexttoward(neg_inf, target_neg_one), neg_max) << inf_err_msg;
+      EXPECT_EQ(nexttoward(pos_inf, target_pos_inf), pos_inf) << inf_err_msg;
+      EXPECT_EQ(nexttoward(neg_inf, target_neg_inf), neg_inf) << inf_err_msg;
+    }
   }
 
   template <bool finite_math_only>
@@ -3329,132 +3359,33 @@ struct TestNextToward {
     }
     ASSERT_EQ(e, 0);
   }
-
-  template <bool finite_math_only>
-  void test_float() const {
-    using Kokkos::nexttoward;
-
-    const FP pos_one{1.0}, pos_two{2.0};
-    const FP neg_one{-1.0}, neg_two{-2.0};
-    const FP pos_zero{0.0}, neg_zero{-0.0};
-    const FP pos_smallest{std::numeric_limits<FP>::denorm_min()};
-    const FP neg_smallest{-std::numeric_limits<FP>::denorm_min()};
-
-    const long double target_pos_one{1.0l}, target_pos_two{2.0l};
-    const long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
-    const long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
-
-    // Check return type.
-    testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
-                                FP>();
-
-    int e = 0;
-    // NaN Handling. If finite-math is enabled, skip this
-    if constexpr (!finite_math_only) {
-      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(nexttoward(
-              pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(nexttoward(
-              pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN()))) {
-        ++e;
-        Kokkos::printf("failed float nexttoward(NaN)\n");
-      }
-    }
-
-    // Zero Handling
-    if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
-        nexttoward(pos_zero, target_neg_one) != neg_smallest ||
-        nexttoward(pos_zero, target_neg_zero) != neg_zero ||
-        nexttoward(neg_zero, target_pos_one) != pos_smallest ||
-        nexttoward(neg_zero, target_neg_one) != neg_smallest ||
-        nexttoward(neg_zero, target_pos_zero) != pos_zero) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(zero)\n");
-    }
-
-    // From Negative Non Zero Handling
-    const FP after_neg_one  = std::nextafter(neg_one, pos_one);
-    const FP before_neg_one = std::nextafter(neg_one, neg_two);
-    if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
-        nexttoward(neg_one, target_pos_one) != after_neg_one ||
-        nexttoward(neg_one, target_neg_two) != before_neg_one) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(negative)\n");
-    }
-
-    // From Positive Non Zero Handling
-    const FP after_pos_one  = std::nextafter(pos_one, pos_two);
-    const FP before_pos_one = std::nextafter(pos_one, neg_one);
-    if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
-        nexttoward(pos_one, target_neg_one) != before_pos_one ||
-        nexttoward(pos_one, target_pos_two) != after_pos_one) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(positive)\n");
-    }
-
-    // From Inf Handling. If finite-math is enabled, skip this
-    // Note: The behavior of nexttoward with infinities is
-    // implementation-defined, but in Kokkos it returns the maximum
-    // finite value when moving towards a finite value.
-    if constexpr (!finite_math_only) {
-      const FP pos_max{std::numeric_limits<FP>::max()};
-      const FP neg_max{-std::numeric_limits<FP>::max()};
-      const FP pos_inf{std::numeric_limits<FP>::infinity()};
-      const FP neg_inf{-std::numeric_limits<FP>::infinity()};
-      const long double target_pos_inf{
-          std::numeric_limits<long double>::infinity()};
-      const long double target_neg_inf{
-          -std::numeric_limits<long double>::infinity()};
-      if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
-          nexttoward(pos_max, target_pos_inf) != pos_inf ||
-          nexttoward(pos_inf, target_pos_one) != pos_max ||
-          nexttoward(neg_inf, target_neg_one) != neg_max ||
-          nexttoward(pos_inf, target_pos_inf) != pos_inf ||
-          nexttoward(neg_inf, target_neg_inf) != neg_inf) {
-        ++e;
-        Kokkos::printf("failed float nexttoward(inf)\n");
-      }
-    }
-
-    ASSERT_EQ(e, 0);
-  }
 };
 
 TEST(TEST_CATEGORY, mathematical_functions_nexttoward) {
-  TestNextToward<int>();
-  TestNextToward<float>();
-  TestNextToward<double>();
-  TestNextToward<long double>();
+  if constexpr (std::is_same_v<TEST_EXECSPACE,
+                               Kokkos::DefaultHostExecutionSpace>) {
+    TestNextToward<int>();
+    TestNextToward<float>();
+    TestNextToward<double>();
+    TestNextToward<long double>();
 #if defined(KOKKOS_ENABLE_CUDA) &&                         \
     defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
     defined(KOKKOS_COMPILER_CLANG)
-  GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
+    GTEST_SKIP() << "FIXME internal compiler error for Clang+Cuda and RDC";
 #elif defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC)
-  GTEST_SKIP() << "FIXME MSVC nexttoward for half precision "
-                  "not implemented yet";
+    GTEST_SKIP() << "FIXME MSVC nexttoward for half precision "
+                    "not implemented yet";
 #else
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  TestNextToward<Kokkos::Experimental::half_t>();
+    TestNextToward<Kokkos::Experimental::half_t>();
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  TestNextToward<Kokkos::Experimental::bhalf_t>();
+    TestNextToward<Kokkos::Experimental::bhalf_t>();
 #endif
 #endif
+  } else {
+    GTEST_SKIP() << "This function has already been tested at host";
+  }
 }
 #endif
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3315,9 +3315,10 @@ struct TestNextToward {
 
     // Special treatements for max, these should be numbers slightly bigger than
     // max_val in double
-    double max_as_double = static_cast<double>(pos_max);
+    double pos_max_as_double = static_cast<double>(pos_max);
+    double neg_max_as_double = static_cast<double>(neg_max);
     const double before_neg_max =
-        std::nextafter(-max_as_double, target_neg_inf);
+        std::nextafter(neg_max_as_double, target_neg_inf);
     const double after_pos_max = std::nextafter(max_as_double, target_pos_inf);
     if (nexttoward(neg_max, target_neg_inf) != before_neg_max ||
         nexttoward(pos_max, target_pos_inf) != after_pos_max) {

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3318,9 +3318,9 @@ struct TestNextToward {
     double pos_max_as_double = static_cast<double>(pos_max);
     double neg_max_as_double = static_cast<double>(neg_max);
     const double before_neg_max =
-        std::nextafter(neg_max_as_double, target_neg_inf);
+        std::nextafter(neg_max_as_double, static_cast<double>(target_neg_inf));
     const double after_pos_max =
-        std::nextafter(pos_max_as_double, target_pos_inf);
+        std::nextafter(pos_max_as_double, static_cast<double>(target_pos_inf));
     if (nexttoward(neg_max, target_neg_inf) != before_neg_max ||
         nexttoward(pos_max, target_pos_inf) != after_pos_max) {
       ++e;

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3224,6 +3224,7 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 double>();
 
+#if !defined(__FINITE_MATH_ONLY__)
     // NaN Handling. Normally, integers do not support NaNs or Infinity
     if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
       if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
@@ -3258,6 +3259,7 @@ struct TestNextToward {
       ++e;
       Kokkos::printf("failed int nexttoward(to NaN)\n");
     }
+#endif
 
     // Zero Handling
     if (nexttoward(pos_zero, target_pos_one) != ref_pos_smallest ||
@@ -3313,6 +3315,7 @@ struct TestNextToward {
       Kokkos::printf("failed int nexttoward(max)\n");
     }
 
+#if !defined(__FINITE_MATH_ONLY__)
     // From Inf Handling
     // Normally, integers do not support NaNs or Infinity
     if constexpr (std::numeric_limits<FP>::has_infinity) {
@@ -3330,6 +3333,7 @@ struct TestNextToward {
         Kokkos::printf("failed int nexttoward(inf)\n");
       }
     }
+#endif
   }
 
   void test_float(int& e) const {
@@ -3357,32 +3361,32 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 FP>();
 
+#if !defined(__FINITE_MATH_ONLY__)
     // NaN Handling. If finite-math is enabled, skip this
-    if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
-      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(nexttoward(
-              pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(nexttoward(
-              pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN()))) {
-        ++e;
-        Kokkos::printf("failed float nexttoward(NaN)\n");
-      }
+    if (!std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(), target_pos_one)) ||
+        !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                               target_pos_one)) ||
+        !std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(nexttoward(
+            pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                       std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                       std::numeric_limits<long double>::signaling_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                       std::numeric_limits<long double>::quiet_NaN())) ||
+        !std::isnan(
+            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                       std::numeric_limits<long double>::signaling_NaN()))) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(NaN)\n");
     }
+#endif
 
     // Zero Handling
     if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
@@ -3415,21 +3419,21 @@ struct TestNextToward {
       Kokkos::printf("failed float nexttoward(positive)\n");
     }
 
+#if !defined(__FINITE_MATH_ONLY__)
     // From Inf Handling. If finite-math is enabled, skip this
     // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
-    if constexpr (std::numeric_limits<FP>::has_infinity) {
-      if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
-          nexttoward(pos_max, target_pos_inf) != pos_inf ||
-          nexttoward(pos_inf, target_pos_one) != pos_max ||
-          nexttoward(neg_inf, target_neg_one) != neg_max ||
-          nexttoward(pos_inf, target_pos_inf) != pos_inf ||
-          nexttoward(neg_inf, target_neg_inf) != neg_inf) {
-        ++e;
-        Kokkos::printf("failed float nexttoward(inf)\n");
-      }
+    if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
+        nexttoward(pos_max, target_pos_inf) != pos_inf ||
+        nexttoward(pos_inf, target_pos_one) != pos_max ||
+        nexttoward(neg_inf, target_neg_one) != neg_max ||
+        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
+        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
+      ++e;
+      Kokkos::printf("failed float nexttoward(inf)\n");
     }
+#endif
   }
 };
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -3096,21 +3096,27 @@ template <class FP>
 struct TestNextToward {
   TestNextToward() { run(); }
   void run() const {
-    int errors = 0;
     if constexpr ((std::is_same_v<FP, Kokkos::Experimental::half_t> ||
                    std::is_same_v<FP,
                                   Kokkos::Experimental::bhalf_t>)&&sizeof(FP) ==
                   2) {
-      test_half(errors);
+      test_half();
     } else if constexpr (std::is_integral_v<FP>) {
-      test_integral(errors);
+#if __FINITE_MATH_ONLY__
+      test_integral<true>();
+#else
+      test_integral<false>();
+#endif
     } else {
-      test_float(errors);
+#if __FINITE_MATH_ONLY__
+      test_float<true>();
+#else
+      test_float<false>();
+#endif
     }
-    ASSERT_EQ(errors, 0);
   }
 
-  void test_half(int& e) const {
+  void test_half() const {
     using Kokkos::isnan;
     using Kokkos::nexttoward;
 
@@ -3134,69 +3140,57 @@ struct TestNextToward {
                                 FP>();
 
     // NaN Handling
-    if (!isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)) ||
-        !isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)) ||
-        !isnan(nexttoward(pos_one, KE::quiet_NaN<long double>::value)) ||
-        !isnan(nexttoward(pos_one, KE::signaling_NaN<long double>::value)) ||
-        !isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                          KE::quiet_NaN<long double>::value)) ||
-        !isnan(nexttoward(KE::quiet_NaN<FP>::value,
-                          KE::signaling_NaN<long double>::value)) ||
-        !isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                          KE::quiet_NaN<long double>::value)) ||
-        !isnan(nexttoward(KE::signaling_NaN<FP>::value,
-                          KE::signaling_NaN<long double>::value))) {
-      ++e;
-      Kokkos::printf("failed half precision nexttoward(NaN)\n");
-    }
+    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value, target_pos_one)));
+    EXPECT_TRUE(
+        isnan(nexttoward(KE::signaling_NaN<FP>::value, target_pos_one)));
+    EXPECT_TRUE(isnan(nexttoward(pos_one, KE::quiet_NaN<long double>::value)));
+    EXPECT_TRUE(
+        isnan(nexttoward(pos_one, KE::signaling_NaN<long double>::value)));
+    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                                 KE::quiet_NaN<long double>::value)));
+    EXPECT_TRUE(isnan(nexttoward(KE::quiet_NaN<FP>::value,
+                                 KE::signaling_NaN<long double>::value)));
+    EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                                 KE::quiet_NaN<long double>::value)));
+    EXPECT_TRUE(isnan(nexttoward(KE::signaling_NaN<FP>::value,
+                                 KE::signaling_NaN<long double>::value)));
 
-    // Zero Handling ()
-    if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
-        nexttoward(pos_zero, target_neg_one) != neg_smallest ||
-        nexttoward(pos_zero, target_neg_zero) != neg_zero ||
-        nexttoward(neg_zero, target_pos_one) != pos_smallest ||
-        nexttoward(neg_zero, target_neg_one) != neg_smallest ||
-        nexttoward(neg_zero, target_pos_zero) != pos_zero) {
-      ++e;
-      Kokkos::printf("failed half precision nexttoward(zero)\n");
-    }
+    // Zero Handling
+    EXPECT_EQ(nexttoward(pos_zero, target_pos_one), pos_smallest);
+    EXPECT_EQ(nexttoward(pos_zero, target_neg_one), neg_smallest);
+    EXPECT_EQ(nexttoward(pos_zero, target_neg_zero), neg_zero);
+    EXPECT_EQ(nexttoward(neg_zero, target_pos_one), pos_smallest);
+    EXPECT_EQ(nexttoward(neg_zero, target_neg_one), neg_smallest);
+    EXPECT_EQ(nexttoward(neg_zero, target_pos_zero), pos_zero);
 
     // From Negative Non Zero Handling
     const FP after_neg_one  = Kokkos::nextafter(neg_one, pos_inf);
     const FP before_neg_one = Kokkos::nextafter(neg_one, neg_inf);
-    if (nexttoward(neg_smallest, target_pos_zero) != neg_zero ||
-        nexttoward(neg_one, target_pos_one) != after_neg_one ||
-        nexttoward(neg_one, target_neg_two) != before_neg_one ||
-        nexttoward(neg_max, target_neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nexttoward(negative)\n");
-    }
+    EXPECT_EQ(nexttoward(neg_smallest, target_pos_zero), neg_zero);
+    EXPECT_EQ(nexttoward(neg_one, target_pos_one), after_neg_one);
+    EXPECT_EQ(nexttoward(neg_one, target_neg_two), before_neg_one);
+    EXPECT_EQ(nexttoward(neg_max, target_neg_inf), neg_inf);
 
     // From Positive Non Zero Handling
     const FP after_pos_one  = Kokkos::nextafter(pos_one, pos_inf);
     const FP before_pos_one = Kokkos::nextafter(pos_one, neg_inf);
-    if (nexttoward(pos_smallest, target_neg_zero) != pos_zero ||
-        nexttoward(pos_one, target_neg_one) != before_pos_one ||
-        nexttoward(pos_one, target_pos_two) != after_pos_one ||
-        nexttoward(pos_max, target_pos_inf) != pos_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nexttoward(positive)\n");
-    }
+    EXPECT_EQ(nexttoward(pos_smallest, target_neg_zero), pos_zero);
+    EXPECT_EQ(nexttoward(pos_one, target_neg_one), before_pos_one);
+    EXPECT_EQ(nexttoward(pos_one, target_pos_two), after_pos_one);
+    EXPECT_EQ(nexttoward(pos_max, target_pos_inf), pos_inf);
 
     // From Inf Handling
     // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
-    if (nexttoward(pos_inf, target_pos_one) != pos_max ||
-        nexttoward(neg_inf, target_neg_one) != neg_max ||
-        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
-        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nexttoward(inf)\n");
-    }
+    EXPECT_EQ(nexttoward(pos_inf, target_pos_one), pos_max);
+    EXPECT_EQ(nexttoward(neg_inf, target_neg_one), neg_max);
+    EXPECT_EQ(nexttoward(pos_inf, target_pos_inf), pos_inf);
+    EXPECT_EQ(nexttoward(neg_inf, target_neg_inf), neg_inf);
   }
 
-  void test_integral(int& e) const {
+  template <bool finite_math_only>
+  void test_integral() const {
     using Kokkos::nexttoward;
 
     // Since FP may be an integral type, we need to declare input constants in
@@ -3224,42 +3218,43 @@ struct TestNextToward {
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 double>();
 
-#if !defined(__FINITE_MATH_ONLY__)
+    int e = 0;
     // NaN Handling. Normally, integers do not support NaNs or Infinity
-    if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
-      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN()))) {
+    if constexpr (!finite_math_only) {
+      if constexpr (std::numeric_limits<FP>::has_quiet_NaN) {
+        if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                                   target_pos_one)) ||
+            !std::isnan(
+                nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                           std::numeric_limits<long double>::quiet_NaN())) ||
+            !std::isnan(nexttoward(
+                std::numeric_limits<FP>::quiet_NaN(),
+                std::numeric_limits<long double>::signaling_NaN()))) {
+          ++e;
+          Kokkos::printf("failed int nexttoward(from quiet_NaN)\n");
+        }
+      }
+      if constexpr (std::numeric_limits<FP>::has_signaling_NaN) {
+        if (!std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                                   target_pos_one)) ||
+            !std::isnan(
+                nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                           std::numeric_limits<long double>::quiet_NaN())) ||
+            !std::isnan(nexttoward(
+                std::numeric_limits<FP>::signaling_NaN(),
+                std::numeric_limits<long double>::signaling_NaN()))) {
+          ++e;
+          Kokkos::printf("failed int nexttoward(from signaling_NaN)\n");
+        }
+      }
+      if (!std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::signaling_NaN()))) {
         ++e;
-        Kokkos::printf("failed int nexttoward(from quiet_NaN)\n");
+        Kokkos::printf("failed int nexttoward(to NaN)\n");
       }
     }
-    if constexpr (std::numeric_limits<FP>::has_signaling_NaN) {
-      if (!std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                                 target_pos_one)) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::quiet_NaN())) ||
-          !std::isnan(
-              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                         std::numeric_limits<long double>::signaling_NaN()))) {
-        ++e;
-        Kokkos::printf("failed int nexttoward(from signaling_NaN)\n");
-      }
-    }
-    if (!std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::signaling_NaN()))) {
-      ++e;
-      Kokkos::printf("failed int nexttoward(to NaN)\n");
-    }
-#endif
 
     // Zero Handling
     if (nexttoward(pos_zero, target_pos_one) != ref_pos_smallest ||
@@ -3315,10 +3310,9 @@ struct TestNextToward {
       Kokkos::printf("failed int nexttoward(max)\n");
     }
 
-#if !defined(__FINITE_MATH_ONLY__)
     // From Inf Handling
     // Normally, integers do not support NaNs or Infinity
-    if constexpr (std::numeric_limits<FP>::has_infinity) {
+    if constexpr (std::numeric_limits<FP>::has_infinity && !finite_math_only) {
       const FP pos_inf{std::numeric_limits<FP>::infinity()};
       const FP neg_inf{-std::numeric_limits<FP>::infinity()};
       const double ref_pos_inf{std::numeric_limits<double>::infinity()};
@@ -3333,10 +3327,11 @@ struct TestNextToward {
         Kokkos::printf("failed int nexttoward(inf)\n");
       }
     }
-#endif
+    ASSERT_EQ(e, 0);
   }
 
-  void test_float(int& e) const {
+  template <bool finite_math_only>
+  void test_float() const {
     using Kokkos::nexttoward;
 
     const FP pos_one{1.0}, pos_two{2.0};
@@ -3344,49 +3339,42 @@ struct TestNextToward {
     const FP pos_zero{0.0}, neg_zero{-0.0};
     const FP pos_smallest{std::numeric_limits<FP>::denorm_min()};
     const FP neg_smallest{-std::numeric_limits<FP>::denorm_min()};
-    const FP pos_max{std::numeric_limits<FP>::max()};
-    const FP neg_max{-std::numeric_limits<FP>::max()};
-    const FP pos_inf{std::numeric_limits<FP>::infinity()};
-    const FP neg_inf{-std::numeric_limits<FP>::infinity()};
 
     const long double target_pos_one{1.0l}, target_pos_two{2.0l};
     const long double target_neg_one{-1.0l}, target_neg_two{-2.0l};
     const long double target_pos_zero{0.0l}, target_neg_zero{-0.0l};
-    const long double target_pos_inf{
-        std::numeric_limits<long double>::infinity()};
-    const long double target_neg_inf{
-        -std::numeric_limits<long double>::infinity()};
 
     // Check return type.
     testing::StaticAssertTypeEq<decltype(nexttoward(pos_one, target_pos_one)),
                                 FP>();
 
-#if !defined(__FINITE_MATH_ONLY__)
+    int e = 0;
     // NaN Handling. If finite-math is enabled, skip this
-    if (!std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(), target_pos_one)) ||
-        !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                               target_pos_one)) ||
-        !std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(nexttoward(
-            pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                       std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::quiet_NaN(),
-                       std::numeric_limits<long double>::signaling_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                       std::numeric_limits<long double>::quiet_NaN())) ||
-        !std::isnan(
-            nexttoward(std::numeric_limits<FP>::signaling_NaN(),
-                       std::numeric_limits<long double>::signaling_NaN()))) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(NaN)\n");
+    if constexpr (!finite_math_only) {
+      if (!std::isnan(nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                                 target_pos_one)) ||
+          !std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(nexttoward(
+              pos_one, std::numeric_limits<long double>::signaling_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::quiet_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::quiet_NaN())) ||
+          !std::isnan(
+              nexttoward(std::numeric_limits<FP>::signaling_NaN(),
+                         std::numeric_limits<long double>::signaling_NaN()))) {
+        ++e;
+        Kokkos::printf("failed float nexttoward(NaN)\n");
+      }
     }
-#endif
 
     // Zero Handling
     if (nexttoward(pos_zero, target_pos_one) != pos_smallest ||
@@ -3419,21 +3407,31 @@ struct TestNextToward {
       Kokkos::printf("failed float nexttoward(positive)\n");
     }
 
-#if !defined(__FINITE_MATH_ONLY__)
     // From Inf Handling. If finite-math is enabled, skip this
     // Note: The behavior of nexttoward with infinities is
     // implementation-defined, but in Kokkos it returns the maximum
     // finite value when moving towards a finite value.
-    if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
-        nexttoward(pos_max, target_pos_inf) != pos_inf ||
-        nexttoward(pos_inf, target_pos_one) != pos_max ||
-        nexttoward(neg_inf, target_neg_one) != neg_max ||
-        nexttoward(pos_inf, target_pos_inf) != pos_inf ||
-        nexttoward(neg_inf, target_neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed float nexttoward(inf)\n");
+    if constexpr (!finite_math_only) {
+      const FP pos_max{std::numeric_limits<FP>::max()};
+      const FP neg_max{-std::numeric_limits<FP>::max()};
+      const FP pos_inf{std::numeric_limits<FP>::infinity()};
+      const FP neg_inf{-std::numeric_limits<FP>::infinity()};
+      const long double target_pos_inf{
+          std::numeric_limits<long double>::infinity()};
+      const long double target_neg_inf{
+          -std::numeric_limits<long double>::infinity()};
+      if (nexttoward(neg_max, target_neg_inf) != neg_inf ||
+          nexttoward(pos_max, target_pos_inf) != pos_inf ||
+          nexttoward(pos_inf, target_pos_one) != pos_max ||
+          nexttoward(neg_inf, target_neg_one) != neg_max ||
+          nexttoward(pos_inf, target_pos_inf) != pos_inf ||
+          nexttoward(neg_inf, target_neg_inf) != neg_inf) {
+        ++e;
+        Kokkos::printf("failed float nexttoward(inf)\n");
+      }
     }
-#endif
+
+    ASSERT_EQ(e, 0);
   }
 };
 


### PR DESCRIPTION
This PR adds [nexttoward](https://en.cppreference.com/w/cpp/numeric/math/nextafter.html).
This function has following overloads

```C++
float nexttoward( float from, long double to );
double nexttoward( double from, long double to );
long double nexttoward( long double from, long double to );
template< class Integer >
double nexttoward( Integer from, long double to );
```

As the second argument is always `long double`, this is a host-only function.
Tests are specialized for `fp16`, `Integer` and `float` types.
In addition, tests are skipped if `finite-math` is enabled
