### PR TITLE
view_hooks: ensure subscriber function is instantiated in device code

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -704,7 +704,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_FUNCTION
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
-      KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
+      // Has to be outside KOKKOS_IF_ON_HOST
+      // we need to make sure the template is actually instantiated or we may have a mismatch on
+      // code those host sees vs what the device sees
+      [[maybe_unused]] auto *copy_construct_ptr = &hooks_policy::template copy_construct<View>;
+      KOKKOS_IF_ON_HOST((copy_construct_ptr(*this, other);))
     }
   }
 #else
@@ -717,7 +721,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View(const View& other)
     requires(has_hooks_policy)
       : base_t{other} {
-    KOKKOS_IF_ON_HOST((hooks_policy::copy_construct(*this, other);))
+    // Has to be outside KOKKOS_IF_ON_HOST
+    // we need to make sure the template is actually instantiated or we may have a mismatch on
+    // code those host sees vs what the device sees
+    [[maybe_unused]] auto *copy_construct_ptr = &hooks_policy::template copy_construct<View>;
+    KOKKOS_IF_ON_HOST((copy_construct_ptr(*this, other);))
   }
 #endif
 
@@ -725,7 +733,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_FUNCTION
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
-      KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
+      // Has to be outside KOKKOS_IF_ON_HOST
+      // we need to make sure the template is actually instantiated or we may have a mismatch on
+      // code those host sees vs what the device sees
+      [[maybe_unused]] auto *move_construct_ptr = &hooks_policy::template move_construct<View>;
+      KOKKOS_IF_ON_HOST((move_construct_ptr(*this, other);))
     }
   }
 #else
@@ -738,7 +750,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View(View&& other)
     requires(has_hooks_policy)
       : base_t{std::move(static_cast<base_t&&>(other))} {
-    KOKKOS_IF_ON_HOST((hooks_policy::move_construct(*this, other);))
+    // Has to be outside KOKKOS_IF_ON_HOST
+    // we need to make sure the template is actually instantiated or we may have a mismatch on
+    // code those host sees vs what the device sees
+    [[maybe_unused]] auto *move_construct_ptr = &hooks_policy::template move_construct<View>;
+    KOKKOS_IF_ON_HOST((move_construct_ptr(*this, other);))
   }
 #endif
 
@@ -748,8 +764,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     base_t::operator=(other);
 
     if constexpr (has_hooks_policy) {
+      // Has to be outside KOKKOS_IF_ON_HOST
+      // we need to make sure the template is actually instantiated or we may have a mismatch on
+      // code those host sees vs what the device sees
+      [[maybe_unused]] auto *copy_assign_ptr = &hooks_policy::template copy_assign<View>;
       KOKKOS_IF_ON_HOST(
-          (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
+          (if (&other != this) { copy_assign_ptr(*this, other); }))
     }
 
     return *this;
@@ -765,8 +785,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     requires(has_hooks_policy)
   {
     base_t::operator=(other);
+    // Has to be outside KOKKOS_IF_ON_HOST
+    // we need to make sure the template is actually instantiated or we may have a mismatch on
+    // code those host sees vs what the device sees
+    [[maybe_unused]] auto *copy_assign_ptr = &hooks_policy::template copy_assign<View>;
     KOKKOS_IF_ON_HOST(
-        (if (&other != this) { hooks_policy::copy_assign(*this, other); }))
+        (if (&other != this) { copy_assign_ptr(*this, other); }))
 
     return *this;
   }
@@ -781,8 +805,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
 
     if constexpr (has_hooks_policy) {
+      // Has to be outside KOKKOS_IF_ON_HOST
+      // we need to make sure the template is actually instantiated or we may have a mismatch on
+      // code those host sees vs what the device sees
+      [[maybe_unused]] auto *move_assign_ptr = &hooks_policy::template move_assign<View>;
       KOKKOS_IF_ON_HOST(
-          (if (&other != this) { hooks_policy::move_assign(*this, other); }))
+          (if (&other != this) { move_assign_ptr(*this, other); }))
     }
 
     return *this;
@@ -798,8 +826,12 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     requires(has_hooks_policy)
   {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
+    // Has to be outside KOKKOS_IF_ON_HOST
+    // we need to make sure the template is actually instantiated or we may have a mismatch on
+    // code those host sees vs what the device sees
+    [[maybe_unused]] auto *move_assign_ptr = &hooks_policy::template move_assign<View>;
     KOKKOS_IF_ON_HOST(
-        (if (&other != this) { hooks_policy::move_assign(*this, other); }))
+        (if (&other != this) { move_assign_ptr(*this, other); }))
 
     return *this;
   }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -705,9 +705,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View(const View& other) : base_t{other} {
     if constexpr (has_hooks_policy) {
       // Has to be outside KOKKOS_IF_ON_HOST
-      // we need to make sure the template is actually instantiated or we may have a mismatch on
-      // code those host sees vs what the device sees
-      [[maybe_unused]] auto *copy_construct_ptr = &hooks_policy::template copy_construct<View>;
+      // we need to make sure the template is actually instantiated or we may
+      // have a mismatch on code those host sees vs what the device sees
+      [[maybe_unused]] auto* copy_construct_ptr =
+          &hooks_policy::template copy_construct<View>;
       KOKKOS_IF_ON_HOST((copy_construct_ptr(*this, other);))
     }
   }
@@ -722,9 +723,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     requires(has_hooks_policy)
       : base_t{other} {
     // Has to be outside KOKKOS_IF_ON_HOST
-    // we need to make sure the template is actually instantiated or we may have a mismatch on
-    // code those host sees vs what the device sees
-    [[maybe_unused]] auto *copy_construct_ptr = &hooks_policy::template copy_construct<View>;
+    // we need to make sure the template is actually instantiated or we may have
+    // a mismatch on code those host sees vs what the device sees
+    [[maybe_unused]] auto* copy_construct_ptr =
+        &hooks_policy::template copy_construct<View>;
     KOKKOS_IF_ON_HOST((copy_construct_ptr(*this, other);))
   }
 #endif
@@ -734,9 +736,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   View(View&& other) : base_t{std::move(static_cast<base_t&&>(other))} {
     if constexpr (has_hooks_policy) {
       // Has to be outside KOKKOS_IF_ON_HOST
-      // we need to make sure the template is actually instantiated or we may have a mismatch on
-      // code those host sees vs what the device sees
-      [[maybe_unused]] auto *move_construct_ptr = &hooks_policy::template move_construct<View>;
+      // we need to make sure the template is actually instantiated or we may
+      // have a mismatch on code those host sees vs what the device sees
+      [[maybe_unused]] auto* move_construct_ptr =
+          &hooks_policy::template move_construct<View>;
       KOKKOS_IF_ON_HOST((move_construct_ptr(*this, other);))
     }
   }
@@ -751,9 +754,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     requires(has_hooks_policy)
       : base_t{std::move(static_cast<base_t&&>(other))} {
     // Has to be outside KOKKOS_IF_ON_HOST
-    // we need to make sure the template is actually instantiated or we may have a mismatch on
-    // code those host sees vs what the device sees
-    [[maybe_unused]] auto *move_construct_ptr = &hooks_policy::template move_construct<View>;
+    // we need to make sure the template is actually instantiated or we may have
+    // a mismatch on code those host sees vs what the device sees
+    [[maybe_unused]] auto* move_construct_ptr =
+        &hooks_policy::template move_construct<View>;
     KOKKOS_IF_ON_HOST((move_construct_ptr(*this, other);))
   }
 #endif
@@ -765,9 +769,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
     if constexpr (has_hooks_policy) {
       // Has to be outside KOKKOS_IF_ON_HOST
-      // we need to make sure the template is actually instantiated or we may have a mismatch on
-      // code those host sees vs what the device sees
-      [[maybe_unused]] auto *copy_assign_ptr = &hooks_policy::template copy_assign<View>;
+      // we need to make sure the template is actually instantiated or we may
+      // have a mismatch on code those host sees vs what the device sees
+      [[maybe_unused]] auto* copy_assign_ptr =
+          &hooks_policy::template copy_assign<View>;
       KOKKOS_IF_ON_HOST(
           (if (&other != this) { copy_assign_ptr(*this, other); }))
     }
@@ -786,11 +791,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   {
     base_t::operator=(other);
     // Has to be outside KOKKOS_IF_ON_HOST
-    // we need to make sure the template is actually instantiated or we may have a mismatch on
-    // code those host sees vs what the device sees
-    [[maybe_unused]] auto *copy_assign_ptr = &hooks_policy::template copy_assign<View>;
-    KOKKOS_IF_ON_HOST(
-        (if (&other != this) { copy_assign_ptr(*this, other); }))
+    // we need to make sure the template is actually instantiated or we may have
+    // a mismatch on code those host sees vs what the device sees
+    [[maybe_unused]] auto* copy_assign_ptr =
+        &hooks_policy::template copy_assign<View>;
+    KOKKOS_IF_ON_HOST((if (&other != this) { copy_assign_ptr(*this, other); }))
 
     return *this;
   }
@@ -806,9 +811,10 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
     if constexpr (has_hooks_policy) {
       // Has to be outside KOKKOS_IF_ON_HOST
-      // we need to make sure the template is actually instantiated or we may have a mismatch on
-      // code those host sees vs what the device sees
-      [[maybe_unused]] auto *move_assign_ptr = &hooks_policy::template move_assign<View>;
+      // we need to make sure the template is actually instantiated or we may
+      // have a mismatch on code those host sees vs what the device sees
+      [[maybe_unused]] auto* move_assign_ptr =
+          &hooks_policy::template move_assign<View>;
       KOKKOS_IF_ON_HOST(
           (if (&other != this) { move_assign_ptr(*this, other); }))
     }
@@ -827,11 +833,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   {
     base_t::operator=(std::move(static_cast<base_t&&>(other)));
     // Has to be outside KOKKOS_IF_ON_HOST
-    // we need to make sure the template is actually instantiated or we may have a mismatch on
-    // code those host sees vs what the device sees
-    [[maybe_unused]] auto *move_assign_ptr = &hooks_policy::template move_assign<View>;
-    KOKKOS_IF_ON_HOST(
-        (if (&other != this) { move_assign_ptr(*this, other); }))
+    // we need to make sure the template is actually instantiated or we may have
+    // a mismatch on code those host sees vs what the device sees
+    [[maybe_unused]] auto* move_assign_ptr =
+        &hooks_policy::template move_assign<View>;
+    KOKKOS_IF_ON_HOST((if (&other != this) { move_assign_ptr(*this, other); }))
 
     return *this;
   }


### PR DESCRIPTION
This fixes an issue where if the subscriber invokes a kernel CUDA would fail at runtime in the kernel call with the error `cudaErrorInvalidDeviceFunction`

This was caused by the subscriber being called under `KOKKOS_IF_ON_HOST` (since it is not valid to call it on device).

However, this meant the subscriber template was not instantiated in the device compiler.

The (kind of gross) solution is to get a member function pointer to the subscriber function; this instantiates it. Then, on host call it and on device just ignore it.