### PR TITLE
Temporarily disable bugprone-* checks failing in OSX CI builds on GH actions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
   bugprone-*,
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
   -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >
   -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
+  -bugprone-random-generator-seed,
   -bugprone-suspicious-include,
   -bugprone-throwing-static-initialization,
   cppcoreguidelines-pro-type-cstyle-cast,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-suspicious-include,
+  -bugprone-throwing-static-initialization,
   cppcoreguidelines-pro-type-cstyle-cast,
   cppcoreguidelines-rvalue-reference-param-not-moved,
   cppcoreguidelines-special-member-functions,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
   bugprone-*,
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
+  -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-suspicious-include,


### PR DESCRIPTION
OSX builds are failing on develop https://github.com/kokkos/kokkos/actions/runs/22559043105/job/65343063733
I propose to suppress them and resolve later so we are not rushing in a fix

* bugprone-invalid-enum-default-initialization
* bugprone-throwing-static-initialization
* bugprone-exception-escape