### PR TITLE
Replace detection idiom with concepts

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_Unique.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_Unique.hpp
@@ -13,37 +13,28 @@ namespace Experimental {
 //
 // overload set1: default predicate, accepting execution space
 //
-template <typename ExecutionSpace, typename IteratorType,
-          std::enable_if_t<Impl::is_iterator_v<IteratorType> &&
-                               is_execution_space<ExecutionSpace>::value,
-                           int> = 0>
-IteratorType unique(const ExecutionSpace& ex, IteratorType first,
-                    IteratorType last) {
+template <ExecutionSpace ExeSpace, std::forward_iterator IteratorType>
+IteratorType unique(const ExeSpace& ex, IteratorType first, IteratorType last) {
   return Impl::unique_exespace_impl("Kokkos::unique_iterator_api_default", ex,
                                     first, last);
 }
 
-template <typename ExecutionSpace, typename IteratorType,
-          std::enable_if_t<Impl::is_iterator_v<IteratorType> &&
-                               is_execution_space<ExecutionSpace>::value,
-                           int> = 0>
-IteratorType unique(const std::string& label, const ExecutionSpace& ex,
+template <ExecutionSpace ExeSpace, std::forward_iterator IteratorType>
+IteratorType unique(const std::string& label, const ExeSpace& ex,
                     IteratorType first, IteratorType last) {
   return Impl::unique_exespace_impl(label, ex, first, last);
 }
 
-template <typename ExecutionSpace, typename DataType, typename... Properties,
-          std::enable_if_t<is_execution_space<ExecutionSpace>::value, int> = 0>
-auto unique(const ExecutionSpace& ex,
+template <ExecutionSpace ExeSpace, typename DataType, typename... Properties>
+auto unique(const ExeSpace& ex,
             const ::Kokkos::View<DataType, Properties...>& view) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
   return Impl::unique_exespace_impl("Kokkos::unique_view_api_default", ex,
                                     begin(view), end(view));
 }
 
-template <typename ExecutionSpace, typename DataType, typename... Properties,
-          std::enable_if_t<is_execution_space<ExecutionSpace>::value, int> = 0>
-auto unique(const std::string& label, const ExecutionSpace& ex,
+template <ExecutionSpace ExeSpace, typename DataType, typename... Properties>
+auto unique(const std::string& label, const ExeSpace& ex,
             const ::Kokkos::View<DataType, Properties...>& view) {
   Impl::static_assert_is_admissible_to_kokkos_std_algorithms(view);
   return Impl::unique_exespace_impl(label, ex, begin(view), end(view));
@@ -52,19 +43,17 @@ auto unique(const std::string& label, const ExecutionSpace& ex,
 //
 // overload set2: custom predicate, accepting execution space
 //
-template <typename ExecutionSpace, typename IteratorType,
-          typename BinaryPredicate,
-          std::enable_if_t<is_execution_space<ExecutionSpace>::value, int> = 0>
-IteratorType unique(const ExecutionSpace& ex, IteratorType first,
-                    IteratorType last, BinaryPredicate pred) {
+template <ExecutionSpace ExeSpace, std::forward_iterator IteratorType,
+          std::indirect_equivalence_relation<IteratorType> BinaryPredicate>
+IteratorType unique(const ExeSpace& ex, IteratorType first, IteratorType last,
+                    BinaryPredicate pred) {
   return Impl::unique_exespace_impl("Kokkos::unique_iterator_api_default", ex,
                                     first, last, pred);
 }
 
-template <typename ExecutionSpace, typename IteratorType,
-          typename BinaryPredicate,
-          std::enable_if_t<is_execution_space<ExecutionSpace>::value, int> = 0>
-IteratorType unique(const std::string& label, const ExecutionSpace& ex,
+template <ExecutionSpace ExeSpace, std::forward_iterator IteratorType,
+          std::indirect_equivalence_relation<IteratorType> BinaryPredicate>
+IteratorType unique(const std::string& label, const ExeSpace& ex,
                     IteratorType first, IteratorType last,
                     BinaryPredicate pred) {
   return Impl::unique_exespace_impl(label, ex, first, last, pred);
@@ -97,10 +86,7 @@ auto unique(const std::string& label, const ExecutionSpace& ex,
 // Note: for now omit the overloads accepting a label
 // since they cause issues on device because of the string allocation.
 //
-template <typename TeamHandleType, typename IteratorType,
-          std::enable_if_t<Impl::is_iterator_v<IteratorType> &&
-                               is_team_handle<TeamHandleType>::value,
-                           int> = 0>
+template <TeamHandle TeamHandleType, std::forward_iterator IteratorType>
 KOKKOS_FUNCTION IteratorType unique(const TeamHandleType& teamHandle,
                                     IteratorType first, IteratorType last) {
   return Impl::unique_team_impl(teamHandle, first, last);

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -114,6 +114,27 @@ struct LaunchBounds {
 
 namespace Kokkos {
 
+#if 1
+// The non-exposed concepts are in namespace ImplConcepts and not Impl, because
+// this macro is sometimes used within namespace Impl
+#define KOKKOS_IMPL_DEFINE_TRAIT_FROM_TYPEDEF(TYPEDEF)                    \
+  namespace ImplConcepts {                                                \
+  template <typename T>                                                   \
+  concept Has##TYPEDEF = requires { typename T::TYPEDEF; };               \
+                                                                          \
+  template <typename T>                                                   \
+  concept Has##TYPEDEF##_type = requires { typename T::TYPEDEF##_type; }; \
+  }                                                                       \
+  template <typename T>                                                   \
+  concept is_##TYPEDEF##_v =                                              \
+      (ImplConcepts::Has##TYPEDEF<T> &&                                   \
+       std::derived_from<T, typename T::TYPEDEF>) ||                      \
+      (ImplConcepts::Has##TYPEDEF##_type<T> &&                            \
+       std::derived_from<T, typename T::TYPEDEF##_type>);                 \
+                                                                          \
+  template <typename T>                                                   \
+  using is_##TYPEDEF = std::bool_constant<is_##TYPEDEF##_v<T>>;
+#else
 #define KOKKOS_IMPL_DEFINE_TRAIT_FROM_TYPEDEF(TYPEDEF)         \
   template <typename T>                                        \
   struct is_##TYPEDEF {                                        \
@@ -131,7 +152,7 @@ namespace Kokkos {
   };                                                           \
   template <typename T>                                        \
   inline constexpr bool is_##TYPEDEF##_v = is_##TYPEDEF<T>::value;
-
+#endif
 #define KOKKOS_IMPL_DEFINE_CONCEPT_AND_TRAIT_FROM_TYPEDEF(TYPEDEF,       \
                                                           CXX20_CONCEPT) \
   KOKKOS_IMPL_DEFINE_TRAIT_FROM_TYPEDEF(TYPEDEF)                         \

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -4,6 +4,7 @@
 /// \file Kokkos_Parallel.hpp
 /// \brief Declaration of parallel operators
 
+#include "Kokkos_BitManipulation.hpp"
 #ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
 #include <Kokkos_Macros.hpp>
 static_assert(false,
@@ -25,8 +26,6 @@ static_assert(false,
 #include <impl/Kokkos_Traits.hpp>
 
 #include <cstddef>
-#include <type_traits>
-#include <typeinfo>
 
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
@@ -34,11 +33,11 @@ static_assert(false,
 namespace Kokkos {
 namespace Impl {
 
-template <class T>
-using execution_space_t = typename T::execution_space;
+template <typename T>
+concept HasExecutionSpace = requires { typename T::execution_space; };
 
-template <class T>
-using device_type_t = typename T::device_type;
+template <typename T>
+concept HasDeviceType = requires { typename T::device_type; };
 
 //----------------------------------------------------------------------------
 /** \brief  Given a Functor and Execution Policy query an execution space.
@@ -49,41 +48,55 @@ using device_type_t = typename T::device_type;
  *  else     use the default
  */
 
+//TODO
+#if 0
+    static_assert(
+        !is_detected<execution_space_t, Policy>::value ||
+            !is_detected<execution_space_t, Functor>::value ||
+            std::is_same_v<policy_execution_space, functor_execution_space>,
+        "A policy with an execution space and a functor with an execution space "
+        "are given but the execution space types do not match!");
+    static_assert(!is_detected<execution_space_t, Policy>::value ||
+                      !is_detected<device_type_t, Functor>::value ||
+                      std::is_same_v<policy_execution_space,
+                                     functor_device_type_execution_space>,
+                  "A policy with an execution space and a functor with a device "
+                  "type are given but the execution space types do not match!");
+    static_assert(!is_detected<device_type_t, Functor>::value ||
+                      !is_detected<execution_space_t, Functor>::value ||
+                      std::is_same_v<functor_device_type_execution_space,
+                                     functor_execution_space>,
+                  "A functor with both an execution space and device type is "
+                  "given but their execution space types do not match!");
+#endif
+
 template <class Functor, class Policy>
-struct FunctorPolicyExecutionSpace {
-  using policy_execution_space  = detected_t<execution_space_t, Policy>;
-  using functor_execution_space = detected_t<execution_space_t, Functor>;
-  using functor_device_type     = detected_t<device_type_t, Functor>;
-  using functor_device_type_execution_space =
-      detected_t<execution_space_t, functor_device_type>;
+struct FunctorPolicyExecutionSpace;
 
-  static_assert(
-      !is_detected<execution_space_t, Policy>::value ||
-          !is_detected<execution_space_t, Functor>::value ||
-          std::is_same_v<policy_execution_space, functor_execution_space>,
-      "A policy with an execution space and a functor with an execution space "
-      "are given but the execution space types do not match!");
-  static_assert(!is_detected<execution_space_t, Policy>::value ||
-                    !is_detected<device_type_t, Functor>::value ||
-                    std::is_same_v<policy_execution_space,
-                                   functor_device_type_execution_space>,
-                "A policy with an execution space and a functor with a device "
-                "type are given but the execution space types do not match!");
-  static_assert(!is_detected<device_type_t, Functor>::value ||
-                    !is_detected<execution_space_t, Functor>::value ||
-                    std::is_same_v<functor_device_type_execution_space,
-                                   functor_execution_space>,
-                "A functor with both an execution space and device type is "
-                "given but their execution space types do not match!");
+template <class Functor, class Policy>
+  requires(HasExecutionSpace<Policy>)
+struct FunctorPolicyExecutionSpace<Functor, Policy> {
+  using execution_space = typename Policy::execution_space;
+};
 
-  using execution_space = detected_or_t<
-      detected_or_t<
-          std::conditional_t<
-              is_detected<device_type_t, Functor>::value,
-              detected_t<execution_space_t, detected_t<device_type_t, Functor>>,
-              Kokkos::DefaultExecutionSpace>,
-          execution_space_t, Functor>,
-      execution_space_t, Policy>;
+template <class Functor, class Policy>
+  requires(!HasExecutionSpace<Policy> && HasExecutionSpace<Functor>)
+struct FunctorPolicyExecutionSpace<Functor, Policy> {
+  using execution_space = typename Functor::execution_space;
+};
+
+template <class Functor, class Policy>
+  requires(!HasExecutionSpace<Policy> && !HasExecutionSpace<Functor> &&
+           HasDeviceType<Functor>)
+struct FunctorPolicyExecutionSpace<Functor, Policy> {
+  using execution_space = typename Functor::device_type::execution_space;
+};
+
+template <class Functor, class Policy>
+  requires(!HasExecutionSpace<Policy> && !HasExecutionSpace<Functor> &&
+           !HasDeviceType<Functor>)
+struct FunctorPolicyExecutionSpace<Functor, Policy> {
+  using execution_space = Kokkos::DefaultExecutionSpace;
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_Parallel.hpp
+++ b/core/src/Kokkos_Parallel.hpp
@@ -36,6 +36,11 @@ namespace Impl {
 template <typename T>
 concept HasExecutionSpace = requires { typename T::execution_space; };
 
+template <typename T, typename U>
+concept HasMatchingExecutionSpace =
+    !HasExecutionSpace<T> || !HasExecutionSpace<U> ||
+    std::same_as<typename T::execution_space, typename U::execution_space>;
+
 template <typename T>
 concept HasDeviceType = requires { typename T::device_type; };
 
@@ -48,14 +53,8 @@ concept HasDeviceType = requires { typename T::device_type; };
  *  else     use the default
  */
 
-//TODO
+// TODO
 #if 0
-    static_assert(
-        !is_detected<execution_space_t, Policy>::value ||
-            !is_detected<execution_space_t, Functor>::value ||
-            std::is_same_v<policy_execution_space, functor_execution_space>,
-        "A policy with an execution space and a functor with an execution space "
-        "are given but the execution space types do not match!");
     static_assert(!is_detected<execution_space_t, Policy>::value ||
                       !is_detected<device_type_t, Functor>::value ||
                       std::is_same_v<policy_execution_space,
@@ -76,6 +75,11 @@ struct FunctorPolicyExecutionSpace;
 template <class Functor, class Policy>
   requires(HasExecutionSpace<Policy>)
 struct FunctorPolicyExecutionSpace<Functor, Policy> {
+  static_assert(
+      HasMatchingExecutionSpace<Policy, Functor>,
+      "A policy with an execution space and a functor with an execution space "
+      "are given but the execution space types do not match!");
+
   using execution_space = typename Policy::execution_space;
 };
 


### PR DESCRIPTION
This is replacing the detection idiom with concepts, both to reduce the maintenance burden (concepts are simpler to use) and to document how to do it, what goes smoothly and what are the pain points.

- Replaced `is##TYPEDEF##_v` with a `concept` instead of a `constexpr inline bool`.  I don't think there are any downsides to this.
- Replaced `is##TYPEDEF` with an alias to `std::bool_constant`.  Except for legacy code, we rarely need `is##TYPEDEF` over `is##TYPEDEF##_v`.
- In Kokkos_Parallel.hpp, changed `FunctorPolicyExecutionSpace` to use concepts instead of the detection idiom.  TODO: get all the `static_assert`s in.  These `static_assert`s are proving difficult, as the detection idiom always returns a type (sometimes `nonesuch`), even for things that don't have the embedded `typedef` we are looking for.
- In Kokkos_Unique, removing uses of `is_iterator` (replacing them with the `concept std::forward_iterator`) with the goal of removing `is_iterator` entirely.  

These may be breaking changes, as I am using the full concept definition to replace older type traits uses.  It's hard to imagine real, valid code which will break, but it is possible.  Overall, I think this is worth it, as it is better to have semantic constraints over just syntactic ones, for both the caller (our customers) and callee (us).

I haven't noticed any real change in compile times (just looking at the elapsed time building, but not a controlled experiment).