### PR TITLE
core(complex) make `conj` `constexpr`

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -692,7 +692,8 @@ operator*(const complex<RealType1>& y, const RealType2& x) noexcept {
 
 //! Imaginary part of a complex number.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION RealType imag(const complex<RealType>& x) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr RealType imag(
+    const complex<RealType>& x) noexcept {
   return x.imag();
 }
 
@@ -704,7 +705,8 @@ KOKKOS_INLINE_FUNCTION constexpr Impl::promote_t<ArithmeticType> imag(
 
 //! Real part of a complex number.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION RealType real(const complex<RealType>& x) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr RealType real(
+    const complex<RealType>& x) noexcept {
   return x.real();
 }
 
@@ -789,9 +791,9 @@ KOKKOS_INLINE_FUNCTION Kokkos::complex<RealType> sqrt(
 
 //! Conjugate of a complex number.
 template <class RealType>
-KOKKOS_INLINE_FUNCTION complex<RealType> conj(
+KOKKOS_INLINE_FUNCTION constexpr complex<RealType> conj(
     const complex<RealType>& x) noexcept {
-  return complex<RealType>(real(x), -imag(x));
+  return {real(x), -imag(x)};
 }
 
 template <class ArithmeticType>

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -461,14 +461,13 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
   static_assert((std::is_same_v<decltype(Kokkos::imag(3.)), double>));
   static_assert((std::is_same_v<decltype(Kokkos::real(4.l)), long double>));
 
-  // FIXME in principle could be checked at compile time too
-  ASSERT_EQ(Kokkos::conj(1), Kokkos::complex<double>(1));
-  ASSERT_EQ(Kokkos::conj(2.f), Kokkos::complex<float>(2.f));
-  ASSERT_EQ(Kokkos::conj(3.), Kokkos::complex<double>(3.));
+  static_assert(Kokkos::conj(1) == Kokkos::complex<double>(1));
+  static_assert(Kokkos::conj(2.f) == Kokkos::complex<float>(2.f));
+  static_assert(Kokkos::conj(3.) == Kokkos::complex<double>(3.));
 // long double has size 12 but Kokkos::complex requires 2*sizeof(T) to be a
 // power of two.
 #ifndef KOKKOS_IMPL_32BIT
-  ASSERT_EQ(Kokkos::conj(4.l), Kokkos::complex<long double>(4.l));
+  static_assert(Kokkos::conj(4.l) == Kokkos::complex<long double>(4.l));
   static_assert(
       (std::is_same_v<decltype(Kokkos::conj(1)), Kokkos::complex<double>>));
 #endif
@@ -691,6 +690,19 @@ constexpr bool test_overload_norm() {
   return true;
 }
 static_assert(test_overload_norm());
+
+constexpr bool test_complex_conj() {
+  static_assert(Kokkos::conj(Kokkos::complex<double>{1., 1.}) ==
+                Kokkos::complex<double>{1., -1.});
+  static_assert(Kokkos::conj(Kokkos::complex<double>{1., -1.}) ==
+                Kokkos::complex<double>{1., 1.});
+  static_assert(Kokkos::conj(Kokkos::complex<double>{-1., 1.}) ==
+                Kokkos::complex<double>{-1., -1.});
+  static_assert(Kokkos::conj(Kokkos::complex<double>{-1., -1.}) ==
+                Kokkos::complex<double>{-1., 1.});
+  return true;
+}
+static_assert(test_complex_conj());
 
 }  // namespace Test
 


### PR DESCRIPTION
This PR adds a missing `constexpr` for `Kokkos::conj`, and for the `real` and `imag` free functions.

Quick reference:
* https://en.cppreference.com/w/cpp/numeric/complex/conj