### PR TITLE
HPX: check default instance fences on finalize

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -78,7 +78,7 @@ std::atomic<uint32_t> HPX::m_next_instance_id{HPX::impl_default_instance_id() +
 uint32_t HPX::m_active_parallel_region_count{0};
 hpx::spinlock HPX::m_active_parallel_region_count_mutex;
 hpx::condition_variable_any HPX::m_active_parallel_region_count_cond;
-HPX::instance_data HPX::m_default_instance_data;
+Kokkos::Impl::HostSharedPtr<HPX::instance_data> HPX::m_default_instance_data;
 
 void HPX::print_configuration(std::ostream &os, const bool) const {
   os << "Host Parallel Execution Space\n";
@@ -170,9 +170,18 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
 
     m_hpx_initialized = true;
   }
+
+  // Create the default instance data.
+  m_default_instance_data = Kokkos::Impl::HostSharedPtr(new instance_data());
 }
 
 void HPX::impl_finalize() {
+  m_default_instance_data->fence(
+      "Kokkos::Experimental::HPX: fence "
+      "to drain internal sender on finalize");
+
+  m_default_instance_data = nullptr;
+
   if (m_hpx_initialized) {
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -162,8 +162,7 @@ class HPX {
     hpx::spinlock m_sender_mutex;
   };
 
-  static void default_instance_deleter(instance_data *) {}
-  static instance_data m_default_instance_data;
+  static Kokkos::Impl::HostSharedPtr<instance_data> m_default_instance_data;
   Kokkos::Impl::HostSharedPtr<instance_data> m_instance_data;
 
  public:
@@ -183,8 +182,7 @@ class HPX {
       : m_instance_data(
             (Kokkos::Impl::check_execution_space_constructor_precondition(
                  name()),
-             Kokkos::Impl::HostSharedPtr<instance_data>(
-                 &m_default_instance_data, &default_instance_deleter))) {}
+             m_default_instance_data)) {}
 
 #pragma GCC diagnostic pop
 
@@ -198,8 +196,7 @@ class HPX {
              mode == instance_mode::independent
                  ? (Kokkos::Impl::HostSharedPtr<instance_data>(
                        new instance_data(m_next_instance_id++)))
-                 : Kokkos::Impl::HostSharedPtr<instance_data>(
-                       &m_default_instance_data, &default_instance_deleter))) {}
+                 : m_default_instance_data)) {}
   explicit HPX(hpx::execution::experimental::unique_any_sender<> &&sender)
       : m_instance_data(
             (Kokkos::Impl::check_execution_space_constructor_precondition(

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -543,6 +543,10 @@ endif()
 
 if(Kokkos_ENABLE_HPX)
   kokkos_add_executable_and_test(CoreUnitTest_HPX SOURCES UnitTestMainInit.cpp ${HPX_SOURCES})
+  kokkos_add_executable_and_test(
+    CoreUnitTest_HPXDefaultInstanceFencesOnFinalize SOURCES UnitTestMain.cpp
+    hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
+  )
   kokkos_add_executable_and_test(CoreUnitTest_HPXInterOp SOURCES UnitTestMain.cpp hpx/TestHPX_InterOp.cpp)
   kokkos_add_executable_and_test(
     CoreUnitTest_HPX_IndependentInstances

--- a/core/unit_test/hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
+++ b/core/unit_test/hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+#include <TestHPX_Category.hpp>
+
+#include "tools/include/ToolTestingUtilities.hpp"
+
+namespace Test {
+
+// Test whether the HPX default instance fences on finalize.
+TEST(hpx, default_instance_fences_on_finalize) {
+  Kokkos::Test::Tools::listen_tool_events(
+      Kokkos::Test::Tools::Config::DisableAll(),
+      Kokkos::Test::Tools::Config::EnableFences());
+
+  auto success = Kokkos::Test::Tools::validate_existence(
+      [&]() {
+        Kokkos::initialize();
+        {
+          const Kokkos::Experimental::HPX exec{};
+
+          Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 100),
+                               KOKKOS_LAMBDA(const auto){});
+        }
+        Kokkos::finalize();
+      },
+      [&](Kokkos::Test::Tools::BeginFenceEvent event) {
+        return Kokkos::Test::Tools::MatchDiagnostic{
+            event.descriptor().find("fence on destruction") !=
+            std::string::npos};
+      });
+
+  ASSERT_TRUE(success);
+
+  Kokkos::Test::Tools::listen_tool_events(
+      Kokkos::Test::Tools::Config::DisableAll());
+}
+
+}  // namespace Test


### PR DESCRIPTION
Follow up for:
- https://github.com/kokkos/kokkos/pull/8626

~~This PR adds two commits.~~

The first commit adds a unit test that checks whether the HPX default instance fences on finalize. With only this first commit, the HPX build in the CI segfaults with an error like

```
Kokkos ERROR: HPX execution space is being destructed after finalize() has been called
6: Backtrace:
6: /home/costmo-user/kokkos/build-clang-HPX/core/src/libkokkoscore.so.5.1(_ZN6Kokkos4Impl15save_stacktraceEv+0x12)[0x767454926ae2] 
...
```

The reason is that #8626 introduced the fence in the destructor of the static member variable `m_default_instance_data`.

https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L166

This member is the HPX backend's equivalent of e.g. `CudaInternal` in the Cuda backend.


The proposed fix is to manage the lifetime of `m_default_instance_data` so that its destructor is called in `impl_finalize`. As in the Cuda and HIP backends, it is proposed to do so by storing `m_default_instance_data` in a `HostSharedPtr`.

In the HPX case, a challenge is that the member `m_default_instance_data` stores a type erased "sender" with the members of the last (few) parallel region(s) that was (were) dispatched. Hence, this `m_default_instance_data` may end up storing itself as part of the policy of that last parallel region, thus causing a circular reference that would prevent `HostSharedPtr` from calling the destructor. To avoid this problem, we insert an additional fence at the beginning of `impl_finalize` to drain the `m_sender` member.

An earlier version of the fix used `std::optional`. An advantage of the current version with `HostSharedPtr` is that we now avoid constructing `m_instance_data` as a `HostSharedPtr` with a deleter that does nothing. The current fix is also more consistent with other backends.

Joint work with @romintomasetti 