### PR TITLE
SYCL: Remove singleton

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -46,8 +46,7 @@ SYCL::~SYCL() { Impl::check_execution_space_destructor_precondition(name()); }
 SYCL::SYCL()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),
-           Impl::HostSharedPtr(&Impl::SYCLInternal::singleton(),
-                               [](Impl::SYCLInternal*) {}))) {}
+           Impl::SYCLInternal::default_instance)) {}
 
 SYCL::SYCL(const sycl::queue& stream)
     : m_space_instance(
@@ -66,7 +65,7 @@ SYCL::SYCL(const sycl::queue& stream)
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
 int SYCL::concurrency() {
-  return Impl::SYCLInternal::singleton().m_maxConcurrency;
+  return Impl::SYCLInternal::default_instance->m_maxConcurrency;
 }
 #else
 int SYCL::concurrency() const { return m_space_instance->m_maxConcurrency; }
@@ -74,7 +73,18 @@ int SYCL::concurrency() const { return m_space_instance->m_maxConcurrency; }
 
 const char* SYCL::name() { return "SYCL"; }
 
-void SYCL::impl_finalize() { Impl::SYCLInternal::singleton().finalize(); }
+void SYCL::impl_finalize() {
+  // The global_unique_token_locks array is static and should only be
+  // deallocated once by the default instance
+  Impl::sycl_global_unique_token_locks(true);
+#ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  desul::Impl::finalize_lock_arrays();
+  desul::Impl::finalize_lock_arrays_sycl(
+      *Impl::SYCLInternal::default_instance->m_queue);
+#endif
+  Impl::SYCLInternal::default_instance->finalize();
+  Impl::SYCLInternal::default_instance = nullptr;
+}
 
 void SYCL::print_configuration(std::ostream& os, bool verbose) const {
   os << "\nRuntime Configuration:\n";
@@ -203,8 +213,13 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
   const auto id =
       ::Kokkos::Impl::get_gpu(settings).value_or(visible_devices[0]);
   std::vector<sycl::device> sycl_devices = Impl::get_sycl_devices();
-  Impl::SYCLInternal::singleton().initialize(sycl_devices[id]);
+  Impl::SYCLInternal::default_instance =
+      Impl::HostSharedPtr(new Impl::SYCLInternal);
+  Impl::SYCLInternal::default_instance->initialize(sycl_devices[id]);
   Impl::SYCLInternal::m_syclDev = id;
+  desul::Impl::init_lock_arrays();
+  desul::Impl::init_lock_arrays_sycl(
+      *Impl::SYCLInternal::default_instance->m_queue);
 }
 
 std::ostream& SYCL::impl_sycl_info(std::ostream& os,

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -51,11 +51,7 @@ SYCL::SYCL()
 SYCL::SYCL(const sycl::queue& stream)
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),
-           Impl::HostSharedPtr(new Impl::SYCLInternal(stream),
-                               [](Impl::SYCLInternal* ptr) {
-                                 ptr->finalize();
-                                 delete ptr;
-                               }))) {
+           Impl::HostSharedPtr(new Impl::SYCLInternal(stream)))) {
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
   if (!stream.is_in_order())
     Kokkos::abort("User provided sycl::queues must be in-order!");
@@ -81,7 +77,6 @@ void SYCL::impl_finalize() {
   desul::Impl::finalize_lock_arrays_sycl(
       *Impl::SYCLInternal::default_instance->m_queue);
 #endif
-  Impl::SYCLInternal::default_instance->finalize();
   Impl::SYCLInternal::default_instance = nullptr;
 }
 

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -210,9 +210,12 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
   Impl::SYCLInternal::default_instance =
       Impl::HostSharedPtr(new Impl::SYCLInternal(sycl_devices[id]));
   Impl::SYCLInternal::m_syclDev = id;
+#ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
+  // Init the array for used for arbitrarily sized atomics
   desul::Impl::init_lock_arrays();
   desul::Impl::init_lock_arrays_sycl(
       *Impl::SYCLInternal::default_instance->m_queue);
+#endif
 }
 
 std::ostream& SYCL::impl_sycl_info(std::ostream& os,

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -75,6 +75,7 @@ void SYCL::impl_finalize() {
 #ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
   desul::Impl::finalize_lock_arrays();
   desul::Impl::finalize_lock_arrays_sycl(
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       *Impl::SYCLInternal::default_instance->m_queue);
 #endif
   Impl::SYCLInternal::default_instance = nullptr;
@@ -214,6 +215,7 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
   // Init the array for used for arbitrarily sized atomics
   desul::Impl::init_lock_arrays();
   desul::Impl::init_lock_arrays_sycl(
+      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       *Impl::SYCLInternal::default_instance->m_queue);
 #endif
 }

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -51,7 +51,7 @@ SYCL::SYCL()
 SYCL::SYCL(const sycl::queue& stream)
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),
-           Impl::HostSharedPtr(new Impl::SYCLInternal,
+           Impl::HostSharedPtr(new Impl::SYCLInternal(stream),
                                [](Impl::SYCLInternal* ptr) {
                                  ptr->finalize();
                                  delete ptr;
@@ -60,7 +60,6 @@ SYCL::SYCL(const sycl::queue& stream)
   if (!stream.is_in_order())
     Kokkos::abort("User provided sycl::queues must be in-order!");
 #endif
-  m_space_instance->initialize(stream);
 }
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
@@ -214,8 +213,7 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
       ::Kokkos::Impl::get_gpu(settings).value_or(visible_devices[0]);
   std::vector<sycl::device> sycl_devices = Impl::get_sycl_devices();
   Impl::SYCLInternal::default_instance =
-      Impl::HostSharedPtr(new Impl::SYCLInternal);
-  Impl::SYCLInternal::default_instance->initialize(sycl_devices[id]);
+      Impl::HostSharedPtr(new Impl::SYCLInternal(sycl_devices[id]));
   Impl::SYCLInternal::m_syclDev = id;
   desul::Impl::init_lock_arrays();
   desul::Impl::init_lock_arrays_sycl(

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -75,8 +75,7 @@ void SYCL::impl_finalize() {
 #ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
   desul::Impl::finalize_lock_arrays();
   desul::Impl::finalize_lock_arrays_sycl(
-      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      *Impl::SYCLInternal::default_instance->m_queue);
+      Impl::SYCLInternal::default_instance->m_queue);
 #endif
   Impl::SYCLInternal::default_instance = nullptr;
 }
@@ -193,7 +192,7 @@ void SYCL::impl_static_fence(const std::string& name) {
         std::scoped_lock lock(Impl::SYCLInternal::mutex);
         for (auto& queue : Impl::SYCLInternal::all_queues) {
           try {
-            (*queue)->wait_and_throw();
+            queue->wait_and_throw();
           } catch (sycl::exception const& e) {
             Kokkos::Impl::throw_runtime_exception(
                 std::string("There was a synchronous SYCL error:\n") +=
@@ -215,8 +214,7 @@ void SYCL::impl_initialize(InitializationSettings const& settings) {
   // Init the array for used for arbitrarily sized atomics
   desul::Impl::init_lock_arrays();
   desul::Impl::init_lock_arrays_sycl(
-      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-      *Impl::SYCLInternal::default_instance->m_queue);
+      Impl::SYCLInternal::default_instance->m_queue);
 #endif
 }
 

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -53,10 +53,7 @@ class SYCL {
     return m_space_instance->impl_get_instance_id();
   }
 
-  sycl::queue& sycl_queue() const noexcept {
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-    return *m_space_instance->m_queue;
-  }
+  sycl::queue& sycl_queue() const noexcept { return m_space_instance->m_queue; }
 
   //@}
   //------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -45,15 +45,6 @@ Kokkos::View<uint32_t*, SYCLDeviceUSMSpace> sycl_global_unique_token_locks(
   return locks;
 }
 
-SYCLInternal::~SYCLInternal() {
-  if (!was_finalized || m_scratchSpace || m_scratchHost || m_scratchFlags) {
-    std::cerr << "Kokkos::SYCL ERROR: Failed to call "
-                 "Kokkos::SYCL::finalize()"
-              << std::endl;
-    std::cerr.flush();
-  }
-}
-
 int SYCLInternal::verify_is_initialized(const char* const label) const {
   if (!is_initialized()) {
     Kokkos::abort((std::string("Kokkos::SYCL::") + label +
@@ -107,9 +98,6 @@ SYCLInternal::SYCLInternal(const sycl::queue& q) {
   KOKKOS_IMPL_CHECK_SYCL_BACKEND_SUPPORT(q.get_backend(),
                                          sycl::backend::ext_oneapi_hip);
 #endif
-
-  if (was_finalized)
-    Kokkos::abort("Calling SYCL::initialize after SYCL::finalize is illegal\n");
 
   m_queue = q;
   // guard pushing to all_queues
@@ -179,11 +167,10 @@ void SYCLInternal::register_team_scratch_event(int scratch_pool_id,
 
 uint32_t SYCLInternal::impl_get_instance_id() const { return m_instance_id; }
 
-void SYCLInternal::finalize() {
+SYCLInternal::~SYCLInternal() {
   SYCLInternal::fence(*m_queue,
                       "Kokkos::SYCLInternal::finalize: fence on finalization",
                       m_instance_id);
-  was_finalized = true;
 
   auto device_mem_space = SYCLDeviceUSMSpace(*m_queue);
   auto host_mem_space   = SYCLHostUSMSpace(*m_queue);
@@ -196,20 +183,10 @@ void SYCLInternal::finalize() {
   if (nullptr != m_scratchFlags)
     device_mem_space.deallocate(m_scratchFlags,
                                 m_scratchFlagsCount * sizeScratchGrain);
-  m_syclDev           = -1;
-  m_scratchSpaceCount = 0;
-  m_scratchSpace      = nullptr;
-  m_scratchHostCount  = 0;
-  m_scratchHost       = nullptr;
-  m_scratchFlagsCount = 0;
-  m_scratchFlags      = nullptr;
-
   for (int i = 0; i < m_n_team_scratch; ++i) {
     if (m_team_scratch_current_size[i] > 0) {
       device_mem_space.deallocate(m_team_scratch_ptr[i],
                                   m_team_scratch_current_size[i]);
-      m_team_scratch_current_size[i] = 0;
-      m_team_scratch_ptr[i]          = nullptr;
     }
   }
 
@@ -219,7 +196,6 @@ void SYCLInternal::finalize() {
     std::scoped_lock lock(mutex);
     all_queues.erase(std::find(all_queues.begin(), all_queues.end(), &m_queue));
   }
-  m_queue.reset();
 }
 
 sycl::global_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -299,6 +299,7 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
   KOKKOS_ASSERT(m_q);
 
   if (m_capacity < n) {
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     AllocationSpace alloc_space(*m_q);
     if (m_data) alloc_space.deallocate(m_data, m_capacity);
 
@@ -315,8 +316,10 @@ size_t SYCLInternal::USMObjectMem<Kind>::reserve(size_t n) {
 template <sycl::usm::alloc Kind>
 void SYCLInternal::USMObjectMem<Kind>::reset() {
   if (m_data) {
+    KOKKOS_ASSERT(m_q);
     // This implies a fence since this class is not copyable
     // and deallocating implies a fence across all registered queues.
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     AllocationSpace alloc_space(*m_q);
     alloc_space.deallocate(m_data, m_capacity);
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -15,8 +15,6 @@ import kokkos.core; // kokkos_malloc
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_Error.hpp>
 
-// FIXME_SYCL
-// NOLINTBEGIN(bugprone-unchecked-optional-access)
 namespace Kokkos {
 namespace Impl {
 
@@ -31,7 +29,7 @@ std::size_t scratch_count(const std::size_t size) {
 
 }  // namespace
 
-std::vector<std::optional<sycl::queue>*> SYCLInternal::all_queues;
+std::vector<sycl::queue*> SYCLInternal::all_queues;
 std::mutex SYCLInternal::mutex;
 
 Kokkos::View<uint32_t*, SYCLDeviceUSMSpace> sycl_global_unique_token_locks(
@@ -79,7 +77,7 @@ SYCLInternal::SYCLInternal(const sycl::device& d)
       }) {
 }
 
-SYCLInternal::SYCLInternal(const sycl::queue& q) {
+SYCLInternal::SYCLInternal(const sycl::queue& q) : m_queue(q) {
 #define KOKKOS_IMPL_CHECK_SYCL_BACKEND_SUPPORT(BACKEND, REQUIRED)            \
   if (BACKEND != REQUIRED)                                                   \
   Kokkos::abort(                                                             \
@@ -97,13 +95,12 @@ SYCLInternal::SYCLInternal(const sycl::queue& q) {
                                          sycl::backend::ext_oneapi_hip);
 #endif
 
-  m_queue = q;
   // guard pushing to all_queues
   {
     std::scoped_lock lock(mutex);
     all_queues.push_back(&m_queue);
   }
-  const sycl::device& d = m_queue->get_device();
+  const sycl::device& d = m_queue.get_device();
 
   m_maxWorkgroupSize =
       d.template get_info<sycl::info::device::max_work_group_size>();
@@ -116,7 +113,7 @@ SYCLInternal::SYCLInternal(const sycl::queue& q) {
       d.template get_info<sycl::info::device::local_mem_size>();
 
   for (auto& usm_mem : m_indirectKernelMem) {
-    usm_mem.reset(*m_queue, m_instance_id);
+    usm_mem.reset(m_queue, m_instance_id);
   }
 }
 
@@ -138,7 +135,7 @@ sycl::global_ptr<void> SYCLInternal::resize_team_scratch_space(
   // Multiple ParallelFor/Reduce Teams can call this function at the same time
   // and invalidate the m_team_scratch_ptr. We use a pool to avoid any race
   // condition.
-  auto mem_space = Kokkos::SYCLDeviceUSMSpace(*m_queue);
+  auto mem_space = Kokkos::SYCLDeviceUSMSpace(m_queue);
   if (m_team_scratch_current_size[scratch_pool_id] == 0 && bytes > 0) {
     m_team_scratch_current_size[scratch_pool_id] = bytes;
     m_team_scratch_ptr[scratch_pool_id] =
@@ -166,12 +163,12 @@ void SYCLInternal::register_team_scratch_event(int scratch_pool_id,
 uint32_t SYCLInternal::impl_get_instance_id() const { return m_instance_id; }
 
 SYCLInternal::~SYCLInternal() {
-  SYCLInternal::fence(*m_queue,
+  SYCLInternal::fence(m_queue,
                       "Kokkos::SYCLInternal::finalize: fence on finalization",
                       m_instance_id);
 
-  auto device_mem_space = SYCLDeviceUSMSpace(*m_queue);
-  auto host_mem_space   = SYCLHostUSMSpace(*m_queue);
+  auto device_mem_space = SYCLDeviceUSMSpace(m_queue);
+  auto host_mem_space   = SYCLHostUSMSpace(m_queue);
   if (nullptr != m_scratchSpace)
     device_mem_space.deallocate(m_scratchSpace,
                                 m_scratchSpaceCount * sizeScratchGrain);
@@ -199,7 +196,7 @@ SYCLInternal::~SYCLInternal() {
 sycl::global_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
   if (verify_is_initialized("scratch_space") &&
       m_scratchSpaceCount < scratch_count(size)) {
-    auto mem_space = Kokkos::SYCLDeviceUSMSpace(*m_queue);
+    auto mem_space = Kokkos::SYCLDeviceUSMSpace(m_queue);
 
     if (nullptr != m_scratchSpace)
       mem_space.deallocate(m_scratchSpace,
@@ -219,7 +216,7 @@ sycl::global_ptr<void> SYCLInternal::scratch_space(const std::size_t size) {
 sycl::global_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
   if (verify_is_initialized("scratch_unified") &&
       m_scratchHostCount < scratch_count(size)) {
-    auto mem_space = Kokkos::SYCLHostUSMSpace(*m_queue);
+    auto mem_space = Kokkos::SYCLHostUSMSpace(m_queue);
 
     if (nullptr != m_scratchHost)
       mem_space.deallocate(m_scratchHost,
@@ -239,7 +236,7 @@ sycl::global_ptr<void> SYCLInternal::scratch_host(const std::size_t size) {
 sycl::global_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
   if (verify_is_initialized("scratch_flags") &&
       m_scratchFlagsCount < scratch_count(size)) {
-    auto mem_space = Kokkos::SYCLDeviceUSMSpace(*m_queue);
+    auto mem_space = Kokkos::SYCLDeviceUSMSpace(m_queue);
 
     if (nullptr != m_scratchFlags)
       mem_space.deallocate(m_scratchFlags,
@@ -255,10 +252,10 @@ sycl::global_ptr<void> SYCLInternal::scratch_flags(const std::size_t size) {
     // We only zero-initialize the allocation when we actually allocate.
     // It's the responsibility of the features using scratch_flags,
     // namely parallel_reduce and parallel_scan, to reset the used values to 0.
-    auto memset_event = m_queue->memset(m_scratchFlags, 0,
-                                        m_scratchFlagsCount * sizeScratchGrain);
+    auto memset_event = m_queue.memset(m_scratchFlags, 0,
+                                       m_scratchFlagsCount * sizeScratchGrain);
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-    m_queue->ext_oneapi_submit_barrier(std::vector{memset_event});
+    m_queue.ext_oneapi_submit_barrier(std::vector{memset_event});
 #endif
   }
 
@@ -339,4 +336,3 @@ template class SYCLInternal::USMObjectMem<sycl::usm::alloc::host>;
 
 }  // namespace Impl
 }  // namespace Kokkos
-   // NOLINTEND(bugprone-unchecked-optional-access)

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -63,31 +63,32 @@ int SYCLInternal::verify_is_initialized(const char* const label) const {
   return is_initialized();
 }
 
-void SYCLInternal::initialize(const sycl::device& d) {
-  auto exception_handler = [](sycl::exception_list exceptions) {
-    bool asynchronous_error = false;
-    for (std::exception_ptr const& e : exceptions) {
-      try {
-        std::rethrow_exception(e);
-      } catch (sycl::exception const& e) {
-        std::cerr << e.what() << '\n';
-        asynchronous_error = true;
-      }
-    }
-    if (asynchronous_error)
-      Kokkos::Impl::throw_runtime_exception(
-          "There was an asynchronous SYCL error!\n");
-  };
+SYCLInternal::SYCLInternal(const sycl::device& d)
+    : SYCLInternal(sycl::queue{
+          d,
+          [](sycl::exception_list exceptions) {
+            bool asynchronous_error = false;
+            for (std::exception_ptr const& e : exceptions) {
+              try {
+                std::rethrow_exception(e);
+              } catch (sycl::exception const& e) {
+                std::cerr << e.what() << '\n';
+                asynchronous_error = true;
+              }
+            }
+            if (asynchronous_error)
+              Kokkos::Impl::throw_runtime_exception(
+                  "There was an asynchronous SYCL error!\n");
+          }
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-  initialize(
-      sycl::queue{d, exception_handler, sycl::property::queue::in_order()});
-#else
-  initialize(sycl::queue{d, exception_handler});
+
+          ,
+          sycl::property::queue::in_order()
 #endif
+      }) {
 }
 
-// FIXME_SYCL
-void SYCLInternal::initialize(const sycl::queue& q) {
+SYCLInternal::SYCLInternal(const sycl::queue& q) {
   KOKKOS_EXPECTS(!is_initialized());
 
 #define KOKKOS_IMPL_CHECK_SYCL_BACKEND_SUPPORT(BACKEND, REQUIRED)            \

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -46,12 +46,12 @@ Kokkos::View<uint32_t*, SYCLDeviceUSMSpace> sycl_global_unique_token_locks(
 }
 
 int SYCLInternal::verify_is_initialized(const char* const label) const {
-  if (!is_initialized()) {
+  if (!default_instance) {
     Kokkos::abort((std::string("Kokkos::SYCL::") + label +
                    " : ERROR device not initialized\n")
                       .c_str());
   }
-  return is_initialized();
+  return static_cast<bool>(default_instance);
 }
 
 SYCLInternal::SYCLInternal(const sycl::device& d)
@@ -80,8 +80,6 @@ SYCLInternal::SYCLInternal(const sycl::device& d)
 }
 
 SYCLInternal::SYCLInternal(const sycl::queue& q) {
-  KOKKOS_EXPECTS(!is_initialized());
-
 #define KOKKOS_IMPL_CHECK_SYCL_BACKEND_SUPPORT(BACKEND, REQUIRED)            \
   if (BACKEND != REQUIRED)                                                   \
   Kokkos::abort(                                                             \

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -62,10 +62,6 @@ int SYCLInternal::verify_is_initialized(const char* const label) const {
   }
   return is_initialized();
 }
-SYCLInternal& SYCLInternal::singleton() {
-  static SYCLInternal self;
-  return self;
-}
 
 void SYCLInternal::initialize(const sycl::device& d) {
   auto exception_handler = [](sycl::exception_list exceptions) {
@@ -135,14 +131,6 @@ void SYCLInternal::initialize(const sycl::queue& q) {
   for (auto& usm_mem : m_indirectKernelMem) {
     usm_mem.reset(*m_queue, m_instance_id);
   }
-
-#ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
-  // Init the array for used for arbitrarily sized atomics
-  if (this == &singleton()) {
-    desul::Impl::init_lock_arrays();
-    desul::Impl::init_lock_arrays_sycl(*m_queue);
-  }
-#endif
 }
 
 int SYCLInternal::acquire_team_scratch_space() {
@@ -195,16 +183,6 @@ void SYCLInternal::finalize() {
                       "Kokkos::SYCLInternal::finalize: fence on finalization",
                       m_instance_id);
   was_finalized = true;
-
-  // The global_unique_token_locks array is static and should only be
-  // deallocated once by the defualt instance
-  if (this == &singleton()) {
-    Impl::sycl_global_unique_token_locks(true);
-#ifdef KOKKOS_IMPL_SYCL_DEVICE_GLOBAL_SUPPORTED
-    desul::Impl::finalize_lock_arrays();
-    desul::Impl::finalize_lock_arrays_sycl(*m_queue);
-#endif
-  }
 
   auto device_mem_space = SYCLDeviceUSMSpace(*m_queue);
   auto host_mem_space   = SYCLHostUSMSpace(*m_queue);
@@ -377,6 +355,8 @@ void SYCLInternal::USMObjectMem<Kind>::reset() {
 }
 
 int SYCLInternal::m_syclDev;
+
+HostSharedPtr<SYCLInternal> SYCLInternal::default_instance;
 
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::shared>;
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::device>;

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -4,7 +4,6 @@
 #ifndef KOKKOS_SYCL_INSTANCE_HPP_
 #define KOKKOS_SYCL_INSTANCE_HPP_
 
-#include <optional>
 #include <sycl/sycl.hpp>
 
 #include <impl/Kokkos_Error.hpp>
@@ -65,11 +64,9 @@ class SYCLInternal {
   uint32_t m_instance_id =
       Kokkos::Tools::Experimental::Impl::idForInstance<Kokkos::SYCL>(
           reinterpret_cast<uintptr_t>(this));
-  std::optional<sycl::queue> m_queue;
+  sycl::queue m_queue;
 
-  // Using std::vector<std::optional<sycl::queue>> reveals a compiler bug when
-  // compiling for the CUDA backend. Storing pointers instead works around this.
-  static std::vector<std::optional<sycl::queue>*> all_queues;
+  static std::vector<sycl::queue*> all_queues;
   // We need a mutex for thread safety when modifying all_queues.
   static std::mutex mutex;
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -4,6 +4,7 @@
 #ifndef KOKKOS_SYCL_INSTANCE_HPP_
 #define KOKKOS_SYCL_INSTANCE_HPP_
 
+#include <optional>
 #include <sycl/sycl.hpp>
 
 #include <impl/Kokkos_Error.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -9,12 +9,16 @@
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
+#include <impl/Kokkos_HostSharedPtr.hpp>
+
 namespace Kokkos {
 namespace Impl {
 
 class SYCLInternal {
  public:
   using size_type = unsigned int;
+
+  static HostSharedPtr<SYCLInternal> default_instance;
 
   SYCLInternal() = default;
   ~SYCLInternal();
@@ -177,8 +181,6 @@ class SYCLInternal {
   IndirectKernelMem& get_indirect_kernel_mem();
 
   bool was_finalized = false;
-
-  static SYCLInternal& singleton();
 
   int verify_is_initialized(const char* const label) const;
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -181,13 +181,9 @@ class SYCLInternal {
   using IndirectKernelMem = USMObjectMem<sycl::usm::alloc::host>;
   IndirectKernelMem& get_indirect_kernel_mem();
 
-  bool was_finalized = false;
-
   int verify_is_initialized(const char* const label) const;
 
   int is_initialized() const { return m_queue.has_value(); }
-
-  void finalize();
 
  private:
   // fence(...) takes any type with a .wait_and_throw() method

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -183,8 +183,6 @@ class SYCLInternal {
 
   int verify_is_initialized(const char* const label) const;
 
-  int is_initialized() const { return m_queue.has_value(); }
-
  private:
   // fence(...) takes any type with a .wait_and_throw() method
   // (sycl::event and sycl::queue)

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -20,7 +20,8 @@ class SYCLInternal {
 
   static HostSharedPtr<SYCLInternal> default_instance;
 
-  SYCLInternal() = default;
+  SYCLInternal(const sycl::device& d);
+  SYCLInternal(const sycl::queue& q);
   ~SYCLInternal();
 
   SYCLInternal(const SYCLInternal&)            = delete;
@@ -183,10 +184,6 @@ class SYCLInternal {
   bool was_finalized = false;
 
   int verify_is_initialized(const char* const label) const;
-
-  void initialize(const sycl::device& d);
-
-  void initialize(const sycl::queue& q);
 
   int is_initialized() const { return m_queue.has_value(); }
 

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -20,8 +20,7 @@ namespace Kokkos {
 namespace Impl {
 
 void DeepCopySYCL(void* dst, const void* src, size_t n) {
-  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-  Impl::SYCLInternal::default_instance->m_queue->memcpy(dst, src, n);
+  Impl::SYCLInternal::default_instance->m_queue.memcpy(dst, src, n);
 }
 
 void DeepCopyAsyncSYCL(const Kokkos::SYCL& instance, void* dst, const void* src,

--- a/core/src/SYCL/Kokkos_SYCL_Space.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.cpp
@@ -21,7 +21,7 @@ namespace Impl {
 
 void DeepCopySYCL(void* dst, const void* src, size_t n) {
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-  Impl::SYCLInternal::singleton().m_queue->memcpy(dst, src, n);
+  Impl::SYCLInternal::default_instance->m_queue->memcpy(dst, src, n);
 }
 
 void DeepCopyAsyncSYCL(const Kokkos::SYCL& instance, void* dst, const void* src,


### PR DESCRIPTION
Part of #8871.
This pull requests:
- Replaces `SYCLInternal::singleton()` with a static member variable
- Merges `SYCLInternal::initialize` with the constructor
- Merges `SYCLInternal::finalize` with the destructor
- Removes `SYCLInternal::is_initialized`
- Removes usage of `std::optional` for `m_queue`.