### PR TITLE
Run containers/performance_tests only when benchmarks are enabled

### DIFF
--- a/containers/CMakeLists.txt
+++ b/containers/CMakeLists.txt
@@ -5,5 +5,5 @@ endif()
 # FIXME_OPENACC: temporarily disabled due to unimplemented features
 if(NOT KOKKOS_ENABLE_OPENACC)
   kokkos_add_test_directories(unit_tests)
-  kokkos_add_test_directories(performance_tests)
+  kokkos_add_benchmark_directories(performance_tests)
 endif()


### PR DESCRIPTION
Many of the most expensive tests found in #8937 come from containers/performance_tests although these builds don't enable benchmarks.