### PR TITLE
Refactor CUDA backend: replace CudaInternal singleton with HostSharedPtr default_instance

### DIFF
--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -34,7 +34,7 @@ cudaStream_t Kokkos::Impl::cuda_get_deep_copy_stream() {
   static cudaStream_t s = nullptr;
   if (s == nullptr) {
     KOKKOS_IMPL_CUDA_SAFE_CALL(
-        (CudaInternal::singleton().cuda_stream_create_wrapper(&s)));
+        (CudaInternal::default_instance->cuda_stream_create_wrapper(&s)));
   }
   return s;
 }
@@ -43,8 +43,9 @@ namespace Kokkos {
 namespace Impl {
 
 void DeepCopyCuda(void *dst, const void *src, size_t n) {
-  KOKKOS_IMPL_CUDA_SAFE_CALL((CudaInternal::singleton().cuda_memcpy_wrapper(
-      dst, src, n, cudaMemcpyDefault)));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(
+      (CudaInternal::default_instance->cuda_memcpy_wrapper(dst, src, n,
+                                                           cudaMemcpyDefault)));
 }
 
 void DeepCopyAsyncCuda(const Cuda &instance, void *dst, const void *src,

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -223,22 +223,30 @@ void CudaInternal::print_configuration(std::ostream &s) const {
 //----------------------------------------------------------------------------
 
 CudaInternal::~CudaInternal() {
-  if (m_scratchSpace || m_scratchFlags || m_scratchUnified) {
-    std::cerr << "Kokkos::Cuda ERROR: Failed to call Kokkos::Cuda::finalize()"
-              << std::endl;
+  this->fence("Kokkos::CudaInternal::~CudaInternal: fence on destruction");
+
+  auto cuda_mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
+  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
+    auto host_mem_space =
+        Kokkos::CudaHostPinnedSpace::impl_create(m_cudaDev, m_stream);
+    cuda_mem_space.deallocate(m_scratchFlags,
+                              m_scratchFlagsCount * sizeScratchGrain);
+    cuda_mem_space.deallocate(m_scratchSpace,
+                              m_scratchSpaceCount * sizeScratchGrain);
+    host_mem_space.deallocate(m_scratchUnified,
+                              m_scratchUnifiedCount * sizeScratchGrain);
+    if (m_scratchFunctorSize > 0) {
+      cuda_mem_space.deallocate(m_scratchFunctor, m_scratchFunctorSize);
+    }
   }
 
-  m_scratchSpaceCount   = 0;
-  m_scratchFlagsCount   = 0;
-  m_scratchUnifiedCount = 0;
-  m_scratchSpace        = nullptr;
-  m_scratchFlags        = nullptr;
-  m_scratchUnified      = nullptr;
-  m_stream              = nullptr;
   for (int i = 0; i < m_n_team_scratch; ++i) {
-    m_team_scratch_current_size[i] = 0;
-    m_team_scratch_ptr[i]          = nullptr;
+    if (m_team_scratch_current_size[i] > 0)
+      cuda_mem_space.deallocate(m_team_scratch_ptr[i],
+                                m_team_scratch_current_size[i]);
   }
+
+  KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_free_wrapper(m_scratch_locks)));
 }
 
 int CudaInternal::verify_is_initialized(const char *const label) const {
@@ -250,10 +258,6 @@ int CudaInternal::verify_is_initialized(const char *const label) const {
   return 0 <= m_cudaDev;
 }
 uint32_t CudaInternal::impl_get_instance_id() const { return m_instance_id; }
-CudaInternal &CudaInternal::singleton() {
-  static CudaInternal self;
-  return self;
-}
 void CudaInternal::fence(const std::string &name) const {
   Impl::cuda_stream_synchronize(m_stream, this, name);
 }
@@ -261,13 +265,7 @@ void CudaInternal::fence() const {
   fence("Kokkos::CudaInternal::fence(): Unnamed Instance Fence");
 }
 
-void CudaInternal::initialize(cudaStream_t stream) {
-  KOKKOS_EXPECTS(!is_initialized());
-
-  if (was_finalized)
-    Kokkos::abort("Calling Cuda::initialize after Cuda::finalize is illegal\n");
-  was_initialized = true;
-
+CudaInternal::CudaInternal(cudaStream_t stream) : m_stream(stream) {
   // Check that the device associated with the stream matches cuda_device
   CUcontext context;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaError_t(cuStreamGetCtx(stream, &context)));
@@ -275,7 +273,6 @@ void CudaInternal::initialize(cudaStream_t stream) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaError_t(cuCtxGetDevice(&m_cudaDev)));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(m_cudaDev));
 
-  m_stream = stream;
   CudaInternal::cuda_devices.insert(m_cudaDev);
 
   // Allocate a staging buffer for constant mem in pinned host memory
@@ -308,11 +305,6 @@ void CudaInternal::initialize(cudaStream_t stream) {
     (void)scratch_unified(16 * sizeof(size_type));
     (void)scratch_flags(reduce_block_count * 2 * sizeof(size_type));
     (void)scratch_space(reduce_block_count * 16 * sizeof(size_type));
-  }
-
-  for (int i = 0; i < m_n_team_scratch; ++i) {
-    m_team_scratch_current_size[i] = 0;
-    m_team_scratch_ptr[i]          = nullptr;
   }
 
   m_num_scratch_locks          = concurrency();
@@ -455,52 +447,6 @@ void CudaInternal::release_team_scratch_space(int scratch_pool_id) {
 
 //----------------------------------------------------------------------------
 
-void CudaInternal::finalize() {
-  // skip if finalize() has already been called
-  if (was_finalized) return;
-
-  was_finalized = true;
-
-  auto cuda_mem_space = Kokkos::CudaSpace::impl_create(m_cudaDev, m_stream);
-  if (nullptr != m_scratchSpace || nullptr != m_scratchFlags) {
-    auto host_mem_space =
-        Kokkos::CudaHostPinnedSpace::impl_create(m_cudaDev, m_stream);
-    cuda_mem_space.deallocate(m_scratchFlags,
-                              m_scratchFlagsCount * sizeScratchGrain);
-    cuda_mem_space.deallocate(m_scratchSpace,
-                              m_scratchSpaceCount * sizeScratchGrain);
-    host_mem_space.deallocate(m_scratchUnified,
-                              m_scratchUnifiedCount * sizeScratchGrain);
-    if (m_scratchFunctorSize > 0) {
-      cuda_mem_space.deallocate(m_scratchFunctor, m_scratchFunctorSize);
-    }
-  }
-
-  for (int i = 0; i < m_n_team_scratch; ++i) {
-    if (m_team_scratch_current_size[i] > 0)
-      cuda_mem_space.deallocate(m_team_scratch_ptr[i],
-                                m_team_scratch_current_size[i]);
-  }
-
-  m_scratchSpaceCount   = 0;
-  m_scratchFlagsCount   = 0;
-  m_scratchUnifiedCount = 0;
-  m_scratchSpace        = nullptr;
-  m_scratchFlags        = nullptr;
-  m_scratchUnified      = nullptr;
-  for (int i = 0; i < m_n_team_scratch; ++i) {
-    m_team_scratch_current_size[i] = 0;
-    m_team_scratch_ptr[i]          = nullptr;
-  }
-
-  KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_free_wrapper(m_scratch_locks)));
-  m_scratch_locks     = nullptr;
-  m_num_scratch_locks = 0;
-  m_cudaDev           = -1;
-}
-
-//----------------------------------------------------------------------------
-
 Cuda::size_type *cuda_internal_scratch_space(const Cuda &instance,
                                              const std::size_t size) {
   return instance.impl_internal_space_instance()->scratch_space(size);
@@ -622,14 +568,20 @@ Kokkos::Cuda::initialize WARNING: Cuda is allocating into UVMSpace by default
 
   //----------------------------------
 
-  cudaStream_t singleton_stream;
+  cudaStream_t stream;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(cuda_device_id));
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&singleton_stream));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream));
 
   // Init the array for used for arbitrarily sized atomics
   desul::Impl::init_lock_arrays();  // FIXME
 
-  Impl::CudaInternal::singleton().initialize(singleton_stream);
+  // Create the default instance.
+  Impl::CudaInternal::default_instance = Impl::HostSharedPtr(
+      new Impl::CudaInternal(stream), [](Impl::CudaInternal *ptr) {
+        cudaStream_t s = ptr->m_stream;
+        delete ptr;
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(s));
+      });
 }
 
 void Cuda::impl_finalize() {
@@ -648,9 +600,8 @@ void Cuda::impl_finalize() {
   KOKKOS_IMPL_CUDA_SAFE_CALL(
       cudaStreamDestroy(Impl::cuda_get_deep_copy_stream()));
 
-  Impl::CudaInternal::singleton().finalize();
-  KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaStreamDestroy(Impl::CudaInternal::singleton().m_stream));
+  // Destroy the default instance.
+  Impl::CudaInternal::default_instance = nullptr;
 }
 
 Cuda::~Cuda() { Impl::check_execution_space_destructor_precondition(name()); }
@@ -658,26 +609,24 @@ Cuda::~Cuda() { Impl::check_execution_space_destructor_precondition(name()); }
 Cuda::Cuda()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),
-           Impl::HostSharedPtr(&Impl::CudaInternal::singleton(),
-                               [](Impl::CudaInternal *) {}))) {}
+           Impl::CudaInternal::default_instance)) {}
 
 KOKKOS_DEPRECATED Cuda::Cuda(cudaStream_t stream, bool manage_stream)
     : Cuda(stream,
            manage_stream ? Impl::ManageStream::yes : Impl::ManageStream::no) {}
 
 Cuda::Cuda(cudaStream_t stream, Impl::ManageStream manage_stream)
-    : m_space_instance((
-          Impl::check_execution_space_constructor_precondition(name()),
-          Impl::HostSharedPtr(
-              new Impl::CudaInternal, [manage_stream](Impl::CudaInternal *ptr) {
-                ptr->finalize();
-                if (static_cast<bool>(manage_stream)) {
-                  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(ptr->m_stream));
-                }
-                delete ptr;
-              }))) {
-  m_space_instance->initialize(stream);
-}
+    : m_space_instance(
+          (Impl::check_execution_space_constructor_precondition(name()),
+           static_cast<bool>(manage_stream)
+               ? Impl::HostSharedPtr(new Impl::CudaInternal(stream),
+                                     [](Impl::CudaInternal *ptr) {
+                                       cudaStream_t s = ptr->m_stream;
+                                       delete ptr;
+                                       KOKKOS_IMPL_CUDA_SAFE_CALL(
+                                           cudaStreamDestroy(s));
+                                     })
+               : Impl::HostSharedPtr(new Impl::CudaInternal(stream)))) {}
 
 void Cuda::print_configuration(std::ostream &os, bool /*verbose*/) const {
   os << "Device Execution Space:\n";
@@ -738,6 +687,7 @@ int g_cuda_space_factory_initialized =
 
 int CudaInternal::m_cudaArch = -1;
 KOKKOS_IMPL_EXPORT cudaDeviceProp CudaInternal::m_deviceProp;
+HostSharedPtr<CudaInternal> CudaInternal::default_instance;
 std::set<int> CudaInternal::cuda_devices = {};
 KOKKOS_IMPL_EXPORT std::map<int, unsigned long *>
     CudaInternal::constantMemHostStagingPerDevice = {};

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_CUDA_INSTANCE_HPP_
 
 #include <vector>
+#include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_Tools.hpp>
 #include <atomic>
 #include <Cuda/Kokkos_Cuda_Error.hpp>
@@ -74,9 +75,6 @@ namespace Kokkos {
 namespace Impl {
 
 class CudaInternal {
- private:
-  CudaInternal(const CudaInternal&);
-  CudaInternal& operator=(const CudaInternal&);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
   static bool kokkos_impl_cuda_use_serial_execution_v;
 #endif
@@ -90,31 +88,32 @@ class CudaInternal {
   static int m_cudaArch;
   static int concurrency();
 
+  static HostSharedPtr<CudaInternal> default_instance;
+
   KOKKOS_IMPL_EXPORT static cudaDeviceProp m_deviceProp;
 
   // Scratch Spaces for Reductions
-  mutable std::size_t m_scratchSpaceCount;
-  mutable std::size_t m_scratchFlagsCount;
-  mutable std::size_t m_scratchUnifiedCount;
-  mutable std::size_t m_scratchFunctorSize;
+  mutable std::size_t m_scratchSpaceCount   = 0;
+  mutable std::size_t m_scratchFlagsCount   = 0;
+  mutable std::size_t m_scratchUnifiedCount = 0;
+  mutable std::size_t m_scratchFunctorSize  = 0;
 
-  mutable size_type* m_scratchSpace;
-  mutable size_type* m_scratchFlags;
-  mutable size_type* m_scratchUnified;
-  mutable size_type* m_scratchFunctor;
-  cudaStream_t m_stream;
-  uint32_t m_instance_id;
+  mutable size_type* m_scratchSpace   = nullptr;
+  mutable size_type* m_scratchFlags   = nullptr;
+  mutable size_type* m_scratchUnified = nullptr;
+  mutable size_type* m_scratchFunctor = nullptr;
+  cudaStream_t m_stream               = nullptr;
+  uint32_t m_instance_id =
+      Kokkos::Tools::Experimental::Impl::idForInstance<Kokkos::Cuda>(
+          reinterpret_cast<uintptr_t>(this));
 
   // Team Scratch Level 1 Space
-  int m_n_team_scratch = 10;
-  mutable int64_t m_team_scratch_current_size[10];
-  mutable void* m_team_scratch_ptr[10];
-  mutable std::atomic_int m_team_scratch_pool[10];
-  int32_t* m_scratch_locks;
-  size_t m_num_scratch_locks;
-
-  bool was_initialized = false;
-  bool was_finalized   = false;
+  int m_n_team_scratch                            = 10;
+  mutable int64_t m_team_scratch_current_size[10] = {};
+  mutable void* m_team_scratch_ptr[10]            = {};
+  mutable std::atomic_int m_team_scratch_pool[10] = {};
+  int32_t* m_scratch_locks                        = nullptr;
+  size_t m_num_scratch_locks                      = 0;
 
   static std::set<int> cuda_devices;
   KOKKOS_IMPL_EXPORT static std::map<int, unsigned long*>
@@ -123,16 +122,12 @@ class CudaInternal {
       constantMemReusablePerDevice;
   KOKKOS_IMPL_EXPORT static std::map<int, std::mutex> constantMemMutexPerDevice;
 
-  static CudaInternal& singleton();
-
   int verify_is_initialized(const char* const label) const;
 
-  int is_initialized() const {
-    return nullptr != m_scratchSpace && nullptr != m_scratchFlags;
-  }
-
-  void initialize(cudaStream_t stream);
-  void finalize();
+  CudaInternal(cudaStream_t stream);
+  ~CudaInternal();
+  CudaInternal(const CudaInternal&)            = delete;
+  CudaInternal& operator=(const CudaInternal&) = delete;
 
   void print_configuration(std::ostream&) const;
 
@@ -143,28 +138,6 @@ class CudaInternal {
 
   void fence(const std::string&) const;
   void fence() const;
-
-  ~CudaInternal();
-
-  CudaInternal()
-      : m_scratchSpaceCount(0),
-        m_scratchFlagsCount(0),
-        m_scratchUnifiedCount(0),
-        m_scratchFunctorSize(0),
-        m_scratchSpace(nullptr),
-        m_scratchFlags(nullptr),
-        m_scratchUnified(nullptr),
-        m_scratchFunctor(nullptr),
-        m_stream(nullptr),
-        m_instance_id(
-            Kokkos::Tools::Experimental::Impl::idForInstance<Kokkos::Cuda>(
-                reinterpret_cast<uintptr_t>(this))) {
-    for (int i = 0; i < m_n_team_scratch; ++i) {
-      m_team_scratch_current_size[i] = 0;
-      m_team_scratch_ptr[i]          = nullptr;
-      m_team_scratch_pool[i]         = 0;
-    }
-  }
 
   // Using CUDA API function/objects will be w.r.t. device 0 unless
   // cudaSetDevice(device_id) is called with the correct device_id.


### PR DESCRIPTION
#### This is a CoPilot generated PR
======================

Refactors `CudaInternal` to match the HIP backend pattern established in #7646. Replaces the static singleton with `HostSharedPtr`-managed lifetime, moves init/finalize logic into constructor/destructor.

### Changes

- **`CudaInternal` class** (`Kokkos_Cuda_Instance.hpp`):
  - `static CudaInternal& singleton()` → `static HostSharedPtr<CudaInternal> default_instance`
  - Default constructor → `CudaInternal(cudaStream_t stream)` (initialization in ctor)
  - `finalize()` cleanup logic → `~CudaInternal()` (with fence before destruction)
  - Removed `initialize()`, `finalize()`, `is_initialized()`, `was_initialized`, `was_finalized`
  - Copy/assign marked `= delete`

- **`Cuda` execution space** (`Kokkos_Cuda_Instance.cpp`):
  - `impl_initialize()`: creates `default_instance` via `HostSharedPtr(new CudaInternal(stream), deleter)`
  - `impl_finalize()`: `default_instance = nullptr`
  - `Cuda()`: copies `default_instance` (was: non-owning ptr to singleton)
  - `Cuda(stream, manage_stream)`: `new CudaInternal(stream)` with conditional stream-destroying deleter

- **`Kokkos_CudaSpace.cpp`**: `CudaInternal::singleton().` → `CudaInternal::default_instance->`

### Pattern (mirrors HIP)

```cpp
// init
Impl::CudaInternal::default_instance = Impl::HostSharedPtr(
    new Impl::CudaInternal(stream), [](Impl::CudaInternal *ptr) {
      cudaStream_t s = ptr->m_stream;
      delete ptr;
      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(s));
    });

// finalize
Impl::CudaInternal::default_instance = nullptr;

// default Cuda instance copies the shared ptr
Cuda::Cuda() : m_space_instance(Impl::CudaInternal::default_instance) {}
```

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> I want the CUDA backend refactored so that the CudaInternal class doesn't have the singleton member, and that the initialization and finalization happens in constructor and destructor respectively. Instead of the singleton it should use a static HostSharedPtr member in the CudaInternal class to track the default instance. This refactor should follow the refactor done for the HIP backend in the PR 7646 (https://github.com/kokkos/kokkos/pull/7646).


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/crtrott/kokkos/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
