### PR TITLE
Re-enable bugprone-invalid-enum-default-initialization check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,6 @@ Checks: >
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,
-  -bugprone-invalid-enum-default-initialization,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -148,6 +148,7 @@ struct to_chars_result {
 template <class Integral>
 KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
                                                      Integral value) {
+  // NOLINTBEGIN(bugprone-invalid-enum-default-initialization)
   using Unsigned = std::conditional_t<sizeof(Integral) <= sizeof(unsigned int),
                                       unsigned int, unsigned long long>;
   Unsigned unsigned_val = value;  // NOLINT(bugprone-signed-char-misuse)
@@ -166,6 +167,7 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
   }
   to_chars_impl(first, len, unsigned_val);
   return {first + len, {}};
+  // NOLINTEND(bugprone-invalid-enum-default-initialization)
 }
 //</editor-fold>
 


### PR DESCRIPTION
An alternative approach would be
```diff
diff --git a/.clang-tidy b/.clang-tidy
index 2b8b1a718..156482087 100644
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,8 @@ CheckOptions:
     value: true
   - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
     value: true
+  - key: bugprone-invalid-enum-default-initialization.IgnoredEnums
+    value: "::Kokkos::Impl::errc"

 FormatStyle: file
 HeaderFilterRegex: '(algorithms|benchmarks|containers|core|example|simd).*\.hpp'
```
I opted for a more localized suppression since it only occurs in one function and that we do not anticipate spread of that use at that time.