### PR TITLE
Enable MPI detection with PALS

### DIFF
--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -17,6 +17,7 @@ int Kokkos::Impl::mpi_ranks_per_node() {
            "MPI_LOCALNRANKS",             // MPICH
                                           // SLURM???
            "PMI_LOCAL_SIZE",              // PMI
+           "PALS_LOCAL_SIZE",             // PALS
        }) {
     char const* str = std::getenv(env_var);
     if (str) {

--- a/core/src/impl/Kokkos_CPUDiscovery.cpp
+++ b/core/src/impl/Kokkos_CPUDiscovery.cpp
@@ -33,6 +33,7 @@ int Kokkos::Impl::mpi_local_rank_on_node() {
            "MPI_LOCALRANKID",             // MPICH
            "SLURM_LOCALID",               // SLURM
            "PMI_LOCAL_RANK",              // PMI
+           "PALS_LOCAL_RANKID",           // PALS
        }) {
     char const* str = std::getenv(env_var);
     if (str) {


### PR DESCRIPTION
Add support for the Cray Parallel Application Launch Service (PALS) when detecting the MPI environment.
Based on #8890.
I was not able to push to the branch since it was issued from an organization repo.
Also somehow I can't merge it so I suggest we just review and merge this PR instead.