### PR TITLE
Print output from compile/link flags check

### DIFF
--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -1029,6 +1029,7 @@ function(kokkos_check_flags)
         WARNING
           "The compiler for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS} in combination with the CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS=${CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS}. Please check the given configuration."
       )
+      kokkos_print_configure_log(KEYWORD "-DKOKKOS_COMPILE_OPTIONS_CHECK")
     endif()
   endif()
 
@@ -1044,6 +1045,7 @@ function(kokkos_check_flags)
         WARNING
           "The linker for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS}. Please check the given configuration."
       )
+      kokkos_print_configure_log(KEYWORD "-DKOKKOS_LINK_OPTIONS_CHECK")
     endif()
   endif()
 endfunction()

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -967,7 +967,6 @@ function(kokkos_print_cmake_configure_log START_REGEX END_REGEX)
     file(STRINGS "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml" LOG_LINES)
 
     foreach(LINE IN LISTS LOG_LINES)
-      #message(STATUS "${START_REGEX} ${LINE}")
       if(LINE MATCHES ${START_REGEX})
         set(START_OUTPUT TRUE)
       endif()

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -984,7 +984,7 @@ function(kokkos_print_configure_log)
       endif()
     endforeach()
     if(START_OUTPUT)
-      message(WARNING "ConfigureLog.yaml shows:\n ${OUTPUT_BLOCK}")
+      message(WARNING "ConfigureLog.yaml shows:\n${OUTPUT_BLOCK}")
     endif()
   endif()
 

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -954,16 +954,11 @@ int main()
   set(${_VAR} ${_RET} CACHE STRING "CXX compiler supports building CUDA")
 endfunction()
 
-# this function is provided to print messages from configure log:
+# this function is provided to print messages from CMake's configure log:
 #
 #       KEYWORD     --> Keyword in a compile line that should be printed
 #
-function(kokkos_print_configure_log)
-  cmake_parse_arguments(INP "" "KEYWORD" "" ${ARGN})
-
-  if(NOT INP_KEYWORD)
-    message(FATAL_ERROR "'kokkos_print_configure_log' requires KEYWORD keyword")
-  endif()
+function(kokkos_print_cmake_configure_log START_REGEX END_REGEX)
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26.0)
     set(OUTPUT_BLOCK "")
@@ -971,7 +966,8 @@ function(kokkos_print_configure_log)
     file(STRINGS "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml" LOG_LINES)
 
     foreach(LINE IN LISTS LOG_LINES)
-      if(LINE MATCHES "${INP_KEYWORD}")
+      #message(STATUS "${START_REGEX} ${LINE}")
+      if(LINE MATCHES ${START_REGEX})
         set(START_OUTPUT TRUE)
       endif()
 
@@ -979,7 +975,7 @@ function(kokkos_print_configure_log)
         string(APPEND OUTPUT_BLOCK "${LINE}\n")
       endif()
 
-      if(LINE MATCHES "exitCode" AND START_OUTPUT)
+      if(LINE MATCHES ${END_REGEX} AND START_OUTPUT)
         break()
       endif()
     endforeach()
@@ -1029,7 +1025,7 @@ function(kokkos_check_flags)
         WARNING
           "The compiler for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS} in combination with the CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS=${CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS}. Please check the given configuration."
       )
-      kokkos_print_configure_log(KEYWORD "-DKOKKOS_COMPILE_OPTIONS_CHECK")
+      kokkos_print_cmake_configure_log("DKOKKOS_COMPILE_OPTIONS_CHECK" "exitCode")
     endif()
   endif()
 
@@ -1045,7 +1041,7 @@ function(kokkos_check_flags)
         WARNING
           "The linker for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS}. Please check the given configuration."
       )
-      kokkos_print_configure_log(KEYWORD "-DKOKKOS_LINK_OPTIONS_CHECK")
+      kokkos_print_cmake_configure_log("DKOKKOS_LINK_OPTIONS_CHECK" "exitCode")
     endif()
   endif()
 endfunction()

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -1041,7 +1041,7 @@ function(kokkos_check_flags)
         WARNING
           "The linker for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS}. Please check the given configuration."
       )
-      kokkos_print_cmake_configure_log("DKOKKOS_LINK_OPTIONS_CHECK" "exitCode")
+      kokkos_print_cmake_configure_log("D ?KOKKOS_LINK_OPTIONS_CHECK" "exitCode")
     endif()
   endif()
 endfunction()

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -965,7 +965,7 @@ function(kokkos_print_configure_log)
     message(FATAL_ERROR "'kokkos_print_configure_log' requires KEYWORD keyword")
   endif()
 
-  if(CMAKE_VERSION VERSION_GREATER 3.26.0)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.26.0)
     set(OUTPUT_BLOCK "")
     set(START_OUTPUT FALSE)
     file(STRINGS "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml" LOG_LINES)

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -954,6 +954,42 @@ int main()
   set(${_VAR} ${_RET} CACHE STRING "CXX compiler supports building CUDA")
 endfunction()
 
+# this function is provided to print messages from configure log:
+#
+#       KEYWORD     --> Keyword in a compile line that should be printed
+#
+function(kokkos_print_configure_log)
+  cmake_parse_arguments(INP "" "KEYWORD" "" ${ARGN})
+
+  if(NOT INP_KEYWORD)
+    message(FATAL_ERROR "'kokkos_print_configure_log' requires KEYWORD keyword")
+  endif()
+
+  if(CMAKE_VERSION VERSION_GREATER 3.26.0)
+    set(OUTPUT_BLOCK "")
+    set(START_OUTPUT FALSE)
+    file(STRINGS "${CMAKE_BINARY_DIR}/CMakeFiles/CMakeConfigureLog.yaml" LOG_LINES)
+
+    foreach(LINE IN LISTS LOG_LINES)
+      if(LINE MATCHES "${INP_KEYWORD}")
+        set(START_OUTPUT TRUE)
+      endif()
+
+      if(START_OUTPUT)
+        string(APPEND OUTPUT_BLOCK "${LINE}\n")
+      endif()
+
+      if(LINE MATCHES "exitCode" AND START_OUTPUT)
+        break()
+      endif()
+    endforeach()
+    if(START_OUTPUT)
+      message(WARNING "ConfigureLog.yaml shows:\n ${OUTPUT_BLOCK}")
+    endif()
+  endif()
+
+endfunction()
+
 # this function is provided to easily select which files use nvcc_wrapper:
 #
 #       COMPILER    --> do check for compiler

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -1025,7 +1025,7 @@ function(kokkos_check_flags)
         WARNING
           "The compiler for ${KOKKOS_COMPILE_LANGUAGE} can not consume flag(s) ${QUOTED_FLAGS} in combination with the CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS=${CMAKE_${KOKKOS_COMPILE_LANGUAGE}_FLAGS}. Please check the given configuration."
       )
-      kokkos_print_cmake_configure_log("DKOKKOS_COMPILE_OPTIONS_CHECK" "exitCode")
+      kokkos_print_cmake_configure_log("D ?KOKKOS_COMPILE_OPTIONS_CHECK" "exitCode")
     endif()
   endif()
 

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -956,7 +956,8 @@ endfunction()
 
 # this function is provided to print messages from CMake's configure log:
 #
-#       KEYWORD     --> Keyword in a compile line that should be printed
+#       START_REGEX     --> Keyword to mark start of output
+#       END_REGEX       --> Keyword to mark end of output
 #
 function(kokkos_print_cmake_configure_log START_REGEX END_REGEX)
 


### PR DESCRIPTION
This PR does two things:

- ~Relaxes the compile/link flags check to a warning to still allow compilation in cases where the check yields false positives~ moved to #8988 
- Introduces a print function of the configure log if CMake>= 3.26 to give more insight to the user

Alternative to #8806
Fixes #8362

This relies on how CMake writes their yaml files (and that the file is flushed after the compile check). I do see that this is potentially brittle, but we can still point users to look at that file if we want to