### PR TITLE
Clang 22 ICE: add a more restrictive guard on DynViewAPI testing

### DIFF
--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -695,9 +695,8 @@ class TestDynViewAPI {
   }
 
   static void run_operator_test_rank67() {
-    // FIXME_HIP The test triggers an internal compiler error in hipcc
-#if !(defined(KOKKOS_ENABLE_HIP) || \
-      (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR > 1))
+    // FIXME_CLANG 22 The test triggers an internal compiler error in clang 22.
+#if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG != 2200)
     TestViewOperator_LeftAndRight<int, device, 7>::testit(2, 3, 4, 2, 3, 4, 2);
 #endif
     TestViewOperator_LeftAndRight<int, device, 6>::testit(2, 3, 4, 2, 3, 4);

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -696,7 +696,7 @@ class TestDynViewAPI {
 
   static void run_operator_test_rank67() {
     // FIXME_CLANG 22 The test triggers an internal compiler error in clang 22.
-#if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG != 2200)
+#if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG < 2200)
     TestViewOperator_LeftAndRight<int, device, 7>::testit(2, 3, 4, 2, 3, 4, 2);
 #endif
     TestViewOperator_LeftAndRight<int, device, 6>::testit(2, 3, 4, 2, 3, 4);

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -696,7 +696,8 @@ class TestDynViewAPI {
 
   static void run_operator_test_rank67() {
     // FIXME_CLANG 22 The test triggers an internal compiler error in clang 22.
-#if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG < 2200)
+#if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG < 2200) || \
+    (KOKKOS_COMPILER_CLANG > 2210)
     TestViewOperator_LeftAndRight<int, device, 7>::testit(2, 3, 4, 2, 3, 4, 2);
 #endif
     TestViewOperator_LeftAndRight<int, device, 6>::testit(2, 3, 4, 2, 3, 4);


### PR DESCRIPTION
closes https://github.com/kokkos/kokkos/issues/8884

Clang 22 (the compiler underneath ROCm/7.2) has an ICE in compiling the `DynViewAPI.hpp` for testing.
The previous guard was skipping the test for `HIP` but it is also present when just enabling host backends with `amdclang++` (see the linked issue)
This PR reworks the guard to exclude the failing Clang version from compiling independent of the backend.
