### PR TITLE
[ci skip] Suppress zero-length-array warnings in Aurora nightly build

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -54,7 +54,7 @@ Aurora:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_INTEL_PVC=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-pass-failed -fp-model=precise'"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-zero-length-array -Wno-pass-failed -fp-model=precise'"
     - ctest -VV
         -D CDASH_MODEL=Nightly
         -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}"


### PR DESCRIPTION
Suppresses the warnings in https://my.cdash.org/builds/3419205/errors. They don't originate from our source code and we are already suppressing the same warning for other SYCL builds.