### PR TITLE
[test] Add code coverage support for Kokkos testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ if(KOKKOS_ENABLE_COVERAGE AND Kokkos_ENABLE_TESTS AND NOT Kokkos_INSTALL_TESTING
       --ignore-filename-regex=".*/gtest/.*"
       --ignore-filename-regex=".*/desul/.*"
       --ignore-filename-regex=".*/mdspan/.*"
+      --ignore-filename-regex=".*/core/src/impl/.*"
     )
     list(JOIN _LLVM_COV_OBJECT_ARGS " " _LLVM_COV_OBJECT_STR)
     list(JOIN _LLVM_COV_IGNORE_ARGS " " _LLVM_COV_IGNORE_STR)
@@ -329,8 +330,7 @@ if(KOKKOS_ENABLE_COVERAGE AND Kokkos_ENABLE_TESTS AND NOT Kokkos_INSTALL_TESTING
         "#!/bin/sh
         set -e
         cd \"${CMAKE_BINARY_DIR}\"
-        \"${LLVM_COV}\" report -instr-profile=default.profdata 
-        \"$<TARGET_FILE:Kokkos_CoreUnitTest_Serial1>\" ${_LLVM_COV_OBJECT_STR} ${_LLVM_COV_IGNORE_STR} | tee coverage_report.txt
+        \"${LLVM_COV}\" report -instr-profile=default.profdata \"$<TARGET_FILE:Kokkos_CoreUnitTest_Serial1>\" ${_LLVM_COV_OBJECT_STR} ${_LLVM_COV_IGNORE_STR} | tee coverage_report.txt
         "
     )
     add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,89 @@ include(${KOKKOS_SRC_PATH}/cmake/kokkos_install.cmake)
 # files
 kokkos_install_additional_files()
 
+# Code coverage target - builds with coverage flags (when Kokkos_ENABLE_COVERAGE=ON)
+# Requires Clang, llvm-profdata, llvm-cov. Uses llvm-cov for reporting.
+if(KOKKOS_ENABLE_COVERAGE AND Kokkos_ENABLE_TESTS AND NOT Kokkos_INSTALL_TESTING)
+  add_custom_target(
+    kokkos_coverage
+    COMMAND ${CMAKE_COMMAND} -E echo "Cleaning previous coverage data..."
+    COMMAND
+      ${CMAKE_COMMAND} -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
+      -P ${CMAKE_SOURCE_DIR}/cmake/coverage_clean.cmake
+  )
+  # Add dependency on kokkoscore and Kokkos_CoreUnitTest_Serial1 
+  # We can add more dependencies if we want to run more tests or benchmarks.
+  add_dependencies(kokkos_coverage kokkoscore)
+  if(TARGET Kokkos_CoreUnitTest_Serial1)
+    add_dependencies(kokkos_coverage Kokkos_CoreUnitTest_Serial1)
+  endif()
+  # Run test from build dir with LLVM_PROFILE_FILE so .profraw is written (must exit normally)
+  # I am ok if we drop this target and just run the test from the build dir.
+  add_custom_target(
+    kokkos_run_coverage_test
+    COMMAND
+      ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}
+      ${CMAKE_COMMAND} -E env "LLVM_PROFILE_FILE=default.profraw"
+      $<TARGET_FILE:Kokkos_CoreUnitTest_Serial1>
+    COMMENT "Running all tests to generate .profraw"
+  )
+  add_dependencies(kokkos_run_coverage_test Kokkos_CoreUnitTest_Serial1)
+  find_program(LLVM_PROFDATA llvm-profdata)
+  find_program(LLVM_COV llvm-cov)
+  if(LLVM_PROFDATA AND LLVM_COV)
+    # For static libs, coverage is in the executable; for shared libs, pass --object
+    set(_LLVM_COV_OBJECT_ARGS)
+    if(BUILD_SHARED_LIBS)
+      set(_LLVM_COV_OBJECT_ARGS --object $<TARGET_FILE:kokkoscore>)
+    endif()
+    # Include only core/src, exclude all paths outside core/src
+    set(_LLVM_COV_IGNORE_ARGS
+      --ignore-filename-regex=".*/algorithms/.*"
+      --ignore-filename-regex=".*/containers/.*"
+      --ignore-filename-regex=".*/simd/.*"
+      --ignore-filename-regex=".*/unit_test/.*"
+      --ignore-filename-regex=".*/unit_tests/.*"
+      --ignore-filename-regex=".*/perf_test/.*"
+      --ignore-filename-regex=".*/tpls/.*"
+      --ignore-filename-regex=".*/gtest/.*"
+      --ignore-filename-regex=".*/desul/.*"
+      --ignore-filename-regex=".*/mdspan/.*"
+    )
+    list(JOIN _LLVM_COV_OBJECT_ARGS " " _LLVM_COV_OBJECT_STR)
+    list(JOIN _LLVM_COV_IGNORE_ARGS " " _LLVM_COV_IGNORE_STR)
+    set(_COVERAGE_REPORT_SH "${CMAKE_BINARY_DIR}/coverage_report.sh")
+    file(
+      GENERATE
+      OUTPUT ${_COVERAGE_REPORT_SH}
+      CONTENT
+        "#!/bin/sh
+        set -e
+        cd \"${CMAKE_BINARY_DIR}\"
+        \"${LLVM_COV}\" report -instr-profile=default.profdata 
+        \"$<TARGET_FILE:Kokkos_CoreUnitTest_Serial1>\" ${_LLVM_COV_OBJECT_STR} ${_LLVM_COV_IGNORE_STR} | tee coverage_report.txt
+        "
+    )
+    add_custom_target(
+      kokkos_coverage_report
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMAND ${LLVM_PROFDATA} merge -sparse -o default.profdata default.profraw
+      COMMAND sh ${_COVERAGE_REPORT_SH}
+      COMMENT "Generating coverage report with llvm-cov (output in coverage_report.txt)"
+    )
+    message(
+      STATUS
+        "Coverage: kokkos_coverage (build), kokkos_run_coverage_test (run), "
+        "kokkos_coverage_report"
+    )
+  else()
+    message(
+      STATUS
+        "Coverage: kokkos_coverage (build), kokkos_run_coverage_test (run). "
+        "Install LLVM (llvm-profdata, llvm-cov) for kokkos_coverage_report"
+    )
+  endif()
+endif()
+
 #  Finally - if we are a subproject - make sure the enabled devices are visible
 if(HAS_PARENT)
   foreach(DEV Kokkos_ENABLED_DEVICES)

--- a/cmake/coverage_clean.cmake
+++ b/cmake/coverage_clean.cmake
@@ -1,0 +1,12 @@
+# Clean previous LLVM coverage data from the build directory.
+# Invoked by kokkos_coverage target with -DCMAKE_BINARY_DIR=<build_dir>.
+if(NOT CMAKE_BINARY_DIR)
+  message(FATAL_ERROR "coverage_clean.cmake requires -DCMAKE_BINARY_DIR=<path>")
+endif()
+foreach(_f default.profraw default.profdata)
+  set(_path "${CMAKE_BINARY_DIR}/${_f}")
+  if(EXISTS "${_path}")
+    file(REMOVE "${_path}")
+    message(STATUS "Removed ${_path}")
+  endif()
+endforeach()

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -192,6 +192,28 @@ if(KOKKOS_ENABLE_COMPILER_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS}")
 endif()
 
+#------------------------------- KOKKOS_COVERAGE (llvm-cov) ---------------------------
+if(KOKKOS_ENABLE_COVERAGE)
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" _COVERAGE_BUILD_TYPE)
+  if(NOT _COVERAGE_BUILD_TYPE STREQUAL "DEBUG")
+    message(
+      FATAL_ERROR
+        "Kokkos_ENABLE_COVERAGE requires CMAKE_BUILD_TYPE=Debug. Configure with -DCMAKE_BUILD_TYPE=Debug"
+    )
+  endif()
+  unset(_COVERAGE_BUILD_TYPE)
+  if(KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
+    global_append(KOKKOS_COMPILE_OPTIONS -fprofile-instr-generate -fcoverage-mapping)
+    global_append(KOKKOS_LINK_OPTIONS -fprofile-instr-generate)
+    message(STATUS "Code coverage (llvm-cov) enabled for core/src - use unit tests in core/unit_test")
+  else()
+    message(
+      FATAL_ERROR
+        "Kokkos_ENABLE_COVERAGE requires Clang. Configure with -DCMAKE_CXX_COMPILER=clang++"
+    )
+  endif()
+endif()
+
 #------------------------------- KOKKOS_CUDA_OPTIONS ---------------------------
 #clear anything that might be in the cache
 global_set(KOKKOS_CUDA_OPTIONS)

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -48,6 +48,10 @@ kokkos_enable_option(
 )
 kokkos_enable_option(IMPL_SYCL_OUT_OF_ORDER_QUEUES OFF "Whether to make Kokkos use out-of-order queues internally")
 kokkos_enable_option(TESTS OFF "Whether to build the unit tests")
+kokkos_enable_option(
+  COVERAGE OFF
+  "Whether to enable code coverage (llvm-cov) for core/src using unit tests. Requires Clang and -DCMAKE_BUILD_TYPE=Debug."
+)
 kokkos_enable_option(BENCHMARKS OFF "Whether to build the benchmarks")
 kokkos_enable_option(EXAMPLES OFF "Whether to build the examples")
 if(Kokkos_ENABLE_BENCHMARKS)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -6,7 +6,8 @@
 # upper-case version for use within
 
 set(Kokkos_OPTIONS_NOT_TO_EXPORT Kokkos_ENABLE_BENCHMARKS Kokkos_ENABLE_EXAMPLES Kokkos_ENABLE_TESTS
-                                 Kokkos_ENABLE_HEADER_SELF_CONTAINMENT_TESTS Kokkos_ENABLE_COMPILER_WARNINGS
+                                 Kokkos_ENABLE_COVERAGE Kokkos_ENABLE_HEADER_SELF_CONTAINMENT_TESTS
+                                 Kokkos_ENABLE_COMPILER_WARNINGS
 )
 
 #

--- a/scripts/coverage_report_summary.sh
+++ b/scripts/coverage_report_summary.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Print header and summary (last line) from llvm-cov coverage_report.txt as markdown table
+# Usage: coverage_report_summary.sh [coverage_report.txt]
+# Default: coverage_report.txt in current directory
+
+REPORT="${1:-coverage_report.txt}"
+if [ ! -f "$REPORT" ]; then
+  echo "Error: $REPORT not found" >&2
+  exit 1
+fi
+
+_header=$(head -1 "$REPORT")
+_data=$(tail -1 "$REPORT")
+
+# Convert space-separated columns to markdown table
+# Splits on 2+ spaces to handle llvm-cov column alignment
+_to_md_row() {
+  printf '%s' "$1" | awk '
+    BEGIN { FS = "  +" }
+    {
+      $1 = $1
+      if (NF > 0) {
+        printf "|"
+        for (i = 1; i <= NF; i++) printf " %s |", $i
+        printf "\n"
+      }
+    }'
+}
+
+_sep_row() {
+  printf '%s' "$1" | awk '
+    BEGIN { FS = "  +" }
+    {
+      $1 = $1
+      if (NF > 0) {
+        printf "|"
+        for (i = 1; i <= NF; i++) printf " --- |"
+        printf "\n"
+      }
+    }'
+}
+
+_to_md_row "$_header"
+_sep_row "$_header"
+_to_md_row "$_data"


### PR DESCRIPTION
This came out of a discussion about speeding up CI by removing redundant test variations or parameter permutations without reducing coverage. To establish a baseline, this PR adds code coverage instrumentation using `llvm-cov`.

## Motivation:
1. Do certain changes of our unit tests result in altered coverage? 
2. Can we remove some test parameter permutations to reduce compilation or runtime while maintaining current coverage?
3. Can we generate insight into and reason about coverage? 
4. Can we add a unit test compilation target that offers highest coverage (bang-for-the-buck)?

## Example output 
Obtained from Kokkos_CoreUnitTest_Serial1:

| Filename | Regions | Missed Regions | Cover | Functions | Missed Functions | Executed | Lines | Missed Lines | Cover | Branches | Missed Branches | Cover |
|----------|--------:|---------------:|------:|----------:|-----------------:|---------:|------:|-------------:|------:|---------:|----------------:|------:|
| TOTAL | 6352 | 2315 | 63.55% | 1445 | 383 | 73.49% | 10897 | 3917 | 64.05% | 2910 | 1418 | 51.27% |

Of course we can format this down to a single number. 

Full output attached.

## CMake changes / compilation:
- `cmake/kokkos_enable_options.cmake` — add `Kokkos_ENABLE_COVERAGE` option
- `cmake/kokkos_arch.cmake` — add flags `-fprofile-instr-generate` and `-fcoverage-mapping`
- `cmake/kokkos_functions.cmake` — add `Kokkos_ENABLE_COVERAGE` to `OPTIONS_NOT_TO_EXPORT`
- `cmake/coverage_clean.cmake` — new file, removes `.profraw`/`.profdata` before runs to void issues of file miss-match between runs
- New script: `scripts/coverage_report_summary.sh` — prints the header and total line as a markdown table.

### Coverage targets:
- `kokkos_coverage`: build with coverage instrumentation
- `kokkos_run_coverage_test`: sets env cars and runs `Kokkos_CoreUnitTest_Serial1` to generate `.profraw` data
- `kokkos_coverage_report`: merges `.profdata`, runs `llvm-cov report`, tees output to `coverage_report.txt`

Coverage is limited to `core/src`. I've exluced algorithms, containers, simd, unit tests, TPLs, gtest, desul, mdspan.

### Cost of compilation and execution
There seems to be an increase of ~20% to compile and run `Kokkos_CoreUnitTest_Serial1` with `DKokkos_ENABLE_COVERAGE=On`.
Compilation time: 
```
6m22.922s (Kokkos_ENABLE_COVERAGE=ON)
5m19.505s (Kokkos_ENABLE_COVERAGE=OFF)
```
Execution time:
```
5m15.236s (Kokkos_ENABLE_COVERAGE=ON)
4m35.223s (Kokkos_ENABLE_COVERAGE=OFF)
```

## Usage
Requires Clang and a Debug build.

1. Configure with coverage enabled:
```cmake
   cmake -B build -DCMAKE_BUILD_TYPE=Debug \
         -DCMAKE_CXX_COMPILER=clang++ \
         -DKokkos_ENABLE_COVERAGE=ON \
         -DKokkos_ENABLE_TESTS=ON
```
2. Build with coverage instrumentation (cleans previous `.profraw`/`.profdata`):
```
   make kokkos_coverage
```
3. Run the core unit test to generate `default.profraw`:
```
    make kokkos_run_coverage_test
```
8. Generate the report (requires `llvm-profdata` and `llvm-cov`):
```
   make kokkos_coverage_report
```
Output is written to build/coverage_report.txt.

9. Optionally: extract a markdown summary table as shown further up
```
   ./scripts/coverage_report_summary.sh build/coverage_report.txt
```

## More examples:
We can get a detailed view. I'd welcome comments on whether this is useful information for `tools` or others.

<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/5263892e-50ee-4686-b7b3-576f37558074" />

## Analytics

Generated from running coverage testing of running `Kokkos_CoreUnitTest_Serial1`.

<img width="600" height="800" alt="coverage_by_metric" src="https://github.com/user-attachments/assets/b0d1b945-5312-4a0b-9e7f-dbdd64619dcd" />

<img width="600" height="800" alt="coverage_per_file" src="https://github.com/user-attachments/assets/2860b6ce-ecbe-4ca6-9952-f392b3c7f9d0" />


<img width="600" height="883" alt="coverage_worst_best" src="https://github.com/user-attachments/assets/72ab6b65-1e6c-4c31-98b1-ecd0a9739898" />

