### PR TITLE
CUDA (clang) - Add no-inline to avoid ICE with HostSharedPtr.

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -40,7 +40,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 // fully inlined into cuda_parallel_launch_local_memory, MachineLICM crashes
 // with a null pointer dereference. noinline on exec_range keeps the loop body
 // in that kernel as a single call instruction, avoiding the crash.
-#if defined(KOKKOS_COMPILER_CLANG)  && KOKKOS_COMPILER_CLANG >= 2000 && KOKKOS_COMPILER_CLANG < 2300 && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG >= 2000 && \
+    KOKKOS_COMPILER_CLANG < 2300 && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_IMPL_EXEC_RANGE_ATTRS __attribute__((noinline)) __device__
 #else
 #define KOKKOS_IMPL_EXEC_RANGE_ATTRS inline __device__

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -40,7 +40,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 // fully inlined into cuda_parallel_launch_local_memory, MachineLICM crashes
 // with a null pointer dereference. noinline on exec_range keeps the loop body
 // in that kernel as a single call instruction, avoiding the crash.
-#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_COMPILER_CLANG)  && KOKKOS_COMPILER_CLANG >= 2000 && KOKKOS_COMPILER_CLANG < 2300 && defined(KOKKOS_ENABLE_CUDA)
 #define KOKKOS_IMPL_EXEC_RANGE_ATTRS __attribute__((noinline)) __device__
 #else
 #define KOKKOS_IMPL_EXEC_RANGE_ATTRS inline __device__

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -36,17 +36,27 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   const FunctorType m_functor;
   const Policy m_policy;
 
+// Workaround for Clang CUDA ICE in MachineLICM pass: when the user functor is
+// fully inlined into cuda_parallel_launch_local_memory, MachineLICM crashes
+// with a null pointer dereference. noinline on exec_range keeps the loop body
+// in that kernel as a single call instruction, avoiding the crash.
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
+#define KOKKOS_IMPL_EXEC_RANGE_ATTRS __attribute__((noinline)) __device__
+#else
+#define KOKKOS_IMPL_EXEC_RANGE_ATTRS inline __device__
+#endif
   template <class TagType>
-  inline __device__ std::enable_if_t<std::is_void_v<TagType>> exec_range(
-      const Member i) const {
+  KOKKOS_IMPL_EXEC_RANGE_ATTRS std::enable_if_t<std::is_void_v<TagType>>
+  exec_range(const Member i) const {
     m_functor(i);
   }
 
   template <class TagType>
-  inline __device__ std::enable_if_t<!std::is_void_v<TagType>> exec_range(
-      const Member i) const {
+  KOKKOS_IMPL_EXEC_RANGE_ATTRS std::enable_if_t<!std::is_void_v<TagType>>
+  exec_range(const Member i) const {
     m_functor(TagType(), i);
   }
+#undef KOKKOS_IMPL_EXEC_RANGE_ATTRS
 
  public:
   using functor_type = FunctorType;


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8915.
The PR avoids inlining user functor in RangePolicy to avoid ICE when building CUDA backend with Clang compiler. 
The ICE occurs in MachineLICM pass when the user functor is fully inlined into cuda_parallel_launch_local_memory, MachineLICM crashes with a null pointer dereference. noinline on exec_range keeps the loop body in that kernel as a single call instruction, avoiding the crash.
