### PR TITLE
core(complex): division operator revised

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -171,6 +171,9 @@ if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_IMPL_MDSPAN)
 endif()
 
 kokkos_enable_option(COMPLEX_ALIGN ON "Whether to align Kokkos::complex to 2*alignof(RealType)")
+kokkos_enable_option(COMPLEX_OVERFLOW_GUARD ON "Use a scaling-based implementation for division")
+kokkos_enable_option(COMPLEX_ON_HOST_NATIVE OFF "Use std::complex::operator/ on host")
+kokkos_enable_option(IMPL_COMPLEX_OVERFLOW_GUARD_ZERO_BRANCH OFF "Handle a zero-valued denominator")
 
 if(KOKKOS_ENABLE_TESTS)
   set(HEADER_SELF_CONTAINMENT_TESTS_DEFAULT ON)

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -11,9 +11,8 @@
 #include <Kokkos_MathematicalFunctions.hpp>
 #include <Kokkos_NumericTraits.hpp>
 #include <Kokkos_ReductionIdentity.hpp>
+#include <impl/Kokkos_Complex.hpp>
 #include <impl/Kokkos_Error.hpp>
-#include <complex>
-#include <type_traits>
 #include <iosfwd>
 #include <tuple>
 
@@ -24,18 +23,24 @@ namespace Kokkos {
 ///   result of a Kokkos::parallel_reduce.
 /// \tparam RealType The type of the real and imaginary parts of the
 ///   complex number.  As with std::complex, this is only defined for
-///   \c float, \c double, and <tt>long double</tt>.  The latter is
-///   currently forbidden in CUDA device kernels.
+///   \c float, \c double, and <tt>long double</tt> (until C++20).  The latter
+///   is currently forbidden in CUDA device kernels.
 template <class RealType>
+  requires std::same_as<RealType, std::remove_cv_t<RealType>>
 class
 #ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
     alignas(2 * sizeof(RealType))
 #endif
         complex {
-  static_assert(std::is_floating_point_v<RealType> &&
-                    std::is_same_v<RealType, std::remove_cv_t<RealType>>,
+#if __cplusplus < 202302L
+  static_assert(std::is_floating_point_v<RealType>,
                 "Kokkos::complex can only be instantiated for a cv-unqualified "
                 "floating point type");
+#else
+  static_assert(std::is_trivially_copyable_v<RealType>,
+                "Kokkos::complex can only be instantiated for a cv-unqualified "
+                "trvially copyable type.");
+#endif
 
  private:
   RealType re_{};
@@ -181,53 +186,14 @@ class
   // Conditional noexcept, just in case RType throws on divide-by-zero
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
       const complex<RealType>& y) noexcept(noexcept(RealType{} / RealType{})) {
-    // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
-    // If the real part is +/-Inf and the imaginary part is -/+Inf,
-    // this won't change the result.
-    const RealType s = fabs(y.real()) + fabs(y.imag());
-
-    // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
-    // In that case, the relation x/y == (x/s) / (y/s) doesn't hold,
-    // because y/s is NaN.
-    // TODO mark this branch unlikely
-    if (s == RealType(0)) {
-      this->re_ /= s;
-      this->im_ /= s;
-    } else {
-      const complex x_scaled(this->re_ / s, this->im_ / s);
-      const complex y_conj_scaled(y.re_ / s, -(y.im_) / s);
-      const RealType y_scaled_abs =
-          y_conj_scaled.re_ * y_conj_scaled.re_ +
-          y_conj_scaled.im_ * y_conj_scaled.im_;  // abs(y) == abs(conj(y))
-      *this = x_scaled * y_conj_scaled;
-      *this /= y_scaled_abs;
-    }
+    *this = *this / y;
     return *this;
   }
 
   constexpr KOKKOS_INLINE_FUNCTION complex& operator/=(
       const std::complex<RealType>& y) noexcept(noexcept(RealType{} /
                                                          RealType{})) {
-    // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
-    // If the real part is +/-Inf and the imaginary part is -/+Inf,
-    // this won't change the result.
-    const RealType s = fabs(y.real()) + fabs(y.imag());
-
-    // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
-    // In that case, the relation x/y == (x/s) / (y/s) doesn't hold,
-    // because y/s is NaN.
-    if (s == RealType(0)) {
-      this->re_ /= s;
-      this->im_ /= s;
-    } else {
-      const complex x_scaled(this->re_ / s, this->im_ / s);
-      const complex y_conj_scaled(y.re_ / s, -(y.im_) / s);
-      const RealType y_scaled_abs =
-          y_conj_scaled.re_ * y_conj_scaled.re_ +
-          y_conj_scaled.im_ * y_conj_scaled.im_;  // abs(y) == abs(conj(y))
-      *this = x_scaled * y_conj_scaled;
-      *this /= y_scaled_abs;
-    }
+    *this = *this / complex<RealType>{y.real(), y.imag()};
     return *this;
   }
 
@@ -787,9 +753,15 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
   }
 }
 
+//! Norm of a complex number.
+template <typename RealType>
+KOKKOS_FUNCTION constexpr RealType norm(const complex<RealType>& z) noexcept {
+  return z.real() * z.real() + z.imag() * z.imag();
+}
+
 //! Conjugate of a complex number.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION complex<RealType> conj(
+constexpr KOKKOS_INLINE_FUNCTION complex<RealType> conj(
     const complex<RealType>& x) noexcept {
   return complex<RealType>(real(x), -imag(x));
 }
@@ -956,32 +928,11 @@ operator/(const complex<RealType1>& x,
 }
 
 //! Binary operator / for complex.
-template <class RealType1, class RealType2>
-KOKKOS_INLINE_FUNCTION complex<std::common_type_t<RealType1, RealType2>>
-operator/(const complex<RealType1>& x,
-          const complex<RealType2>& y) noexcept(noexcept(RealType1{} /
-                                                         RealType2{})) {
-  // Scale (by the "1-norm" of y) to avoid unwarranted overflow.
-  // If the real part is +/-Inf and the imaginary part is -/+Inf,
-  // this won't change the result.
-  using common_real_type   = std::common_type_t<RealType1, RealType2>;
-  const common_real_type s = fabs(real(y)) + fabs(imag(y));
-
-  // If s is 0, then y is zero, so x/y == real(x)/0 + i*imag(x)/0.
-  // In that case, the relation x/y == (x/s) / (y/s) doesn't hold,
-  // because y/s is NaN.
-  if (s == 0.0) {
-    return complex<common_real_type>(real(x) / s, imag(x) / s);
-  } else {
-    const complex<common_real_type> x_scaled(real(x) / s, imag(x) / s);
-    const complex<common_real_type> y_conj_scaled(real(y) / s, -imag(y) / s);
-    const RealType1 y_scaled_abs =
-        real(y_conj_scaled) * real(y_conj_scaled) +
-        imag(y_conj_scaled) * imag(y_conj_scaled);  // abs(y) == abs(conj(y))
-    complex<common_real_type> result = x_scaled * y_conj_scaled;
-    result /= y_scaled_abs;
-    return result;
-  }
+template <class RealType>
+KOKKOS_INLINE_FUNCTION constexpr complex<RealType> operator/(
+    const complex<RealType>& x,
+    const complex<RealType>& y) noexcept(noexcept(RealType{} / RealType{})) {
+  return Impl::complex_div(x, y);
 }
 
 //! Binary operator / for complex and real numbers

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -552,6 +552,7 @@ export {
   using ::Kokkos::nexttoward;
   using ::Kokkos::nexttowardf;
   using ::Kokkos::nexttowardl;
+  using ::Kokkos::norm;
   using ::Kokkos::pow;
   using ::Kokkos::powf;
   using ::Kokkos::powl;

--- a/core/src/impl/Kokkos_Complex.hpp
+++ b/core/src/impl/Kokkos_Complex.hpp
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOS_IMPL_COMPLEX_HPP
+#define KOKKOS_IMPL_COMPLEX_HPP
+
+#include <complex>
+#include <concepts>
+#include <type_traits>
+
+namespace Kokkos {
+template <class RealType>
+  requires std::same_as<RealType, std::remove_cv_t<RealType>>
+class
+#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
+    alignas(2 * sizeof(RealType))
+#endif
+        complex;
+
+template <typename RealType>
+KOKKOS_FUNCTION constexpr RealType norm(const complex<RealType>& z) noexcept;
+
+template <class RealType>
+constexpr KOKKOS_INLINE_FUNCTION complex<RealType> conj(
+    const complex<RealType>& x) noexcept;
+}  // namespace Kokkos
+
+namespace Kokkos::Impl {
+
+/**
+ * @brief Naive complex division implementation.
+ *
+ * References:
+ * https://github.com/gcc-mirror/gcc/blob/8758503918a91dacff4dbc7126eced21787fbfc9/libstdc%2B%2B-v3/include/std/complex#L355-L367
+ * https://github.com/llvm/llvm-project/blob/5b64aeb409ecd9f8e9ff95ffe5fde7eb6a26146c/libcxx/include/complex#L821-L831
+ */
+template <typename RealType>
+KOKKOS_FUNCTION constexpr complex<RealType> complex_naive_div(
+    const complex<RealType>& x, const complex<RealType>& y) noexcept {
+  const RealType norm = Kokkos::norm(y);
+  return {(x.real() * y.real() + x.imag() * y.imag()) / norm,
+          (x.imag() * y.real() - x.real() * y.imag()) / norm};
+}
+
+/**
+ * @brief Complex division using max-norm scaling to reduce the risk of
+ *        overflow.
+ *
+ * The standard approach to complex division is:
+ *   (a+bi)/(c+di) = ((ac+bd) + (bc-ad)i) / (c²+d²)
+ * where the squared denominator c²+d² can overflow for large but finite
+ * inputs (e.g. c = d = 1e154 for double).
+ *
+ * LLVM specializes this operation, see:
+ * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/clang/lib/CodeGen/CGExprComplex.cpp#L1065-L1079
+ * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/compiler-rt/lib/builtins/divdc3.c#L20
+ *
+ * They allow a few different ways to treat it, see
+ * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/clang/lib/CodeGen/CGExprComplex.cpp#L1029.
+ *
+ * GCC also specializes, see
+ * https://github.com/gcc-mirror/gcc/blob/8758503918a91dacff4dbc7126eced21787fbfc9/libstdc%2B%2B-v3/include/std/complex#L1734-L1741
+ * https://github.com/gcc-mirror/gcc/blob/8758503918a91dacff4dbc7126eced21787fbfc9/gcc/tree-complex.cc#L1352
+ *
+ * There is the following attempt
+ * https://github.com/jtravs/cuda_complex/blob/master/cuda_complex.hpp#L553
+ * at porting the algorithm from
+ * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/compiler-rt/lib/builtins/divdc3.c#L20.
+ *
+ * However, we think it has too many expensive operations and branches
+ * to lead to acceptable performance on devices such as GPUs.
+ *
+ * Instead, this implementation scales the inputs, and therefore has:
+ *  * zero branch
+ *  * uniform execution across all threads (of a warp)
+ *
+ * The template parameter @p EnableBranching controls the behavior when
+ * the denominator is zero.
+ * For performance reasons (branching induces divergence), branching can be
+ * disabled.
+ */
+template <bool EnableBranching, std::floating_point RealType>
+KOKKOS_FUNCTION constexpr complex<RealType> complex_scaling_div(
+    const complex<RealType>& x, const complex<RealType>& y) noexcept {
+  const RealType scale =
+      Kokkos::fmax(Kokkos::fabs(y.real()), Kokkos::fabs(y.imag()));
+  if constexpr (EnableBranching) {
+    if (scale == RealType(0)) {
+      return {x.real() / scale, x.imag() / scale};
+    }
+  }
+  const complex<RealType> x_scaled      = x / scale;
+  const complex<RealType> y_conj_scaled = Kokkos::conj(y) / scale;
+  const RealType y_conj_scaled_norm     = Kokkos::norm(y_conj_scaled);
+  return (x_scaled * y_conj_scaled) / y_conj_scaled_norm;
+}
+
+template <std::floating_point RealType>
+KOKKOS_FUNCTION constexpr complex<RealType> complex_div_choice(
+    const complex<RealType>& x, const complex<RealType>& y) noexcept {
+#if !defined(KOKKOS_ENABLE_COMPLEX_OVERFLOW_GUARD)
+  return complex_naive_div(x, y);
+#else
+#if defined(KOKKOS_ENABLE_IMPL_COMPLEX_OVERFLOW_GUARD_ZERO_BRANCH)
+  return complex_scaling_div<true>(x, y);
+#else
+  return complex_scaling_div<false>(x, y);
+#endif
+#endif
+}
+
+template <std::floating_point RealType>
+KOKKOS_FUNCTION constexpr complex<RealType> complex_div(
+    const complex<RealType>& x, const complex<RealType>& y) noexcept {
+#if defined(KOKKOS_ENABLE_COMPLEX_ON_HOST_NATIVE)
+  KOKKOS_IF_ON_HOST(
+      (const auto tmp = std::complex<RealType>{x.real(), x.imag()} /
+                        std::complex<RealType>{y.real(), y.imag()};
+       return {tmp.real(), tmp.imag()};))
+#else
+  KOKKOS_IF_ON_HOST(return complex_div_choice(x, y);)
+#endif
+
+  KOKKOS_IF_ON_DEVICE(return complex_div_choice(x, y);)
+}
+
+// Need to scale both numerator and denormintor to avoid over and underflow
+template <typename T>
+KOKKOS_FUNCTION complex<T> complex_iec559_div(const complex<T>& x,
+                                              const complex<T>& y) {
+  int __ilogbw = 0;
+  T __a        = x.real();
+  T __b        = x.imag();
+  T __c        = y.real();
+  T __d        = y.imag();
+  T __logbw = Kokkos::logb(Kokkos::fmax(Kokkos::fabs(__c), Kokkos::fabs(__d)));
+  if (Kokkos::isfinite(__logbw)) {
+    __ilogbw = static_cast<int>(__logbw);
+    // Scale all four components by the same factor so the ratio is preserved
+    // exactly, and cross-products a*d / b*d no longer underflow when a,b are
+    // subnormal and the denominator exponent is very negative.
+    __a = Kokkos::scalbn(__a, -__ilogbw);
+    __b = Kokkos::scalbn(__b, -__ilogbw);
+    __c = Kokkos::scalbn(__c, -__ilogbw);
+    __d = Kokkos::scalbn(__d, -__ilogbw);
+  }
+  T __denom = __c * __c + __d * __d;
+  // No scalbn needed: ilogbw cancelled out in numerator and denominator.
+  T __x = (__a * __c + __b * __d) / __denom;
+  T __y = (__b * __c - __a * __d) / __denom;
+  if (Kokkos::isnan(__x) && Kokkos::isnan(__y)) {
+    if ((__denom == T(0)) && (!Kokkos::isnan(__a) || !Kokkos::isnan(__b))) {
+      __x = Kokkos::copysign(T(INFINITY), __c) * __a;
+      __y = Kokkos::copysign(T(INFINITY), __c) * __b;
+    } else if ((Kokkos::isinf(__a) || Kokkos::isinf(__b)) &&
+               Kokkos::isfinite(__c) && Kokkos::isfinite(__d)) {
+      __a = Kokkos::copysign(Kokkos::isinf(__a) ? T(1) : T(0), __a);
+      __b = Kokkos::copysign(Kokkos::isinf(__b) ? T(1) : T(0), __b);
+      __x = T(INFINITY) * (__a * __c + __b * __d);
+      __y = T(INFINITY) * (__b * __c - __a * __d);
+    } else if (Kokkos::isinf(__logbw) && __logbw > T(0) &&
+               Kokkos::isfinite(x.real()) && Kokkos::isfinite(x.imag())) {
+      __c = Kokkos::copysign(Kokkos::isinf(__c) ? T(1) : T(0), __c);
+      __d = Kokkos::copysign(Kokkos::isinf(__d) ? T(1) : T(0), __d);
+      __x = T(0) * (__a * __c + __b * __d);
+      __y = T(0) * (__b * __c - __a * __d);
+    }
+  }
+  return {__x, __y};
+}
+
+/**
+ * Adapted from
+ * https://github.com/jtravs/cuda_complex/blob/master/cuda_complex.hpp#L553,
+ * similar to
+ * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/compiler-rt/lib/builtins/divdc3.c#L20.
+ *
+ * Though it's cheaper on gpus, it seems to fail more often then the scaling.
+ */
+template <typename T>
+KOKKOS_FUNCTION complex<T> complex_iec559_div_old(const complex<T>& x,
+                                              const complex<T>& y) {
+  int __ilogbw = 0;
+  T __a        = x.real();
+  T __b        = x.imag();
+  T __c        = y.real();
+  T __d        = y.imag();
+  T __logbw = Kokkos::logb(Kokkos::fmax(Kokkos::fabs(__c), Kokkos::fabs(__d)));
+  if (Kokkos::isfinite(__logbw)) {
+    __ilogbw = static_cast<int>(__logbw);
+    __c      = Kokkos::scalbn(__c, -__ilogbw);
+    __d      = Kokkos::scalbn(__d, -__ilogbw);
+  }
+  T __denom = __c * __c + __d * __d;
+  T __x     = Kokkos::scalbn((__a * __c + __b * __d) / __denom, -__ilogbw);
+  T __y     = Kokkos::scalbn((__b * __c - __a * __d) / __denom, -__ilogbw);
+  if (Kokkos::isnan(__x) && Kokkos::isnan(__y)) {
+    if ((__denom == T(0)) && (!Kokkos::isnan(__a) || !Kokkos::isnan(__b))) {
+      __x = Kokkos::copysign(T(INFINITY), __c) * __a;
+      __y = Kokkos::copysign(T(INFINITY), __c) * __b;
+    } else if ((Kokkos::isinf(__a) || Kokkos::isinf(__b)) &&
+               Kokkos::isfinite(__c) && Kokkos::isfinite(__d)) {
+      __a = Kokkos::copysign(Kokkos::isinf(__a) ? T(1) : T(0), __a);
+      __b = Kokkos::copysign(Kokkos::isinf(__b) ? T(1) : T(0), __b);
+      __x = T(INFINITY) * (__a * __c + __b * __d);
+      __y = T(INFINITY) * (__b * __c - __a * __d);
+    } else if (Kokkos::isinf(__logbw) && __logbw > T(0) &&
+               Kokkos::isfinite(__a) && Kokkos::isfinite(__b)) {
+      __c = Kokkos::copysign(Kokkos::isinf(__c) ? T(1) : T(0), __c);
+      __d = Kokkos::copysign(Kokkos::isinf(__d) ? T(1) : T(0), __d);
+      __x = T(0) * (__a * __c + __b * __d);
+      __y = T(0) * (__b * __c - __a * __d);
+    }
+  }
+  return {__x, __y};
+}
+
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_IMPL_COMPLEX_HPP

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -457,9 +457,9 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
   static_assert((std::is_same_v<decltype(Kokkos::real(4.l)), long double>));
 
   // FIXME in principle could be checked at compile time too
-  ASSERT_EQ(Kokkos::conj(1), Kokkos::complex<double>(1));
-  ASSERT_EQ(Kokkos::conj(2.f), Kokkos::complex<float>(2.f));
-  ASSERT_EQ(Kokkos::conj(3.), Kokkos::complex<double>(3.));
+  static_assert(Kokkos::conj(1) == Kokkos::complex<double>(1));
+  static_assert(Kokkos::conj(2.f) == Kokkos::complex<float>(2.f));
+  static_assert(Kokkos::conj(3.) == Kokkos::complex<double>(3.));
 // long double has size 12 but Kokkos::complex requires 2*sizeof(T) to be a
 // power of two.
 #ifndef KOKKOS_IMPL_32BIT
@@ -473,6 +473,11 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
       (std::is_same_v<decltype(Kokkos::conj(3.)), Kokkos::complex<double>>));
   static_assert((std::is_same_v<decltype(Kokkos::conj(4.l)),
                                 Kokkos::complex<long double>>));
+
+  static_assert(Kokkos::norm(Kokkos::complex<float>{3., 4.}) ==
+                3. * 3. + 4. * 4.);
+  static_assert(Kokkos::norm(Kokkos::complex<double>{5., 6.}) ==
+                5. * 5. + 6. * 6.);
 }
 
 template <class ExecSpace>
@@ -668,6 +673,172 @@ constexpr bool comparison_in_constant_expression() {
 }
 
 static_assert(comparison_in_constant_expression());
+
+template <typename T>
+void expect_complex_eq(const T &actual, const T &expected,
+                       const char *statement_actual,
+                       const char *statement_expected, const char *file,
+                       int line) {
+  auto nan_aware_eq = [](const double a, const double b) {
+    return (std::isnan(a) && std::isnan(b)) || (a == b);
+  };
+  if (!nan_aware_eq(actual.real(), expected.real()) ||
+      !nan_aware_eq(actual.imag(), expected.imag())) {
+    ADD_FAILURE_AT(file, line)
+        << "\tExpecting " << expected << " from " << statement_expected << "\n"
+        << "\tbut got\n"
+        << actual << " from " << statement_actual;
+  }
+}
+
+TEST(TEST_CATEGORY, STDC_IEC_559_COMPLEX) {
+#if !defined(__STDC_IEC_559_COMPLEX__)
+  FAIL() << "__STDC_IEC_559_COMPLEX__ is not defined.";
+#endif
+}
+
+#define EXPECT_COMPLEX_EQ(actual, expected)                                 \
+  expect_complex_eq(KOKKOS_IMPL_STRIP_PARENS(actual),                       \
+                    KOKKOS_IMPL_STRIP_PARENS(expected), #actual, #expected, \
+                    __FILE__, __LINE__)
+
+TEST(TEST_CATEGORY, complex_operator_div) {
+  {
+    constexpr auto res =
+        Kokkos::complex<double>{4., 2.} / Kokkos::complex<double>{2., 1.};
+    static_assert(res.real() == 2. && res.imag() == 0.);
+  }
+  {
+    constexpr auto res =
+        Kokkos::complex<double>{1., 0.} / Kokkos::complex<double>{0., 1.};
+    static_assert(res.real() == 0. && res.imag() == -1.);
+  }
+
+#define CHECK_COMPLEX_DIV(x_r, x_i, y_r, y_i, naive, scale_br, scale, iec559, \
+                          std_complex)                                        \
+  EXPECT_COMPLEX_EQ(                                                          \
+      (Kokkos::Impl::complex_naive_div(Kokkos::complex<double>{x_r, x_i},     \
+                                       Kokkos::complex<double>{y_r, y_i})),   \
+      (Kokkos::complex<double> KOKKOS_IMPL_STRIP_PARENS(naive)));             \
+  EXPECT_COMPLEX_EQ(                                                          \
+      (Kokkos::Impl::complex_scaling_div<true>(                               \
+          Kokkos::complex<double>{x_r, x_i},                                  \
+          Kokkos::complex<double>{y_r, y_i})),                                \
+      (Kokkos::complex<double> KOKKOS_IMPL_STRIP_PARENS(scale_br)));          \
+  EXPECT_COMPLEX_EQ(                                                          \
+      (Kokkos::Impl::complex_scaling_div<false>(                              \
+          Kokkos::complex<double>{x_r, x_i},                                  \
+          Kokkos::complex<double>{y_r, y_i})),                                \
+      (Kokkos::complex<double> KOKKOS_IMPL_STRIP_PARENS(scale)));             \
+  EXPECT_COMPLEX_EQ(                                                          \
+      (Kokkos::Impl::complex_iec559_div(Kokkos::complex<double>{x_r, x_i},    \
+                                        Kokkos::complex<double>{y_r, y_i})),  \
+      (Kokkos::complex<double> KOKKOS_IMPL_STRIP_PARENS(iec559)));            \
+  EXPECT_COMPLEX_EQ(                                                          \
+      (std::complex<double>{x_r, x_i} / std::complex<double>{y_r, y_i}),      \
+      (std::complex<double> KOKKOS_IMPL_STRIP_PARENS(std_complex)));
+
+  // Check the behavior when dividing by 0. Branching is useful to return {inf, NaN}.
+  CHECK_COMPLEX_DIV(1., 0., 0., 0., ({std::nan(""), std::nan("")}),
+                    ({std::numeric_limits<double>::infinity(), std::nan("")}),
+                    ({std::nan(""), std::nan("")}),
+                    ({std::numeric_limits<double>::infinity(), std::nan("")}),
+                    ({std::numeric_limits<double>::infinity(), std::nan("")}))
+
+  // Ordinary integers - all methods agree.
+  CHECK_COMPLEX_DIV(1., 2., 3., 4., ({0.44, 0.08}), ({0.44, 0.08}),
+                    ({0.44, 0.08}), ({0.44, 0.08}), ({0.44, 0.08}))
+
+  // Pure real divided by pure real - all methods agree.
+  CHECK_COMPLEX_DIV(6., 0., 2., 0., ({3., 0.}), ({3., 0.}), ({3., 0.}),
+                    ({3., 0.}), ({3., 0.}))
+
+  // Pure real divided by pure imag.
+  CHECK_COMPLEX_DIV(1., 0., 0., 2., ({0., -0.5}), ({0., -0.5}), ({0., -0.5}),
+                    ({0., -0.5}), ({0., -0.5}))
+
+  // Pure-imag divided by pure-real.
+  CHECK_COMPLEX_DIV(0., 4., 3., 0., ({0., 4. / 3.}), ({0., 4. / 3.}),
+                    ({0., 4. / 3.}), ({0., 4. / 3.}), ({0., 4. / 3.}))
+
+  // All negative parts.
+  CHECK_COMPLEX_DIV(-3., -7., -1., -2., ({3.4, 0.2}), ({3.4, 0.2}),
+                    ({3.4, 0.2}), ({3.4, 0.2}), ({3.4, 0.2}))
+
+  // Denominator real part much larger than imaginary part.
+  CHECK_COMPLEX_DIV(1., 1., 1.e+200, 1.e-05, ({0., 0.}), ({1.e-200, 1.e-200}),
+                    ({1.e-200, 1.e-200}), ({1.e-200, 1.e-200}),
+                    ({1.e-200, 1.e-200}))
+
+  // Denominator real part much smaller than imaginary part.
+  CHECK_COMPLEX_DIV(1., 1., 1.e-05, 1.e+200, ({0., 0.}), ({1e-200, -1e-200}),
+                    ({1e-200, -1e-200}), ({1e-200, -1e-200}),
+                    ({1e-200, -1e-200}))
+
+  // Large denominator parts such that c^2 + d^2 overflows.
+  CHECK_COMPLEX_DIV(1., 0., 1.e+154, 1.e+154, ({0., 0.}), ({5.e-155, -5.e-155}),
+                    ({5.e-155, -5.e-155}), ({5.e-155, -5.e-155}),
+                    ({5.e-155, -5.e-155}))
+
+  // Large/tiny mixed denominator.
+  CHECK_COMPLEX_DIV(10., 1000., 1.e+150, -1.e-05,
+                    ({1.0000000000000002e-149, 1.0000000000000001e-147}),
+                    ({1.e-149, 1.e-147}), ({1.e-149, 1.e-147}),
+                    ({1.0000000000000002e-149, 1.0000000000000001e-147}),
+                    ({1.e-149, 1.e-147}))
+
+  // Numerator real part near DBL_MAX.
+  CHECK_COMPLEX_DIV(
+      1.7976931348623157e+308, 0., 2., 0.,
+      ({std::numeric_limits<double>::infinity(), 0.}),
+      ({8.988465674311579e+307, 0.}), ({8.988465674311579e+307, 0.}),
+      ({8.988465674311579e+307, 0.}), ({8.988465674311579e+307, 0.}))
+
+  // Tiny numerator real part.
+  CHECK_COMPLEX_DIV(1e-300, 0., 1., 1., ({5.e-301, -5.e-301}),
+                    ({5.e-301, -5.e-301}), ({5.e-301, -5.e-301}),
+                    ({5.e-301, -5.e-301}), ({5.e-301, -5.e-301}))
+
+  // Subnormal numerator real part.
+  CHECK_COMPLEX_DIV(5e-324, 5e-324, 1., 1., ({5e-324, 0.}), ({5e-324, 0.}),
+                    ({5e-324, 0.}), ({5e-324, 0.}), ({5e-324, 0.}))
+
+  // Both components large, same magnitude.
+  CHECK_COMPLEX_DIV(1.e+154, 1.e+154, 1.e+154, 1.e+154, ({std::nan(""), 0.}),
+                    ({1., 0.}), ({1., 0.}), ({1., 0.}), ({1., 0.}))
+
+  // Denominator imaginary part dominates.
+  CHECK_COMPLEX_DIV(1., 2., 0.5, 1.e+150,
+                    ({2.0000000000000003e-150, -1.0000000000000001e-150}),
+                    ({2.e-150, -1e-150}), ({2.e-150, -1.e-150}),
+                    ({2.0000000000000003e-150, -1.0000000000000001e-150}),
+                    ({2.e-150, -1.e-150}))
+
+  // From section 2.3 of "A Robust Complex Division in Scilab" (Baudin et al).
+  CHECK_COMPLEX_DIV(1., 1., 1., 0x1p1023, ({0., -0.}),
+                    ({0x1p-1023, -0x1p-1023}), ({0x1p-1023, -0x1p-1023}),
+                    ({0x1p-1023, -0x1p-1023}), ({0x1p-1023, -0x1p-1023}))
+
+  // From section 2.5 of "A Robust Complex Division in Scilab" (Baudin et al).
+  CHECK_COMPLEX_DIV(0x1p1023, 0x1p-1023, 0x1p677, 0x1p-677,
+                    ({std::nan(""), 0.}), ({0x1p346, 0.}), ({0x1p346, 0.}),
+                    ({0x1p346, 0.}), ({0x1p346, -0x1p-1008}))
+
+  // From figure 6 of "A Robust Complex Division in Scilab" (Baudin et al).
+  CHECK_COMPLEX_DIV(0x1p-1074, 0x1p-1074, 0x1p-1073, 0x1p-1074,
+                    ({std::nan(""), std::nan("")}), ({0.6, 0.2}), ({0.6, 0.2}),
+                    ({0.6, 0.2}), ({0.6, 0.2}))
+
+  // From figure 6 of "A Robust Complex Division in Scilab" (Baudin et al).
+  CHECK_COMPLEX_DIV(0x1p1023, 0x1p1023, 1., 1.,
+                    ({std::numeric_limits<double>::infinity(), 0.}),
+                    ({std::numeric_limits<double>::infinity(), 0.}),
+                    ({std::numeric_limits<double>::infinity(), 0.}),
+                    ({std::numeric_limits<double>::infinity(), 0.}),
+                    ({std::numeric_limits<double>::infinity(), 0.}))
+}
+
+#undef CHECK_COMPLEX_DIV
 
 }  // namespace Test
 


### PR DESCRIPTION
## Summary

 * Remove the `s == RealType(0)` branch the `operator/` of `Kokkos::complex` for GPU performance
 * Switch from 1-norm to max-norm scaling.

## Background

### What compilers do for native complex types

Compilers provide specialized implementations for complex division (*e.g.*, for double or float) instead of using the straightforward, naïve formula. These tailored algorithms reduce the risk of overflow and thereby expand the range of inputs that can be handled safely.

* LLVM specializes this operation, see:
   * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/clang/lib/CodeGen/CGExprComplex.cpp#L1065-L1079
   * https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/compiler-rt/lib/builtins/divdc3.c#L20
* GCC also specializes, see
   * https://github.com/gcc-mirror/gcc/blob/8758503918a91dacff4dbc7126eced21787fbfc9/libstdc%2B%2B-v3/include/std/complex#L1734-L1741
   * https://github.com/gcc-mirror/gcc/blob/8758503918a91dacff4dbc7126eced21787fbfc9/gcc/tree-complex.cc#L1352

A few resources worth reading:
* https://dl.acm.org/doi/10.1145/368637.368661
* https://doi.org/10.48550/arXiv.1210.4539 (Baudin-Smith)
* https://beej.us/guide/bgc/html/split/complex-numbers.html
* https://www.dsc.ufcg.edu.br/~cnum/modulos/Modulo2/IEEE754_2008.pdf

So it seems that must compiler actually try to follow `__STDC_IEC_559_COMPLEX__`.

### Why we cannot use these on GPU (apart from missing `__device__` annotation)

They use many data-dependent branches (warp divergence), though these branches seems unlikely.

They use functions like `logb` or `scalbn`. I am not sure of their cost on GPUs.

A possible followup for this PR would be to evaluate the impact of using a similar implementation also for the device fallback, and evaluate how much the branching may harm the performance. A device-ready implementation of such an algorithm is available [here](https://github.com/jtravs/cuda_complex/blob/master/cuda_complex.hpp#L553). But for evaluating the performance impact, we'd need a proper benchmark with representative data.

### The behavior of `complex{...} / complex{0., 0.}` is unspecified

I couldn't find anything in the C or C++ standard that specifies the result of dividing a complex number by another complex number with zero magnitude. Therefore, we can safely discard the condition `s == RealType(0)` in the current implementation, as relying on the result of this operation would constitute undefined behavior (?).

A side note is that "[IEC 60559](https://en.wikipedia.org/wiki/IEEE_754-2008) compatible complex arithmetic (Annex G)" seems optional.

## Changes

1. Move the implementation of `operator/` to `Kokkos::Impl::complex_scaling_div` that we can test separately.
2. Switch from 1-norm to max-norm for the scaling.
3. Expose the following options:
    * `KOKKOS_ENABLE_COMPLEX_OVERFLOW_GUARD` defaulting to `ON`. Set it to `OFF` to use the naïve implementation of the division.
    * `KOKKOS_ENABLE_IMPL_COMPLEX_OVERFLOW_GUARD_ZERO_BRANCH` defaulting to `OFF`. Set it to `ON` to retrieve the special handling of the zero-valued denominator. :warning: We'd need to set to to `ON` if we want this PR not to change the output compared to status quo.
    * `COMPLEX_ON_HOST_NATIVE` defaulting to `OFF`. Set it to `ON` to use the compiler provided `std::complex::operator/` on host. May be useful for people wanting to use compiler-specific handling of the operation. See https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fcomplex-arithmetic for instance.

## Related

- #7618
- #7742