### PR TITLE
Remove warning when compiling Cuda builds with "-Wall -Wextra -pedantic"

### DIFF
--- a/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
+++ b/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp
@@ -297,7 +297,7 @@ KOKKOS_INLINE_FUNCTION void device_check_bitwise_ops() {
     constexpr int signed_half_shift =
         std::is_signed_v<DataType> ? half_shift - 1 : half_shift;
     constexpr DataType lo_set =
-        std::numeric_limits<DataType>::max() >> signed_half_shift;
+        Kokkos::Experimental::finite_max_v<DataType> >> signed_half_shift;
     constexpr DataType hi_set = ~lo_set;
 #else
     constexpr DataType hi_set = all_set << half_shift;


### PR DESCRIPTION
Compiling with `nvcc` and flags `-Wall -Wextra -pedantic` produced the warning:
```
/gpfs/users/gannayp/kokkos_dev/simd/unit_tests/include/TestSIMD_BitwiseOps.hpp(300): warning #20013-D: calling a constexpr __host__ function("max") from a __host__ __device__ function("device_check_bitwise_ops") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
          std::numeric_limits<DataType>::max() >> signed_half_shift;
          ^
          detected during:
            instantiation of "void device_check_bitwise_ops<Abi,DataType>() [with Abi=Kokkos::Experimental::simd_abi::scalar, DataType=int32_t]" at line 322
            instantiation of "void device_check_bitwise_ops_all_types<Abi,DataTypes...>(Kokkos::Experimental::Impl::data_types<DataTypes...>) [with Abi=Kokkos::Experimental::simd_abi::scalar, DataTypes=<int32_t, uint32_t, int64_t, uint64_t, double, float>]" at line 329
            instantiation of "void device_check_bitwise_ops_all_abis(Kokkos::Experimental::Impl::abi_set<Abis...>) [with Abis=<Kokkos::Experimental::simd_abi::scalar>]" at line 335

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
``` 