### PR TITLE
Fix using non device-copyable functors in MDRangePolicy

### DIFF
--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -193,7 +193,7 @@ struct DeviceIterate {
   const array_type m_lower;
   const array_type m_upper;
   const array_type m_extent;  // tile_size * num_tiles
-  Functor m_functor;
+  const Functor& m_functor;
 
 #ifdef KOKKOS_ENABLE_SYCL
   const EmulateCUDADim3<index_type> gridDim;


### PR DESCRIPTION
Should fix https://github.com/kokkos/kokkos/pull/8638#issuecomment-3844665635.