### PR TITLE
Pin docker images used in SNL CI

### DIFF
--- a/scripts/docker/snl-ci-dockerfiles/cuda-12.2.2_openblas-0.3.29_x86-64.dockerfile
+++ b/scripts/docker/snl-ci-dockerfiles/cuda-12.2.2_openblas-0.3.29_x86-64.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:9.7@sha256:0d37bd2384f10881a2b0fdf695af99816fdf468a499fe3ace43da84c3cb566aa
+FROM registry.access.redhat.com/ubi9:9.6@sha256:f22847515e7909e5e6ae980cb8626ecea2411a4277e59852b1661e0aaffb6df2
 
 # certs may be needed for your system, e.g.
 #ADD <your>.crt /etc/pki/ca-trust/source/anchors/<your>.crt

--- a/scripts/docker/snl-ci-dockerfiles/cuda-12.2.2_openblas-0.3.29_x86-64.dockerfile
+++ b/scripts/docker/snl-ci-dockerfiles/cuda-12.2.2_openblas-0.3.29_x86-64.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.access.redhat.com/ubi9:9.7@sha256:0d37bd2384f10881a2b0fdf695af99816fdf468a499fe3ace43da84c3cb566aa
 
 # certs may be needed for your system, e.g.
 #ADD <your>.crt /etc/pki/ca-trust/source/anchors/<your>.crt

--- a/scripts/docker/snl-ci-dockerfiles/intel-oneapi-basekit-2024.2.1-0-devel-ubuntu22.04.dockerfile
+++ b/scripts/docker/snl-ci-dockerfiles/intel-oneapi-basekit-2024.2.1-0-devel-ubuntu22.04.dockerfile
@@ -1,4 +1,4 @@
-FROM intel/oneapi-basekit:2024.2.1-0-devel-ubuntu22.04
+FROM intel/oneapi-basekit:2024.2.1-0-devel-ubuntu22.04@sha256:c148163a0476fad50ad46a473c03dc5ca9058fdf5cba69287a4836b3d9ae8bff
 
 # certs may be needed for your system, e.g.
 #ADD <your>.crt /etc/pki/ca-trust/source/anchors/<your>.crt

--- a/scripts/docker/snl-ci-dockerfiles/rocm-6.2.1_openblas-0.3.28_zen3_gfx90a.dockerfile
+++ b/scripts/docker/snl-ci-dockerfiles/rocm-6.2.1_openblas-0.3.28_zen3_gfx90a.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:9.7@sha256:0d37bd2384f10881a2b0fdf695af99816fdf468a499fe3ace43da84c3cb566aa
+FROM registry.access.redhat.com/ubi9:9.5@sha256:a010f5a7096ea45d77c2df0779c28b1829112816d6fb248bb2d2ed0e04f94498
 
 # certs may be needed for your system, e.g.
 #ADD <your>.crt /etc/pki/ca-trust/source/anchors/<your>.crt

--- a/scripts/docker/snl-ci-dockerfiles/rocm-6.2.1_openblas-0.3.28_zen3_gfx90a.dockerfile
+++ b/scripts/docker/snl-ci-dockerfiles/rocm-6.2.1_openblas-0.3.28_zen3_gfx90a.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9:latest
+FROM registry.access.redhat.com/ubi9:9.7@sha256:0d37bd2384f10881a2b0fdf695af99816fdf468a499fe3ace43da84c3cb566aa
 
 # certs may be needed for your system, e.g.
 #ADD <your>.crt /etc/pki/ca-trust/source/anchors/<your>.crt


### PR DESCRIPTION
Fix: 
* https://github.com/kokkos/kokkos/security/code-scanning/112
* https://github.com/kokkos/kokkos/security/code-scanning/111
* https://github.com/kokkos/kokkos/security/code-scanning/110

I assumed amd64 for the [red hat images](https://catalog.redhat.com/en/software/containers/ubi9/ubi/615bcf606feffc5384e8452e?architecture=amd64&image=)