### PR TITLE
CI: Set KOKKOS_NUM_THREADS for GH200 job

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -54,6 +54,7 @@ NVIDIA-GH200:
   image: nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
   script:
     - apt-get update && apt-get install -y cmake git python3
+    - export KOKKOS_NUM_THREADS=8
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=${BUILD_TYPE}"

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -1,6 +1,7 @@
 .common-setup:
   stage: test
   variables:
+    OMP_NUM_THREADS: "8"
     OMP_PLACES: "threads"
     OMP_PROC_BIND: "spread"
   before_script:
@@ -54,7 +55,6 @@ NVIDIA-GH200:
   image: nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
   script:
     - apt-get update && apt-get install -y cmake git python3
-    - export KOKKOS_NUM_THREADS=8
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=${BUILD_TYPE}"
@@ -242,9 +242,6 @@ NVIDIA-GRACE-GRACE:
   image: ubuntu:latest
   script:
     - apt-get update && apt-get install -y cmake git g++
-    - export OMP_NUM_THREADS=8
-    - export OMP_PROC_BIND=close
-    - export OMP_PLACES=cores
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=${BUILD_TYPE}"

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -2,8 +2,8 @@
   stage: test
   variables:
     OMP_NUM_THREADS: "8"
-    OMP_PLACES: "threads"
-    OMP_PROC_BIND: "spread"
+    OMP_PLACES: "cores"
+    OMP_PROC_BIND: "close"
   before_script:
     - if [ ${CI_PIPELINE_SOURCE} == "schedule" ]; then
         export CDASH_MODEL="Nightly";


### PR DESCRIPTION
The `Kokkos_CoreUnitTest_OpenMP` test was timing out in the NVIDIA-GH200 CI job. Setting KOKKOS_NUM_THREADS speeds up the test significantly and should prevent the timeouts