### PR TITLE
WIP: MDRange flat iterate

### DIFF
--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -15,6 +15,7 @@ static_assert(false,
 #include <Kokkos_Rank.hpp>
 #include <Kokkos_Array.hpp>
 #include <impl/KokkosExp_Host_IterateTile.hpp>
+#include <MDRange/Kokkos_FlatIterate.hpp>
 #include <Kokkos_ExecPolicy.hpp>
 #include <type_traits>
 #include <array>

--- a/core/src/MDRange/Kokkos_FlatIterate.hpp
+++ b/core/src/MDRange/Kokkos_FlatIterate.hpp
@@ -1,0 +1,10 @@
+#include <type_traits>
+#include <utility>
+#include "../Kokkos_Array.hpp"
+#include "../Kokkos_Layout.hpp"
+
+namespace Kokkos::Impl {
+
+template <class MDRP, class Functor, class Tag>
+class FlatIterate;
+}  // namespace Kokkos::Impl

--- a/core/src/MDRange/Kokkos_FlatIterate.hpp
+++ b/core/src/MDRange/Kokkos_FlatIterate.hpp
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_MDRANGE_FLATITERATE_HPP
+#define KOKKOS_MDRANGE_FLATITERATE_HPP
+
 #include <type_traits>
 #include <utility>
 #include "../Kokkos_Array.hpp"
@@ -7,4 +13,20 @@ namespace Kokkos::Impl {
 
 template <class MDRP, class Functor, class Tag>
 class FlatIterate;
+
+
+template <typename IndexType, IndexType End, typename ItegerSequence>
+struct make_reverse_integer_sequence_impl;
+
+template <typename IndexType, IndexType End, IndexType... Indices>
+struct make_reverse_integer_sequence_impl<
+    IndexType, End, std::integer_sequence<IndexType, Indices...>>
+    : std::type_identity<std::integer_sequence<IndexType, End - 1 - Indices...>> {};
+
+template <typename IndexType, IndexType N>
+using make_reverse_integer_sequence =
+    typename make_reverse_integer_sequence_impl<
+        IndexType, N, std::make_integer_sequence<IndexType, N>>::type;
 }  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_MDRANGE_FLATITERATE_HPP

--- a/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Parallel_For.hpp
@@ -7,6 +7,7 @@
 #include <omp.h>
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
+#include <MDRange/Kokkos_FlatIterate.hpp>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -138,6 +139,117 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::OpenMP> {
 };
 
 // MDRangePolicy impl
+template <class MDRP, class Functor, class Tag>
+  requires std::same_as<typename MDRP::execution_space, Kokkos::OpenMP>
+class FlatIterate<MDRP, Functor, Tag> {
+ public:
+  using range_policy         = typename MDRP::impl_range_policy;
+  using index_type           = typename range_policy::index_type;
+  using iteration_pattern    = typename MDRP::iteration_pattern;
+  using point_type           = typename MDRP::point_type;
+  static constexpr auto rank = MDRP::rank;
+
+  FlatIterate(const MDRP& mdrp, const Functor& fun)
+      : m_md_range_policy(mdrp), m_functor(fun) {}
+
+  void exec(Static) const {
+    if constexpr (iteration_pattern::inner_direction == Iterate::Right) {
+      exec_rank(std::make_integer_sequence<int, rank>{}, m_tag, Static{});
+    } else {
+      exec_rank(make_reverse_integer_sequence<int, rank>{}, m_tag, Static{});
+    }
+  }
+
+  const MDRP& policy() const noexcept { return m_md_range_policy; }
+
+ private:
+  struct NoTag {};
+
+  void apply_to_functor(const point_type& point, NoTag) const {
+    apply(m_functor, point);
+  }
+
+  template<typename AnyTag>
+  void apply_to_functor(const point_type& point, AnyTag tag) const {
+    apply(
+        [tag, this]<typename... Args>(Args&&... args) {
+          m_functor(tag, std::forward<Args>(args)...);
+        },
+        point);
+  }
+
+
+  template <int R1, class TagOrNoTag>
+  void exec_rank(std::integer_sequence< int, R1>, TagOrNoTag tag, Static) const {
+    point_type p;
+    using array_index_type = typename MDRP::array_index_type;
+    #pragma omp parallel for schedule(static, 1) firstprivate(p)
+    for ( array_index_type i = m_md_range_policy.m_lower[R1];
+          i < m_md_range_policy.m_upper[R1]; ++i) {
+      p[R1] = i;
+      apply_to_functor(p, tag);
+    }
+  }
+
+
+  template <int R1, int R2, class TagOrNoTag>
+  void exec_rank(std::integer_sequence< int, R1, R2>, TagOrNoTag tag, Static) const {
+    point_type p;
+    using array_index_type = typename MDRP::array_index_type;
+    #pragma omp parallel for schedule(static, 1) collapse(2) firstprivate(p)
+    for (array_index_type i = m_md_range_policy.m_lower[R1];
+         i < m_md_range_policy.m_upper[R1]; ++i) {
+      for (array_index_type j = m_md_range_policy.m_lower[R2];
+           j < m_md_range_policy.m_upper[R2]; ++j) {
+        p[R1] = i;
+        p[R2] = j;
+        apply_to_functor(p, tag);
+      }
+    }
+  }
+
+  template <int R1, int R2, int R3, class TagOrNoTag, int... Rs>
+  void exec_rank(std::integer_sequence< int, R1, R2, R3, Rs...>, TagOrNoTag tag, Static) const {
+    point_type p;
+    using array_index_type = typename MDRP::array_index_type;
+    #pragma omp parallel for schedule(static, 1) collapse(3) firstprivate(p)
+    for (array_index_type i = m_md_range_policy.m_lower[R1];
+         i < m_md_range_policy.m_upper[R1]; ++i) {
+      for (array_index_type j = m_md_range_policy.m_lower[R2];
+           j < m_md_range_policy.m_upper[R2]; ++j) {
+        for (array_index_type k = m_md_range_policy.m_lower[R3];
+             k < m_md_range_policy.m_upper[R3]; ++k) {
+          p[R1] = i;
+          p[R2] = j;
+          p[R3] = k;
+          exec_rank_nested(std::integer_sequence< int, Rs... >{}, p, tag);
+        }
+      }
+    }
+  }
+
+  template <class TagOrNoTag>
+  void exec_rank_nested(std::integer_sequence<int>, point_type& point, TagOrNoTag tag) const {
+    apply_to_functor(point, tag);
+  }
+
+  template <int Rank, int... RemRanks, class TagOrNoTag>
+  void exec_rank_nested(std::integer_sequence<int, Rank, RemRanks...>,
+                 point_type& point, TagOrNoTag tag) const {
+    using array_index_type = typename MDRP::array_index_type;
+    for (array_index_type i = m_md_range_policy.m_lower[Rank];
+         i < m_md_range_policy.m_upper[Rank]; ++i) {
+      point[Rank] = i;
+      exec_rank_nested(std::integer_sequence<int, RemRanks...>{}, point,
+                tag);
+    }
+  }
+
+  const MDRP m_md_range_policy;
+  const Functor m_functor;
+  static constexpr std::conditional_t<std::is_void_v<Tag>, NoTag, Tag> m_tag{};
+};
+
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
                   Kokkos::OpenMP> {
@@ -149,18 +261,19 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using Member = typename Policy::member_type;
 
   using index_type   = typename Policy::index_type;
-  using iterate_type = typename Kokkos::Impl::HostIterateTile<
-      MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
+  //using iterate_type = typename Kokkos::Impl::HostIterateTile<
+  //    MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
+  using iterate_type = FlatIterate<MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag>;
 
   OpenMPInternal* m_instance;
   const iterate_type m_iter;
 
-  inline void exec_range(const Member ibeg, const Member iend) const {
-    KOKKOS_PRAGMA_IVDEP_IF_ENABLED
-    for (Member iwork = ibeg; iwork < iend; ++iwork) {
-      m_iter(iwork);
-    }
-  }
+  //inline void exec_range(const Member ibeg, const Member iend) const {
+  //  KOKKOS_PRAGMA_IVDEP_IF_ENABLED
+  //  for (Member iwork = ibeg; iwork < iend; ++iwork) {
+  //    m_iter(iwork);
+  //  }
+  //}
 
   template <class Policy>
   typename std::enable_if_t<
@@ -191,41 +304,14 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     // Serialize kernels on the same execution space instance
     std::lock_guard<std::mutex> lock(m_instance->m_instance_mutex);
 
-    if (execute_in_serial(m_iter.m_rp.space())) {
-      exec_range(0, m_iter.m_rp.m_num_tiles);
+    if (execute_in_serial(m_iter.policy().space())) {
+      m_iter.exec(Static{});
+      //exec_range(0, m_iter.m_rp.m_num_tiles);
       return;
     }
 
-#ifndef KOKKOS_INTERNAL_DISABLE_NATIVE_OPENMP
-    execute_parallel<Policy>();
-#else
-    constexpr bool is_dynamic =
-        std::is_same<typename Policy::schedule_type::type,
-                     Kokkos::Dynamic>::value;
-
-#pragma omp parallel num_threads(m_instance->thread_pool_size())
-    {
-      HostThreadTeamData& data = *(m_instance->get_thread_data());
-
-      data.set_work_partition(m_iter.m_rp.m_num_tiles, 1);
-
-      if (is_dynamic) {
-        // Make sure work partition is set before stealing
-        if (data.pool_rendezvous()) data.pool_rendezvous_release();
-      }
-
-      std::pair<int64_t, int64_t> range(0, 0);
-
-      do {
-        range = is_dynamic ? data.get_work_stealing_chunk()
-                           : data.get_work_partition();
-
-        exec_range(range.first, range.second);
-
-      } while (is_dynamic && 0 <= range.first);
-    }
-    // END #pragma omp parallel
-#endif
+    m_iter.exec(Static{});
+    //execute_parallel<Policy>();
   }
 
   inline ParallelFor(const FunctorType& arg_functor, MDRangePolicy arg_policy)

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -41,7 +41,7 @@ class FlatIterate<MDRP, Functor, Tag> {
 
   void exec() const {
     point_type p;
-    if constexpr (iteration_pattern::inner_direction == Iterate::Left) {
+    if constexpr (iteration_pattern::inner_direction == Iterate::Right) {
       exec_rank(std::make_integer_sequence<int, rank>{}, p, m_tag);
     } else {
       exec_rank(make_reverse_integer_sequence<int, rank>{}, p, m_tag);

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -12,20 +12,6 @@
 
 namespace Kokkos {
 namespace Impl {
-
-template <typename IndexType, IndexType End, typename ItegerSequence>
-struct make_reverse_integer_sequence_impl;
-
-template <typename IndexType, IndexType End, IndexType... Indices>
-struct make_reverse_integer_sequence_impl<
-    IndexType, End, std::integer_sequence<IndexType, Indices...>>
-    : std::type_identity<std::integer_sequence<IndexType, End - 1 - Indices...>> {};
-
-template <typename IndexType, IndexType N>
-using make_reverse_integer_sequence =
-    typename make_reverse_integer_sequence_impl<
-        IndexType, N, std::make_integer_sequence<IndexType, N>>::type;
-
 template <class MDRP, class Functor, class Tag>
   requires std::same_as<typename MDRP::execution_space, Kokkos::Serial>
 class FlatIterate<MDRP, Functor, Tag> {

--- a/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_MDRange.hpp
@@ -4,11 +4,94 @@
 #ifndef KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 #define KOKKOS_SERIAL_PARALLEL_MDRANGE_HPP
 
+#include <concepts>
 #include <Kokkos_Parallel.hpp>
 #include <KokkosExp_MDRangePolicy.hpp>
+#include <MDRange/Kokkos_FlatIterate.hpp>
+#include <impl/Kokkos_Utilities.hpp>
 
 namespace Kokkos {
 namespace Impl {
+
+template <typename IndexType, IndexType End, typename ItegerSequence>
+struct make_reverse_integer_sequence_impl;
+
+template <typename IndexType, IndexType End, IndexType... Indices>
+struct make_reverse_integer_sequence_impl<
+    IndexType, End, std::integer_sequence<IndexType, Indices...>>
+    : std::type_identity<std::integer_sequence<IndexType, End - 1 - Indices...>> {};
+
+template <typename IndexType, IndexType N>
+using make_reverse_integer_sequence =
+    typename make_reverse_integer_sequence_impl<
+        IndexType, N, std::make_integer_sequence<IndexType, N>>::type;
+
+template <class MDRP, class Functor, class Tag>
+  requires std::same_as<typename MDRP::execution_space, Kokkos::Serial>
+class FlatIterate<MDRP, Functor, Tag> {
+ public:
+  using range_policy         = typename MDRP::impl_range_policy;
+  using index_type           = typename range_policy::index_type;
+  using iteration_pattern    = typename MDRP::iteration_pattern;
+  using point_type           = typename MDRP::point_type;
+  static constexpr auto rank = MDRP::rank;
+
+  FlatIterate(const MDRP& mdrp, const Functor& fun)
+      : m_md_range_policy(mdrp), m_functor(fun) {}
+
+  void exec() const {
+    point_type p;
+    if constexpr (iteration_pattern::inner_direction == Iterate::Left) {
+      exec_rank(std::make_integer_sequence<int, rank>{}, p, m_tag);
+    } else {
+      exec_rank(make_reverse_integer_sequence<int, rank>{}, p, m_tag);
+    }
+  }
+
+  const MDRP& policy() const noexcept { return m_md_range_policy; }
+
+ private:
+  struct NoTag {};
+
+  void apply_to_functor(const point_type& point, NoTag) const {
+    apply(m_functor, point);
+  }
+
+  template<typename AnyTag>
+  void apply_to_functor(const point_type& point, AnyTag tag) const {
+    apply(
+        [tag, this]<typename... Args>(Args&&... args) {
+          m_functor(tag, std::forward<Args>(args)...);
+        },
+        point);
+  }
+
+  template <int Rank, class TagOrNoTag>
+  void exec_rank(std::integer_sequence<int, Rank>, point_type& point, TagOrNoTag tag) const {
+    using array_index_type = typename MDRP::array_index_type;
+    for (array_index_type i = m_md_range_policy.m_lower[Rank];
+         i < m_md_range_policy.m_upper[Rank]; ++i) {
+      point[Rank] = i;
+      apply_to_functor(point, tag);
+    }
+  }
+
+  template <int Rank, int SecondRank, int... RemRanks, class TagOrNoTag>
+  void exec_rank(std::integer_sequence<int, Rank, SecondRank, RemRanks...>,
+                 point_type& point, TagOrNoTag tag) const {
+    using array_index_type = typename MDRP::array_index_type;
+    for (array_index_type i = m_md_range_policy.m_lower[Rank];
+         i < m_md_range_policy.m_upper[Rank]; ++i) {
+      point[Rank] = i;
+      exec_rank(std::integer_sequence<int, SecondRank, RemRanks...>{}, point,
+                tag);
+    }
+  }
+
+  const MDRP m_md_range_policy;
+  const Functor m_functor;
+  static constexpr std::conditional_t<std::is_void_v<Tag>, NoTag, Tag> m_tag{};
+};
 
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
@@ -17,16 +100,18 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using MDRangePolicy = Kokkos::MDRangePolicy<Traits...>;
   using Policy        = typename MDRangePolicy::impl_range_policy;
 
-  using iterate_type = typename Kokkos::Impl::HostIterateTile<
-      MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
+  //using iterate_type = typename Kokkos::Impl::HostIterateTile<
+  //    MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag, void>;
+  using iterate_type = FlatIterate<MDRangePolicy, FunctorType, typename MDRangePolicy::work_tag>;
 
   const iterate_type m_iter;
 
   void exec() const {
-    const typename Policy::member_type e = m_iter.m_rp.m_num_tiles;
-    for (typename Policy::member_type i = 0; i < e; ++i) {
-      m_iter(i);
-    }
+    //const typename Policy::member_type e = m_iter.policy().m_num_tiles;
+    //for (typename Policy::member_type i = 0; i < e; ++i) {
+    //  m_iter(i);
+    //}
+    m_iter.exec();
   }
 
  public:
@@ -38,7 +123,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     // Make sure kernels are running sequentially even when using multiple
     // threads
     auto* internal_instance =
-        m_iter.m_rp.space().impl_internal_space_instance();
+        m_iter.policy().space().impl_internal_space_instance();
     std::lock_guard<std::mutex> lock(internal_instance->m_instance_mutex);
 #endif
     this->exec();

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -237,6 +237,35 @@ template <typename T>
 constexpr bool dependent_false_v = !sizeof(T*);
 //==============================================================================
 
+// Apply and Invoke that are GPU-friendly
+// Honestly mostly cribbed from
+// https://en.cppreference.com/w/cpp/utility/functional/invoke.html
+// and https://en.cppreference.com/w/cpp/utility/apply.html
+template <class F, class... Args>
+constexpr KOKKOS_INLINE_FUNCTION std::invoke_result_t<F, Args...> invoke(
+    F&& f, Args&&... args) noexcept(std::is_nothrow_invocable_v<F, Args...>) {
+  // Don't support memfun pointers right now
+  static_assert(!std::is_member_pointer_v<std::remove_cvref_t<F>>);
+  return std::forward<F>(f)(std::forward<Args>(args)...);
+}
+
+template <class F, class TupleLike, std::size_t... Indices>
+constexpr KOKKOS_INLINE_FUNCTION decltype(auto)
+apply_impl(F &&fun, TupleLike &&tup, std::index_sequence<Indices...>)
+{
+  using namespace std;
+  return invoke(std::forward<F>(fun), get<Indices>(std::forward<TupleLike>(tup))...);
+}
+
+template <class F, class TupleLike>
+constexpr KOKKOS_INLINE_FUNCTION decltype(auto)
+apply(F &&fun, TupleLike &&tup)
+{
+  return apply_impl(std::forward<F>(fun), std::forward<TupleLike>(tup), std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<TupleLike>>>{});
+}
+
+
+
 }  // namespace Impl
 }  // namespace Kokkos
 


### PR DESCRIPTION
This is very WIP. I need to do more thorough benchmarking, so far this is about on par in the serial tests with previous results. The code isn't optimized at all and still messy.

My goal with this is to also create an abstraction for MDRangePolicy iteration strategy. The idea would be to perhaps give users more control about what strategy to use.

Still todo:

- [ ] Come up with a concept for iteration strategies
- [ ] Clean up hook into MDRange strategy
- [ ] Pull out GPU-friendly apply and invoke into a separate PR
- [ ] Add OpenMP FlatIterate
- [ ] Add Threads FlatIterate
- [ ] Make HostIterateTile conform to new iteration strategy concept
- [ ] Add benchmarking