### PR TITLE
Revert "Run containers/performance_tests only when benchmarks are enabled"

### DIFF
--- a/containers/CMakeLists.txt
+++ b/containers/CMakeLists.txt
@@ -5,5 +5,5 @@ endif()
 # FIXME_OPENACC: temporarily disabled due to unimplemented features
 if(NOT KOKKOS_ENABLE_OPENACC)
   kokkos_add_test_directories(unit_tests)
-  kokkos_add_benchmark_directories(performance_tests)
+  kokkos_add_test_directories(performance_tests)
 endif()


### PR DESCRIPTION
Reverts kokkos/kokkos#8945

I had not noticed that GH actions had not run.

```
CMake Error at cmake/kokkos_tribits.cmake:190 (get_target_property):
  get_target_property() called with non-existent target "GTest::gtest".
Call Stack (most recent call first):
  cmake/kokkos_tribits.cmake:92 (kokkos_add_test_executable)
  containers/performance_tests/CMakeLists.txt:12 (kokkos_add_executable_and_test)
```