### PR TITLE
OpenMP: Warn on exec space instance created within omp region

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -151,12 +151,18 @@ OpenMPInternal::OpenMPInternal(int arg_pool_size)
     : m_pool_size{arg_pool_size}, m_level{omp_get_level()}, m_pool() {
   // guard pushing to all_instances
   {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    if (omp_get_level() != 0)
-      Kokkos::abort(
+    if (omp_get_level() != 0) {
+      constexpr char msg[] =
           "Kokkos::OpenMP instances can only be created outside OpenMP "
-          "regions!");
+          "regions!";
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+      if (Kokkos::show_warnings()) {
+        std::cerr << msg << '\n';
+      }
+#else
+      Kokkos::abort(msg);
 #endif
+    }
     std::scoped_lock lock(all_instances_mutex);
     all_instances.push_back(this);
   }


### PR DESCRIPTION
Fix #8917
When detecting that `OpenMP::OpenMP(int)` was called with an omp region, we were terminating the program via Kokkos::abort iff code deprecated code 4 was enabled and continuing without raising a warning otherwise.
This PR proposes to warn unless warnings are explicitly disabled.