### PR TITLE
Set HEARTBEAT_CHECK_INTERVAL in jenkins

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -18,6 +18,14 @@ pipeline {
     }
 
     stages {
+        stage('Configure heartbeat') {
+            steps {
+                 script {
+                     System.setProperty("org.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL", "86400")
+                 }
+            }
+        }
+
         stage('Pre-Commit') {
             agent {
                 docker {


### PR DESCRIPTION
This should hopefully take care of
```
(JENKINS-48300: if on an extremely laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=86400)
```