### PR TITLE
Permananently disable bugprone-exception-escape

### DIFF
--- a/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
+++ b/algorithms/src/std_algorithms/Kokkos_IterSwap.hpp
@@ -47,7 +47,6 @@ void iter_swap_impl(IteratorType1 a, IteratorType2 b) {
 
 // iter_swap
 template <class IteratorType1, class IteratorType2>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void iter_swap(IteratorType1 a, IteratorType2 b) {
   Impl::iter_swap_impl(a, b);
 }

--- a/benchmarks/.clang-tidy
+++ b/benchmarks/.clang-tidy
@@ -1,4 +1,0 @@
-Checks: >
-   -bugprone-exception-escape
-
-InheritParentConfig: true

--- a/benchmarks/atomic/main.cpp
+++ b/benchmarks/atomic/main.cpp
@@ -52,7 +52,7 @@ double test_no_atomic(int L, int N, int M, int K, int R,
   return time;
 }
 
-int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
   {
     if (argc < 8) {

--- a/benchmarks/gather/main.cpp
+++ b/benchmarks/gather/main.cpp
@@ -11,7 +11,7 @@ import kokkos.core;
 #include "gather.hpp"
 #include <cstdlib>
 
-int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);
 
   if (argc < 8) {

--- a/benchmarks/stream/stream-kokkos.cpp
+++ b/benchmarks/stream/stream-kokkos.cpp
@@ -220,7 +220,7 @@ int run_benchmark() {
   return rc;
 }
 
-int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
   printf(HLINE);
   printf("Kokkos STREAM Benchmark\n");
   printf(HLINE);

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -122,7 +122,6 @@ class HPX {
 
   struct instance_data {
     instance_data() = default;
-    // NOLINTNEXTLINE(bugprone-exception-escape)
     ~instance_data() {
       fence("Kokkos::Experimental::HPX: fence on destruction");
     }
@@ -323,7 +322,6 @@ class HPX {
                        hpx::threads::thread_stacksize stacksize =
                            hpx::threads::thread_stacksize::default_) const {
     impl_bulk_plain_erased(force_synchronous, is_light_weight_policy,
-                           // NOLINTNEXTLINE(bugprone-exception-escape)
                            {[functor](Index i) { functor.execute_range(i); }},
                            n, stacksize);
   }

--- a/core/src/View/Kokkos_ViewTracker.hpp
+++ b/core/src/View/Kokkos_ViewTracker.hpp
@@ -80,7 +80,6 @@ struct ViewTracker {
     return *this;
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   KOKKOS_INLINE_FUNCTION ViewTracker& operator=(ViewTracker&& rhs) {
     return *this = static_cast<const ViewTracker&>(rhs);
   }

--- a/core/src/impl/Kokkos_CheckUsage.hpp
+++ b/core/src/impl/Kokkos_CheckUsage.hpp
@@ -98,7 +98,6 @@ struct CheckUsage<UsageRequires::insideExecEnv> {
   }
 };
 
-// NOLINTBEGIN(bugprone-exception-escape)
 inline void check_execution_space_constructor_precondition(
     char const* name) noexcept {
   if (Kokkos::is_finalized()) {
@@ -127,7 +126,6 @@ inline void check_execution_space_destructor_precondition(
     Kokkos::abort(err.c_str());
   }
 }
-// NOLINTEND(bugprone-exception-escape)
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -155,7 +155,6 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   return devices;
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] int Kokkos::device_id() noexcept {
 #if defined(KOKKOS_ENABLE_CUDA)
   int device = Cuda().cuda_device();
@@ -767,7 +766,6 @@ void initialize_internal(const Kokkos::InitializationSettings& settings) {
 
 // declared noexcept such that std::terminate is called if any of the registered
 // function throws
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void call_registered_finalize_hook_functions() noexcept {
   while (!finalize_hooks.empty()) {
     auto const& func = finalize_hooks.top();

--- a/core/src/impl/Kokkos_HostSharedPtr.hpp
+++ b/core/src/impl/Kokkos_HostSharedPtr.hpp
@@ -103,7 +103,6 @@ class HostSharedPtr {
   }
 
  private:
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   KOKKOS_FUNCTION void cleanup() noexcept {
     KOKKOS_IF_ON_HOST((
         // If m_counter is set, then this instance is responsible for managing

--- a/core/src/impl/Kokkos_InitializationSettings.hpp
+++ b/core/src/impl/Kokkos_InitializationSettings.hpp
@@ -12,19 +12,19 @@
 namespace Kokkos {
 
 class InitializationSettings {
-#define KOKKOS_IMPL_DECLARE(TYPE, NAME)                                      \
- private:                                                                    \
-  std::optional<TYPE> m_##NAME;                                              \
-                                                                             \
- public:                                                                     \
-  InitializationSettings& set_##NAME(TYPE NAME) {                            \
-    m_##NAME = NAME;                                                         \
-    return *this;                                                            \
-  }                                                                          \
-  bool has_##NAME() const noexcept { return static_cast<bool>(m_##NAME); }   \
-  TYPE get_##NAME() const noexcept /* NOLINT(bugprone-exception-escape) */ { \
-    return *m_##NAME; /* NOLINT(bugprone-unchecked-optional-access) */       \
-  }                                                                          \
+#define KOKKOS_IMPL_DECLARE(TYPE, NAME)                                    \
+ private:                                                                  \
+  std::optional<TYPE> m_##NAME;                                            \
+                                                                           \
+ public:                                                                   \
+  InitializationSettings& set_##NAME(TYPE NAME) {                          \
+    m_##NAME = NAME;                                                       \
+    return *this;                                                          \
+  }                                                                        \
+  bool has_##NAME() const noexcept { return static_cast<bool>(m_##NAME); } \
+  TYPE get_##NAME() const noexcept {                                       \
+    return *m_##NAME; /* NOLINT(bugprone-unchecked-optional-access) */     \
+  }                                                                        \
   static_assert(true, "no-op to require trailing semicolon")
 
  public:

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -623,7 +623,6 @@ union SharedAllocationTracker {
 
   // Copy:
   KOKKOS_FORCEINLINE_FUNCTION
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~SharedAllocationTracker(){KOKKOS_IMPL_SHARED_ALLOCATION_TRACKER_DECREMENT}
 
   KOKKOS_FORCEINLINE_FUNCTION

--- a/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc_timpl.hpp
@@ -18,7 +18,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// NOLINTBEGIN(bugprone-exception-escape)
 template <class MemorySpace>
 SharedAllocationRecordCommon<MemorySpace>::~SharedAllocationRecordCommon() {
   auto alloc_ptr  = SharedAllocationRecord<void, void>::m_alloc_ptr;
@@ -36,7 +35,6 @@ HostInaccessibleSharedAllocationRecordCommon<
   m_space.deallocate(label.c_str(), alloc_ptr, alloc_size,
                      alloc_size - sizeof(SharedAllocationHeader));
 }
-// NOLINTEND(bugprone-exception-escape)
 
 template <class MemorySpace>
 SharedAllocationRecordCommon<MemorySpace>::SharedAllocationRecordCommon(

--- a/core/unit_test/UnitTest_DeviceAndThreads.cpp
+++ b/core/unit_test/UnitTest_DeviceAndThreads.cpp
@@ -111,7 +111,7 @@ int print_flag(std::string const& flag) {
   return EXIT_FAILURE;
 }
 
-int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+int main(int argc, char* argv[]) {
   Kokkos::ScopeGuard guard(argc, argv);
   if (argc != 2) {
     std::cerr << "Usage: <executable> NAME_OF_FLAG\n";

--- a/core/unit_test/tools/TestAllCalls.cpp
+++ b/core/unit_test/tools/TestAllCalls.cpp
@@ -16,7 +16,7 @@ import kokkos.core;
 #include <iostream>
 #include <sstream>
 
-int main(int argc, char** argv) {  // NOLINT(bugprone-exception-escape)
+int main(int argc, char** argv) {
   Kokkos::initialize(argc, argv);
   {
     // This test only uses host kernel launch mechanisms. This is to allow for

--- a/example/.clang-tidy
+++ b/example/.clang-tidy
@@ -1,4 +1,0 @@
-Checks: >
-  -bugprone-exception-escape
-
-InheritParentConfig: true

--- a/simd/perf_tests/.clang-tidy
+++ b/simd/perf_tests/.clang-tidy
@@ -1,4 +1,0 @@
-Checks: >
-   -bugprone-exception-escape
-
-InheritParentConfig: true


### PR DESCRIPTION
Looking at #8930, the `bugprone-exception-escape` just creates warnings, we don't really care about. In particular, every function that creates a `std::string` somewhere in its stack potentionally throws an exception.
Thus, this pull request suggests to just remove the check.