### PR TITLE
core: `noexcept` specifications for move of exec

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -122,9 +122,10 @@ class Cuda {
   //! \name  Cuda space instances
 
   KOKKOS_DEFAULTED_FUNCTION Cuda(const Cuda&) = default;
-  KOKKOS_FUNCTION Cuda(Cuda&& other) : Cuda(static_cast<const Cuda&>(other)) {}
+  KOKKOS_FUNCTION Cuda(Cuda&& other) noexcept
+      : Cuda(static_cast<const Cuda&>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION Cuda& operator=(const Cuda&) = default;
-  KOKKOS_FUNCTION Cuda& operator=(Cuda&& other) {
+  KOKKOS_FUNCTION Cuda& operator=(Cuda&& other) noexcept {
     return *this = static_cast<const Cuda&>(other);
   }
   ~Cuda();

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -35,9 +35,10 @@ class HIP {
   using scratch_memory_space = ScratchMemorySpace<HIP>;
 
   KOKKOS_DEFAULTED_FUNCTION HIP(const HIP&) = default;
-  KOKKOS_FUNCTION HIP(HIP&& other) : HIP(static_cast<const HIP&>(other)) {}
+  KOKKOS_FUNCTION HIP(HIP&& other) noexcept
+      : HIP(static_cast<const HIP&>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION HIP& operator=(const HIP&) = default;
-  KOKKOS_FUNCTION HIP& operator=(HIP&& other) {
+  KOKKOS_FUNCTION HIP& operator=(HIP&& other) noexcept {
     return *this = static_cast<const HIP&>(other);
   }
   ~HIP();

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -208,9 +208,10 @@ class HPX {
                  m_next_instance_id++, std::move(sender))))) {}
 
   KOKKOS_DEFAULTED_FUNCTION HPX(const HPX &) = default;
-  KOKKOS_FUNCTION HPX(HPX &&other) : HPX(static_cast<const HPX &>(other)) {}
+  KOKKOS_FUNCTION HPX(HPX &&other) noexcept
+      : HPX(static_cast<const HPX &>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION HPX &operator=(const HPX &) = default;
-  KOKKOS_FUNCTION HPX &operator=(HPX &&other) {
+  KOKKOS_FUNCTION HPX &operator=(HPX &&other) noexcept {
     return *this = static_cast<const HPX &>(other);
   }
 

--- a/core/src/OpenACC/Kokkos_OpenACC.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC.hpp
@@ -63,9 +63,10 @@ class OpenACC {
   using scratch_memory_space = ScratchMemorySpace<OpenACC>;
 
   OpenACC(const OpenACC&) = default;
-  OpenACC(OpenACC&& other) : OpenACC(static_cast<const OpenACC&>(other)) {}
+  OpenACC(OpenACC&& other) noexcept
+      : OpenACC(static_cast<const OpenACC&>(other)) {}
   OpenACC& operator=(const OpenACC&) = default;
-  OpenACC& operator=(OpenACC&& other) {
+  OpenACC& operator=(OpenACC&& other) noexcept {
     return *this = static_cast<const OpenACC&>(other);
   }
   ~OpenACC();

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -52,10 +52,10 @@ class OpenMP {
   using scratch_memory_space = ScratchMemorySpace<OpenMP>;
 
   KOKKOS_DEFAULTED_FUNCTION OpenMP(const OpenMP&) = default;
-  KOKKOS_FUNCTION OpenMP(OpenMP&& other)
+  KOKKOS_FUNCTION OpenMP(OpenMP&& other) noexcept
       : OpenMP(static_cast<const OpenMP&>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION OpenMP& operator=(const OpenMP&) = default;
-  KOKKOS_FUNCTION OpenMP& operator=(OpenMP&& other) {
+  KOKKOS_FUNCTION OpenMP& operator=(OpenMP&& other) noexcept {
     return *this = static_cast<const OpenMP&>(other);
   }
   ~OpenMP();

--- a/core/src/SYCL/Kokkos_SYCL.hpp
+++ b/core/src/SYCL/Kokkos_SYCL.hpp
@@ -44,9 +44,9 @@ class SYCL {
   using scratch_memory_space = ScratchMemorySpace<SYCL>;
 
   SYCL(const SYCL&) = default;
-  SYCL(SYCL&& other) : SYCL(static_cast<const SYCL&>(other)) {}
+  SYCL(SYCL&& other) noexcept : SYCL(static_cast<const SYCL&>(other)) {}
   SYCL& operator=(const SYCL&) = default;
-  SYCL& operator=(SYCL&& other) {
+  SYCL& operator=(SYCL&& other) noexcept {
     return *this = static_cast<const SYCL&>(other);
   }
   ~SYCL();

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -99,10 +99,10 @@ class Serial {
   //@}
 
   KOKKOS_DEFAULTED_FUNCTION Serial(const Serial&) = default;
-  KOKKOS_FUNCTION Serial(Serial&& other)
+  KOKKOS_FUNCTION Serial(Serial&& other) noexcept
       : Serial(static_cast<const Serial&>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION Serial& operator=(const Serial&) = default;
-  KOKKOS_FUNCTION Serial& operator=(Serial&& other) {
+  KOKKOS_FUNCTION Serial& operator=(Serial&& other) noexcept {
     return *this = static_cast<const Serial&>(other);
   }
   ~Serial();

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -102,10 +102,10 @@ class Threads {
   uint32_t impl_instance_id() const noexcept { return 1; }
 
   KOKKOS_DEFAULTED_FUNCTION Threads(const Threads&) = default;
-  KOKKOS_FUNCTION Threads(Threads&& other)
+  KOKKOS_FUNCTION Threads(Threads&& other) noexcept
       : Threads(static_cast<const Threads&>(other)) {}
   KOKKOS_DEFAULTED_FUNCTION Threads& operator=(const Threads&) = default;
-  KOKKOS_FUNCTION Threads& operator=(Threads&& other) {
+  KOKKOS_FUNCTION Threads& operator=(Threads&& other) noexcept {
     return *this = static_cast<const Threads&>(other);
   }
 

--- a/core/unit_test/TestExecutionSpace.hpp
+++ b/core/unit_test/TestExecutionSpace.hpp
@@ -75,6 +75,16 @@ constexpr bool test_execspace_explicit_construction() {
 
 static_assert(test_execspace_explicit_construction());
 
+consteval bool test_execspace_nothrow_copy_and_move() {
+  static_assert(std::is_nothrow_copy_constructible_v<TEST_EXECSPACE>);
+  static_assert(std::is_nothrow_copy_assignable_v<TEST_EXECSPACE>);
+  static_assert(std::is_nothrow_move_constructible_v<TEST_EXECSPACE>);
+  static_assert(std::is_nothrow_move_assignable_v<TEST_EXECSPACE>);
+  return true;
+}
+
+static_assert(test_execspace_nothrow_copy_and_move());
+
 // We don't actually promise a tool-observable event and acknowledge that some
 // backend mights not need a fence to ensure that all enqueued work has finished
 // before an execution space instance is destroyed. Therefore we might want to


### PR DESCRIPTION
PR #8689 changed the move operations for executions spaces to implementations in terms of the defaulted copy operations.

However, as these move operations are now no longer defaulted, they are no longer noexcept.

The goal of this PR is thus to restore the noexcept by adding noexcept expressions.

Joint work with @romintomasetti.

@masterleinad, would you have a moment to take a look?
