### PR TITLE
Do not export symbol for team policy helper

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -166,7 +166,6 @@ export {
   using ::Kokkos::Schedule;
   using ::Kokkos::single;
   using ::Kokkos::Static;
-  using ::Kokkos::team_policy_check_valid_storage_level_argument;
   using ::Kokkos::TeamHandle;
   using ::Kokkos::TeamPolicy;
   using ::Kokkos::TeamThreadMDRange;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -553,6 +553,9 @@ inline std::enable_if_t<!std::is_integral_v<iType>, int> extract_vector_length(
   return 1;
 }
 
+// Causes abnormal program termination if level is not `0` or `1`
+void team_policy_check_valid_storage_level_argument(int level);
+
 }  // namespace Impl
 
 Impl::PerTeamValue PerTeam(const size_t& arg);
@@ -593,9 +596,6 @@ struct ScratchRequest {
     per_thread = thread_value.value;
   }
 };
-
-// Causes abnormal program termination if level is not `0` or `1`
-void team_policy_check_valid_storage_level_argument(int level);
 
 /** \brief  Execution policy for parallel work over a league of teams of
  * threads.
@@ -715,27 +715,27 @@ class TeamPolicy
                                  internal_policy&>,
                   "internal set_chunk_size should return a reference");
 
-    team_policy_check_valid_storage_level_argument(level);
+    Impl::team_policy_check_valid_storage_level_argument(level);
     return static_cast<TeamPolicy&>(
         internal_policy::set_scratch_size(level, per_team));
   }
   inline TeamPolicy& set_scratch_size(const int& level,
                                       const Impl::PerThreadValue& per_thread) {
-    team_policy_check_valid_storage_level_argument(level);
+    Impl::team_policy_check_valid_storage_level_argument(level);
     return static_cast<TeamPolicy&>(
         internal_policy::set_scratch_size(level, per_thread));
   }
   inline TeamPolicy& set_scratch_size(const int& level,
                                       const Impl::PerTeamValue& per_team,
                                       const Impl::PerThreadValue& per_thread) {
-    team_policy_check_valid_storage_level_argument(level);
+    Impl::team_policy_check_valid_storage_level_argument(level);
     return static_cast<TeamPolicy&>(
         internal_policy::set_scratch_size(level, per_team, per_thread));
   }
   inline TeamPolicy& set_scratch_size(const int& level,
                                       const Impl::PerThreadValue& per_thread,
                                       const Impl::PerTeamValue& per_team) {
-    team_policy_check_valid_storage_level_argument(level);
+    Impl::team_policy_check_valid_storage_level_argument(level);
     return static_cast<TeamPolicy&>(
         internal_policy::set_scratch_size(level, per_team, per_thread));
   }

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -29,7 +29,9 @@ Impl::PerThreadValue PerThread(const size_t& arg) {
   return Impl::PerThreadValue(arg);
 }
 
-void team_policy_check_valid_storage_level_argument(int level) {
+}  // namespace Kokkos
+
+void Kokkos::Impl::team_policy_check_valid_storage_level_argument(int level) {
   if (!(level == 0 || level == 1)) {
     std::stringstream ss;
     ss << "TeamPolicy::set_scratch_size(/*level*/ " << level
@@ -37,5 +39,3 @@ void team_policy_check_valid_storage_level_argument(int level) {
     abort(ss.str().c_str());
   }
 }
-
-}  // namespace Kokkos


### PR DESCRIPTION
Move team_policy_check_valid_team_size_argument() to Impl:: and do not include the symbol in the core module.