### PR TITLE
Add PALS_LOCAL_RANKID to the list of local on-node RANKID env-vars

### DIFF
--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -33,6 +33,7 @@ int Kokkos::Impl::mpi_local_rank_on_node() {
            "MPI_LOCALRANKID",             // MPICH
            "SLURM_LOCALID",               // SLURM
            "PMI_LOCAL_RANK",              // PMI
+           "PALS_LOCAL_RANKID",           // PALS
        }) {
     char const* str = std::getenv(env_var);
     if (str) {


### PR DESCRIPTION
Add PALS_LOCAL_RANKID to the list of local on-node RANKID env-vars.

Fixes kokkos/kokkos#8889