### PR TITLE
core(complex): norm

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -801,6 +801,18 @@ KOKKOS_INLINE_FUNCTION constexpr complex<Impl::promote_t<ArithmeticType>> conj(
   return complex<type>(x, -type());
 }
 
+//! Norm of a complex number.
+template <class RealType>
+KOKKOS_INLINE_FUNCTION constexpr RealType norm(const complex<RealType>& x) {
+  return x.real() * x.real() + x.imag() * x.imag();
+}
+
+template <class ArithmeticType>
+KOKKOS_INLINE_FUNCTION constexpr Impl::promote_t<ArithmeticType> norm(
+    ArithmeticType x) {
+  return static_cast<Impl::promote_t<ArithmeticType>>(x) * x;
+}
+
 //! Exponential of a complex number.
 template <class RealType>
 KOKKOS_INLINE_FUNCTION complex<RealType> exp(const complex<RealType>& x) {

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -552,6 +552,7 @@ export {
   using ::Kokkos::nexttoward;
   using ::Kokkos::nexttowardf;
   using ::Kokkos::nexttowardl;
+  using ::Kokkos::norm;
   using ::Kokkos::pow;
   using ::Kokkos::powf;
   using ::Kokkos::powl;

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -346,6 +346,10 @@ struct TestComplexSpecialFunctions {
     r = std::log10(a);
     ASSERT_FLOAT_EQ(h_results(18).real(), r.real());
     ASSERT_FLOAT_EQ(h_results(18).imag(), r.imag());
+    // norm
+    r = std::norm(a);
+    ASSERT_FLOAT_EQ(h_results(19).real(), r.real());
+    ASSERT_FLOAT_EQ(h_results(19).imag(), r.imag());
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -372,6 +376,7 @@ struct TestComplexSpecialFunctions {
     d_results(16) = Kokkos::acos(a);
     d_results(17) = Kokkos::atan(a);
     d_results(18) = Kokkos::log10(a);
+    d_results(19) = Kokkos::norm(a);
   }
 };
 
@@ -668,6 +673,24 @@ constexpr bool comparison_in_constant_expression() {
 }
 
 static_assert(comparison_in_constant_expression());
+
+constexpr bool test_complex_norm() {
+  return Kokkos::norm(Kokkos::complex<double>{4., 2.}) == 20.;
+}
+static_assert(test_complex_norm());
+
+constexpr bool test_overload_norm() {
+  constexpr auto res_int = Kokkos::norm(int(100000));
+  static_assert(std::same_as<decltype(res_int), const double>);
+  static_assert(res_int == 1e10);
+
+  constexpr auto res_float = Kokkos::norm(float(666.));
+  static_assert(std::same_as<decltype(res_float), const float>);
+  static_assert(res_float == 666. * 666.);
+
+  return true;
+}
+static_assert(test_overload_norm());
 
 }  // namespace Test
 


### PR DESCRIPTION
Implement `Kokkos::norm` both for `Kokkos::complex` and additional overloads for floating point and integer types.

Quick reference:
* https://en.cppreference.com/w/cpp/numeric/complex/norm.html