### PR TITLE
Abort when loading a profiling library with no callbacks

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -262,31 +262,6 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.declare_optimization_goal == r.declare_optimization_goal;
 }
 
-// true if any callback is set
-bool eventSetAny(const EventSet& e) {
-  return e.init != nullptr || e.finalize != nullptr ||
-         e.parse_args != nullptr || e.print_help != nullptr ||
-         e.begin_parallel_for != nullptr || e.end_parallel_for != nullptr ||
-         e.begin_parallel_reduce != nullptr ||
-         e.end_parallel_reduce != nullptr || e.begin_parallel_scan != nullptr ||
-         e.end_parallel_scan != nullptr || e.push_region != nullptr ||
-         e.pop_region != nullptr || e.allocate_data != nullptr ||
-         e.deallocate_data != nullptr || e.create_profile_section != nullptr ||
-         e.start_profile_section != nullptr ||
-         e.stop_profile_section != nullptr ||
-         e.destroy_profile_section != nullptr || e.profile_event != nullptr ||
-         e.begin_deep_copy != nullptr || e.end_deep_copy != nullptr ||
-         e.begin_fence != nullptr || e.end_fence != nullptr ||
-         e.sync_dual_view != nullptr || e.modify_dual_view != nullptr ||
-         e.declare_metadata != nullptr ||
-         e.provide_tool_programming_interface != nullptr ||
-         e.request_tool_settings != nullptr ||
-         e.declare_output_type != nullptr || e.declare_input_type != nullptr ||
-         e.request_output_values != nullptr ||
-         e.begin_tuning_context != nullptr || e.end_tuning_context != nullptr ||
-         e.declare_optimization_goal != nullptr;
-}
-
 enum class MayRequireGlobalFencing : bool { No, Yes };
 template <typename Callback, typename... Args>
 inline void invoke_kokkosp_callback(
@@ -643,6 +618,36 @@ void initialize(const std::string& profileLibrary) {
     return;
   }
 
+  Experimental::no_profiling.init     = nullptr;
+  Experimental::no_profiling.finalize = nullptr;
+
+  Experimental::no_profiling.begin_parallel_for    = nullptr;
+  Experimental::no_profiling.begin_parallel_scan   = nullptr;
+  Experimental::no_profiling.begin_parallel_reduce = nullptr;
+  Experimental::no_profiling.end_parallel_scan     = nullptr;
+  Experimental::no_profiling.end_parallel_for      = nullptr;
+  Experimental::no_profiling.end_parallel_reduce   = nullptr;
+
+  Experimental::no_profiling.push_region     = nullptr;
+  Experimental::no_profiling.pop_region      = nullptr;
+  Experimental::no_profiling.allocate_data   = nullptr;
+  Experimental::no_profiling.deallocate_data = nullptr;
+
+  Experimental::no_profiling.begin_deep_copy = nullptr;
+  Experimental::no_profiling.end_deep_copy   = nullptr;
+
+  Experimental::no_profiling.create_profile_section  = nullptr;
+  Experimental::no_profiling.start_profile_section   = nullptr;
+  Experimental::no_profiling.stop_profile_section    = nullptr;
+  Experimental::no_profiling.destroy_profile_section = nullptr;
+
+  Experimental::no_profiling.profile_event = nullptr;
+
+  Experimental::no_profiling.declare_input_type    = nullptr;
+  Experimental::no_profiling.declare_output_type   = nullptr;
+  Experimental::no_profiling.request_output_values = nullptr;
+  Experimental::no_profiling.end_tuning_context    = nullptr;
+
   if (auto end_first_library = profileLibrary.find(';');
       end_first_library != 0) {
     auto profileLibraryName = profileLibrary.substr(0, end_first_library);
@@ -736,10 +741,13 @@ void initialize(const std::string& profileLibrary) {
       lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
                       Experimental::current_callbacks.request_tool_settings);
 
-      if (!Experimental::eventSetAny(Experimental::current_callbacks)) {
-        std::cerr << "Warning: Kokkos was configured to load a profiling "
-                     "library, but no profiling interface symbols were found "
-                     "in that library.\n";
+      if (Experimental::eventSetsEqual(Experimental::current_callbacks,
+                                       Experimental::no_profiling)) {
+        std::stringstream msg;
+        msg << "Error: No profiling interface symbols were found "
+               "in profiling library "
+            << profileLibraryName << ".\n";
+        Kokkos::abort(msg.str().c_str());
       }
     }
   }
@@ -781,36 +789,6 @@ void initialize(const std::string& profileLibrary) {
       Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
 
 #endif
-
-  Experimental::no_profiling.init     = nullptr;
-  Experimental::no_profiling.finalize = nullptr;
-
-  Experimental::no_profiling.begin_parallel_for    = nullptr;
-  Experimental::no_profiling.begin_parallel_scan   = nullptr;
-  Experimental::no_profiling.begin_parallel_reduce = nullptr;
-  Experimental::no_profiling.end_parallel_scan     = nullptr;
-  Experimental::no_profiling.end_parallel_for      = nullptr;
-  Experimental::no_profiling.end_parallel_reduce   = nullptr;
-
-  Experimental::no_profiling.push_region     = nullptr;
-  Experimental::no_profiling.pop_region      = nullptr;
-  Experimental::no_profiling.allocate_data   = nullptr;
-  Experimental::no_profiling.deallocate_data = nullptr;
-
-  Experimental::no_profiling.begin_deep_copy = nullptr;
-  Experimental::no_profiling.end_deep_copy   = nullptr;
-
-  Experimental::no_profiling.create_profile_section  = nullptr;
-  Experimental::no_profiling.start_profile_section   = nullptr;
-  Experimental::no_profiling.stop_profile_section    = nullptr;
-  Experimental::no_profiling.destroy_profile_section = nullptr;
-
-  Experimental::no_profiling.profile_event = nullptr;
-
-  Experimental::no_profiling.declare_input_type    = nullptr;
-  Experimental::no_profiling.declare_output_type   = nullptr;
-  Experimental::no_profiling.request_output_values = nullptr;
-  Experimental::no_profiling.end_tuning_context    = nullptr;
 
   updateProfileLibraryState();
 }

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -261,6 +261,32 @@ bool eventSetsEqual(const EventSet& l, const EventSet& r) {
          l.request_output_values == r.request_output_values &&
          l.declare_optimization_goal == r.declare_optimization_goal;
 }
+
+// true if any callback is set
+bool eventSetAny(const EventSet& e) {
+  return e.init != nullptr || e.finalize != nullptr ||
+         e.parse_args != nullptr || e.print_help != nullptr ||
+         e.begin_parallel_for != nullptr || e.end_parallel_for != nullptr ||
+         e.begin_parallel_reduce != nullptr ||
+         e.end_parallel_reduce != nullptr || e.begin_parallel_scan != nullptr ||
+         e.end_parallel_scan != nullptr || e.push_region != nullptr ||
+         e.pop_region != nullptr || e.allocate_data != nullptr ||
+         e.deallocate_data != nullptr || e.create_profile_section != nullptr ||
+         e.start_profile_section != nullptr ||
+         e.stop_profile_section != nullptr ||
+         e.destroy_profile_section != nullptr || e.profile_event != nullptr ||
+         e.begin_deep_copy != nullptr || e.end_deep_copy != nullptr ||
+         e.begin_fence != nullptr || e.end_fence != nullptr ||
+         e.sync_dual_view != nullptr || e.modify_dual_view != nullptr ||
+         e.declare_metadata != nullptr ||
+         e.provide_tool_programming_interface != nullptr ||
+         e.request_tool_settings != nullptr ||
+         e.declare_output_type != nullptr || e.declare_input_type != nullptr ||
+         e.request_output_values != nullptr ||
+         e.begin_tuning_context != nullptr || e.end_tuning_context != nullptr ||
+         e.declare_optimization_goal != nullptr;
+}
+
 enum class MayRequireGlobalFencing : bool { No, Yes };
 template <typename Callback, typename... Args>
 inline void invoke_kokkosp_callback(
@@ -709,6 +735,12 @@ void initialize(const std::string& profileLibrary) {
           Experimental::current_callbacks.provide_tool_programming_interface);
       lookup_function(firstProfileLibrary, "kokkosp_request_tool_settings",
                       Experimental::current_callbacks.request_tool_settings);
+
+      if (!Experimental::eventSetAny(Experimental::current_callbacks)) {
+        std::cerr << "Warning: Kokkos was configured to load a profiling "
+                     "library, but no profiling interface symbols were found "
+                     "in that library.\n";
+      }
     }
   }
 #else

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -777,14 +777,29 @@ if(KOKKOS_ENABLE_LIBDL)
     target_compile_features(kokkosprinter-tool PUBLIC cxx_std_14)
   endif()
 
+  kokkos_add_test_library(kokkos-empty-profiling-tool SHARED SOURCES tools/empty-tool.cpp)
+
   kokkos_add_test_executable(ProfilingAllCalls tools/TestAllCalls.cpp)
 
   kokkos_add_test_executable(ToolsInitialization UnitTestMain.cpp tools/TestToolsInitialization.cpp)
+
+  kokkos_add_test_executable(EmptyProfilingLibraryDeathTest UnitTestMain.cpp tools/TestEmptyProfilingLibrary.cpp)
 
   set(ADDRESS_REGEX "0x[0-9a-f]*")
   set(MEMSPACE_REGEX "[HC][ou][sd][ta][a-zA-Z]*")
   set(SIZE_REGEX "[0-9]*")
   set(SKIP_SCRATCH_INITIALIZATION_REGEX ".*")
+
+  # check that loading a library with no profiling callbacks produces an error
+  kokkos_add_test(
+    SKIP_TRIBITS
+    NAME
+    ProfilingTestErrorNoCallbacks
+    EXE
+    EmptyProfilingLibraryDeathTest
+    TOOL
+    kokkos-empty-profiling-tool
+  )
 
   # check help works via environment variable
   kokkos_add_test(

--- a/core/unit_test/tools/TestEmptyProfilingLibrary.cpp
+++ b/core/unit_test/tools/TestEmptyProfilingLibrary.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <Kokkos_Core.hpp>
+
+TEST(ProfilingDeathTest, EmptyProfilingLibraryErrors) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  ASSERT_DEATH(
+      {
+        Kokkos::initialize();
+        Kokkos::finalize();
+      },
+      "Error: No profiling interface symbols were found in profiling library");
+}

--- a/core/unit_test/tools/empty-tool.cpp
+++ b/core/unit_test/tools/empty-tool.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+// Intentionally provides no Kokkos profiling interface symbols.
+// Used to test that loading a library with no callbacks produces an error.
+
+extern "C" {
+void not_a_profiling_callback() {}
+}


### PR DESCRIPTION
I was helping a user who somehow mis-built a Kokkos Tool and had some trouble understanding what had happened.