### PR TITLE
Provide more math functions in quadruple precision

### DIFF
--- a/core/src/impl/Kokkos_QuadPrecisionMath.hpp
+++ b/core/src/impl/Kokkos_QuadPrecisionMath.hpp
@@ -72,19 +72,19 @@ inline __float128 ceil(__float128 x) { return ::ceilq(x); }
 inline __float128 floor(__float128 x) { return ::floorq(x); }
 inline __float128 trunc(__float128 x) { return ::truncq(x); }
 inline __float128 round(__float128 x) { return ::roundq(x); }
-// lround
-// llround
+inline long lround(__float128 x) { return ::lroundq(x); }
+inline long long llround(__float128 x) { return ::llroundq(x); }
 inline __float128 nearbyint(__float128 x) { return ::nearbyintq(x); }
-// rint
-// lrint
-// llrint
+inline __float128 rint(__float128 x) { return ::rintq(x); }
+inline long lrint(__float128 x) { return ::lrintq(x); }
+inline long long llrint(__float128 x) { return ::llrintq(x); }
 // Floating point manipulation functions
-// frexp
-// ldexp
-// modf
-// scalbn
-// scalbln
-// ilog
+inline __float128 frexp(__float128 num, int* exp) { return ::frexpq(num, exp); }
+inline __float128 ldexp(__float128 num, int exp) { return ::ldexpq(num, exp); }
+inline __float128 modf(__float128 num, __float128* iptr) { return ::modfq(num, iptr); }
+inline __float128 scalbn(__float128 num, int exp) { return ::scalbnq(num, exp); }
+inline __float128 scalbln(__float128 num, long exp) { return ::scalblnq(num, exp); }
+inline int ilogb(__float128 x) { return ::ilogbq(x); }
 inline __float128 logb(__float128 x) { return ::logbq(x); }
 inline __float128 nextafter(__float128 x, __float128 y) { return ::nextafterq(x, y); }
 // nexttoward

--- a/core/unit_test/TestQuadPrecisionMath.hpp
+++ b/core/unit_test/TestQuadPrecisionMath.hpp
@@ -63,12 +63,25 @@ TEST(TEST_CATEGORY, quad_precision_reductions) {
 TEST(TEST_CATEGORY, quad_precision_common_math_functions) {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, 1),
-      KOKKOS_LAMBDA(int) {
+      KOKKOS_LAMBDA(int i) {
         (void)Kokkos::fabs((__float128)0);
         (void)Kokkos::sqrt((__float128)1);
         (void)Kokkos::exp((__float128)2);
         (void)Kokkos::sin((__float128)3);
         (void)Kokkos::cosh((__float128)4);
+        (void)Kokkos::lround((__float128)5);
+        (void)Kokkos::llround((__float128)6);
+        (void)Kokkos::nearbyint((__float128)7);
+        (void)Kokkos::rint((__float128)8);
+        (void)Kokkos::lrint((__float128)9);
+        (void)Kokkos::llrint((__float128)10);
+        (void)Kokkos::frexp((__float128)11, &i);
+        (void)Kokkos::ldexp((__float128)12, i);
+        __float128 dummy;
+        (void)Kokkos::modf((__float128)13, &dummy);
+        (void)Kokkos::scalbn((__float128)14, i);
+        (void)Kokkos::scalbln((__float128)15, i);
+        (void)Kokkos::ilogb((__float128)16);
       });
 }
 


### PR DESCRIPTION
For reference, here is how we currently test the quad math functions
https://github.com/kokkos/kokkos/blob/d9449cf8853cde33699b851d9b950f84410867c0/core/unit_test/TestQuadPrecisionMath.hpp#L63-L73

We need to look whether/how we can refactor the regular math functions tests to handle them there but I don;t know if that is a good reason to delay adding these functions.