### PR TITLE
Fix misalignment issues for CUDA and HIP combined reducers

### DIFF
--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -11,7 +11,6 @@
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
 
-#include <algorithm>
 #include <utility>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -11,6 +11,7 @@
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_AnonymousSpace.hpp>
 
+#include <algorithm>
 #include <utility>
 
 namespace Kokkos {
@@ -41,12 +42,28 @@ struct CombinedReducerValueItemImpl {
 
 //==============================================================================
 
+// Dummy struct used to get the alignment of CombinedReducerValueImpl.
+template <class IdxSeq, class... ValueTypes>
+struct DummyCombinedReducerValueImpl;
+
+template <size_t... Idxs, class... Types>
+struct DummyCombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
+                                     Types...>
+    : CombinedReducerValueItemImpl<Idxs, Types>... {};
+
 template <class IdxSeq, class... ValueTypes>
 struct CombinedReducerValueImpl;
 
+// CombinedReducerValueImpl has to be aligned to at least alignof(int) and its
+// sizeof must be a multiple of sizeof(int), as we might access it through an
+// int* in the CUDA and HIP reduction kernels.
 template <size_t... Idxs, class... ValueTypes>
-struct CombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
-                                ValueTypes...>
+struct alignas(
+    std::max(alignof(int),
+             alignof(DummyCombinedReducerValueImpl<
+                     std::integer_sequence<size_t, Idxs...>, ValueTypes...>)))
+    CombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
+                             ValueTypes...>
     : CombinedReducerValueItemImpl<Idxs, ValueTypes>... {
  public:
   KOKKOS_DEFAULTED_FUNCTION

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -42,29 +42,22 @@ struct CombinedReducerValueItemImpl {
 
 //==============================================================================
 
-// Dummy struct used to get the alignment of CombinedReducerValueImpl.
-template <class IdxSeq, class... ValueTypes>
-struct DummyCombinedReducerValueImpl;
-
-template <size_t... Idxs, class... Types>
-struct DummyCombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
-                                     Types...>
-    : CombinedReducerValueItemImpl<Idxs, Types>... {};
+// Dummy struct used to align CombinedReducerValueImpl to at least alignof(int).
+// CombinedReducerValueImpl has to be aligned to at least alignof(int) and its
+// sizeof must be a multiple of sizeof(int), as we might access it through an
+// int* in the CUDA and HIP reduction kernels.
+struct alignas(int) AlignmentHelper {};
 
 template <class IdxSeq, class... ValueTypes>
 struct CombinedReducerValueImpl;
 
-// CombinedReducerValueImpl has to be aligned to at least alignof(int) and its
-// sizeof must be a multiple of sizeof(int), as we might access it through an
-// int* in the CUDA and HIP reduction kernels.
 template <size_t... Idxs, class... ValueTypes>
-struct alignas(
-    std::max(alignof(int),
-             alignof(DummyCombinedReducerValueImpl<
-                     std::integer_sequence<size_t, Idxs...>, ValueTypes...>)))
-    CombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
-                             ValueTypes...>
-    : CombinedReducerValueItemImpl<Idxs, ValueTypes>... {
+struct CombinedReducerValueImpl<std::integer_sequence<size_t, Idxs...>,
+                                ValueTypes...> :
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+    AlignmentHelper,
+#endif
+    CombinedReducerValueItemImpl<Idxs, ValueTypes>... {
  public:
   KOKKOS_DEFAULTED_FUNCTION
   constexpr CombinedReducerValueImpl() = default;

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -249,6 +249,35 @@ class CombinedReduceFunctorSameType {
   }
 };
 
+template <class ValueType, class DeviceType>
+class CombinedReduceFunctorManySameType {
+ public:
+  using size_type = int64_t;
+
+  const size_type nwork;
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr explicit CombinedReduceFunctorManySameType(
+      const size_type& arg_nwork)
+      : nwork(arg_nwork) {}
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(size_type iwork, ValueType& dst1, ValueType& dst2,
+                  ValueType& dst3, ValueType& dst4, ValueType& dst5,
+                  ValueType& dst6, ValueType& dst7, ValueType& dst8,
+                  ValueType& dst9) const {
+    dst1 += 1;
+    dst2 += 2;
+    dst3 += 3;
+    dst4 += -1;
+    dst5 += -2;
+    dst6 += -3;
+    dst7 += iwork + 1;
+    dst8 += nwork - iwork;
+    dst9 += 0;
+  }
+};
+
 namespace {
 
 template <typename ScalarType, class DeviceType>
@@ -536,6 +565,25 @@ TEST(TEST_CATEGORY, int64_t_reduce_dynamic_view) {
 
 // FIXME_OPENACC: Not yet implemented.
 #ifndef KOKKOS_ENABLE_OPENACC
+TEST(TEST_CATEGORY, int16_combined_reduce) {
+  using functor_type = CombinedReduceFunctorSameType<int16_t, TEST_EXECSPACE>;
+  constexpr uint64_t nw = 10;
+
+  uint64_t nsum = (nw / 2) * (nw + 1);
+
+  int16_t result1 = 0;
+  int16_t result2 = 0;
+  int16_t result3 = 0;
+
+  Kokkos::parallel_reduce("int16_combined_reduce",
+                          Kokkos::RangePolicy<TEST_EXECSPACE>(0, nw),
+                          functor_type(nw), result1, result2, result3);
+
+  ASSERT_EQ(nw, uint64_t(result1));
+  ASSERT_EQ(nsum, uint64_t(result2));
+  ASSERT_EQ(nsum, uint64_t(result3));
+}
+
 TEST(TEST_CATEGORY, int_combined_reduce) {
   using functor_type = CombinedReduceFunctorSameType<int64_t, TEST_EXECSPACE>;
   constexpr uint64_t nw = 1000;
@@ -553,6 +601,72 @@ TEST(TEST_CATEGORY, int_combined_reduce) {
   ASSERT_EQ(nw, uint64_t(result1));
   ASSERT_EQ(nsum, uint64_t(result2));
   ASSERT_EQ(nsum, uint64_t(result3));
+}
+
+TEST(TEST_CATEGORY, many_int8_combined_reduce) {
+  using functor_type =
+      CombinedReduceFunctorManySameType<int8_t, TEST_EXECSPACE>;
+  constexpr int64_t nw = 10;
+
+  int64_t nsum = (nw / 2) * (nw + 1);
+
+  int8_t result1 = 0;
+  int8_t result2 = 0;
+  int8_t result3 = 0;
+  int8_t result4 = 0;
+  int8_t result5 = 0;
+  int8_t result6 = 0;
+  int8_t result7 = 0;
+  int8_t result8 = 0;
+  int8_t result9 = 0;
+
+  Kokkos::parallel_reduce("many_int8_combined_reduce",
+                          Kokkos::RangePolicy<TEST_EXECSPACE>(0, nw),
+                          functor_type(nw), result1, result2, result3, result4,
+                          result5, result6, result7, result8, result9);
+
+  ASSERT_EQ(nw, int64_t(result1));
+  ASSERT_EQ(2 * nw, int64_t(result2));
+  ASSERT_EQ(3 * nw, int64_t(result3));
+  ASSERT_EQ(-nw, int64_t(result4));
+  ASSERT_EQ(-2 * nw, int64_t(result5));
+  ASSERT_EQ(-3 * nw, int64_t(result6));
+  ASSERT_EQ(nsum, int64_t(result7));
+  ASSERT_EQ(nsum, int64_t(result8));
+  ASSERT_EQ(0, int64_t(result9));
+}
+
+TEST(TEST_CATEGORY, many_int16_combined_reduce) {
+  using functor_type =
+      CombinedReduceFunctorManySameType<int16_t, TEST_EXECSPACE>;
+  constexpr int64_t nw = 10;
+
+  int64_t nsum = (nw / 2) * (nw + 1);
+
+  int16_t result1 = 0;
+  int16_t result2 = 0;
+  int16_t result3 = 0;
+  int16_t result4 = 0;
+  int16_t result5 = 0;
+  int16_t result6 = 0;
+  int16_t result7 = 0;
+  int16_t result8 = 0;
+  int16_t result9 = 0;
+
+  Kokkos::parallel_reduce("many_int16_combined_reduce",
+                          Kokkos::RangePolicy<TEST_EXECSPACE>(0, nw),
+                          functor_type(nw), result1, result2, result3, result4,
+                          result5, result6, result7, result8, result9);
+
+  ASSERT_EQ(nw, int64_t(result1));
+  ASSERT_EQ(2 * nw, int64_t(result2));
+  ASSERT_EQ(3 * nw, int64_t(result3));
+  ASSERT_EQ(-nw, int64_t(result4));
+  ASSERT_EQ(-2 * nw, int64_t(result5));
+  ASSERT_EQ(-3 * nw, int64_t(result6));
+  ASSERT_EQ(nsum, int64_t(result7));
+  ASSERT_EQ(nsum, int64_t(result8));
+  ASSERT_EQ(0, int64_t(result9));
 }
 
 TEST(TEST_CATEGORY, mdrange_combined_reduce) {


### PR DESCRIPTION
On Cuda and Hip, using a combined reducer with a combination of datatypes giving a `sizeof(CombinedReducerValueImpl)` which is > 4 and not a multiple of 4 leads to wrong results. Additionally, if `sizeof(CombinedReducerValueImpl) > 16` and `alignof(CombinedReducerValueImpl) < 4` we get a misaligned write error.

In the `operator()` of Cuda and Hip `ParallelReduce`, each thread handles a `CombinedReducerValueImpl` which is split in "words" of 1, 2 or 4 bytes chunks depending on `sizeof(CombinedReducerValueImpl)`, if the sizeof is not a multiple of 4, we get the wrong number of words, for example with three `int16_t`, `sizeof(CombinedReducerValueImpl) == 6` which results in `word_count = 6 / 4 = 1`.
https://github.com/kokkos/kokkos/blob/fdc2eabb11ee4d28726ae50efe7424f598c08a93/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp#L192-L196

When `sizeof(CombinedReducerValueImpl) > 16`, which is for example the case when reducing nine `int16_t`, a `CombinedReducerValueImpl*` (which has an aligment of 2) is reinterpreted as an `int*`, which leads to a misaligned write error in this call to `in_place_shfl` https://github.com/kokkos/kokkos/blob/f58d70314ce28b4ccff5b078e2187226e48f09b2/core/src/Cuda/Kokkos_Cuda_ReduceScan.hpp#L200

Making sure that `CombinedReducerValueImpl` is aligned on at least `alignof(int)` solves both of these issues, for the second one it is obvious, for the first one if `alignof(CombinedReducerValueImpl) >= 4` then `sizeof(CombinedReducerValueImpl)` has to be a multiple of 4.

I also added tests for reductions of three `int16_t`, nine `int8_t` and nine `int16_t`.

Fixes #8426