### PR TITLE
simd: fix simd construction in device build (avx2)

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -203,9 +203,14 @@ using simd_mask = basic_simd_mask<T, simd_abi::Impl::native_abi<T, N>>;
 
 template <typename T, typename... Flags>
   requires Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
-KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
-simd_unchecked_load(const T* ptr,
-                    simd_flags<Flags...> flag = simd_flag_default) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_FORCEINLINE_FUNCTION
+#endif
+    basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
+    simd_unchecked_load(const T* ptr,
+                        simd_flags<Flags...> flag = simd_flag_default) {
   return simd_unchecked_load<
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(ptr, flag);
 }

--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_SIMD_HPP
 
 #include <Kokkos_SIMD_Common.hpp>
+#include <Kokkos_SIMD_Base.hpp>
 #include <Kokkos_SIMD_Scalar.hpp>
 #include <Kokkos_Macros.hpp>
 
@@ -202,10 +203,9 @@ using simd_mask = basic_simd_mask<T, simd_abi::Impl::native_abi<T, N>>;
 
 template <typename T, typename... Flags>
   requires Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
-    simd_unchecked_load(const T* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
+KOKKOS_FORCEINLINE_FUNCTION basic_simd<T, simd_abi::Impl::host_fixed_native<T>>
+simd_unchecked_load(const T* ptr,
+                    simd_flags<Flags...> flag = simd_flag_default) {
   return simd_unchecked_load<
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(ptr, flag);
 }
@@ -346,5 +346,9 @@ using device_abi_set = abi_set<simd_abi::scalar>;
 
 }  // namespace Experimental
 }  // namespace Kokkos
+
+#ifdef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+#undef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+#endif
 
 #endif

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -2061,7 +2061,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     }
 // missing return statement warning with cuda >= 12.9
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1290) && \
-    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+        defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK) ||                   \
+    defined(KOKKOS_COMPILER_NVHPC)
     return value_type{};
 #endif
   }
@@ -2709,6 +2710,11 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
       case 3: return _mm256_extract_epi64(m_value, 0x3);
       default: Kokkos::abort("Index out of bound"); break;
     }
+#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1290) && \
+        defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK) ||                   \
+    defined(KOKKOS_COMPILER_NVHPC)
+    return value_type{};
+#endif
   }
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
@@ -3044,7 +3050,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
       default: Kokkos::abort("Index out of bound"); break;
     }
 #if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1290) && \
-    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
+        defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK) ||                   \
+    defined(KOKKOS_COMPILER_NVHPC)
     return value_type{};
 #endif
   }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -102,6 +102,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
       basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -151,6 +152,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 template <>
@@ -221,6 +223,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
       basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -269,6 +272,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 template <>
@@ -342,6 +346,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
       basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -390,6 +395,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 template <>
@@ -458,6 +464,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
       basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -507,6 +514,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 template <>
@@ -579,6 +587,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
       basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -628,6 +637,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
   impl_operator_ne(T const& rhs) const noexcept {
     return impl_operator_eq(rhs).impl_operator_lnot();
   }
+#endif
 };
 
 template <>
@@ -700,6 +710,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
       basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -749,6 +760,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 template <>
@@ -821,6 +833,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
       basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -870,6 +883,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_ne(T const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
+#endif
 };
 
 KOKKOS_FORCEINLINE_FUNCTION
@@ -1078,8 +1092,8 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_pd(
             ptr, _mm256_castpd_si256(static_cast<__m256d>(mask))))
@@ -1098,6 +1112,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
       basic_simd<double, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -1172,6 +1187,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -1419,8 +1435,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask))))
@@ -1439,6 +1455,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
       basic_simd<float, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -1503,6 +1520,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   impl_operator_lt(T const& rhs) const noexcept {
     return mask_type(_mm_cmplt_ps(m_value, rhs.m_value));
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -1748,8 +1766,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_ps(
             ptr, _mm256_castps_si256(static_cast<__m256>(mask))))
@@ -1768,6 +1786,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
       basic_simd<float, simd_abi::avx2_fixed_size<8>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -1838,6 +1857,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -2085,8 +2105,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_maskload_epi32(ptr, static_cast<__m128i>(mask)))
 #endif
@@ -2104,6 +2124,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
       basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -2222,6 +2243,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_le(T const& rhs) const noexcept {
     return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -2425,8 +2447,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi32(ptr, static_cast<__m256i>(mask)))
 #endif
@@ -2444,6 +2466,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
       basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -2560,6 +2583,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   impl_operator_lt(T const& rhs) const noexcept {
     return !impl_operator_ge(rhs);
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -2761,8 +2785,8 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))
@@ -2781,6 +2805,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
       basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -2899,6 +2924,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_lt(T const& rhs) const noexcept {
     return !impl_operator_ge(rhs);
   }
+#endif
 };
 
 }  // namespace Experimental
@@ -3108,8 +3134,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
-      FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr,
+      [[maybe_unused]] mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))
@@ -3128,6 +3154,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
       basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
 #endif
 
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
   template <typename T = value_type>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
   impl_subscript_operator(Impl::simd_size_t i) const {
@@ -3146,7 +3173,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(static_cast<__m256i>(m_value));
+    return T(~value_type(0)) - m_value;
   }
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
@@ -3258,6 +3285,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   impl_operator_lt(T const& rhs) const noexcept {
     return rhs > m_value;
   }
+#endif
 };
 
 }  // namespace Experimental

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1256,7 +1256,7 @@ KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
       return (
           Experimental::basic_simd<double,
                                    Experimental::simd_abi::avx2_fixed_size<4>>(
-              _mm256_cbrt_pd(static_cast<__m256d>(a))));
+              _mm256_exp_pd(static_cast<__m256d>(a))));
     })
 
 KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
@@ -2080,7 +2080,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      implementation const& value_in) noexcept
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
@@ -2187,6 +2187,10 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
 #endif
   }
 
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(_mm_sub_epi32(_mm_set1_epi32(0), static_cast<__m128i>(m_value)));
+  }
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
     return T(_mm_andnot_si128(m_value, T(~value_type(0)).m_value));
@@ -2329,29 +2333,21 @@ KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
               _mm256_cvtepi32_pd(static_cast<__m128i>(a))));
     })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int32_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_max_epi32(static_cast<__m128i>(a), static_cast<__m128i>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<std::int32_t,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_max_epi32(static_cast<__m128i>(a), static_cast<__m128i>(b))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int32_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_min_epi32(static_cast<__m128i>(a), static_cast<__m128i>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<std::int32_t,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_min_epi32(static_cast<__m128i>(a), static_cast<__m128i>(b))));
+    })
 
 namespace Experimental {
 
@@ -2442,7 +2438,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      implementation const& value_in) noexcept
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
@@ -2549,6 +2545,11 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
 #endif
   }
 
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(
+        _mm256_sub_epi32(_mm256_set1_epi32(0), static_cast<__m256i>(m_value)));
+  }
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
     return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
@@ -2690,29 +2691,19 @@ KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
               _mm256_cvtepi32_ps(static_cast<__m256i>(a))));
     })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int32_t,
-                         Experimental::simd_abi::avx2_fixed_size<8>>
-max(Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_max_epi32(static_cast<__m256i>(a), static_cast<__m256i>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (Experimental::basic_simd<
+              std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>(
+          _mm256_max_epi32(static_cast<__m256i>(a), static_cast<__m256i>(b))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int32_t,
-                         Experimental::simd_abi::avx2_fixed_size<8>>
-min(Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
-        std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_min_epi32(static_cast<__m256i>(a), static_cast<__m256i>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (Experimental::basic_simd<
+              std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>(
+          _mm256_min_epi32(static_cast<__m256i>(a), static_cast<__m256i>(b))));
+    })
 
 namespace Experimental {
 
@@ -2805,7 +2796,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      implementation const& value_in) noexcept
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
@@ -2913,14 +2904,13 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   }
 
   template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
-  }
-
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
     return T(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
   }
 
   template <typename T = basic_simd>
@@ -3067,31 +3057,21 @@ KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
               _mm256_setr_pd(a[0], a[1], a[2], a[3])));
     })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int64_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::basic_simd<
-        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
-                         static_cast<__m256i>(b > a)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
+                             static_cast<__m256i>(b > a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::int64_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::basic_simd<
-        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
-                         static_cast<__m256i>(b < a)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
+                             static_cast<__m256i>(b < a))));
+    })
 
 namespace Experimental {
 
@@ -3299,6 +3279,10 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
 
   template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(static_cast<__m256i>(m_value));
+  }
+  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
     return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
   }
@@ -3348,9 +3332,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sra(T const& rhs) const noexcept
-    requires(!std::is_arithmetic_v<T>)
-  {
+  impl_operator_sra(T const& rhs) const noexcept {
     return _mm256_srlv_epi64(static_cast<__m256i>(m_value),
                              static_cast<__m256i>(rhs));
   }
@@ -3361,7 +3343,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  operator_sra(Impl::simd_size_t rhs) const noexcept {
+  impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
     return _mm256_srli_epi64(static_cast<__m256i>(m_value), rhs);
   }
 
@@ -3450,31 +3432,21 @@ KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
               _mm256_setr_pd(a[0], a[1], a[2], a[3])));
     })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::uint64_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::basic_simd<
-        std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::uint64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
-                         static_cast<__m256i>(b > a)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
+                             static_cast<__m256i>(b > a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<std::uint64_t,
-                         Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::basic_simd<
-        std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<std::uint64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
-                         static_cast<__m256i>(b < a)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_blendv_epi8(static_cast<__m256i>(a), static_cast<__m256i>(b),
+                             static_cast<__m256i>(b < a))));
+    })
 
 namespace Experimental {
 

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -32,14 +32,15 @@ template <>
 class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256d;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256d;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256d)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -156,14 +157,15 @@ template <>
 class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m128;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m128;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m128)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -174,7 +176,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
 
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-     [[maybe_unused]] value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value))))
 #endif
@@ -273,14 +275,15 @@ template <>
 class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>> {
+  using abi_vector_type = __m256;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -290,7 +293,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-     [[maybe_unused]] value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value))))
 #endif
@@ -393,14 +396,15 @@ template <>
 class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m128i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m128i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m128i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -509,14 +513,15 @@ template <>
 class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -629,14 +634,15 @@ template <>
 class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -749,14 +755,15 @@ template <>
 class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_mask_base<
           basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
   using base_type = Impl::basic_simd_mask_base<
       basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -876,7 +883,8 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other)))
 #endif
@@ -885,7 +893,8 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
 #endif
@@ -894,7 +903,8 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
 #endif
@@ -903,7 +913,8 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other)))
 #endif
@@ -912,7 +923,8 @@ basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other)))
 #endif
@@ -939,7 +951,8 @@ basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -957,7 +970,8 @@ basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif
@@ -966,7 +980,8 @@ basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -984,7 +999,8 @@ basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const&
+        other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif
@@ -995,12 +1011,13 @@ template <>
 class basic_simd<double, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_base<
           basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256d;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256d;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256d)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = double;
@@ -1037,7 +1054,8 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm256_setr_pd(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -1060,7 +1078,8 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_pd(
             ptr, _mm256_castpd_si256(static_cast<__m256d>(mask))))
@@ -1334,12 +1353,13 @@ template <>
 class basic_simd<float, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_base<
           basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m128;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m128;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m128)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = float;
@@ -1399,7 +1419,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask))))
@@ -1659,12 +1680,13 @@ template <>
 class basic_simd<float, simd_abi::avx2_fixed_size<8>>
     : public Impl::basic_simd_base<
           basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
+  using abi_vector_type = __m256;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = float;
@@ -1726,7 +1748,8 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_ps(
             ptr, _mm256_castps_si256(static_cast<__m256>(mask))))
@@ -1993,14 +2016,15 @@ template <>
 class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_base<
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m128i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m128i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m128i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
   using base_type = Impl::basic_simd_base<
       basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = std::int32_t;
@@ -2037,7 +2061,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_setr_epi32(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2060,7 +2085,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_maskload_epi32(ptr, static_cast<__m128i>(mask)))
 #endif
@@ -2328,14 +2354,15 @@ template <>
 class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     : public Impl::basic_simd_base<
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
   using base_type = Impl::basic_simd_base<
       basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = std::int32_t;
@@ -2370,7 +2397,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi32(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2397,7 +2425,8 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi32(ptr, static_cast<__m256i>(mask)))
 #endif
@@ -2661,14 +2690,15 @@ template <>
 class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_base<
           basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
   using base_type = Impl::basic_simd_base<
       basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
   static_assert(sizeof(long long) == 8);
 
@@ -2707,7 +2737,8 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2730,7 +2761,8 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))
@@ -3002,14 +3034,15 @@ template <>
 class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     : public Impl::basic_simd_base<
           basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+  using abi_vector_type = __m256i;
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  using implementation_type = __m256i;
+  using implementation_type = abi_vector_type;
 #else
-  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+  using implementation_type = Kokkos::Array<char, sizeof(abi_vector_type)>;
 #endif
-  implementation_type m_value;
   using base_type = Impl::basic_simd_base<
       basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
+  alignas(alignof(abi_vector_type)) implementation_type m_value;
 
  public:
   using value_type = std::uint64_t;
@@ -3051,7 +3084,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -3074,7 +3108,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask,
+      FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -29,227 +29,291 @@ class avx2_fixed_size {};
 }  // namespace simd_abi
 
 template <>
-class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> {
-  __m256d m_value;
+class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256d;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256d)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value)))) {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value))))
+#endif
+  {
   }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<double>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256d const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 2>())),
             -std::int64_t(
-                gen(std::integral_constant<Impl::simd_size_t, 3>()))))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
+                gen(std::integral_constant<Impl::simd_size_t, 3>())))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm256_andnot_pd(m_value, basic_simd_mask(true).m_value));
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_pd(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_pd(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm256_and_pd(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_pd(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm256_or_pd(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_xor_pd(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_pd(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_movemask_pd(lhs.m_value) ==
-                           _mm256_movemask_pd(rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_pd(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_pd(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm256_movemask_pd(m_value) == _mm256_movemask_pd(rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
 template <>
-class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> {
-  __m128 m_value;
+class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m128;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m128)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value)))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value))))
+#endif
+  {
+  }
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<float>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m128 const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 2>())),
             -std::int32_t(
-                gen(std::integral_constant<Impl::simd_size_t, 3>()))))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
+                gen(std::integral_constant<Impl::simd_size_t, 3>())))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm_andnot_ps(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm_andnot_ps(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_or_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm_and_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_xor_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm_or_ps(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_movemask_ps(lhs.m_value) ==
-                           _mm_movemask_ps(rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm_and_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm_or_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm_xor_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm_movemask_ps(m_value) == _mm_movemask_ps(rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
 template <>
-class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
-  __m256 m_value;
+class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 8> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256 const& value_in) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value))))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<float>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
@@ -259,183 +323,233 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> {
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 5>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 6>())),
             -std::int32_t(
-                gen(std::integral_constant<Impl::simd_size_t, 7>()))))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
+                gen(std::integral_constant<Impl::simd_size_t, 7>())))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm256_andnot_ps(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_ps(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm256_and_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_xor_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm256_or_ps(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_movemask_ps(lhs.m_value) ==
-                           _mm256_movemask_ps(rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm256_movemask_ps(m_value) == _mm256_movemask_ps(rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> {
-  __m128i m_value;
+class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m128i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m128i)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm_set1_epi32(-std::int32_t(value))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm_set1_epi32(-std::int32_t(value)))
+#endif
+  {
+  }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<std::int32_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m128i const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 2>())),
-            -std::int32_t(
-                gen(std::integral_constant<Impl::simd_size_t, 3>())))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
+            -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 3>()))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm_andnot_si128(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_and_si128(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm_andnot_si128(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_or_si128(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm_and_si128(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_xor_si128(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm_or_si128(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm_movemask_ps(_mm_castsi128_ps(lhs.m_value)) ==
-                           _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm_and_si128(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm_or_si128(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm_xor_si128(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
+             _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
-  __m256i m_value;
+class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 8> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm256_set1_epi32(-std::int32_t(value))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_epi32(-std::int32_t(value)))
+#endif
+  {
+  }
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<Impl::simd_size_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
@@ -444,1474 +558,1621 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 4>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 5>())),
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 6>())),
-            -std::int32_t(
-                gen(std::integral_constant<Impl::simd_size_t, 7>())))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const noexcept {
-    return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
+            -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 7>()))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_ps(_mm256_castsi256_ps(lhs.m_value)) ==
-        _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
+             _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return impl_operator_eq(rhs).impl_operator_lnot();
   }
 };
 
 template <>
-class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> {
-  __m256i m_value;
+class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<std::int64_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 2>())),
-            -std::int64_t(
-                gen(std::integral_constant<Impl::simd_size_t, 3>())))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
+            -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 3>()))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
-        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+             _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
 template <>
-class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
-  __m256i m_value;
+class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_mask_base<
+          basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  using base_type = Impl::basic_simd_mask_base<
+      basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       value_type value) noexcept
-      : m_value(_mm256_set1_epi64x(-std::int64_t(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      __m256i const& value_in) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<U, abi_type> const& other) noexcept
       : basic_simd_mask([&](Impl::simd_size_t i) {
           return static_cast<std::uint64_t>(other[i]);
         }) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask(
       basic_simd_mask<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<double, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       basic_simd_mask<std::int64_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
       G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 1>())),
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 2>())),
-            -std::int64_t(
-                gen(std::integral_constant<Impl::simd_size_t, 3>())))) {}
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
-    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
+            -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 3>()))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator!() const noexcept {
-    return operator~();
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit
+  operator implementation_type() const noexcept {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
-  operator~() const noexcept {
-    return basic_simd_mask(
-        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_mask_base<
+      basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs & rhs;
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
+    return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator||(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return lhs | rhs;
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+    return impl_operator_bnot();
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator&(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_and_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(true).m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator|(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_or_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_lor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator^(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(_mm256_xor_si256(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_land(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator==(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return basic_simd_mask(
-        _mm256_movemask_pd(_mm256_castsi256_pd(lhs.m_value)) ==
-        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd_mask operator!=(
-      basic_simd_mask const& lhs, basic_simd_mask const& rhs) noexcept {
-    return !operator==(lhs, rhs);
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_eq(T const& rhs) const noexcept {
+    return T(_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+             _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  }
+  template <typename T = basic_simd_mask>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
 };
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<float, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
-    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
-    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
     basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<float, abi_type> const& other) noexcept
-    : m_value(_mm_castps_si128(static_cast<__m128>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm_castps_si128(static_cast<__m128>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
     basic_simd_mask<float, abi_type> const& other) noexcept
-    : m_value(_mm256_castps_si256(static_cast<__m256>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castps_si256(static_cast<__m256>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<double, abi_type> const& other) noexcept
-    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
-    : m_value(static_cast<__m256i>(other)) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(static_cast<__m256i>(other))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<double, abi_type> const& other) noexcept
-    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_castpd_si256(static_cast<__m256d>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
     basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
-    : m_value(static_cast<__m256i>(other)) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(static_cast<__m256i>(other))
+#endif
+{
+}
 
 template <>
-class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
-  __m256d m_value;
+class basic_simd<double, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_base<
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256d;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256d)>;
+#endif
+  implementation_type m_value;
 
  public:
   using value_type = double;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
-      : m_value(_mm256_set1_pd(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256d const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_pd(value_type(value)))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      G&& gen) noexcept
-      : m_value(_mm256_setr_pd(
-            gen(std::integral_constant<Impl::simd_size_t, 0>()),
-            gen(std::integral_constant<Impl::simd_size_t, 1>()),
-            gen(std::integral_constant<Impl::simd_size_t, 2>()),
-            gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm256_load_pd(ptr);
-    } else {
-      m_value = _mm256_loadu_pd(ptr);
-    }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            _mm256_setr_pd(gen(std::integral_constant<Impl::simd_size_t, 0>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 1>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 2>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 3>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm256_maskload_pd(
-        ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm256_load_pd(ptr)
+                : _mm256_loadu_pd(ptr))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_maskload_pd(
+            ptr, _mm256_castpd_si256(static_cast<__m256d>(mask))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_loadu_pd(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_load_pd(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_storeu_pd(ptr, m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_store_pd(ptr, m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const noexcept {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_base<
+      basic_simd<double, simd_abi::avx2_fixed_size<4>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     value_type tmp[size()];
     _mm256_storeu_pd(tmp, m_value);
     return tmp[i];
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256d()
-      const noexcept {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(_mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(
-        _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm256_add_pd(static_cast<__m256d>(m_value),
+                           static_cast<__m256d>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm256_sub_pd(static_cast<__m256d>(m_value),
+                           static_cast<__m256d>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T(_mm256_mul_pd(static_cast<__m256d>(m_value),
+                           static_cast<__m256d>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_div(T const& rhs) const noexcept {
+    return T(_mm256_div_pd(static_cast<__m256d>(m_value),
+                           static_cast<__m256d>(rhs)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_mul_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_div_pd(static_cast<__m256d>(lhs), static_cast<__m256d>(rhs)));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_EQ_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_GE_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_LE_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_GT_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-copysign(Experimental::basic_simd<
-             double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-         Experimental::basic_simd<
-             double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
-                    _mm256_and_pd(sign_mask, static_cast<__m256d>(b))));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    copysign, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      __m256d const sign_mask = _mm256_set1_pd(-0.0);
+      return (Experimental::basic_simd<
+              double, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_xor_pd(_mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)),
+                        _mm256_and_pd(sign_mask, static_cast<__m256d>(b)))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  __m256d const sign_mask = _mm256_set1_pd(-0.0);
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      __m256d const sign_mask = _mm256_set1_pd(-0.0);
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_andnot_pd(sign_mask, static_cast<__m256d>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
-      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_round_pd(static_cast<__m256d>(a),
-                      (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    floor, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_round_pd(static_cast<__m256d>(a),
+                              (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_round_pd(static_cast<__m256d>(a),
-                      (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    ceil, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_round_pd(static_cast<__m256d>(a),
+                              (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
-      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_round_pd(static_cast<__m256d>(a),
-                      (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    round, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              double, Experimental::simd_abi::avx2_fixed_size<4>>(
+          _mm256_round_pd(static_cast<__m256d>(a),
+                          (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
-      double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_round_pd(static_cast<__m256d>(a),
-                      (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    trunc, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_round_pd(static_cast<__m256d>(a),
+                              (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-sqrt(Experimental::basic_simd<
-     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_sqrt_pd(static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    sqrt, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_sqrt_pd(static_cast<__m256d>(a))));
+    })
 
 #ifdef KOKKOS_HAVE_INTEL_SVML
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-cbrt(Experimental::basic_simd<
-     double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_cbrt_pd(static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    cbrt, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cbrt_pd(static_cast<__m256d>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-exp(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_exp_pd(static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    exp, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cbrt_pd(static_cast<__m256d>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-log(Experimental::basic_simd<
-    double, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_log_pd(static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    log, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_log_pd(static_cast<__m256d>(a))));
+    })
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-fma(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-    Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
-                      static_cast<__m256d>(c)));
-}
+KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(
+    fma, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_fmadd_pd(static_cast<__m256d>(a), static_cast<__m256d>(b),
+                              static_cast<__m256d>(c))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-max(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_max_pd(static_cast<__m256d>(a), static_cast<__m256d>(b))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-min(Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        double, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_min_pd(static_cast<__m256d>(a), static_cast<__m256d>(b))));
+    })
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(const double* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, double, simd_abi::avx2_fixed_size<4>,
+    { return (basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, flag)); })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, double, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, double, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, double, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<double, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const double* ptr,
-        basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, double, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm256_store_pd(ptr, static_cast<__m256d>(simd));
-  } else {
-    _mm256_storeu_pd(ptr, static_cast<__m256d>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, double, simd_abi::avx2_fixed_size<4>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm256_store_pd(ptr, static_cast<__m256d>(simd));
+      } else {
+        _mm256_storeu_pd(ptr, static_cast<__m256d>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
-                      static_cast<__m256d>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    unchecked, double, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
+                          static_cast<__m256d>(simd));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
-                      static_cast<__m256d>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    partial, double, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
+                          static_cast<__m256d>(simd));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<double, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<double, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<double, simd_abi::avx2_fixed_size<4>>(
-      _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
-                       static_cast<__m256d>(a)));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, double, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<double, simd_abi::avx2_fixed_size<4>>(
+          _mm256_blendv_pd(static_cast<__m256d>(c), static_cast<__m256d>(b),
+                           static_cast<__m256d>(a))));
+    })
 
 template <>
-class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
-  __m128 m_value;
+class basic_simd<float, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_base<
+          basic_simd<float, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m128;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m128)>;
+#endif
+  implementation_type m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m128 const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
-      : m_value(_mm_set1_ps(value_type(value))) {}
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value)
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm_set1_ps(value_type(value)))
+#endif
+  {
+  }
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_setr_ps(gen(std::integral_constant<Impl::simd_size_t, 0>()),
                         gen(std::integral_constant<Impl::simd_size_t, 1>()),
                         gen(std::integral_constant<Impl::simd_size_t, 2>()),
-                        gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm_load_ps(ptr);
-    } else {
-      m_value = _mm_loadu_ps(ptr);
-    }
+                        gen(std::integral_constant<Impl::simd_size_t, 3>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm_load_ps(ptr)
+                : _mm_loadu_ps(ptr))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm_loadu_ps(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm_load_ps(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm_store_ps(ptr, m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const noexcept {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_base<
+      basic_simd<float, simd_abi::avx2_fixed_size<4>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     auto index = _mm_cvtsi32_si128(i);
     auto tmp   = _mm_permutevar_ps(m_value, index);
     return _mm_cvtss_f32(tmp);
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128()
-      const noexcept {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm_add_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm_sub_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return basic_simd(_mm_mul_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_div(T const& rhs) const noexcept {
+    return T(_mm_div_ps(m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_add_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpeq_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_sub_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpneq_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_mul_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpge_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm_div_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return mask_type(_mm_cmple_ps(m_value, rhs.m_value));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpeq_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpgt_ps(m_value, rhs.m_value));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpneq_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpge_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmple_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmpgt_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm_cmplt_ps(lhs.m_value, rhs.m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return mask_type(_mm_cmplt_ps(m_value, rhs.m_value));
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-copysign(Experimental::basic_simd<
-             float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-         Experimental::basic_simd<
-             float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_xor_ps(_mm_andnot_ps(sign_mask, static_cast<__m128>(a)),
-                 _mm_and_ps(sign_mask, static_cast<__m128>(b))));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    copysign, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      __m128 const sign_mask = _mm_set1_ps(-0.0);
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_xor_ps(_mm_andnot_ps(sign_mask, static_cast<__m128>(a)),
+                         _mm_and_ps(sign_mask, static_cast<__m128>(b)))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> abs(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  __m128 const sign_mask = _mm_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_andnot_ps(sign_mask, static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      __m128 const sign_mask = _mm_set1_ps(-0.0);
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_andnot_ps(sign_mask, static_cast<__m128>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_round_ps(static_cast<__m128>(a),
-                   (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    floor, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_round_ps(static_cast<__m128>(a),
+                           (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_round_ps(static_cast<__m128>(a),
-                   (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    ceil, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_round_ps(static_cast<__m128>(a),
+                           (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_round_ps(static_cast<__m128>(a),
-                   (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    round, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_round_ps(static_cast<__m128>(a),
+                           (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_round_ps(static_cast<__m128>(a),
-                   (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    trunc, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (Experimental::basic_simd<
+              float, Experimental::simd_abi::avx2_fixed_size<4>>(_mm_round_ps(
+          static_cast<__m128>(a), (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_sqrt_ps(static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    sqrt, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_sqrt_ps(static_cast<__m128>(a))));
+    })
 
 #ifdef KOKKOS_HAVE_INTEL_SVML
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>>
-cbrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_cbrt_ps(static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    cbrt, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_cbrt_ps(static_cast<__m128>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> exp(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_exp_ps(static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    exp, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_exp_ps(static_cast<__m128>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> log(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_log_ps(static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    log, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_log_ps(static_cast<__m128>(a))));
+    })
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> fma(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
-                   static_cast<__m128>(c)));
-}
+KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(
+    fma, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_fmadd_ps(static_cast<__m128>(a), static_cast<__m128>(b),
+                           static_cast<__m128>(c))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> max(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_max_ps(static_cast<__m128>(a), static_cast<__m128>(b))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<4>> min(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<4>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_min_ps(static_cast<__m128>(a), static_cast<__m128>(b))));
+    })
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(const float* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<4>,
+    { return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, flag)); })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, float, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, float, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm_store_ps(ptr, static_cast<__m128>(simd));
-  } else {
-    _mm_storeu_ps(ptr, static_cast<__m128>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, float, simd_abi::avx2_fixed_size<4>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm_store_ps(ptr, static_cast<__m128>(simd));
+      } else {
+        _mm_storeu_ps(ptr, static_cast<__m128>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
-                   static_cast<__m128>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    unchecked, float, simd_abi::avx2_fixed_size<4>, {
+      _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
+                       static_cast<__m128>(simd));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
-                   static_cast<__m128>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    partial, float, simd_abi::avx2_fixed_size<4>, {
+      _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
+                       static_cast<__m128>(simd));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<float, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<4>>(_mm_blendv_ps(
-      static_cast<__m128>(c), static_cast<__m128>(b), static_cast<__m128>(a)));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, float, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<4>>(
+          _mm_blendv_ps(static_cast<__m128>(c), static_cast<__m128>(b),
+                        static_cast<__m128>(a))));
+    })
 
 template <>
-class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
-  __m256 m_value;
+class basic_simd<float, simd_abi::avx2_fixed_size<8>>
+    : public Impl::basic_simd_base<
+          basic_simd<float, simd_abi::avx2_fixed_size<8>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256)>;
+#endif
+  implementation_type m_value;
 
  public:
   using value_type = float;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 8> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
-      : m_value(_mm256_set1_ps(value_type(value))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256 const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_ps(value_type(value)))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(G&& gen)
-      : m_value(_mm256_setr_ps(
-            gen(std::integral_constant<Impl::simd_size_t, 0>()),
-            gen(std::integral_constant<Impl::simd_size_t, 1>()),
-            gen(std::integral_constant<Impl::simd_size_t, 2>()),
-            gen(std::integral_constant<Impl::simd_size_t, 3>()),
-            gen(std::integral_constant<Impl::simd_size_t, 4>()),
-            gen(std::integral_constant<Impl::simd_size_t, 5>()),
-            gen(std::integral_constant<Impl::simd_size_t, 6>()),
-            gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm256_load_ps(ptr);
-    } else {
-      m_value = _mm256_loadu_ps(ptr);
-    }
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            _mm256_setr_ps(gen(std::integral_constant<Impl::simd_size_t, 0>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 1>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 2>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 3>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 4>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 5>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 6>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 7>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value =
-        _mm256_maskload_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm256_load_ps(ptr)
+                : _mm256_loadu_ps(ptr))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_maskload_ps(
+            ptr, _mm256_castps_si256(static_cast<__m256>(mask))))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_loadu_ps(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_load_ps(ptr);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_storeu_ps(ptr, m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_store_ps(ptr, m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_base<
+      basic_simd<float, simd_abi::avx2_fixed_size<8>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     auto index = _mm256_set1_epi32(i);
     auto tmp   = _mm256_permutevar8x32_ps(m_value, index);
     return _mm256_cvtss_f32(tmp);
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256()
-      const {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm256_add_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm256_sub_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T(_mm256_mul_ps(m_value, rhs.m_value));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_div(T const& rhs) const noexcept {
+    return T(_mm256_div_ps(m_value, rhs.m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_add_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sub_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mul_ps(lhs.m_value, rhs.m_value));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator/(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_div_ps(lhs.m_value, rhs.m_value));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_EQ_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_GE_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_LE_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_GT_OS));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmp_ps(static_cast<__m256>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-copysign(Experimental::basic_simd<
-             float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-         Experimental::basic_simd<
-             float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
-                    _mm256_and_ps(sign_mask, static_cast<__m256>(b))));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    copysign, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      __m256 const sign_mask = _mm256_set1_ps(-0.0);
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_xor_ps(_mm256_andnot_ps(sign_mask, static_cast<__m256>(a)),
+                            _mm256_and_ps(sign_mask, static_cast<__m256>(b)))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> abs(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  __m256 const sign_mask = _mm256_set1_ps(-0.0);
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_andnot_ps(sign_mask, static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      __m256 const sign_mask = _mm256_set1_ps(-0.0);
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_andnot_ps(sign_mask, static_cast<__m256>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-floor(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_round_ps(static_cast<__m256>(a),
-                      (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    floor, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_round_ps(static_cast<__m256>(a),
+                              (_MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-ceil(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_round_ps(static_cast<__m256>(a),
-                      (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    ceil, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_round_ps(static_cast<__m256>(a),
+                              (_MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-round(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_round_ps(static_cast<__m256>(a),
-                      (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    round, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (Experimental::basic_simd<
+              float, Experimental::simd_abi::avx2_fixed_size<8>>(
+          _mm256_round_ps(static_cast<__m256>(a),
+                          (_MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-trunc(Experimental::basic_simd<
-      float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_round_ps(static_cast<__m256>(a),
-                      (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    trunc, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_round_ps(static_cast<__m256>(a),
+                              (_MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-sqrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_sqrt_ps(static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    sqrt, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_sqrt_ps(static_cast<__m256>(a))));
+    })
 
 #ifdef __INTEL_COMPILER
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-cbrt(Experimental::basic_simd<
-     float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_cbrt_ps(static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    cbrt, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_cbrt_ps(static_cast<__m256>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> exp(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_exp_ps(static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    exp, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_exp_ps(static_cast<__m256>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> log(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_log_ps(static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    log, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_log_ps(static_cast<__m256>(a))));
+    })
 
 #endif
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> fma(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& c) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
-                      static_cast<__m256>(c)));
-}
+KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(
+    fma, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_fmadd_ps(static_cast<__m256>(a), static_cast<__m256>(b),
+                              static_cast<__m256>(c))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> max(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    max, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_max_ps(static_cast<__m256>(a), static_cast<__m256>(b))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>> min(
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& a,
-    Experimental::basic_simd<
-        float, Experimental::simd_abi::avx2_fixed_size<8>> const& b) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b)));
-}
+KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(
+    min, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_min_ps(static_cast<__m256>(a), static_cast<__m256>(b))));
+    })
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<8>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(const float* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<8>,
+    { return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, flag)); })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, float, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, float, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<8>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<float, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const float* ptr,
-        basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, float, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm256_store_ps(ptr, static_cast<__m256>(simd));
-  } else {
-    _mm256_storeu_ps(ptr, static_cast<__m256>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, float, simd_abi::avx2_fixed_size<8>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm256_store_ps(ptr, static_cast<__m256>(simd));
+      } else {
+        _mm256_storeu_ps(ptr, static_cast<__m256>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
-  _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
-                      static_cast<__m256>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    unchecked, float, simd_abi::avx2_fixed_size<8>, {
+      _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
+                          static_cast<__m256>(simd));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
-  _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
-                      static_cast<__m256>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    partial, float, simd_abi::avx2_fixed_size<8>, {
+      _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
+                          static_cast<__m256>(simd));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<float, simd_abi::avx2_fixed_size<8>> condition(
-    basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& a,
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& b,
-    basic_simd<float, simd_abi::avx2_fixed_size<8>> const& c) {
-  return basic_simd<float, simd_abi::avx2_fixed_size<8>>(_mm256_blendv_ps(
-      static_cast<__m256>(c), static_cast<__m256>(b), static_cast<__m256>(a)));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, float, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<float, simd_abi::avx2_fixed_size<8>>(
+          _mm256_blendv_ps(static_cast<__m256>(c), static_cast<__m256>(b),
+                           static_cast<__m256>(a))));
+    })
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
-  __m128i m_value;
+class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_base<
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m128i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m128i)>;
+#endif
+  implementation_type m_value;
+  using base_type = Impl::basic_simd_base<
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m128i const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value)
-      : m_value(_mm_set1_epi32(value_type(value))) {}
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value)
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm_set1_epi32(value_type(value)))
+#endif
+  {
+  }
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<double, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      G&& gen) noexcept
-      : m_value(_mm_setr_epi32(
-            gen(std::integral_constant<Impl::simd_size_t, 0>()),
-            gen(std::integral_constant<Impl::simd_size_t, 1>()),
-            gen(std::integral_constant<Impl::simd_size_t, 2>()),
-            gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
-    } else {
-      m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
-    }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            _mm_setr_epi32(gen(std::integral_constant<Impl::simd_size_t, 0>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 1>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 2>()),
+                           gen(std::integral_constant<Impl::simd_size_t, 3>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm_load_si128(reinterpret_cast<__m128i const*>(ptr))
+                : _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr)))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm_maskload_epi32(ptr, static_cast<__m128i>(mask)))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m128i()
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask_type(true)), m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask_type(true)), m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
     return m_value;
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
-    return basic_simd(
-        _mm_andnot_si128(m_value, basic_simd(~value_type(0)).m_value));
-  }
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_base<
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm_extract_epi32(m_value, 0x0);
       case 1: return _mm_extract_epi32(m_value, 0x1);
@@ -1926,131 +2187,147 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_add_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_sub_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_mullo_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_and_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_or_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_xor_si128(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_sllv_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm_srav_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(lhs), rhs));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd(_mm_slli_epi32(static_cast<__m128i>(lhs), rhs));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm_andnot_si128(m_value, T(~value_type(0)).m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmpeq_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm_add_epi32(static_cast<__m128i>(m_value),
+                           static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm_sub_epi32(static_cast<__m128i>(m_value),
+                           static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T(_mm_mullo_epi32(static_cast<__m128i>(m_value),
+                             static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm_and_si128(static_cast<__m128i>(m_value),
+                           static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmplt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(
+        _mm_or_si128(static_cast<__m128i>(m_value), static_cast<__m128i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(
-        _mm_cmpgt_epi32(static_cast<__m128i>(lhs), static_cast<__m128i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm_xor_si128(static_cast<__m128i>(m_value),
+                           static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(T const& rhs) const noexcept {
+    return T(_mm_sllv_epi32(static_cast<__m128i>(m_value),
+                            static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(T const& rhs) const noexcept {
+    return T(_mm_srav_epi32(static_cast<__m128i>(m_value),
+                            static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(int rhs) const noexcept {
+    return T(_mm_slli_epi32(static_cast<__m128i>(m_value), rhs));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(int rhs) const noexcept {
+    return T(_mm_srai_epi32(static_cast<__m128i>(m_value), rhs));
+  }
+
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpeq_epi32(static_cast<__m128i>(m_value),
+                                     static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return mask_type(_mm_cmplt_epi32(static_cast<__m128i>(m_value),
+                                     static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm_cmpgt_epi32(static_cast<__m128i>(m_value),
+                                     static_cast<__m128i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return impl_operator_gt(rhs) || impl_operator_eq(rhs);
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
-    std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  __m128i const rhs = static_cast<__m128i>(a);
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm_abs_epi32(rhs));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      __m128i const rhs = static_cast<__m128i>(a);
+      return (
+          Experimental::basic_simd<std::int32_t,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm_abs_epi32(rhs)));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    floor, double, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cvtepi32_pd(static_cast<__m128i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    ceil, double, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cvtepi32_pd(static_cast<__m128i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    round, double, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cvtepi32_pd(static_cast<__m128i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_cvtepi32_pd(static_cast<__m128i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    trunc, double, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_cvtepi32_pd(static_cast<__m128i>(a))));
+    })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 Experimental::basic_simd<std::int32_t,
@@ -2078,145 +2355,119 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(const std::int32_t* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm_store_si128(reinterpret_cast<__m128i*>(ptr),
-                    static_cast<__m128i>(simd));
-  } else {
-    _mm_storeu_si128(reinterpret_cast<__m128i*>(ptr),
-                     static_cast<__m128i>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<4>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm_store_si128(reinterpret_cast<__m128i*>(ptr),
+                        static_cast<__m128i>(simd));
+      } else {
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(ptr),
+                         static_cast<__m128i>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
-                      static_cast<__m128i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(unchecked, std::int32_t,
+                                         simd_abi::avx2_fixed_size<4>, {
+                                           _mm_maskstore_epi32(
+                                               ptr, static_cast<__m128i>(mask),
+                                               static_cast<__m128i>(simd));
+                                         })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
-                      static_cast<__m128i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(partial, std::int32_t,
+                                         simd_abi::avx2_fixed_size<4>, {
+                                           _mm_maskstore_epi32(
+                                               ptr, static_cast<__m128i>(mask),
+                                               static_cast<__m128i>(simd));
+                                         })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
-      _mm_castps_si128(
-          _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
-                        _mm_castsi128_ps(static_cast<__m128i>(b)),
-                        _mm_castsi128_ps(static_cast<__m128i>(a)))));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, std::int32_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>(
+          _mm_castps_si128(
+              _mm_blendv_ps(_mm_castsi128_ps(static_cast<__m128i>(c)),
+                            _mm_castsi128_ps(static_cast<__m128i>(b)),
+                            _mm_castsi128_ps(static_cast<__m128i>(a))))));
+    })
 
 template <>
-class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
-  __m256i m_value;
+class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
+    : public Impl::basic_simd_base<
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  implementation_type m_value;
+  using base_type = Impl::basic_simd_base<
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
 
  public:
   using value_type = std::int32_t;
   using abi_type   = simd_abi::avx2_fixed_size<8>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 8> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
-      : m_value(_mm256_set1_epi32(value_type(value))) {}
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_epi32(value_type(value)))
+#endif
+  {
+  }
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<float, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi32(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
@@ -2225,25 +2476,67 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 4>()),
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
-            gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr));
-    } else {
-      m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
-    }
+            gen(std::integral_constant<Impl::simd_size_t, 7>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr))
+                : _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr)))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_maskload_epi32(ptr, static_cast<__m256i>(mask)))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class Impl::basic_simd_base<
+      basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
 // _mm256_cvtsi256_si32 was not added in GCC until 11
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
     value_type tmp[size()];
@@ -2256,140 +2549,146 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
-    return basic_simd(
-        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm256_add_epi32(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm256_sub_epi32(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T(_mm256_mullo_epi32(static_cast<__m256i>(m_value),
+                                static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
+                             static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(T const& rhs) const noexcept {
+    return T(_mm256_sllv_epi32(static_cast<__m256i>(m_value),
+                               static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(T const& rhs) const noexcept {
+    return T(_mm256_srav_epi32(static_cast<__m256i>(m_value),
+                               static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
+    return T(_mm256_slli_epi32(static_cast<__m256i>(m_value), rhs));
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
+    return T(_mm256_srai_epi32(static_cast<__m256i>(m_value), rhs));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_epi32(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(lhs),
-                                         static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return impl_operator_gt(rhs) || impl_operator_eq(rhs);
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return impl_operator_lt(rhs) || impl_operator_eq(rhs);
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(lhs), rhs));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs >= rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return !impl_operator_ge(rhs);
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>>
-abs(Experimental::basic_simd<
-    std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  __m256i const rhs = static_cast<__m256i>(a);
-  return Experimental::basic_simd<std::int32_t,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_abs_epi32(rhs));
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      __m256i const rhs = static_cast<__m256i>(a);
+      return (
+          Experimental::basic_simd<std::int32_t,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_abs_epi32(rhs)));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-floor(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    floor, float, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_cvtepi32_ps(static_cast<__m256i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-ceil(Experimental::basic_simd<
-     std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    ceil, float, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_cvtepi32_ps(static_cast<__m256i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-round(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    round, float, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_cvtepi32_ps(static_cast<__m256i>(a))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<float, Experimental::simd_abi::avx2_fixed_size<8>>
-trunc(Experimental::basic_simd<
-      std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>> const& a) {
-  return Experimental::basic_simd<float,
-                                  Experimental::simd_abi::avx2_fixed_size<8>>(
-      _mm256_cvtepi32_ps(static_cast<__m256i>(a)));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    trunc, float, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (
+          Experimental::basic_simd<float,
+                                   Experimental::simd_abi::avx2_fixed_size<8>>(
+              _mm256_cvtepi32_ps(static_cast<__m256i>(a))));
+    })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 Experimental::basic_simd<std::int32_t,
@@ -2417,113 +2716,83 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<8>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(const std::int32_t* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      return (
+          basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<8>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    simd_unchecked_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<8>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
-    simd_partial_load(
-        const std::int32_t* ptr,
-        basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
-                       static_cast<__m256i>(simd));
-  } else {
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
-                        static_cast<__m256i>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, std::int32_t, simd_abi::avx2_fixed_size<8>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
+                           static_cast<__m256i>(simd));
+      } else {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
+                            static_cast<__m256i>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
-    std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(unchecked, std::int32_t,
+                                         simd_abi::avx2_fixed_size<8>, {
+                                           _mm256_maskstore_epi32(
+                                               ptr, static_cast<__m256i>(mask),
+                                               static_cast<__m256i>(simd));
+                                         })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
-    std::int32_t* ptr,
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(partial, std::int32_t,
+                                         simd_abi::avx2_fixed_size<8>, {
+                                           _mm256_maskstore_epi32(
+                                               ptr, static_cast<__m256i>(mask),
+                                               static_cast<__m256i>(simd));
+                                         })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> condition(
-    basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& a,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& b,
-    basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& c) {
-  return basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
-      _mm256_castps_si256(
-          _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
-                           _mm256_castsi256_ps(static_cast<__m256i>(b)),
-                           _mm256_castsi256_ps(static_cast<__m256i>(a)))));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, std::int32_t, Experimental::simd_abi::avx2_fixed_size<8>, {
+      return (basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>(
+          _mm256_castps_si256(
+              _mm256_blendv_ps(_mm256_castsi256_ps(static_cast<__m256i>(c)),
+                               _mm256_castsi256_ps(static_cast<__m256i>(b)),
+                               _mm256_castsi256_ps(static_cast<__m256i>(a))))));
+    })
 
 template <>
-class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
-  __m256i m_value;
+class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_base<
+          basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  implementation_type m_value;
+  using base_type = Impl::basic_simd_base<
+      basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
 
   static_assert(sizeof(long long) == 8);
 
@@ -2532,58 +2801,108 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      __m256i const& value_in) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      implementation const& value_in) noexcept
       : m_value(value_in) {}
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
-      : m_value(_mm256_set1_epi64x(value_type(value))) {}
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_set1_epi64x(value_type(value)))
+#endif
+  {
+  }
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
         })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
-            gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
-    } else {
-      m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
-    }
+            gen(std::integral_constant<Impl::simd_size_t, 3>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr))
+                : _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr)))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                      static_cast<__m256i>(mask)))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class basic_simd_base<
+      basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm256_extract_epi64(m_value, 0x0);
       case 1: return _mm256_extract_epi64(m_value, 0x1);
@@ -2591,106 +2910,114 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       case 3: return _mm256_extract_epi64(m_value, 0x3);
       default: Kokkos::abort("Index out of bound"); break;
     }
-#if defined(KOKKOS_COMPILER_NVCC) && (KOKKOS_COMPILER_NVCC >= 1290) && \
-    defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-    return value_type{};
-#endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
-    return basic_simd(
-        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
-  }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator-() const noexcept {
-    return basic_simd(
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
+    return T(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm256_add_epi64(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm256_sub_epi64(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](Impl::simd_size_t i) { return lhs[i] * rhs[i]; });
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
+                             static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(lhs),
-                                        static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(T const& rhs) const noexcept {
+    return T(_mm256_sllv_epi64(static_cast<__m256i>(m_value),
+                               static_cast<__m256i>(rhs)));
+  }
+  template <typename T = basic_simd>
+  // fallback basic_simd shift right arithmetic using generator constructor
+  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(T const& rhs) const noexcept {
+    return T([&](Impl::simd_size_t i) { return m_value[i] >> rhs[i]; });
+  }
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
+    return T(_mm256_slli_epi64(static_cast<__m256i>(m_value), rhs));
   }
   // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](Impl::simd_size_t i) { return lhs[i] >> rhs[i]; });
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(lhs), rhs));
-  }
-  // fallback basic_simd shift right arithmetic using generator constructor
-  // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return basic_simd([&](Impl::simd_size_t i) { return lhs[i] >> rhs; });
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
+    return T([&](Impl::simd_size_t i) { return m_value[i] >> rhs; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs > rhs) || (lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return impl_operator_gt(rhs) || impl_operator_eq(rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return (lhs < rhs) || (lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return rhs > lhs;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return !impl_operator_ge(rhs);
   }
 };
 
@@ -2698,52 +3025,47 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
 
 // Manually computing absolute values, because _mm256_abs_epi64
 // is not in AVX2; it's available in AVX512.
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
-    std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<std::int64_t,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      [&](Experimental::Impl::simd_size_t i) {
-        return (a[i] < 0) ? -a[i] : a[i];
-      });
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(
+    abs, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<std::int64_t,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              [&](Experimental::Impl::simd_size_t i) {
+                return (a[i] < 0) ? -a[i] : a[i];
+              }));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
-      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    floor, double, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    ceil, double, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
-      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    round, double, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
-      std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    trunc, double, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 Experimental::basic_simd<std::int64_t,
@@ -2773,174 +3095,196 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(const std::int64_t* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(
-        const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
-    simd_partial_load(
-        const std::int64_t* ptr,
-        basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                     flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
-                       static_cast<__m256i>(simd));
-  } else {
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
-                        static_cast<__m256i>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
+                           static_cast<__m256i>(simd));
+      } else {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
+                            static_cast<__m256i>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
-                         static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    unchecked, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
+                             static_cast<__m256i>(mask),
+                             static_cast<__m256i>(simd));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int64_t* ptr,
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
-                         static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    partial, std::int64_t, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
+                             static_cast<__m256i>(mask),
+                             static_cast<__m256i>(simd));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_castpd_si256(
-          _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
-                           _mm256_castsi256_pd(static_cast<__m256i>(b)),
-                           _mm256_castsi256_pd(static_cast<__m256i>(a)))));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, std::int64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>(
+          _mm256_castpd_si256(
+              _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                               _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                               _mm256_castsi256_pd(static_cast<__m256i>(a))))));
+    })
 
 template <>
-class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
-  __m256i m_value;
+class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
+    : public Impl::basic_simd_base<
+          basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>> {
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+  using implementation_type = __m256i;
+#else
+  using implementation_type = Kokkos::Array<char, sizeof(__m256i)>;
+#endif
+  implementation_type m_value;
+  using base_type = Impl::basic_simd_base<
+      basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
 
  public:
   using value_type = std::uint64_t;
   using abi_type   = simd_abi::avx2_fixed_size<4>;
   using mask_type  = basic_simd_mask<value_type, abi_type>;
 
-  static constexpr std::integral_constant<Impl::simd_size_t, 4> size{};
+  static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi64x(
-            Kokkos::bit_cast<std::int64_t>(value_type(value)))) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr basic_simd(
-      __m256i const& value_in) noexcept
+            Kokkos::bit_cast<std::int64_t>(value_type(value))))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd(
+      implementation_type const& value_in) noexcept
       : m_value(value_in) {}
   template <typename U>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit(
+  KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
       basic_simd(basic_simd<U, abi_type> const& other) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
-        })) {}
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+        }))
+#endif
+  {
+  }
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int32_t, abi_type> const& other) noexcept;
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
+  KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::int64_t, abi_type> const& other) noexcept;
   template <class G>
     requires Impl::InvocableWithReturnType<
-        G, value_type, std::integral_constant<Impl::simd_size_t, 0>>
+        G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
-            gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
-    if constexpr (std::is_same_v<FlagType,
-                                 simd_flags<simd_alignment_vector_aligned>>) {
-      m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
-    } else {
-      m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
-    }
+            gen(std::integral_constant<Impl::simd_size_t, 3>())))
+#endif
+  {
   }
   template <typename FlagType>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask));
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(
+            std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
+                ? _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr))
+                : _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr)))
+#endif
+  {
+  }
+  template <typename FlagType>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+      : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                      static_cast<__m256i>(mask)))
+#endif
+  {
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
-  operator[](Impl::simd_size_t i) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       element_aligned_tag) {
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
+                                                       vector_aligned_tag) {
+    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
+                                    static_cast<__m256i>(mask_type(true)));
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
+      value_type* ptr, element_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
+  }
+  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
+                                                     vector_aligned_tag) const {
+    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
+                           static_cast<__m256i>(mask_type(true)), m_value);
+  }
+#endif
+
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
+      const {
+    return m_value;
+  }
+
+#ifdef KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+ private:
+  friend class basic_simd_base<
+      basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>>;
+#endif
+
+  template <typename T = value_type>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm256_extract_epi64(m_value, 0x0);
       case 1: return _mm256_extract_epi64(m_value, 0x1);
@@ -2954,85 +3298,97 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
 #endif
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit operator __m256i()
-      const {
-    return m_value;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
+    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd operator~() const noexcept {
-    return basic_simd(
-        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_plus(T const& rhs) const noexcept {
+    return T(_mm256_add_epi64(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator+(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_add_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
-  }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator-(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_sub_epi64(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_minus(T const& rhs) const noexcept {
+    return T(_mm256_sub_epi64(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator*(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd([&](Impl::simd_size_t i) { return lhs[i] * rhs[i]; });
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_mul(T const& rhs) const noexcept {
+    return T([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator&(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_and_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_band(T const& rhs) const noexcept {
+    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator|(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_or_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_bor(T const& rhs) const noexcept {
+    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
+                             static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator^(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return basic_simd(
-        _mm256_xor_si256(static_cast<__m256i>(lhs), static_cast<__m256i>(rhs)));
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_xor(T const& rhs) const noexcept {
+    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                              static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_sllv_epi64(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(T const& rhs) const noexcept {
+    return _mm256_sllv_epi64(static_cast<__m256i>(m_value),
                              static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return _mm256_srlv_epi64(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sra(T const& rhs) const noexcept
+    requires(!std::is_arithmetic_v<T>)
+  {
+    return _mm256_srlv_epi64(static_cast<__m256i>(m_value),
                              static_cast<__m256i>(rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator<<(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return _mm256_slli_epi64(static_cast<__m256i>(lhs), rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
+    return _mm256_slli_epi64(static_cast<__m256i>(m_value), rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend basic_simd operator>>(
-      basic_simd const& lhs, Impl::simd_size_t rhs) noexcept {
-    return _mm256_srli_epi64(static_cast<__m256i>(lhs), rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  operator_sra(Impl::simd_size_t rhs) const noexcept {
+    return _mm256_srli_epi64(static_cast<__m256i>(m_value), rhs);
   }
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator==(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(lhs),
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_eq(T const& rhs) const noexcept {
+    return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator!=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs == rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ne(T const& rhs) const noexcept {
+    return !impl_operator_eq(rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs < rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_ge(T const& rhs) const noexcept {
+    return !(m_value < rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<=(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return !(lhs > rhs);
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_le(T const& rhs) const noexcept {
+    return !(m_value > rhs);
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator>(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_gt(T const& rhs) const noexcept {
     // We use the following bit trick to compute the unsigned comparison from
     // the signed values since there is no intrinsic for unsigned int comparison
     // in AVX2: (a < 0) ^ (b < 0) ^ (a > b)
@@ -3043,61 +3399,56 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
     // give opposite results (negative values are higher than positive values
     // when interpreting them as unsigned). In that case:
     //  (a < 0) != (b < 0) => (a < 0) ^ (b < 0) = 1, and 1 ^ (a > b) == !(a > b)
-    basic_simd<std::int64_t, abi_type> signed_lhs{static_cast<__m256i>(lhs)};
+    basic_simd<std::int64_t, abi_type> signed_lhs{
+        static_cast<__m256i>(m_value)};
     basic_simd<std::int64_t, abi_type> signed_rhs{static_cast<__m256i>(rhs)};
     return static_cast<mask_type>((signed_lhs < 0) ^ (signed_rhs < 0) ^
                                   (signed_lhs > signed_rhs));
   }
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION friend mask_type operator<(
-      basic_simd const& lhs, basic_simd const& rhs) noexcept {
-    return rhs > lhs;
+  template <typename T = basic_simd>
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
+  impl_operator_lt(T const& rhs) const noexcept {
+    return rhs > m_value;
   }
 };
 
 }  // namespace Experimental
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION Experimental::basic_simd<
-    std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>>
-abs(Experimental::basic_simd<
-    std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return a;
-}
+KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(abs, std::uint64_t,
+                                     Experimental::simd_abi::avx2_fixed_size<4>,
+                                     { return a; })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-floor(Experimental::basic_simd<
-      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    floor, double, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-ceil(Experimental::basic_simd<
-     std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    ceil, double, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-round(Experimental::basic_simd<
-      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    round, double, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-Experimental::basic_simd<double, Experimental::simd_abi::avx2_fixed_size<4>>
-trunc(Experimental::basic_simd<
-      std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>> const& a) {
-  return Experimental::basic_simd<double,
-                                  Experimental::simd_abi::avx2_fixed_size<4>>(
-      _mm256_setr_pd(a[0], a[1], a[2], a[3]));
-}
+KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(
+    trunc, double, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (
+          Experimental::basic_simd<double,
+                                   Experimental::simd_abi::avx2_fixed_size<4>>(
+              _mm256_setr_pd(a[0], a[1], a[2], a[3])));
+    })
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 Experimental::basic_simd<std::uint64_t,
@@ -3127,171 +3478,178 @@ min(Experimental::basic_simd<
 
 namespace Experimental {
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
-    simd_unchecked_load(const std::uint64_t* ptr,
-                        simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(
+    unchecked, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      return (
+          basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    unchecked, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                      flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_unchecked_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    unchecked, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                      flag));
+    })
 
-template <typename... Flags>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(
+    partial, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                      flag));
+    })
 
-template <typename SimdType, typename... Flags>
-  requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<std::uint64_t,
-                                                 simd_abi::avx2_fixed_size<4>>
-simd_partial_load(
-    const std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    simd_flags<Flags...> flag = simd_flag_default) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
-                                                                 flag);
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(
+    partial, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(ptr, mask,
+                                                                      flag));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
-                               simd_flags<simd_alignment_vector_aligned>>) {
-    _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
-                       static_cast<__m256i>(simd));
-  } else {
-    _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
-                        static_cast<__m256i>(simd));
-  }
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(
+    unchecked, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      if constexpr (std::is_same_v<decltype(flag),
+                                   simd_flags<simd_alignment_vector_aligned>>) {
+        _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
+                           static_cast<__m256i>(simd));
+      } else {
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(ptr),
+                            static_cast<__m256i>(simd));
+      }
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
-                         static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    unchecked, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
+                             static_cast<__m256i>(mask),
+                             static_cast<__m256i>(simd));
+    })
 
-template <typename FlagType>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::uint64_t* ptr,
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
-  _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
-                         static_cast<__m256i>(mask),
-                         static_cast<__m256i>(simd));
-}
+KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(
+    partial, std::uint64_t, simd_abi::avx2_fixed_size<4>, {
+      _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
+                             static_cast<__m256i>(mask),
+                             static_cast<__m256i>(simd));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> condition(
-    basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& a,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& b,
-    basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& c) {
-  return basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
-      _mm256_castpd_si256(
-          _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
-                           _mm256_castsi256_pd(static_cast<__m256i>(b)),
-                           _mm256_castsi256_pd(static_cast<__m256i>(a)))));
-}
+KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
+    condition, std::uint64_t, Experimental::simd_abi::avx2_fixed_size<4>, {
+      return (basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>(
+          _mm256_castpd_si256(
+              _mm256_blendv_pd(_mm256_castsi256_pd(static_cast<__m256i>(c)),
+                               _mm256_castsi256_pd(static_cast<__m256i>(b)),
+                               _mm256_castsi256_pd(static_cast<__m256i>(a))))));
+    })
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<float, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtps_pd(static_cast<__m128>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<double, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtpd_ps(static_cast<__m256d>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtpd_ps(static_cast<__m256d>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>>::basic_simd(
     basic_simd<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<float, abi_type> const& other) noexcept
-    : m_value(_mm_cvtps_epi32(static_cast<__m128>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm_cvtps_epi32(static_cast<__m128>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<double, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtpd_epi32(static_cast<__m256d>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtpd_epi32(static_cast<__m256d>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd(
     basic_simd<float, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::uint64_t, abi_type> const& other) noexcept
-    : m_value(static_cast<__m256i>(other)) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(static_cast<__m256i>(other))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int32_t, abi_type> const& other) noexcept
-    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other))) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
+#endif
+{
+}
 
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
     basic_simd<std::int64_t, abi_type> const& other) noexcept
-    : m_value(static_cast<__m256i>(other)) {}
+#ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
+    : m_value(static_cast<__m256i>(other))
+#endif
+{
+}
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::avx2_fixed_size<4>, {

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -103,53 +103,47 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm256_movemask_pd(m_value) & (1 << i)) != 0;
   }
 
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_pd(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_pd(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm256_and_pd(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_pd(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm256_or_pd(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_pd(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_pd(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_pd(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_pd(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_pd(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_pd(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_xor_pd(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm256_movemask_pd(m_value) == _mm256_movemask_pd(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_movemask_pd(m_value) ==
+                           _mm256_movemask_pd(rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -224,52 +218,46 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm_movemask_ps(m_value) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm_andnot_ps(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm_andnot_ps(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm_and_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_and_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm_or_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_or_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm_and_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_and_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm_or_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_or_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm_xor_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_xor_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm_movemask_ps(m_value) == _mm_movemask_ps(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_movemask_ps(m_value) ==
+                           _mm_movemask_ps(rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -347,52 +335,46 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm256_movemask_ps(m_value) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_ps(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_ps(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm256_and_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm256_or_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_xor_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm256_movemask_ps(m_value) == _mm256_movemask_ps(rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_movemask_ps(m_value) ==
+                           _mm256_movemask_ps(rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -465,53 +447,46 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm_movemask_ps(_mm_castsi128_ps(m_value)) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm_andnot_si128(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm_andnot_si128(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm_and_si128(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_and_si128(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm_or_si128(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_or_si128(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm_and_si128(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_and_si128(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm_or_si128(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_or_si128(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm_xor_si128(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_xor_si128(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
-             _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm_movemask_ps(_mm_castsi128_ps(m_value)) ==
+                           _mm_movemask_ps(_mm_castsi128_ps(rhs.m_value)));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -588,53 +563,47 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_xor_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
-             _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_ps(_mm256_castsi256_ps(m_value)) ==
+        _mm256_movemask_ps(_mm256_castsi256_ps(rhs.m_value)));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return impl_operator_eq(rhs).impl_operator_lnot();
   }
 #endif
@@ -711,53 +680,47 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_xor_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
-             _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -834,53 +797,47 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     return (_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) & (1 << i)) != 0;
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_lnot() const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lnot() const noexcept {
     return impl_operator_bnot();
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(true).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bnot() const noexcept {
+    return basic_simd_mask(
+        _mm256_andnot_si256(m_value, basic_simd_mask(true).m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_lor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_lor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_land(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_land(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_band(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_and_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_bor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_or_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_xor(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(_mm256_xor_si256(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_eq(T const& rhs) const noexcept {
-    return T(_mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
-             _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_eq(basic_simd_mask const& rhs) const noexcept {
+    return basic_simd_mask(
+        _mm256_movemask_pd(_mm256_castsi256_pd(m_value)) ==
+        _mm256_movemask_pd(_mm256_castsi256_pd(rhs.m_value)));
   }
-  template <typename T = basic_simd_mask>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_ne(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask
+  impl_operator_ne(basic_simd_mask const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
 #endif
@@ -1113,77 +1070,67 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     value_type tmp[size()];
     _mm256_storeu_pd(tmp, m_value);
     return tmp[i];
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(_mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(
+        _mm256_sub_pd(_mm256_set1_pd(0.0), static_cast<__m256d>(m_value)));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm256_add_pd(static_cast<__m256d>(m_value),
-                           static_cast<__m256d>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_add_pd(static_cast<__m256d>(m_value),
+                                    static_cast<__m256d>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm256_sub_pd(static_cast<__m256d>(m_value),
-                           static_cast<__m256d>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sub_pd(static_cast<__m256d>(m_value),
+                                    static_cast<__m256d>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T(_mm256_mul_pd(static_cast<__m256d>(m_value),
-                           static_cast<__m256d>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_mul_pd(static_cast<__m256d>(m_value),
+                                    static_cast<__m256d>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_div(T const& rhs) const noexcept {
-    return T(_mm256_div_pd(static_cast<__m256d>(m_value),
-                           static_cast<__m256d>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_div(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_div_pd(static_cast<__m256d>(m_value),
+                                    static_cast<__m256d>(rhs)));
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_EQ_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_NEQ_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_GE_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_LE_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_GT_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_pd(static_cast<__m256d>(m_value),
                                    static_cast<__m256d>(rhs), _CMP_LT_OS));
   }
@@ -1456,68 +1403,57 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     auto index = _mm_cvtsi32_si128(i);
     auto tmp   = _mm_permutevar_ps(m_value, index);
     return _mm_cvtss_f32(tmp);
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(_mm_sub_ps(_mm_set1_ps(0.0), m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm_add_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_add_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm_sub_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_sub_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
     return basic_simd(_mm_mul_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_div(T const& rhs) const noexcept {
-    return T(_mm_div_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_div(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_div_ps(m_value, rhs.m_value));
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpeq_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpneq_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpge_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmple_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpgt_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmplt_ps(m_value, rhs.m_value));
   }
 #endif
@@ -1787,73 +1723,62 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     auto index = _mm256_set1_epi32(i);
     auto tmp   = _mm256_permutevar8x32_ps(m_value, index);
     return _mm256_cvtss_f32(tmp);
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(_mm256_sub_ps(_mm256_set1_ps(0.0), m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm256_add_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_add_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm256_sub_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sub_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T(_mm256_mul_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_mul_ps(m_value, rhs.m_value));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_div(T const& rhs) const noexcept {
-    return T(_mm256_div_ps(m_value, rhs.m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_div(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_div_ps(m_value, rhs.m_value));
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_EQ_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_NEQ_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_GE_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_LE_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_GT_OS));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmp_ps(static_cast<__m256>(m_value),
                                    static_cast<__m256>(rhs), _CMP_LT_OS));
   }
@@ -2125,8 +2050,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm_extract_epi32(m_value, 0x0);
@@ -2142,105 +2066,91 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
 #endif
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(_mm_sub_epi32(_mm_set1_epi32(0), static_cast<__m128i>(m_value)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(
+        _mm_sub_epi32(_mm_set1_epi32(0), static_cast<__m128i>(m_value)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm_andnot_si128(m_value, T(~value_type(0)).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bnot() const noexcept {
+    return basic_simd(
+        _mm_andnot_si128(m_value, basic_simd(~value_type(0)).m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm_add_epi32(static_cast<__m128i>(m_value),
-                           static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_add_epi32(static_cast<__m128i>(m_value),
+                                    static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm_sub_epi32(static_cast<__m128i>(m_value),
-                           static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_sub_epi32(static_cast<__m128i>(m_value),
+                                    static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T(_mm_mullo_epi32(static_cast<__m128i>(m_value),
-                             static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_mullo_epi32(static_cast<__m128i>(m_value),
+                                      static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm_and_si128(static_cast<__m128i>(m_value),
-                           static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_band(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_and_si128(static_cast<__m128i>(m_value),
+                                    static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bor(basic_simd const& rhs) const noexcept {
+    return basic_simd(
         _mm_or_si128(static_cast<__m128i>(m_value), static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm_xor_si128(static_cast<__m128i>(m_value),
-                           static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_xor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_xor_si128(static_cast<__m128i>(m_value),
+                                    static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sll(T const& rhs) const noexcept {
-    return T(_mm_sllv_epi32(static_cast<__m128i>(m_value),
-                            static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sll(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_sllv_epi32(static_cast<__m128i>(m_value),
+                                     static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sra(T const& rhs) const noexcept {
-    return T(_mm_srav_epi32(static_cast<__m128i>(m_value),
-                            static_cast<__m128i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sra(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm_srav_epi32(static_cast<__m128i>(m_value),
+                                     static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sll(int rhs) const noexcept {
-    return T(_mm_slli_epi32(static_cast<__m128i>(m_value), rhs));
+    return basic_simd(_mm_slli_epi32(static_cast<__m128i>(m_value), rhs));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sra(int rhs) const noexcept {
-    return T(_mm_srai_epi32(static_cast<__m128i>(m_value), rhs));
+    return basic_simd(_mm_srai_epi32(static_cast<__m128i>(m_value), rhs));
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpeq_epi32(static_cast<__m128i>(m_value),
                                      static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmplt_epi32(static_cast<__m128i>(m_value),
                                      static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm_cmpgt_epi32(static_cast<__m128i>(m_value),
                                      static_cast<__m128i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return impl_operator_gt(rhs) || impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
 #endif
@@ -2467,8 +2377,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
 // _mm256_cvtsi256_si32 was not added in GCC until 11
 #if defined(KOKKOS_COMPILER_GNU) && (KOKKOS_COMPILER_GNU < 1100)
@@ -2482,105 +2391,90 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
 #endif
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(
         _mm256_sub_epi32(_mm256_set1_epi32(0), static_cast<__m256i>(m_value)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bnot() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm256_add_epi32(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_add_epi32(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm256_sub_epi32(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sub_epi32(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T(_mm256_mullo_epi32(static_cast<__m256i>(m_value),
-                                static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_mullo_epi32(static_cast<__m256i>(m_value),
+                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_band(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_and_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
-                             static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_or_si256(static_cast<__m256i>(m_value),
+                                      static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_xor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sll(T const& rhs) const noexcept {
-    return T(_mm256_sllv_epi32(static_cast<__m256i>(m_value),
-                               static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sll(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sllv_epi32(static_cast<__m256i>(m_value),
+                                        static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sra(T const& rhs) const noexcept {
-    return T(_mm256_srav_epi32(static_cast<__m256i>(m_value),
-                               static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sra(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_srav_epi32(static_cast<__m256i>(m_value),
+                                        static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
-    return T(_mm256_slli_epi32(static_cast<__m256i>(m_value), rhs));
+    return basic_simd(_mm256_slli_epi32(static_cast<__m256i>(m_value), rhs));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
-    return T(_mm256_srai_epi32(static_cast<__m256i>(m_value), rhs));
+    return basic_simd(_mm256_srai_epi32(static_cast<__m256i>(m_value), rhs));
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmpeq_epi32(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return impl_operator_gt(rhs) || impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmpgt_epi32(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return !impl_operator_ge(rhs);
   }
 #endif
@@ -2806,8 +2700,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm256_extract_epi64(m_value, 0x0);
@@ -2818,110 +2711,96 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     }
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(
         _mm256_sub_epi64(_mm256_set1_epi64x(0), static_cast<__m256i>(m_value)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bnot() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm256_add_epi64(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_add_epi64(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm256_sub_epi64(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sub_epi64(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit signed integers is not available in AVX2
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_band(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_and_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
-                             static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_or_si256(static_cast<__m256i>(m_value),
+                                      static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_xor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sll(T const& rhs) const noexcept {
-    return T(_mm256_sllv_epi64(static_cast<__m256i>(m_value),
-                               static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sll(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sllv_epi64(static_cast<__m256i>(m_value),
+                                        static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sra(T const& rhs) const noexcept {
-    return T([&](Impl::simd_size_t i) { return m_value[i] >> rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sra(basic_simd const& rhs) const noexcept {
+    return basic_simd(
+        [&](Impl::simd_size_t i) { return m_value[i] >> rhs[i]; });
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
-    return T(_mm256_slli_epi64(static_cast<__m256i>(m_value), rhs));
+    return basic_simd(_mm256_slli_epi64(static_cast<__m256i>(m_value), rhs));
   }
   // fallback basic_simd shift right arithmetic using generator constructor
   // Shift right arithmetic for 64bit packed ints is not availalbe in AVX2
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
-    return T([&](Impl::simd_size_t i) { return m_value[i] >> rhs; });
+    return basic_simd([&](Impl::simd_size_t i) { return m_value[i] >> rhs; });
   }
 
   // AVX2 only has eq and gt comparisons for int64
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return impl_operator_gt(rhs) || impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return impl_operator_lt(rhs) || impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmpgt_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return !impl_operator_ge(rhs);
   }
 #endif
@@ -3155,8 +3034,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 #endif
 
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
-  template <typename T = value_type>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION value_type
   impl_subscript_operator(Impl::simd_size_t i) const {
     switch (i) {
       case 0: return _mm256_extract_epi64(m_value, 0x0);
@@ -3171,99 +3049,85 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 #endif
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_neg() const noexcept {
-    return T(~value_type(0)) - m_value;
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_neg() const noexcept {
+    return basic_simd(~value_type(0)) - m_value;
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T impl_operator_bnot() const noexcept {
-    return T(_mm256_andnot_si256(m_value, T(~value_type(0)).m_value));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bnot() const noexcept {
+    return basic_simd(
+        _mm256_andnot_si256(m_value, basic_simd(~value_type(0)).m_value));
   }
 
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_plus(T const& rhs) const noexcept {
-    return T(_mm256_add_epi64(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_plus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_add_epi64(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_minus(T const& rhs) const noexcept {
-    return T(_mm256_sub_epi64(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_minus(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_sub_epi64(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
   // fallback basic_simd multiplication using generator constructor
   // multiplying vectors of 64-bit unsigned integers is not available in AVX2
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_mul(T const& rhs) const noexcept {
-    return T([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_mul(basic_simd const& rhs) const noexcept {
+    return basic_simd([&](Impl::simd_size_t i) { return m_value[i] * rhs[i]; });
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_band(T const& rhs) const noexcept {
-    return T(_mm256_and_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_band(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_and_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_bor(T const& rhs) const noexcept {
-    return T(_mm256_or_si256(static_cast<__m256i>(m_value),
-                             static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_bor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_or_si256(static_cast<__m256i>(m_value),
+                                      static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_xor(T const& rhs) const noexcept {
-    return T(_mm256_xor_si256(static_cast<__m256i>(m_value),
-                              static_cast<__m256i>(rhs)));
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_xor(basic_simd const& rhs) const noexcept {
+    return basic_simd(_mm256_xor_si256(static_cast<__m256i>(m_value),
+                                       static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sll(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sll(basic_simd const& rhs) const noexcept {
     return _mm256_sllv_epi64(static_cast<__m256i>(m_value),
                              static_cast<__m256i>(rhs));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
-  impl_operator_sra(T const& rhs) const noexcept {
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
+  impl_operator_sra(basic_simd const& rhs) const noexcept {
     return _mm256_srlv_epi64(static_cast<__m256i>(m_value),
                              static_cast<__m256i>(rhs));
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sll(Impl::simd_size_t rhs) const noexcept {
     return _mm256_slli_epi64(static_cast<__m256i>(m_value), rhs);
   }
-  template <typename T = basic_simd>
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T
+  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd
   impl_operator_sra(Impl::simd_size_t rhs) const noexcept {
     return _mm256_srli_epi64(static_cast<__m256i>(m_value), rhs);
   }
 
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_eq(T const& rhs) const noexcept {
+  impl_operator_eq(basic_simd const& rhs) const noexcept {
     return mask_type(_mm256_cmpeq_epi64(static_cast<__m256i>(m_value),
                                         static_cast<__m256i>(rhs)));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ne(T const& rhs) const noexcept {
+  impl_operator_ne(basic_simd const& rhs) const noexcept {
     return !impl_operator_eq(rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_ge(T const& rhs) const noexcept {
+  impl_operator_ge(basic_simd const& rhs) const noexcept {
     return !(m_value < rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_le(T const& rhs) const noexcept {
+  impl_operator_le(basic_simd const& rhs) const noexcept {
     return !(m_value > rhs);
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_gt(T const& rhs) const noexcept {
+  impl_operator_gt(basic_simd const& rhs) const noexcept {
     // We use the following bit trick to compute the unsigned comparison from
     // the signed values since there is no intrinsic for unsigned int comparison
     // in AVX2: (a < 0) ^ (b < 0) ^ (a > b)
@@ -3280,9 +3144,8 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     return static_cast<mask_type>((signed_lhs < 0) ^ (signed_rhs < 0) ^
                                   (signed_lhs > signed_rhs));
   }
-  template <typename T = basic_simd>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION mask_type
-  impl_operator_lt(T const& rhs) const noexcept {
+  impl_operator_lt(basic_simd const& rhs) const noexcept {
     return rhs > m_value;
   }
 #endif

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -48,7 +48,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
 
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
@@ -169,7 +169,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
 
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
@@ -283,7 +283,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
@@ -400,7 +400,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
@@ -512,7 +512,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
@@ -629,7 +629,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
@@ -746,7 +746,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
       [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
@@ -997,7 +997,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
@@ -1331,7 +1331,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       implementation_type const& value_in) noexcept
       : m_value(value_in) {}
@@ -1649,7 +1649,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
@@ -1978,7 +1978,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       implementation_type const& value_in) noexcept
       : m_value(value_in) {}
@@ -2303,7 +2303,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 8> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       implementation_type const& value_in) noexcept
       : m_value(value_in) {}
@@ -2627,7 +2627,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       implementation_type const& value_in) noexcept
       : m_value(value_in) {}
@@ -2956,7 +2956,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 
   static constexpr Kokkos::Impl::integral_constant<Impl::simd_size_t, 4> size{};
 
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd() noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION basic_simd() noexcept = default;
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -50,7 +50,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
 
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_pd(_mm256_set1_epi64x(-std::int64_t(value))))
 #endif
@@ -78,7 +78,7 @@ class basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_pd(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -174,7 +174,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
 
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+     [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_castsi128_ps(_mm_set1_epi32(-std::int32_t(value))))
 #endif
@@ -196,7 +196,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_castsi128_ps(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -290,7 +290,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+     [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_ps(_mm256_set1_epi32(-std::int32_t(value))))
 #endif
@@ -312,7 +312,7 @@ class basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_castsi256_ps(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -410,7 +410,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_set1_epi32(-std::int32_t(value)))
 #endif
@@ -432,7 +432,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -526,7 +526,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi32(-std::int32_t(value)))
 #endif
@@ -548,7 +548,7 @@ class basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi32(
             -std::int32_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -646,7 +646,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
 #endif
@@ -672,7 +672,7 @@ class basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -766,7 +766,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 
   KOKKOS_FORCEINLINE_FUNCTION basic_simd_mask() noexcept = default;
   KOKKOS_FORCEINLINE_FUNCTION explicit basic_simd_mask(
-      value_type value) noexcept
+      [[maybe_unused]] value_type value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi64x(-std::int64_t(value)))
 #endif
@@ -792,7 +792,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd_mask(
-      G&& gen) noexcept
+      [[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             -std::int64_t(gen(std::integral_constant<Impl::simd_size_t, 0>())),
@@ -867,7 +867,7 @@ class basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtps_pd(static_cast<__m128>(other)))
 #endif
@@ -876,7 +876,7 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other)))
 #endif
@@ -885,7 +885,7 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
 #endif
@@ -894,7 +894,7 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_pd(static_cast<__m256i>(other)))
 #endif
@@ -903,7 +903,7 @@ basic_simd_mask<double, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other)))
 #endif
@@ -912,7 +912,7 @@ basic_simd_mask<float, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castsi256_ps(static_cast<__m256i>(other)))
 #endif
@@ -921,7 +921,7 @@ basic_simd_mask<float, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm_castps_si128(static_cast<__m128>(other)))
 #endif
@@ -930,7 +930,7 @@ basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
-    basic_simd_mask<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castps_si256(static_cast<__m256>(other)))
 #endif
@@ -939,7 +939,7 @@ basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -948,7 +948,7 @@ basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<double, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<double, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castpd_si256(static_cast<__m256d>(other)))
 #endif
@@ -957,7 +957,7 @@ basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::uint64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif
@@ -966,7 +966,7 @@ basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -975,7 +975,7 @@ basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<double, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<double, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_castpd_si256(static_cast<__m256d>(other)))
 #endif
@@ -984,7 +984,7 @@ basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd_mask(
-    basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd_mask<std::int64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif
@@ -1013,7 +1013,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_pd(value_type(value)))
 #endif
@@ -1037,7 +1037,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm256_setr_pd(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -1049,7 +1049,7 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -1060,36 +1060,13 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_pd(
             ptr, _mm256_castpd_si256(static_cast<__m256d>(mask))))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_loadu_pd(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_load_pd(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_storeu_pd(ptr, m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_store_pd(ptr, m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
@@ -1378,7 +1355,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value)
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_set1_ps(value_type(value)))
 #endif
@@ -1399,7 +1376,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_setr_ps(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -1411,7 +1388,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -1422,36 +1399,13 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask))))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm_loadu_ps(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm_load_ps(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm_storeu_ps(ptr, m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm_store_ps(ptr, m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const noexcept {
@@ -1723,7 +1677,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_ps(value_type(value)))
 #endif
@@ -1745,7 +1699,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(G&& gen)
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] G&& gen)
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm256_setr_ps(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -1761,7 +1715,7 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -1772,36 +1726,13 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_ps(
             ptr, _mm256_castps_si256(static_cast<__m256>(mask))))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_loadu_ps(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_load_ps(ptr);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_storeu_ps(ptr, m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_store_ps(ptr, m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
@@ -2085,7 +2016,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value)
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value)
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_set1_epi32(value_type(value)))
 #endif
@@ -2106,7 +2037,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             _mm_setr_epi32(gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2118,7 +2049,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -2129,35 +2060,12 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm_maskload_epi32(ptr, static_cast<__m128i>(mask)))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask_type(true)), m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask_type(true)), m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
@@ -2443,7 +2351,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi32(value_type(value)))
 #endif
@@ -2462,7 +2370,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi32(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2478,7 +2386,7 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -2489,35 +2397,12 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi32(ptr, static_cast<__m256i>(mask)))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask_type(true)), m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
@@ -2801,7 +2686,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi64x(value_type(value)))
 #endif
@@ -2822,7 +2707,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -2834,7 +2719,7 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -2845,40 +2730,13 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
-                           static_cast<__m256i>(mask_type(true)), m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
-                           static_cast<__m256i>(mask_type(true)), m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
@@ -3164,7 +3022,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   template <class U>
     requires std::convertible_to<U, value_type>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION basic_simd(U&& value) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd([[maybe_unused]] U&& value) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_set1_epi64x(
             Kokkos::bit_cast<std::int64_t>(value_type(value))))
@@ -3177,7 +3035,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   template <typename U>
   KOKKOS_FORCEINLINE_FUNCTION explicit(
       Impl::needs_explicit_conversion_v<U, value_type>)
-      basic_simd(basic_simd<U, abi_type> const& other) noexcept
+      basic_simd([[maybe_unused]] basic_simd<U, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(basic_simd([&](Impl::simd_size_t i) {
           return static_cast<value_type>(other[i]);
@@ -3193,7 +3051,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
     requires Impl::InvocableWithReturnType<
         G, value_type, Kokkos::Impl::integral_constant<Impl::simd_size_t, 0>>
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd([[maybe_unused]] G&& gen) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_setr_epi64x(
             gen(std::integral_constant<Impl::simd_size_t, 0>()),
@@ -3205,7 +3063,7 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(
             std::is_same_v<FlagType, simd_flags<simd_alignment_vector_aligned>>
@@ -3216,40 +3074,13 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>
   }
   template <typename FlagType>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      [[maybe_unused]] const value_type* ptr, mask_type const& mask, FlagType) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
       : m_value(_mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                       static_cast<__m256i>(mask)))
 #endif
   {
   }
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       element_aligned_tag) {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_load() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_from(value_type const* ptr,
-                                                       vector_aligned_tag) {
-    m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
-                                    static_cast<__m256i>(mask_type(true)));
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(
-      value_type* ptr, element_aligned_tag) const {
-    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
-                           static_cast<__m256i>(mask_type(true)), m_value);
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use simd_unchecked_store() instead")
-  KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void copy_to(value_type* ptr,
-                                                     vector_aligned_tag) const {
-    _mm256_maskstore_epi64(reinterpret_cast<long long*>(ptr),
-                           static_cast<__m256i>(mask_type(true)), m_value);
-  }
-#endif
 
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit operator implementation_type()
       const {
@@ -3517,7 +3348,7 @@ KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtps_pd(static_cast<__m128>(other)))
 #endif
@@ -3526,7 +3357,7 @@ basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_pd(static_cast<__m128i>(other)))
 #endif
@@ -3535,7 +3366,7 @@ basic_simd<double, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<double, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<double, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtpd_ps(static_cast<__m256d>(other)))
 #endif
@@ -3544,7 +3375,7 @@ basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm_cvtepi32_ps(static_cast<__m128i>(other)))
 #endif
@@ -3553,7 +3384,7 @@ basic_simd<float, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<float, simd_abi::avx2_fixed_size<8>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_ps(static_cast<__m256i>(other)))
 #endif
@@ -3562,7 +3393,7 @@ basic_simd<float, simd_abi::avx2_fixed_size<8>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm_cvtps_epi32(static_cast<__m128>(other)))
 #endif
@@ -3571,7 +3402,7 @@ basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<double, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<double, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtpd_epi32(static_cast<__m256d>(other)))
 #endif
@@ -3580,7 +3411,7 @@ basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd(
-    basic_simd<float, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<float, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtps_epi32(static_cast<__m256>(other)))
 #endif
@@ -3589,7 +3420,7 @@ basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -3598,7 +3429,7 @@ basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::uint64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::uint64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif
@@ -3607,7 +3438,7 @@ basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int32_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int32_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(_mm256_cvtepi32_epi64(static_cast<__m128i>(other)))
 #endif
@@ -3616,7 +3447,7 @@ basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
 
 KOKKOS_FORCEINLINE_FUNCTION
 basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>>::basic_simd(
-    basic_simd<std::int64_t, abi_type> const& other) noexcept
+    [[maybe_unused]] basic_simd<std::int64_t, abi_type> const& other) noexcept
 #ifndef KOKKOS_SIMD_IMPL_DEVICE_SIMD
     : m_value(static_cast<__m256i>(other))
 #endif

--- a/simd/src/Kokkos_SIMD_Base.hpp
+++ b/simd/src/Kokkos_SIMD_Base.hpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_SIMD_BASE_HPP
+#define KOKKOS_SIMD_BASE_HPP
+
+#include <Kokkos_SIMD_Common.hpp>
+#include "impl/Kokkos_SIMD_Impl_Macros.hpp"
+
+#ifdef KOKKOS_SIMD_COMMON_MATH_HPP
+#error \
+    "Kokkos_SIMD_Base.hpp must be included before Kokkos_SIMD_Common_Math.hpp!"
+#endif
+
+namespace Kokkos {
+namespace Experimental {
+namespace Impl {
+
+template <typename Derived>
+class basic_simd_mask_base {
+ public:
+  KOKKOS_SIMD_IMPL_SUBSCRIPT_OPERATOR([], subscript_operator, Impl::simd_size_t)
+
+  KOKKOS_SIMD_IMPL_UNARY_OPERATOR(!, operator_lnot)
+  KOKKOS_SIMD_IMPL_UNARY_OPERATOR(~, operator_bnot)
+
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(&&, operator_land, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(||, operator_lor, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(&, operator_band, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(|, operator_bor, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(^, operator_xor, Derived const&,
+                                   Derived const&)
+
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(&=, operator_bandeq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(|=, operator_boreq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(^=, operator_xoreq,
+                                                Derived const&)
+
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(==, operator_eq, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(!=, operator_ne, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(>=, operator_ge, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(<=, operator_le, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(>, operator_gt, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(<, operator_lt, Derived const&)
+};
+
+template <typename Derived>
+class basic_simd_base {
+ public:
+  KOKKOS_SIMD_IMPL_SUBSCRIPT_OPERATOR([], subscript_operator, Impl::simd_size_t)
+
+  KOKKOS_SIMD_IMPL_UNARY_OPERATOR(-, operator_neg)
+  KOKKOS_SIMD_IMPL_UNARY_OPERATOR(~, operator_bnot)
+
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(+, operator_plus, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(-, operator_minus, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(*, operator_mul, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(/, operator_div, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(&, operator_band, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(|, operator_bor, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(^, operator_xor, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(<<, operator_sll, Derived const&,
+                                   Impl::simd_size_t)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(<<, operator_sll, Derived const&,
+                                   Derived const&)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(>>, operator_sra, Derived const&,
+                                   Impl::simd_size_t)
+  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(>>, operator_sra, Derived const&,
+                                   Derived const&)
+
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(+=, operator_pluseq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(-=, operator_minuseq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(*=, operator_muleq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(/=, operator_diveq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(&=, operator_bandeq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(|=, operator_boreq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(^=, operator_xoreq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(<<=, operator_slleq,
+                                                Derived const&)
+  KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(>>=, operator_sraeq,
+                                                Derived const&)
+
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(==, operator_eq, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(!=, operator_ne, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(>=, operator_ge, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(<=, operator_le, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(>, operator_gt, Derived const&)
+  KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(<, operator_lt, Derived const&)
+};
+
+}  // namespace Impl
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif

--- a/simd/src/Kokkos_SIMD_Base.hpp
+++ b/simd/src/Kokkos_SIMD_Base.hpp
@@ -12,9 +12,7 @@
     "Kokkos_SIMD_Base.hpp must be included before Kokkos_SIMD_Common_Math.hpp!"
 #endif
 
-namespace Kokkos {
-namespace Experimental {
-namespace Impl {
+namespace Kokkos::Experimental::Impl {
 
 template <typename Derived>
 class basic_simd_mask_base {
@@ -108,8 +106,6 @@ class basic_simd_base {
   KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(<, operator_lt, Derived const&)
 };
 
-}  // namespace Impl
-}  // namespace Experimental
-}  // namespace Kokkos
+}  // namespace Kokkos::Experimental::Impl
 
 #endif

--- a/simd/src/Kokkos_SIMD_Base.hpp
+++ b/simd/src/Kokkos_SIMD_Base.hpp
@@ -5,7 +5,7 @@
 #define KOKKOS_SIMD_BASE_HPP
 
 #include <Kokkos_SIMD_Common.hpp>
-#include "impl/Kokkos_SIMD_Impl_Macros.hpp"
+#include <impl/Kokkos_SIMD_Impl_Macros.hpp>
 
 #ifdef KOKKOS_SIMD_COMMON_MATH_HPP
 #error \
@@ -71,13 +71,13 @@ class basic_simd_base {
   KOKKOS_SIMD_IMPL_BINARY_OPERATOR(^, operator_xor, Derived const&,
                                    Derived const&)
   KOKKOS_SIMD_IMPL_BINARY_OPERATOR(<<, operator_sll, Derived const&,
-                                   Impl::simd_size_t)
-  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(<<, operator_sll, Derived const&,
                                    Derived const&)
   KOKKOS_SIMD_IMPL_BINARY_OPERATOR(>>, operator_sra, Derived const&,
-                                   Impl::simd_size_t)
-  KOKKOS_SIMD_IMPL_BINARY_OPERATOR(>>, operator_sra, Derived const&,
                                    Derived const&)
+  KOKKOS_SIMD_IMPL_SHIFT_SCALAR_OPERATOR(<<, operator_sll, Derived const&,
+                                         Impl::simd_size_t)
+  KOKKOS_SIMD_IMPL_SHIFT_SCALAR_OPERATOR(>>, operator_sra, Derived const&,
+                                         Impl::simd_size_t)
 
   KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(+=, operator_pluseq,
                                                 Derived const&)
@@ -97,6 +97,12 @@ class basic_simd_base {
                                                 Derived const&)
   KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(>>=, operator_sraeq,
                                                 Derived const&)
+  KOKKOS_SIMD_IMPL_SHIFT_SCALAR_ASSIGN_OPERATOR(<<=, operator_slleq,
+                                                Derived const&,
+                                                Impl::simd_size_t)
+  KOKKOS_SIMD_IMPL_SHIFT_SCALAR_ASSIGN_OPERATOR(>>=, operator_sraeq,
+                                                Derived const&,
+                                                Impl::simd_size_t)
 
   KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(==, operator_eq, Derived const&)
   KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(!=, operator_ne, Derived const&)

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -10,7 +10,9 @@ import kokkos.core;
 import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
+#include <impl/Kokkos_Utilities.hpp>
 #endif
+
 #include <impl/Kokkos_SIMD_Impl_Macros.hpp>
 #include <impl/Kokkos_SIMD_RangesCtorSupport.hpp>
 #include <cstdint>
@@ -18,6 +20,19 @@ import kokkos.core_impl;
 #include <functional>
 #include <utility>
 #include <type_traits>
+
+#if (defined(__GNUC__) && __GNUC__ >= 13) || \
+    (defined(__clang__) && __clang_major__ >= 16)
+#define KOKKOS_IMPL_FRIEND_BASE_ACCESS_RESTRICTION
+#endif
+
+// FIXME Temporary flag to identify which simd types have not yet been modified
+// to be device constructible. To be removed when the rest of simd types are
+// device constructible
+#if defined(KOKKOS_ARCH_AVX512XEON) || defined(KOKKOS_ARCH_ARM_SVE) || \
+    defined(KOKKOS_ARCH_ARM_NEON)
+#define KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+#endif
 
 namespace Kokkos {
 
@@ -145,157 +160,265 @@ concept SimdIntegral = SimdVecType<V> && std::integral<typename V::value_type>;
 // operator@=(basic_simd<T, Abi>&, U&&)
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator+(Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] + rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator+(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator+(U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs + rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) +
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator+=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator+=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs + std::forward<U>(rhs);
   return lhs;
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator-(Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] - rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator-(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator-(U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs - rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) -
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator-=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator-=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs - std::forward<U>(rhs);
   return lhs;
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator*(Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] * rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator*(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator*(U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs * rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) *
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator*=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator*=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs * std::forward<U>(rhs);
   return lhs;
 }
 
 template <std::integral T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::basic_simd<T, Abi> const& lhs,
-    Experimental::basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator/(Experimental::basic_simd<T, Abi> const& lhs,
+              Experimental::basic_simd<T, Abi> const& rhs) {
   return Experimental::basic_simd<T, Abi>(
       [&](Impl::simd_size_t i) { return lhs[i] / rhs[i]; });
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator/(Experimental::basic_simd<T, Abi> const& lhs, U rhs) {
   using result_member = decltype(lhs[0] / rhs);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, Impl::Arithmetic U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto operator/(
-    U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    auto
+    operator/(U lhs, Experimental::basic_simd<T, Abi> const& rhs) {
   using result_member = decltype(lhs / rhs[0]);
   return Experimental::basic_simd<result_member, Abi>(lhs) /
          Experimental::basic_simd<result_member, Abi>(rhs);
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator/=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator/=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs / std::forward<U>(rhs);
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator&=(
-    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd_mask<T, Abi>&
+    operator&=(basic_simd_mask<T, Abi>& lhs,
+               basic_simd_mask<T, Abi> const& rhs) {
   lhs = lhs & rhs;
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator|=(
-    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd_mask<T, Abi>&
+    operator|=(basic_simd_mask<T, Abi>& lhs,
+               basic_simd_mask<T, Abi> const& rhs) {
   lhs = lhs | rhs;
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd_mask<T, Abi>& operator^=(
-    basic_simd_mask<T, Abi>& lhs, basic_simd_mask<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd_mask<T, Abi>&
+    operator^=(basic_simd_mask<T, Abi>& lhs,
+               basic_simd_mask<T, Abi> const& rhs) {
   lhs = lhs ^ rhs;
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator&=(
-    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator&=(basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
   lhs = lhs & rhs;
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator|=(
-    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator|=(basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
   lhs = lhs | rhs;
   return lhs;
 }
 
 template <class T, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator^=(
-    basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator^=(basic_simd<T, Abi>& lhs, basic_simd<T, Abi> const& rhs) {
   lhs = lhs ^ rhs;
   return lhs;
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator>>=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator>>=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs >> std::forward<U>(rhs);
   return lhs;
 }
 
 template <class T, class U, Impl::NonScalarAbi Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION basic_simd<T, Abi>& operator<<=(
-    basic_simd<T, Abi>& lhs, U&& rhs) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    basic_simd<T, Abi>&
+    operator<<=(basic_simd<T, Abi>& lhs, U&& rhs) {
   lhs = lhs << std::forward<U>(rhs);
   return lhs;
 }
@@ -312,8 +435,13 @@ KOKKOS_FORCEINLINE_FUNCTION bool none_of(bool a) { return !a; }
 // fallback implementations of reductions across basic_simd_mask:
 
 template <class T, class Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
-    basic_simd_mask<T, Abi> const& a) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    bool
+    all_of(basic_simd_mask<T, Abi> const& a) {
   for (Impl::simd_size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
     if (!a[i]) return false;
   }
@@ -321,8 +449,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool all_of(
 }
 
 template <class T, class Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
-    basic_simd_mask<T, Abi> const& a) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    bool
+    any_of(basic_simd_mask<T, Abi> const& a) {
   for (Impl::simd_size_t i = 0; i < basic_simd_mask<T, Abi>::size(); ++i) {
     if (a[i]) return true;
   }
@@ -330,8 +463,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool any_of(
 }
 
 template <class T, class Abi>
-KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION bool none_of(
-    basic_simd_mask<T, Abi> const& a) {
+#ifdef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
+KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
+#else
+KOKKOS_INLINE_FUNCTION
+#endif
+    bool
+    none_of(basic_simd_mask<T, Abi> const& a) {
   return !any_of(a);
 }
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -9,6 +9,7 @@
 #include <cfloat>
 
 #include <Kokkos_SIMD_Common.hpp>
+#include <Kokkos_SIMD_Base.hpp>
 
 #ifdef KOKKOS_SIMD_COMMON_MATH_HPP
 #error \
@@ -26,7 +27,8 @@ class scalar {};
 
 template <class T>
 class basic_simd_mask<T, simd_abi::scalar> {
-  bool m_value;
+  using implementation_type = bool;
+  implementation_type m_value;
 
  public:
   using value_type = bool;
@@ -163,7 +165,8 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr bool none_of(
 
 template <class T>
 class basic_simd<T, simd_abi::scalar> {
-  T m_value;
+  using implementation_type = T;
+  implementation_type m_value;
 
  public:
   using value_type = T;

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -190,7 +190,8 @@
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
       R&& in, const I& indices,                                           \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
-    EXPR                                                                  \
+    KOKKOS_IF_ON_HOST((EXPR))                                             \
+    KOKKOS_IF_ON_DEVICE((return V{};))                                    \
   }
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(DATA_TYPE,      \
@@ -212,7 +213,8 @@
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
       R&& in, const typename I::mask_type& mask, const I& indices,        \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
-    EXPR                                                                  \
+    KOKKOS_IF_ON_HOST((EXPR))                                             \
+    KOKKOS_IF_ON_DEVICE((return V{};))                                    \
   }
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(      \
@@ -234,7 +236,7 @@
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
       const V& v, R&& out, const I& indices,                                \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
-    EXPR                                                                    \
+    KOKKOS_IF_ON_HOST((EXPR))                                               \
   }
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(DATA_TYPE,      \
@@ -256,7 +258,7 @@
       const V& v, R&& out, const typename I::mask_type& mask,               \
       const I& indices,                                                     \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
-    EXPR                                                                    \
+    KOKKOS_IF_ON_HOST((EXPR))                                               \
   }
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(      \

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -12,120 +12,169 @@
 #define KOKKOS_SIMD_IMPL_DEVICE_SIMD
 #endif
 
-#define KOKKOS_SIMD_IMPL_UNARY_OPERATOR(OP, FN_NAME)                      \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP() const noexcept \
-    requires requires(Derived d) {                                        \
-      { d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)() };                     \
-    }                                                                     \
-  {                                                                       \
-    KOKKOS_IF_ON_HOST((return static_cast<Derived const*>(this)           \
-                           ->KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)();))  \
-    KOKKOS_IF_ON_DEVICE((return Derived{};))                              \
+#define KOKKOS_SIMD_IMPL_UNARY_OPERATOR(OP, FN_NAME)                           \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP() const noexcept {    \
+    KOKKOS_IF_ON_HOST((if constexpr (requires(Derived d) {                     \
+                                       d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(        \
+                                           FN_NAME)();                         \
+                                     }) {                                      \
+      return static_cast<Derived const*>(this)->KOKKOS_SIMD_IMPL_FN_PREFIX_FN( \
+          FN_NAME)();                                                          \
+    }))                                                                        \
+    return Derived{};                                                          \
   }
 
-#define KOKKOS_SIMD_IMPL_SUBSCRIPT_OPERATOR(OP, FN_NAME, ARG_TYPE)           \
-  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP(ARG_TYPE arg) const \
-    requires requires(Derived d) {                                           \
-      { d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(arg) };                     \
-    }                                                                        \
-  {                                                                          \
-    KOKKOS_IF_ON_HOST((return static_cast<Derived const*>(this)              \
-                           ->KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(arg);))  \
-    KOKKOS_IF_ON_DEVICE((return typename Derived::value_type{};))            \
+#define KOKKOS_SIMD_IMPL_SUBSCRIPT_OPERATOR(OP, FN_NAME, ARG_TYPE)             \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP(                      \
+      [[maybe_unused]] ARG_TYPE arg) const {                                   \
+    KOKKOS_IF_ON_HOST((if constexpr (requires(Derived d) {                     \
+                                       d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(        \
+                                           FN_NAME)(arg);                      \
+                                     }) {                                      \
+      return static_cast<Derived const*>(this)->KOKKOS_SIMD_IMPL_FN_PREFIX_FN( \
+          FN_NAME)(arg);                                                       \
+    }))                                                                        \
+    return typename Derived::value_type{};                                     \
   }
 
 #define KOKKOS_SIMD_IMPL_BINARY_OPERATOR(OP, FN_NAME, ARG_TYPE1, ARG_TYPE2) \
   KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(            \
-      ARG_TYPE1 lhs, ARG_TYPE2 rhs) noexcept                                \
-    requires requires {                                                     \
-      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                  \
-    }                                                                       \
-  {                                                                         \
-    KOKKOS_IF_ON_HOST(                                                      \
-        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))          \
-    KOKKOS_IF_ON_DEVICE((return Derived{};))                                \
+      [[maybe_unused]] ARG_TYPE1 lhs,                                       \
+      [[maybe_unused]] ARG_TYPE2 rhs) noexcept {                            \
+    KOKKOS_IF_ON_HOST((                                                     \
+        if constexpr (requires {                                            \
+                        lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);    \
+                      }) {                                                  \
+          return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);           \
+        } else {                                                            \
+          return Derived([&](simd_size_t i) { return lhs[i] OP rhs[i]; });  \
+        }))                                                                 \
+    return Derived{};                                                       \
   }
 
-#define KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(OP, FN_NAME, ARG_TYPE) \
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto& operator OP(            \
-      ARG_TYPE lhs, ARG_TYPE rhs) noexcept                                   \
-    requires requires {                                                      \
-      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                   \
-    }                                                                        \
-  {                                                                          \
-    KOKKOS_IF_ON_HOST(                                                       \
-        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))           \
-    KOKKOS_IF_ON_DEVICE((return Derived{};))                                 \
+#define KOKKOS_SIMD_IMPL_SHIFT_SCALAR_OPERATOR(OP, FN_NAME, ARG_TYPE1,   \
+                                               ARG_TYPE2)                \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(         \
+      [[maybe_unused]] ARG_TYPE1 lhs,                                    \
+      [[maybe_unused]] ARG_TYPE2 rhs) noexcept {                         \
+    KOKKOS_IF_ON_HOST((                                                  \
+        if constexpr (requires {                                         \
+                        lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs); \
+                      }) {                                               \
+          return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);        \
+        } else {                                                         \
+          return Derived([&](simd_size_t i) { return lhs[i] OP rhs; });  \
+        }))                                                              \
+    return Derived{};                                                    \
   }
 
-#define KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(OP, FN_NAME, ARG_TYPE)         \
-  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(            \
-      ARG_TYPE lhs, ARG_TYPE rhs) noexcept                                  \
-    requires requires {                                                     \
-      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                  \
-    }                                                                       \
-  {                                                                         \
-    KOKKOS_IF_ON_HOST(                                                      \
-        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))          \
-    KOKKOS_IF_ON_DEVICE((                                                   \
-        if constexpr (std::is_same_v<typename Derived::value_type, bool>) { \
-          return Derived{};                                                 \
-        } else { return typename Derived::mask_type{}; }))                  \
+#define KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(OP, FN_NAME, ARG_TYPE)   \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto& operator OP(              \
+      [[maybe_unused]] ARG_TYPE lhs, [[maybe_unused]] ARG_TYPE rhs) noexcept { \
+    KOKKOS_IF_ON_HOST((                                                        \
+        if constexpr (requires {                                               \
+                        lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);       \
+                      }) {                                                     \
+          return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);              \
+        } else {                                                               \
+          lhs = lhs OP rhs;                                                    \
+          return lhs;                                                          \
+        }))                                                                    \
+    return Derived{};                                                          \
   }
 
-#define KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
-                                             EXPR)                         \
-  KOKKOS_FORCEINLINE_FUNCTION                                              \
-  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                   \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a) noexcept {   \
-    KOKKOS_IF_ON_HOST((EXPR))                                              \
-    KOKKOS_IF_ON_DEVICE(                                                   \
-        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
+#define KOKKOS_SIMD_IMPL_SHIFT_SCALAR_ASSIGN_OPERATOR(OP, FN_NAME, ARG_TYPE1, \
+                                                      ARG_TYPE2)              \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(              \
+      [[maybe_unused]] ARG_TYPE1 lhs,                                         \
+      [[maybe_unused]] ARG_TYPE2 rhs) noexcept {                              \
+    KOKKOS_IF_ON_HOST((                                                       \
+        if constexpr (requires {                                              \
+                        lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);      \
+                      }) {                                                    \
+          return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);             \
+        } else {                                                              \
+          lhs = lhs OP std::forward<ARG_TYPE2>(rhs);                          \
+          return lhs;                                                         \
+        }))                                                                   \
+    return Derived{};                                                         \
+  }
+
+#define KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(OP, FN_NAME, ARG_TYPE)            \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(               \
+      [[maybe_unused]] ARG_TYPE lhs, [[maybe_unused]] ARG_TYPE rhs) noexcept { \
+    KOKKOS_IF_ON_HOST((if constexpr (requires {                                \
+                                       lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(      \
+                                           FN_NAME)(rhs);                      \
+                                     }) {                                      \
+      return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);                  \
+    }))                                                                        \
+    if constexpr (std::is_same_v<typename Derived::value_type, bool>) {        \
+      return Derived{};                                                        \
+    } else {                                                                   \
+      return typename Derived::mask_type{};                                    \
+    }                                                                          \
+  }
+
+#define KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE,  \
+                                             EXPR)                          \
+  KOKKOS_FORCEINLINE_FUNCTION                                               \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                    \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& \
+          a) noexcept {                                                     \
+    KOKKOS_IF_ON_HOST((EXPR))                                               \
+    KOKKOS_IF_ON_DEVICE(                                                    \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))          \
   }
 
 #define KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(FN_NAME, RETURN_DATA_TYPE,          \
                                            INPUT_DATA_TYPE, ABI_TYPE, EXPR)    \
   KOKKOS_FORCEINLINE_FUNCTION                                                  \
   Experimental::basic_simd<RETURN_DATA_TYPE, ABI_TYPE> FN_NAME(                \
-      Experimental::basic_simd<INPUT_DATA_TYPE, ABI_TYPE> const& a) noexcept { \
+      [[maybe_unused]] Experimental::basic_simd<INPUT_DATA_TYPE,               \
+                                                ABI_TYPE> const& a) noexcept { \
     KOKKOS_IF_ON_HOST((EXPR))                                                  \
     KOKKOS_IF_ON_DEVICE(                                                       \
         (return Experimental::basic_simd<RETURN_DATA_TYPE, ABI_TYPE>{};))      \
   }
 
-#define KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
-                                              EXPR)                         \
-  KOKKOS_FORCEINLINE_FUNCTION                                               \
-  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                    \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a,               \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b) noexcept {    \
-    KOKKOS_IF_ON_HOST((EXPR))                                               \
-    KOKKOS_IF_ON_DEVICE(                                                    \
-        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))          \
+#define KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE,    \
+                                              EXPR)                            \
+  KOKKOS_FORCEINLINE_FUNCTION                                                  \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                       \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a, \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const&    \
+          b) noexcept {                                                        \
+    KOKKOS_IF_ON_HOST((EXPR))                                                  \
+    KOKKOS_IF_ON_DEVICE(                                                       \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))             \
   }
 
-#define KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, \
-                                                     ABI_TYPE, EXPR)     \
-  KOKKOS_FORCEINLINE_FUNCTION                                            \
-  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                 \
-      Experimental::basic_simd_mask<DATA_TYPE, ABI_TYPE> const& a,       \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b,            \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& c) noexcept { \
-    KOKKOS_IF_ON_HOST((EXPR))                                            \
-    KOKKOS_IF_ON_DEVICE(                                                 \
-        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))       \
+#define KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE,       \
+                                                     ABI_TYPE, EXPR)           \
+  KOKKOS_FORCEINLINE_FUNCTION                                                  \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                       \
+      [[maybe_unused]] Experimental::basic_simd_mask<DATA_TYPE,                \
+                                                     ABI_TYPE> const& a,       \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b, \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const&    \
+          c) noexcept {                                                        \
+    KOKKOS_IF_ON_HOST((EXPR))                                                  \
+    KOKKOS_IF_ON_DEVICE(                                                       \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))             \
   }
 
-#define KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
-                                               EXPR)                         \
-  KOKKOS_FORCEINLINE_FUNCTION                                                \
-  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                     \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a,                \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b,                \
-      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& c) noexcept {     \
-    KOKKOS_IF_ON_HOST((EXPR))                                                \
-    KOKKOS_IF_ON_DEVICE(                                                     \
-        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))           \
+#define KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE,   \
+                                               EXPR)                           \
+  KOKKOS_FORCEINLINE_FUNCTION                                                  \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                       \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a, \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b, \
+      [[maybe_unused]] Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const&    \
+          c) noexcept {                                                        \
+    KOKKOS_IF_ON_HOST((EXPR))                                                  \
+    KOKKOS_IF_ON_DEVICE(                                                       \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))             \
   }
 
 #define KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(PREFIX, DATA_TYPE, ABI_TYPE, \
@@ -133,8 +182,9 @@
   template <typename SimdType, typename... Flags>                            \
     requires std::same_as<typename SimdType::abi_type, ABI_TYPE>             \
   KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
-      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
-                           simd_flags<Flags...> flag = simd_flag_default) {  \
+      simd_##PREFIX##_load(                                                  \
+          [[maybe_unused]] const DATA_TYPE* ptr,                             \
+          [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {  \
     KOKKOS_IF_ON_HOST((EXPR))                                                \
     KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
   }
@@ -143,9 +193,10 @@
                                                 EXPR)                        \
   template <typename... Flags>                                               \
   KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
-      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
-                           basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
-                           simd_flags<Flags...> flag = simd_flag_default) {  \
+      simd_##PREFIX##_load(                                                  \
+          [[maybe_unused]] const DATA_TYPE* ptr,                             \
+          [[maybe_unused]] basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
+          [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {  \
     KOKKOS_IF_ON_HOST((EXPR))                                                \
     KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
   }
@@ -155,9 +206,10 @@
   template <typename SimdType, typename... Flags>                            \
     requires std::same_as<typename SimdType::abi_type, ABI_TYPE>             \
   KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
-      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
-                           basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
-                           simd_flags<Flags...> flag = simd_flag_default) {  \
+      simd_##PREFIX##_load(                                                  \
+          [[maybe_unused]] const DATA_TYPE* ptr,                             \
+          [[maybe_unused]] basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
+          [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {  \
     KOKKOS_IF_ON_HOST((EXPR))                                                \
     KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
   }
@@ -166,7 +218,8 @@
                                                  EXPR)                        \
   template <typename... Flags>                                                \
   KOKKOS_FORCEINLINE_FUNCTION void simd_##PREFIX##_store(                     \
-      basic_simd<DATA_TYPE, ABI_TYPE> const& simd, DATA_TYPE* ptr,            \
+      [[maybe_unused]] basic_simd<DATA_TYPE, ABI_TYPE> const& simd,           \
+      [[maybe_unused]] DATA_TYPE* ptr,                                        \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {       \
     KOKKOS_IF_ON_HOST((EXPR))                                                 \
   }
@@ -175,8 +228,9 @@
                                                  EXPR)                        \
   template <typename... Flags>                                                \
   KOKKOS_FORCEINLINE_FUNCTION void simd_##PREFIX##_store(                     \
-      basic_simd<DATA_TYPE, ABI_TYPE> const& simd, DATA_TYPE* ptr,            \
-      basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask,                       \
+      [[maybe_unused]] basic_simd<DATA_TYPE, ABI_TYPE> const& simd,           \
+      [[maybe_unused]] DATA_TYPE* ptr,                                        \
+      [[maybe_unused]] basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask,      \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {       \
     KOKKOS_IF_ON_HOST((EXPR))                                                 \
   }
@@ -188,7 +242,7 @@
     requires Impl::Ranges::sized_range<R> &&                              \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
-      R&& in, const I& indices,                                           \
+      [[maybe_unused]] R&& in, [[maybe_unused]] const I& indices,         \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
     KOKKOS_IF_ON_HOST((EXPR))                                             \
     KOKKOS_IF_ON_DEVICE((return V{};))                                    \
@@ -211,7 +265,9 @@
     requires Impl::Ranges::sized_range<R> &&                              \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
-      R&& in, const typename I::mask_type& mask, const I& indices,        \
+      [[maybe_unused]] R&& in,                                            \
+      [[maybe_unused]] const typename I::mask_type& mask,                 \
+      [[maybe_unused]] const I& indices,                                  \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {   \
     KOKKOS_IF_ON_HOST((EXPR))                                             \
     KOKKOS_IF_ON_DEVICE((return V{};))                                    \
@@ -234,7 +290,8 @@
     requires Impl::Ranges::sized_range<R> &&                                \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
-      const V& v, R&& out, const I& indices,                                \
+      [[maybe_unused]] const V& v, [[maybe_unused]] R&& out,                \
+      [[maybe_unused]] const I& indices,                                    \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
     KOKKOS_IF_ON_HOST((EXPR))                                               \
   }
@@ -255,8 +312,9 @@
     requires Impl::Ranges::sized_range<R> &&                                \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
-      const V& v, R&& out, const typename I::mask_type& mask,               \
-      const I& indices,                                                     \
+      [[maybe_unused]] const V& v, [[maybe_unused]] R&& out,                \
+      [[maybe_unused]] const typename I::mask_type& mask,                   \
+      [[maybe_unused]] const I& indices,                                    \
       [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {     \
     KOKKOS_IF_ON_HOST((EXPR))                                               \
   }

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -49,7 +49,7 @@
         } else {                                                            \
           return Derived([&](simd_size_t i) { return lhs[i] OP rhs[i]; });  \
         }))                                                                 \
-    return Derived{};                                                       \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                                \
   }
 
 #define KOKKOS_SIMD_IMPL_SHIFT_SCALAR_OPERATOR(OP, FN_NAME, ARG_TYPE1,   \
@@ -65,7 +65,7 @@
         } else {                                                         \
           return Derived([&](simd_size_t i) { return lhs[i] OP rhs; });  \
         }))                                                              \
-    return Derived{};                                                    \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                             \
   }
 
 #define KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(OP, FN_NAME, ARG_TYPE)   \
@@ -80,7 +80,7 @@
           lhs = lhs OP rhs;                                                    \
           return lhs;                                                          \
         }))                                                                    \
-    return Derived{};                                                          \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                                   \
   }
 
 #define KOKKOS_SIMD_IMPL_SHIFT_SCALAR_ASSIGN_OPERATOR(OP, FN_NAME, ARG_TYPE1, \
@@ -97,7 +97,7 @@
           lhs = lhs OP std::forward<ARG_TYPE2>(rhs);                          \
           return lhs;                                                         \
         }))                                                                   \
-    return Derived{};                                                         \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                                  \
   }
 
 #define KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(OP, FN_NAME, ARG_TYPE)            \

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -4,6 +4,183 @@
 #ifndef KOKKOS_SIMD_IMPL_MACROS_HPP
 #define KOKKOS_SIMD_IMPL_MACROS_HPP
 
+#define KOKKOS_SIMD_IMPL_FN_PREFIX_FN(fn) impl_##fn
+
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(__CUDA_ARCH__)) ||         \
+    (defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)) || \
+    (defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
+#define KOKKOS_SIMD_IMPL_DEVICE_SIMD
+#endif
+
+#define KOKKOS_SIMD_IMPL_UNARY_OPERATOR(OP, FN_NAME)                      \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP() const noexcept \
+    requires requires(Derived d) {                                        \
+      { d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)() };                     \
+    }                                                                     \
+  {                                                                       \
+    KOKKOS_IF_ON_HOST((return static_cast<Derived const*>(this)           \
+                           ->KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)();))  \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                              \
+  }
+
+#define KOKKOS_SIMD_IMPL_SUBSCRIPT_OPERATOR(OP, FN_NAME, ARG_TYPE)           \
+  KOKKOS_FORCEINLINE_FUNCTION constexpr auto operator OP(ARG_TYPE arg) const \
+    requires requires(Derived d) {                                           \
+      { d.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(arg) };                     \
+    }                                                                        \
+  {                                                                          \
+    KOKKOS_IF_ON_HOST((return static_cast<Derived const*>(this)              \
+                           ->KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(arg);))  \
+    KOKKOS_IF_ON_DEVICE((return typename Derived::value_type{};))            \
+  }
+
+#define KOKKOS_SIMD_IMPL_BINARY_OPERATOR(OP, FN_NAME, ARG_TYPE1, ARG_TYPE2) \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(            \
+      ARG_TYPE1 lhs, ARG_TYPE2 rhs) noexcept                                \
+    requires requires {                                                     \
+      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                  \
+    }                                                                       \
+  {                                                                         \
+    KOKKOS_IF_ON_HOST(                                                      \
+        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))          \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                                \
+  }
+
+#define KOKKOS_SIMD_IMPL_COMPOUND_ASSIGNMENT_OPERATOR(OP, FN_NAME, ARG_TYPE) \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto& operator OP(            \
+      ARG_TYPE lhs, ARG_TYPE rhs) noexcept                                   \
+    requires requires {                                                      \
+      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                   \
+    }                                                                        \
+  {                                                                          \
+    KOKKOS_IF_ON_HOST(                                                       \
+        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))           \
+    KOKKOS_IF_ON_DEVICE((return Derived{};))                                 \
+  }
+
+#define KOKKOS_SIMD_IMPL_COMPARISON_OPERATOR(OP, FN_NAME, ARG_TYPE)         \
+  KOKKOS_FORCEINLINE_FUNCTION friend constexpr auto operator OP(            \
+      ARG_TYPE lhs, ARG_TYPE rhs) noexcept                                  \
+    requires requires {                                                     \
+      { lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs) };                  \
+    }                                                                       \
+  {                                                                         \
+    KOKKOS_IF_ON_HOST(                                                      \
+        (return lhs.KOKKOS_SIMD_IMPL_FN_PREFIX_FN(FN_NAME)(rhs);))          \
+    KOKKOS_IF_ON_DEVICE((                                                   \
+        if constexpr (std::is_same_v<typename Derived::value_type, bool>) { \
+          return Derived{};                                                 \
+        } else { return typename Derived::mask_type{}; }))                  \
+  }
+
+#define KOKKOS_SIMD_IMPL_UNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
+                                             EXPR)                         \
+  KOKKOS_FORCEINLINE_FUNCTION                                              \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                   \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a) noexcept {   \
+    KOKKOS_IF_ON_HOST((EXPR))                                              \
+    KOKKOS_IF_ON_DEVICE(                                                   \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
+  }
+
+#define KOKKOS_SIMD_IMPL_ROUNDING_FUNCTION(FN_NAME, RETURN_DATA_TYPE,          \
+                                           INPUT_DATA_TYPE, ABI_TYPE, EXPR)    \
+  KOKKOS_FORCEINLINE_FUNCTION                                                  \
+  Experimental::basic_simd<RETURN_DATA_TYPE, ABI_TYPE> FN_NAME(                \
+      Experimental::basic_simd<INPUT_DATA_TYPE, ABI_TYPE> const& a) noexcept { \
+    KOKKOS_IF_ON_HOST((EXPR))                                                  \
+    KOKKOS_IF_ON_DEVICE(                                                       \
+        (return Experimental::basic_simd<RETURN_DATA_TYPE, ABI_TYPE>{};))      \
+  }
+
+#define KOKKOS_SIMD_IMPL_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
+                                              EXPR)                         \
+  KOKKOS_FORCEINLINE_FUNCTION                                               \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                    \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a,               \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b) noexcept {    \
+    KOKKOS_IF_ON_HOST((EXPR))                                               \
+    KOKKOS_IF_ON_DEVICE(                                                    \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))          \
+  }
+
+#define KOKKOS_SIMD_IMPL_MASKED_BINARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, \
+                                                     ABI_TYPE, EXPR)     \
+  KOKKOS_FORCEINLINE_FUNCTION                                            \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                 \
+      Experimental::basic_simd_mask<DATA_TYPE, ABI_TYPE> const& a,       \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b,            \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& c) noexcept { \
+    KOKKOS_IF_ON_HOST((EXPR))                                            \
+    KOKKOS_IF_ON_DEVICE(                                                 \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))       \
+  }
+
+#define KOKKOS_SIMD_IMPL_TERNARY_MATH_FUNCTION(FN_NAME, DATA_TYPE, ABI_TYPE, \
+                                               EXPR)                         \
+  KOKKOS_FORCEINLINE_FUNCTION                                                \
+  Experimental::basic_simd<DATA_TYPE, ABI_TYPE> FN_NAME(                     \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& a,                \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& b,                \
+      Experimental::basic_simd<DATA_TYPE, ABI_TYPE> const& c) noexcept {     \
+    KOKKOS_IF_ON_HOST((EXPR))                                                \
+    KOKKOS_IF_ON_DEVICE(                                                     \
+        (return Experimental::basic_simd<DATA_TYPE, ABI_TYPE>{};))           \
+  }
+
+#define KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_LOAD(PREFIX, DATA_TYPE, ABI_TYPE, \
+                                                EXPR)                        \
+  template <typename SimdType, typename... Flags>                            \
+    requires std::same_as<typename SimdType::abi_type, ABI_TYPE>             \
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
+      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
+                           simd_flags<Flags...> flag = simd_flag_default) {  \
+    KOKKOS_IF_ON_HOST((EXPR))                                                \
+    KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
+  }
+
+#define KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_LOAD(PREFIX, DATA_TYPE, ABI_TYPE, \
+                                                EXPR)                        \
+  template <typename... Flags>                                               \
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
+      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
+                           basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
+                           simd_flags<Flags...> flag = simd_flag_default) {  \
+    KOKKOS_IF_ON_HOST((EXPR))                                                \
+    KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
+  }
+
+#define KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_NATIVE_LOAD(PREFIX, DATA_TYPE,    \
+                                                       ABI_TYPE, EXPR)       \
+  template <typename SimdType, typename... Flags>                            \
+    requires std::same_as<typename SimdType::abi_type, ABI_TYPE>             \
+  KOKKOS_FORCEINLINE_FUNCTION basic_simd<DATA_TYPE, ABI_TYPE>                \
+      simd_##PREFIX##_load(const DATA_TYPE* ptr,                             \
+                           basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask, \
+                           simd_flags<Flags...> flag = simd_flag_default) {  \
+    KOKKOS_IF_ON_HOST((EXPR))                                                \
+    KOKKOS_IF_ON_DEVICE((return basic_simd<DATA_TYPE, ABI_TYPE>{};))         \
+  }
+
+#define KOKKOS_SIMD_IMPL_LOAD_STORE_NATIVE_STORE(PREFIX, DATA_TYPE, ABI_TYPE, \
+                                                 EXPR)                        \
+  template <typename... Flags>                                                \
+  KOKKOS_FORCEINLINE_FUNCTION void simd_##PREFIX##_store(                     \
+      basic_simd<DATA_TYPE, ABI_TYPE> const& simd, DATA_TYPE* ptr,            \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {       \
+    KOKKOS_IF_ON_HOST((EXPR))                                                 \
+  }
+
+#define KOKKOS_SIMD_IMPL_LOAD_STORE_MASKED_STORE(PREFIX, DATA_TYPE, ABI_TYPE, \
+                                                 EXPR)                        \
+  template <typename... Flags>                                                \
+  KOKKOS_FORCEINLINE_FUNCTION void simd_##PREFIX##_store(                     \
+      basic_simd<DATA_TYPE, ABI_TYPE> const& simd, DATA_TYPE* ptr,            \
+      basic_simd_mask<DATA_TYPE, ABI_TYPE> const& mask,                       \
+      [[maybe_unused]] simd_flags<Flags...> flag = simd_flag_default) {       \
+    KOKKOS_IF_ON_HOST((EXPR))                                                 \
+  }
+
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE,    \
                                                     ABI_TYPE, EXPR)       \
   template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,        \

--- a/simd/unit_tests/TestSIMD.cpp
+++ b/simd/unit_tests/TestSIMD.cpp
@@ -14,3 +14,4 @@
 #include <TestSIMD_Construction.hpp>
 #include <TestSIMD_LoadStore.hpp>
 #include <TestSIMD_MemoryPermute.hpp>
+#include <TestSIMD_InDeviceConstruction.hpp>

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -17,7 +17,7 @@ KOKKOS_INLINE_FUNCTION void test_simd_constructions() {
   using simd_type  = T;
   using value_type = typename simd_type::value_type;
 
-  value_type arr[1];
+  value_type arr[1] = {0};
 
   [[maybe_unused]] simd_type a{0};
   [[maybe_unused]] simd_type b(arr, Kokkos::Experimental::simd_flag_default);
@@ -42,9 +42,7 @@ template <typename T>
 KOKKOS_INLINE_FUNCTION void test_basic_simd_operators() {
   T a{0}, b{1};
   (void)(a[0]);
-  if constexpr (std::is_signed_v<typename T::value_type>) {
-    (void)(-a);
-  }
+  (void)(-a);
   (void)(a + b);
   (void)(a - b);
   (void)(a * b);

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -151,8 +151,10 @@ TEST(simd, host_simd_construction_in_device_build) {
     GTEST_SKIP();
   }
 
+#ifndef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
   test_host_simd_construction_in_device_functor{}(0);
   Kokkos::parallel_for(1, test_host_simd_construction_in_device_functor{});
+#endif
 }
 
 #endif

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -14,9 +14,13 @@ import kokkos.simd;
 
 template <typename T>
 KOKKOS_INLINE_FUNCTION void test_simd_constructions() {
-  using simd_type = T;
+  using simd_type  = T;
+  using value_type = typename simd_type::value_type;
+
+  value_type arr[1];
 
   [[maybe_unused]] simd_type a{0};
+  [[maybe_unused]] simd_type b(arr, Kokkos::Experimental::simd_flag_default);
   [[maybe_unused]] simd_type gen(
       KOKKOS_LAMBDA(Kokkos::Experimental::Impl::simd_size_t i) { return i; });
   [[maybe_unused]] simd_type copy(a);

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_SIMD_IN_DEVICE_CONSTRUCTION_HPP
+#define KOKKOS_TEST_SIMD_IN_DEVICE_CONSTRUCTION_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.simd;
+#else
+#include <Kokkos_SIMD.hpp>
+#endif
+#include <SIMDTesting_Utilities.hpp>
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void test_simd_constructions() {
+  using simd_type = T;
+
+  [[maybe_unused]] simd_type a{0};
+  [[maybe_unused]] simd_type gen(
+      KOKKOS_LAMBDA(Kokkos::Experimental::Impl::simd_size_t i) { return i; });
+  [[maybe_unused]] simd_type copy(a);
+  [[maybe_unused]] simd_type move(std::move(gen));
+}
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void test_mask_constructions() {
+  using mask_type = T;
+
+  [[maybe_unused]] mask_type a{false};
+  [[maybe_unused]] mask_type gen(KOKKOS_LAMBDA(
+      Kokkos::Experimental::Impl::simd_size_t i) { return (i == 0); });
+  [[maybe_unused]] mask_type copy(a);
+  [[maybe_unused]] mask_type move(std::move(gen));
+}
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void test_basic_simd_operators() {
+  T a{0}, b{0};
+  (void)(a[0]);
+  (void)(a + b);
+  (void)(a - b);
+  (void)(a * b);
+  (void)(a / b);
+  (void)(a += b);
+  (void)(a -= b);
+  (void)(a /= b);
+  (void)(a == b);
+  (void)(a != b);
+  (void)(a >= b);
+  (void)(a <= b);
+  (void)(a > b);
+  (void)(a < b);
+}
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void test_basic_mask_operators() {
+  T a{false}, b{true};
+  (void)!a;
+  (void)(a && b);
+  (void)(a || b);
+  (void)(a & b);
+  (void)(a | b);
+  (void)(a ^ b);
+  (void)(a &= b);
+  (void)(a |= b);
+  (void)(a ^= b);
+  (void)(a == b);
+  (void)(a != b);
+
+  // FIXME fallback impl needeed
+  // (void) (a>=b);
+  // (void) (a<=b);
+  // (void) (a>b);
+  // (void) (a<b);
+}
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION void test_basic_math_fns() {
+  T a{};
+  Kokkos::abs(a);
+  Kokkos::floor(a);
+  Kokkos::ceil(a);
+  Kokkos::round(a);
+  Kokkos::trunc(a);
+}
+
+template <typename Abi, typename DataType>
+KOKKOS_INLINE_FUNCTION void test_host_simd_construction() {
+  using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
+  using mask_type = Kokkos::Experimental::basic_simd_mask<DataType, Abi>;
+
+  if constexpr (is_simd_avail_v<DataType, Abi>) {
+    test_simd_constructions<simd_type>();
+    test_mask_constructions<mask_type>();
+    test_basic_simd_operators<simd_type>();
+    test_basic_mask_operators<mask_type>();
+    test_basic_math_fns<simd_type>();
+  }
+}
+
+template <typename Abi, typename... DataTypes>
+KOKKOS_INLINE_FUNCTION void check_host_simd_construction_all_types(
+    Kokkos::Experimental::Impl::data_types<DataTypes...>) {
+  (test_host_simd_construction<Abi, DataTypes>(), ...);
+}
+
+template <typename... Abis>
+KOKKOS_INLINE_FUNCTION void check_host_simd_construction_all_abis(
+    Kokkos::Experimental::Impl::abi_set<Abis...>) {
+  using DataTypes = Kokkos::Experimental::Impl::data_type_set;
+  (check_host_simd_construction_all_types<Abis>(DataTypes()), ...);
+}
+
+struct test_host_simd_construction_in_device_functor {
+  KOKKOS_INLINE_FUNCTION void operator()(int) const {
+    check_host_simd_construction_all_abis(
+        Kokkos::Experimental::Impl::host_abi_set());
+  }
+};
+
+// FIXME This test should eventually be integrated into other simd unit tests
+TEST(simd, host_simd_construction_in_device_build) {
+  using scalar_simd_abi = Kokkos::Experimental::simd_abi::scalar;
+  using host_simd_abi =
+      Kokkos::Experimental::simd_abi::Impl::host_fixed_native<double>;
+
+  if constexpr (std::same_as<host_simd_abi, scalar_simd_abi>) {
+    GTEST_SKIP();
+  }
+
+  test_host_simd_construction_in_device_functor{}(0);
+  Kokkos::parallel_for(1, test_host_simd_construction_in_device_functor{});
+}
+
+#endif

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -36,15 +36,36 @@ KOKKOS_INLINE_FUNCTION void test_mask_constructions() {
 
 template <typename T>
 KOKKOS_INLINE_FUNCTION void test_basic_simd_operators() {
-  T a{0}, b{0};
+  T a{0}, b{1};
   (void)(a[0]);
+  if constexpr (std::is_signed_v<typename T::value_type>) {
+    (void)(-a);
+  }
   (void)(a + b);
   (void)(a - b);
   (void)(a * b);
   (void)(a / b);
   (void)(a += b);
   (void)(a -= b);
+  (void)(a *= b);
   (void)(a /= b);
+  if constexpr (std::is_integral_v<typename T::value_type>) {
+    (void)(~a);
+    (void)(a & b);
+    (void)(a | b);
+    (void)(a ^ b);
+    (void)(a << b);
+    (void)(a >> b);
+    (void)(a << 0);
+    (void)(a >> 0);
+    (void)(a &= b);
+    (void)(a |= b);
+    (void)(a ^= b);
+    (void)(a <<= b);
+    (void)(a >>= b);
+    (void)(a <<= 0);
+    (void)(a >>= 0);
+  }
   (void)(a == b);
   (void)(a != b);
   (void)(a >= b);
@@ -57,6 +78,7 @@ template <typename T>
 KOKKOS_INLINE_FUNCTION void test_basic_mask_operators() {
   T a{false}, b{true};
   (void)!a;
+  (void)(~a);
   (void)(a && b);
   (void)(a || b);
   (void)(a & b);
@@ -68,7 +90,7 @@ KOKKOS_INLINE_FUNCTION void test_basic_mask_operators() {
   (void)(a == b);
   (void)(a != b);
 
-  // FIXME fallback impl needeed
+  // FIXME fallback impl needed
   // (void) (a>=b);
   // (void) (a<=b);
   // (void) (a>b);

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -138,6 +138,7 @@ KOKKOS_INLINE_FUNCTION void check_host_simd_construction_all_abis(
   (check_host_simd_construction_all_types<Abis>(DataTypes()), ...);
 }
 
+template <typename = void>
 struct test_host_simd_construction_in_device_functor {
   KOKKOS_INLINE_FUNCTION void operator()(int) const {
     check_host_simd_construction_all_abis(

--- a/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
+++ b/simd/unit_tests/include/TestSIMD_InDeviceConstruction.hpp
@@ -154,9 +154,14 @@ TEST(simd, host_simd_construction_in_device_build) {
     GTEST_SKIP();
   }
 
+// FIXME Temporarily disabling this test for OpenACC; there isn't a
+// reliable, portable compile-time flag to detect the device compilation context
+// to gate the device-only path
+#ifndef KOKKOS_ENABLE_OPENACC
 #ifndef KOKKOS_IMPL_SIMD_DEVICE_COMPAT_TRANSITION
   test_host_simd_construction_in_device_functor{}(0);
   Kokkos::parallel_for(1, test_host_simd_construction_in_device_functor{});
+#endif
 #endif
 }
 


### PR DESCRIPTION
Supersedes #8643 

This PR is the first step to address an issue with constructing a non-native abi (non-scalar) Kokkos simd type in a device enabled build.

Currently, constructing a non-scalar kokkos simd type in a function decorated with `KOKKOS_FUNCTION` or a lambda with `KOKKOS_LAMBDA` is heavily limited in a device build, since the device-side compilation will not recognize host-only vector and intrinsic:
```c++
KOKKOS_LAMBDA(const int) {
  Kokkos::Experimental::basic_simd<data_type, non_scalar_abi_type> simd;  // fails to compile
}
```
<br>

As a side-effect, simd constructions using generator constructors is also impeded if device is enabled, producing the host function call from device code warnings
```c++
auto simd = non_scalar_simd_type(KOKKOS_LAMBDA(const int) { return non_scalar_simd[i]; });  // warns about calling a __host__ function from a __host__ __device__ function
```
<br>

Consequently, this introduced unnecessary complications when using kokkos simd with device callable lambda/function, leading to inconsistent compilation errors depending on the simd type
```c++
auto simd = simd_type([&](const int) { return simd2[i]; });  // fails in device build if simd_type is scalar

auto simd = simd_type(KOKKOS_LAMBDA(const int) { return simd2[i]; });  // fails in device build if simd_type is not scalar
```
<br>
Changes in this PR consists of conversions in constructors and functions of avx2 kokkos simd types to be device callable. This is done by placing in a dummy array and encapsulating intrinsic calls in `KOKKOS_IF_ON_HOST` for device compilation.

These changes only allow construction. Their functionalities on device are omitted for now.