### PR TITLE
Identify homebrew llvm as KOKKOS_COMPILER_CLANG

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -126,7 +126,8 @@
 // CRAY compiler for host code
 #define KOKKOS_COMPILER_CRAYC _CRAYC
 
-#elif defined(__APPLE_CC__) && defined(__clang__)
+#elif defined(__APPLE_CC__) && defined(__clang__) && \
+    defined(__apple_build_version__)
 #define KOKKOS_COMPILER_APPLECC __APPLE_CC__
 
 #elif defined(__NVCOMPILER)


### PR DESCRIPTION
In the same vein as https://github.com/kokkos/kokkos/pull/8592, this pull request makes sure that we treat `homebrew` clang` as `KOKKOS_COMPILER_CLANG` and not `KOKKOS_COMPILER_APPLECC`.
I noticed the "issue" when I was running into https://github.com/kokkos/kokkos/pull/8903.