### PR TITLE
Enforce TeamPolicy constructor preconditions

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -661,6 +661,7 @@ class TeamPolicy
           << ") must be greater than or equal to 1";
       Kokkos::abort(err.str().c_str());
     }
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
     int const vector_length_max = internal_policy::vector_length_max();
     if (vector_length > vector_length_max) {
       std::stringstream err;
@@ -668,6 +669,7 @@ class TeamPolicy
           << ") exceeds the maximum allowed (" << vector_length_max << ")";
       Kokkos::abort(err.str().c_str());
     }
+#endif
     return vector_length;
   }
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -20,6 +20,7 @@ static_assert(false,
 #include <typeinfo>
 #endif
 #include <limits>
+#include <sstream>
 #include <type_traits>
 
 //----------------------------------------------------------------------------
@@ -637,30 +638,35 @@ class TeamPolicy
 
   static int validate_league_size_argument(int league_size) {
     if (league_size < 0) {
-      Kokkos::abort(
-          "Kokkos::TeamPolicy error: league_size argument must be greater or "
-          "equal to 0");
+      std::stringstream err;
+      err << "Kokkos::TeamPolicy error: league_size (" << league_size
+          << ") must be greater than or equal to 0";
+      Kokkos::abort(err.str().c_str());
     }
     return league_size;
   }
   static int validate_team_size_argument(int team_size) {
     if (team_size < 1) {
-      Kokkos::abort(
-          "Kokkos::TeamPolicy error: team_size argument must be greater or "
-          "equal to 1");
+      std::stringstream err;
+      err << "Kokkos::TeamPolicy error: team_size (" << team_size
+          << ") must be greater than or equal to 1";
+      Kokkos::abort(err.str().c_str());
     }
     return team_size;
   }
   static int validate_vector_length_argument(int vector_length) {
     if (vector_length < 1) {
-      Kokkos::abort(
-          "Kokkos::TeamPolicy error: vector_length argument must be greater or "
-          "equal to 1");
+      std::stringstream err;
+      err << "Kokkos::TeamPolicy error: vector_length (" << vector_length
+          << ") must be greater than or equal to 1";
+      Kokkos::abort(err.str().c_str());
     }
-    if (vector_length > internal_policy::vector_length_max()) {
-      Kokkos::abort(
-          "Kokkos::TeamPolicy error: vector_length argument must be less or "
-          "equal to vector_length_max()");
+    int const vector_length_max = internal_policy::vector_length_max();
+    if (vector_length > vector_length_max) {
+      std::stringstream err;
+      err << "Kokkos::TeamPolicy error: vector_length (" << vector_length
+          << ") exceeds the maximum allowed (" << vector_length_max << ")";
+      Kokkos::abort(err.str().c_str());
     }
     return vector_length;
   }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -635,6 +635,36 @@ class TeamPolicy
   template <class... OtherProperties>
   friend class TeamPolicy;
 
+  static int validate_league_size_argument(int league_size) {
+    if (league_size < 0) {
+      Kokkos::abort(
+          "Kokkos::TeamPolicy error: league_size argument must be greater or "
+          "equal to 0");
+    }
+    return league_size;
+  }
+  static int validate_team_size_argument(int team_size) {
+    if (team_size < 1) {
+      Kokkos::abort(
+          "Kokkos::TeamPolicy error: team_size argument must be greater or "
+          "equal to 1");
+    }
+    return team_size;
+  }
+  static int validate_vector_length_argument(int vector_length) {
+    if (vector_length < 1) {
+      Kokkos::abort(
+          "Kokkos::TeamPolicy error: vector_length argument must be greater or "
+          "equal to 1");
+    }
+    if (vector_length > internal_policy::vector_length_max()) {
+      Kokkos::abort(
+          "Kokkos::TeamPolicy error: vector_length argument must be less or "
+          "equal to vector_length_max()");
+    }
+    return vector_length;
+  }
+
  public:
   using traits = Impl::PolicyTraits<Properties...>;
 
@@ -643,47 +673,46 @@ class TeamPolicy
   TeamPolicy() : internal_policy(0, AUTO) {}
 
   /** \brief  Construct policy with the given instance of the execution space */
-  TeamPolicy(const typename traits::execution_space& space_,
-             int league_size_request, int team_size_request,
-             int vector_length_request = 1)
-      : internal_policy(space_, league_size_request, team_size_request,
-                        vector_length_request) {}
+  TeamPolicy(const typename traits::execution_space& space_, int league_size,
+             int team_size, int vector_length = 1)
+      : internal_policy(space_, validate_league_size_argument(league_size),
+                        validate_team_size_argument(team_size),
+                        validate_vector_length_argument(vector_length)) {}
 
-  TeamPolicy(const typename traits::execution_space& space_,
-             int league_size_request, const Kokkos::AUTO_t&,
-             int vector_length_request = 1)
-      : internal_policy(space_, league_size_request, Kokkos::AUTO(),
-                        vector_length_request) {}
+  TeamPolicy(const typename traits::execution_space& space_, int league_size,
+             Kokkos::AUTO_t, int vector_length = 1)
+      : internal_policy(space_, validate_league_size_argument(league_size),
+                        Kokkos::AUTO,
+                        validate_vector_length_argument(vector_length)) {}
 
-  TeamPolicy(const typename traits::execution_space& space_,
-             int league_size_request, const Kokkos::AUTO_t&,
-             const Kokkos::AUTO_t&)
-      : internal_policy(space_, league_size_request, Kokkos::AUTO(),
-                        Kokkos::AUTO()) {}
-  TeamPolicy(const typename traits::execution_space& space_,
-             int league_size_request, const int team_size_request,
-             const Kokkos::AUTO_t&)
-      : internal_policy(space_, league_size_request, team_size_request,
-                        Kokkos::AUTO()) {}
+  TeamPolicy(const typename traits::execution_space& space_, int league_size,
+             Kokkos::AUTO_t, Kokkos::AUTO_t)
+      : internal_policy(space_, league_size, Kokkos::AUTO, Kokkos::AUTO) {}
+
+  TeamPolicy(const typename traits::execution_space& space_, int league_size,
+             const int team_size, Kokkos::AUTO_t)
+      : internal_policy(space_, validate_league_size_argument(league_size),
+                        validate_team_size_argument(team_size), Kokkos::AUTO) {}
+
   /** \brief  Construct policy with the default instance of the execution space
    */
-  TeamPolicy(int league_size_request, int team_size_request,
-             int vector_length_request = 1)
-      : internal_policy(league_size_request, team_size_request,
-                        vector_length_request) {}
+  TeamPolicy(int league_size, int team_size, int vector_length = 1)
+      : internal_policy(validate_league_size_argument(league_size),
+                        validate_team_size_argument(team_size),
+                        validate_vector_length_argument(vector_length)) {}
 
-  TeamPolicy(int league_size_request, const Kokkos::AUTO_t&,
-             int vector_length_request = 1)
-      : internal_policy(league_size_request, Kokkos::AUTO(),
-                        vector_length_request) {}
+  TeamPolicy(int league_size, Kokkos::AUTO_t, int vector_length = 1)
+      : internal_policy(validate_league_size_argument(league_size),
+                        Kokkos::AUTO,
+                        validate_vector_length_argument(vector_length)) {}
 
-  TeamPolicy(int league_size_request, const Kokkos::AUTO_t&,
-             const Kokkos::AUTO_t&)
-      : internal_policy(league_size_request, Kokkos::AUTO(), Kokkos::AUTO()) {}
-  TeamPolicy(int league_size_request, const int team_size_request,
-             const Kokkos::AUTO_t&)
-      : internal_policy(league_size_request, team_size_request,
-                        Kokkos::AUTO()) {}
+  TeamPolicy(int league_size, Kokkos::AUTO_t, Kokkos::AUTO_t)
+      : internal_policy(validate_league_size_argument(league_size),
+                        Kokkos::AUTO, Kokkos::AUTO) {}
+
+  TeamPolicy(int league_size, int team_size, Kokkos::AUTO_t)
+      : internal_policy(validate_league_size_argument(league_size),
+                        validate_team_size_argument(team_size), Kokkos::AUTO) {}
 
   template <class... OtherProperties>
   TeamPolicy(const TeamPolicy<OtherProperties...> p) : internal_policy(p) {

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -239,6 +239,7 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
                "Kokkos::TeamPolicy error: vector_length \\(-2\\) must be "
                "greater than or equal to 1");
 
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
   auto const max_allowed =
       Kokkos::TeamPolicy<TEST_EXECSPACE>::vector_length_max();
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, max_allowed + 1),
@@ -252,6 +253,7 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
           std::to_string(max_allowed + 2) +
           "\\) exceeds the maximum allowed \\(" + std::to_string(max_allowed) +
           "\\)");
+#endif
 }
 
 }  // namespace

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -183,4 +183,70 @@ TEST(TEST_CATEGORY, team_policy_impl_set_space) {
   ASSERT_EQ(policy_new.league_size(), 42);
 }
 
+TEST(TEST_CATEGORY_DEATH, team_policy_invalid_league_size) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1),
+               "Kokkos::TeamPolicy error: league_size argument must be greater "
+               "or equal to 0");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: league_size argument must be greater "
+               "or equal to 0");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1, 1),
+               "Kokkos::TeamPolicy error: league_size argument must be greater "
+               "or equal to 0");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO, 1),
+               "Kokkos::TeamPolicy error: league_size argument must be greater "
+               "or equal to 0");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: league_size argument must be greater "
+               "or equal to 0");
+
+  EXPECT_DEATH(
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO, Kokkos::AUTO),
+      "Kokkos::TeamPolicy error: league_size argument must be greater or equal "
+      "to 0");
+}
+
+TEST(TEST_CATEGORY_DEATH, team_policy_invalid_team_size) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0),
+               "Kokkos::TeamPolicy error: team_size argument must be greater "
+               "or equal to 1");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0, 1),
+               "Kokkos::TeamPolicy error: team_size argument must be greater "
+               "or equal to 1");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: team_size argument must be greater "
+               "or equal to 1");
+}
+
+TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, -1),
+               "Kokkos::TeamPolicy error: vector_length argument must be "
+               "greater or equal to 1");
+
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, -1),
+               "Kokkos::TeamPolicy error: vector_length argument must be "
+               "greater or equal to 1");
+
+  auto const too_large =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>::vector_length_max() + 1;
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, too_large),
+               "Kokkos::TeamPolicy error: vector_length argument must be less "
+               "or equal to vector_length_max()");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, too_large),
+               "Kokkos::TeamPolicy error: vector_length argument must be less "
+               "or equal to vector_length_max()");
+}
+
 }  // namespace

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -187,66 +187,71 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_league_size) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1),
-               "Kokkos::TeamPolicy error: league_size argument must be greater "
-               "or equal to 0");
+               "Kokkos::TeamPolicy error: league_size \\(-1\\) must be greater "
+               "than or equal to 0");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO),
-               "Kokkos::TeamPolicy error: league_size argument must be greater "
-               "or equal to 0");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-2, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: league_size \\(-2\\) must be greater "
+               "than or equal to 0");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1, 1),
-               "Kokkos::TeamPolicy error: league_size argument must be greater "
-               "or equal to 0");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-3, 1, 1),
+               "Kokkos::TeamPolicy error: league_size \\(-3\\) must be greater "
+               "than or equal to 0");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO, 1),
-               "Kokkos::TeamPolicy error: league_size argument must be greater "
-               "or equal to 0");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-4, Kokkos::AUTO, 1),
+               "Kokkos::TeamPolicy error: league_size \\(-4\\) must be greater "
+               "than or equal to 0");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1, Kokkos::AUTO),
-               "Kokkos::TeamPolicy error: league_size argument must be greater "
-               "or equal to 0");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-5, 1, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: league_size \\(-5\\) must be greater "
+               "than or equal to 0");
 
   EXPECT_DEATH(
-      Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, Kokkos::AUTO, Kokkos::AUTO),
-      "Kokkos::TeamPolicy error: league_size argument must be greater or equal "
-      "to 0");
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(-6, Kokkos::AUTO, Kokkos::AUTO),
+      "Kokkos::TeamPolicy error: league_size \\(-6\\) must be greater than or "
+      "equal to 0");
 }
 
 TEST(TEST_CATEGORY_DEATH, team_policy_invalid_team_size) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0),
-               "Kokkos::TeamPolicy error: team_size argument must be greater "
-               "or equal to 1");
+               "Kokkos::TeamPolicy error: team_size \\(0\\) must be greater "
+               "than or equal to 1");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0, 1),
-               "Kokkos::TeamPolicy error: team_size argument must be greater "
-               "or equal to 1");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, -1, 1),
+               "Kokkos::TeamPolicy error: team_size \\(-1\\) must be greater "
+               "than or equal to 1");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0, Kokkos::AUTO),
-               "Kokkos::TeamPolicy error: team_size argument must be greater "
-               "or equal to 1");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, -2, Kokkos::AUTO),
+               "Kokkos::TeamPolicy error: team_size \\(-2\\) must be greater "
+               "than or equal to 1");
 }
 
 TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, -1),
-               "Kokkos::TeamPolicy error: vector_length argument must be "
-               "greater or equal to 1");
+               "Kokkos::TeamPolicy error: vector_length \\(-1\\) must be "
+               "greater than or equal to 1");
 
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, -1),
-               "Kokkos::TeamPolicy error: vector_length argument must be "
-               "greater or equal to 1");
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, -2),
+               "Kokkos::TeamPolicy error: vector_length \\(-2\\) must be "
+               "greater than or equal to 1");
 
-  auto const too_large =
-      Kokkos::TeamPolicy<TEST_EXECSPACE>::vector_length_max() + 1;
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, too_large),
-               "Kokkos::TeamPolicy error: vector_length argument must be less "
-               "or equal to vector_length_max\\(\\)");
-  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, too_large),
-               "Kokkos::TeamPolicy error: vector_length argument must be less "
-               "or equal to vector_length_max\\(\\)");
+  auto const max_allowed =
+      Kokkos::TeamPolicy<TEST_EXECSPACE>::vector_length_max();
+  EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, max_allowed + 1),
+               std::string("Kokkos::TeamPolicy error: vector_length \\(") +
+                   std::to_string(max_allowed + 1) +
+                   "\\) exceeds the maximum allowed \\(" +
+                   std::to_string(max_allowed) + "\\)");
+  EXPECT_DEATH(
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, max_allowed + 2),
+      std::string("Kokkos::TeamPolicy error: vector_length \\(") +
+          std::to_string(max_allowed + 2) +
+          "\\) exceeds the maximum allowed \\(" + std::to_string(max_allowed) +
+          "\\)");
 }
 
 }  // namespace

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -243,10 +243,10 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
       Kokkos::TeamPolicy<TEST_EXECSPACE>::vector_length_max() + 1;
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, too_large),
                "Kokkos::TeamPolicy error: vector_length argument must be less "
-               "or equal to vector_length_max()");
+               "or equal to vector_length_max\\(\\)");
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO, too_large),
                "Kokkos::TeamPolicy error: vector_length argument must be less "
-               "or equal to vector_length_max()");
+               "or equal to vector_length_max\\(\\)");
 }
 
 }  // namespace

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -1044,7 +1044,11 @@ TEST(TEST_CATEGORY, triple_nested_parallelism) {
   if (!std::is_same_v<TEST_EXECSPACE, Kokkos::SYCL>)
 #endif
   {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     TestTripleNestedReduce<double, TEST_EXECSPACE>(8192, 2048, 16, 33);
+#else
+    TestTripleNestedReduce<double, TEST_EXECSPACE>(8192, 2048, 16, 31);
+#endif
     TestTripleNestedReduce<double, TEST_EXECSPACE>(8192, 2048, 16, 19);
   }
   TestTripleNestedReduce<double, TEST_EXECSPACE>(8192, 2048, 16, 16);


### PR DESCRIPTION
Addresses #8898

I did not bother adding death tests with a leading execution space argument.  I think it is good enough as is.