### PR TITLE
Expand guard for all archs on `HIP`

### DIFF
--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -148,7 +148,7 @@ TEST(TEST_CATEGORY, view_moved_from) {
   test_moved_from_view(Kokkos::View<int, ExecutionSpace>("v0"));
   test_moved_from_view(Kokkos::View<float*, ExecutionSpace>("v1", 1));
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
-  // FIXME_HIP ROCm 7.1 on MI300 triggers an internal compiler error in the
+  // FIXME_HIP ROCm 7.1 triggers an internal compiler error in the
   // CHECK macro
 #if !(defined(KOKKOS_ENABLE_HIP) && \
       (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1))

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -150,10 +150,8 @@ TEST(TEST_CATEGORY, view_moved_from) {
   Kokkos::View<double**, ExecutionSpace> v2("v2", 1, 2);
   // FIXME_HIP ROCm 7.1 on MI300 triggers an internal compiler error in the
   // CHECK macro
-#if !(                                                    \
-    defined(KOKKOS_ENABLE_HIP) &&                         \
-    (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1) && \
-    (defined(KOKKOS_ARCH_AMD_GFX942) || defined(KOKKOS_ARCH_AMD_GFX942_APU)))
+#if !(defined(KOKKOS_ENABLE_HIP) && \
+      (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR == 1))
   test_moved_from_view(Kokkos::View<double**, ExecutionSpace>(
       v2.data(), v2.extent(0), v2.extent(1)));
 #endif


### PR DESCRIPTION
I am seeing Clang 20 ICE `ROCm 7.1.1` for `-DKokkos_ARCH_AMD_GFX90A=ON`.
We previously disabled the ICE'ing test for MI300A in https://github.com/kokkos/kokkos/pull/8706
But it seems to be independent of the target architecture. Thus this PR extends the guard to all archs with `ROCm 7.1`

I did not investigate if it is failing due to the same print problem @Rombur identified in #8706 
Related to issue https://github.com/kokkos/kokkos/issues/8635

```
clang++: error: unable to execute command: Segmentation fault (core dumped)
clang++: error: clang frontend command failed due to signal (use -v to see invocation)
AMD clang version 20.0.0git (https://github.com/RadeonOpenCompute/llvm-project roc-7.1.1 25444 27682a16360e33e37c4f3cc6adf9a620733f8fe1)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm-7.1.1/lib/llvm/bin
Configuration file: /opt/rocm-7.1.1/lib/llvm/bin/clang++.cfg
[ 96%] Building CXX object core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/hip/TestHIPHostPinned_SharedAlloc.cpp.o
clang++: note: diagnostic msg: Error generating preprocessed source(s).
failed to execute:/opt/rocm-7.1.1/lib/llvm/bin/clang++  --offload-arch=gfx90a --offload-arch=gfx942  -DKOKKOS_DEPENDENCE -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__=1 -I/home/users/jakobbludau/kokkos_cuda13/build/core/unit_test -I/home/users/jakobbludau/kokkos_cuda13/core/unit_test -I/home/users/jakobbludau/kokkos_cuda13/core/unit_test/category_files -I/home/users/jakobbludau/kokkos_cuda13/build -I/home/users/jakobbludau/kokkos_cuda13/build/core/src -I/home/users/jakobbludau/kokkos_cuda13/core/src -I/home/users/jakobbludau/kokkos_cuda13/build/containers/src -I/home/users/jakobbludau/kokkos_cuda13/containers/src -I/home/users/jakobbludau/kokkos_cuda13/build/algorithms/src -I/home/users/jakobbludau/kokkos_cuda13/algorithms/src -I/home/users/jakobbludau/kokkos_cuda13/build/simd/src -I/home/users/jakobbludau/kokkos_cuda13/simd/src -isystem /home/users/jakobbludau/kokkos_cuda13/tpls/gtest -isystem /home/users/jakobbludau/kokkos_cuda13/tpls/desul/include -isystem /home/users/jakobbludau/kokkos_cuda13/tpls/mdspan/include -x c++ -O2 -g -DNDEBUG -std=gnu++20 -fno-rtti -pthread -march=native -mtune=native -fno-gpu-rdc -xhip -x hip -MD -MT core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/hip/TestHIP_ViewMove.cpp.o -MF CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/hip/TestHIP_ViewMove.cpp.o.d -o "CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/hip/TestHIP_ViewMove.cpp.o" -c /home/users/jakobbludau/kokkos_cuda13/build/core/unit_test/hip/TestHIP_ViewMove.cpp
gmake[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/build.make:1577: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_HIP.dir/hip/TestHIP_ViewMove.cpp.o] Error 1
```
