### PR TITLE
Always run pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,6 +2,13 @@ name: pre-commit
 
 on:
   workflow_call:
+  push:
+    branches:
+      - develop
+  pull_request:
+    paths-ignore:
+    - '**/*.md'
+    types: [ opened, reopened, synchronize ]
 
 permissions: read-all
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,9 +2,6 @@ name: pre-commit
 
 on:
   workflow_call:
-  push:
-    branches:
-      - develop
   pull_request:
     types: [ opened, reopened, synchronize ]
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - develop
   pull_request:
-    paths-ignore:
-    - '**/*.md'
     types: [ opened, reopened, synchronize ]
 
 permissions: read-all

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,8 @@ name: pre-commit
 on:
   workflow_call:
   pull_request:
+    paths:
+      - '**/*.md'
     types: [ opened, reopened, synchronize ]
 
 permissions: read-all


### PR DESCRIPTION
We didn't notice whitespace issues in https://github.com/kokkos/kokkos/pull/8948 since we don't run GitHub actions if we only `*.md` files are modified.
This pull request proposes to always run pre-commit resulting in a dupliacte check for most builds that is still cheap (~1 minute).