### PR TITLE
Fix -Wundef warnings about KOKKOS_VERSION* not being defined

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -18,6 +18,12 @@
  *  KOKKOS_ENABLE_CUDA_UVM            Use CUDA UVM for Cuda memory space.
  */
 
+#ifndef KOKKOS_DONT_INCLUDE_CORE_CONFIG_H
+#include <KokkosCore_config.h>
+#include <impl/Kokkos_DesulAtomicsConfig.hpp>
+#include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
+#endif
+
 #define KOKKOS_VERSION_LESS(MAJOR, MINOR, PATCH) \
   (KOKKOS_VERSION < ((MAJOR)*10000 + (MINOR)*100 + (PATCH)))
 
@@ -36,12 +42,6 @@
 #if !KOKKOS_VERSION_EQUAL(KOKKOS_VERSION_MAJOR, KOKKOS_VERSION_MINOR, \
                           KOKKOS_VERSION_PATCH)
 #error implementation bug
-#endif
-
-#ifndef KOKKOS_DONT_INCLUDE_CORE_CONFIG_H
-#include <KokkosCore_config.h>
-#include <impl/Kokkos_DesulAtomicsConfig.hpp>
-#include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 #endif
 
 #if __has_include(<version>)


### PR DESCRIPTION
Partial fix for #8954 
Make sure we include the config file with all our macro defines before introducing the macro version comparison helpers.

```
/path/to/kokkos/core/src/Kokkos_Macros.hpp:36:6: warning: 'KOKKOS_VERSION' is not defined, evaluates to 0 [-Wundef]
   36 | #if !KOKKOS_VERSION_EQUAL(KOKKOS_VERSION_MAJOR, KOKKOS_VERSION_MINOR, \
      |      ^
/path/to/kokkos/core/src/Kokkos_Macros.hpp:34:4: note: expanded from macro 'KOKKOS_VERSION_EQUAL'
   34 |   (KOKKOS_VERSION == ((MAJOR)*10000 + (MINOR)*100 + (PATCH)))
      |    ^
/path/to/kokkos/core/src/Kokkos_Macros.hpp:36:27: warning: 'KOKKOS_VERSION_MAJOR' is not defined, evaluates to 0 [-Wundef]
   36 | #if !KOKKOS_VERSION_EQUAL(KOKKOS_VERSION_MAJOR, KOKKOS_VERSION_MINOR, \
      |                           ^
/path/to/kokkos/core/src/Kokkos_Macros.hpp:36:49: warning: 'KOKKOS_VERSION_MINOR' is not defined, evaluates to 0 [-Wundef]
   36 | #if !KOKKOS_VERSION_EQUAL(KOKKOS_VERSION_MAJOR, KOKKOS_VERSION_MINOR, \
      |                                                 ^
/path/to/kokkos/core/src/Kokkos_Macros.hpp:37:27: warning: 'KOKKOS_VERSION_PATCH' is not defined, evaluates to 0 [-Wundef]
   37 |                           KOKKOS_VERSION_PATCH)
      |                           ^
```