### PR TITLE
CI: disable spurious failing tests

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -74,6 +74,7 @@ NVIDIA-GH200:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON"
     - export CTEST_BUILD_NAME="NVIDIA-GH200"
+    - export GTEST_FILTER="-cuda.debug_pin_um_to_host"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}
         -D GITHUB_PR_ID="${GITHUB_PR_ID}"
@@ -221,6 +222,7 @@ AMD-MI300A:
     - export CTEST_BUILD_NAME="AMD-MI300A"
     - export HSA_XNACK=1
     - export KOKKOS_DEVICE_ID=3
+    - export GTEST_FILTER="-hip.graph_capture"
     - ctest -VV
       -D CDASH_MODEL=${CDASH_MODEL}
       -D GITHUB_PR_ID="${GITHUB_PR_ID}"

--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -222,6 +222,7 @@ AMD-MI300A:
     - export CTEST_BUILD_NAME="AMD-MI300A"
     - export HSA_XNACK=1
     - export KOKKOS_DEVICE_ID=3
+    # FIXME Reenable hip.graph_capture for rocm 7 testing
     - export GTEST_FILTER="-hip.graph_capture"
     - ctest -VV
       -D CDASH_MODEL=${CDASH_MODEL}

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -137,6 +137,7 @@ pipeline {
                         }
                     }
                     environment {
+                        // FIXME Reenable hip.graph_capture for rocm 7 testing
                         GTEST_FILTER = '-hip.graph_capture'
                     }
                     steps {
@@ -425,6 +426,7 @@ pipeline {
                         OMP_MAX_ACTIVE_LEVELS = 3
                         OMP_PLACES = 'threads'
                         OMP_PROC_BIND = 'spread'
+                        // FIXME Reenable hip.graph_capture for rocm 7 testing
                         GTEST_FILTER = '-hip.graph_capture'
                     }
                     steps {
@@ -470,7 +472,8 @@ pipeline {
                         }
                     }
                     environment {
-                        // FIXME Test returns a wrong value
+                        // FIXME hip_hostpinned.view_allocation_large_rank test returns a wrong value
+                        // FIXME Reenable hip.graph_capture for rocm 7 testing
                         GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank:hip.graph_capture'
                     }
                     steps {

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -136,6 +136,9 @@ pipeline {
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
+                    environment {
+                        GTEST_FILTER = '-hip.graph_capture'
+                    }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
@@ -422,6 +425,7 @@ pipeline {
                         OMP_MAX_ACTIVE_LEVELS = 3
                         OMP_PLACES = 'threads'
                         OMP_PROC_BIND = 'spread'
+                        GTEST_FILTER = '-hip.graph_capture'
                     }
                     steps {
                         sh 'ccache --zero-stats'
@@ -467,7 +471,7 @@ pipeline {
                     }
                     environment {
                         // FIXME Test returns a wrong value
-                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank'
+                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank:hip.graph_capture'
                     }
                     steps {
                         sh 'ccache --zero-stats'


### PR DESCRIPTION
- HIP builds with ROCm versions < 7: disable hip.graph_capture due to problems reported in e.g. https://github.com/kokkos/kokkos/issues/8359 , the future resolution is unlikely to be backported to a ROCm 6 patch release
- NVIDIA-GH200: disable cuda.debug_pin_um_to_host due to spurious timeouts