### PR TITLE
Reference to SLSA GitHub Generator by tag instead of digest

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -43,7 +43,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       # Upload provenance to a new release


### PR DESCRIPTION
See https://github.com/slsa-framework/slsa-github-generator/blob/4d014fae4dbd39eb09e8d40348b73db095e6ba9a/README.md#referencing-slsa-builders-and-generators

> At present, the GitHub Actions provided in this repository as builders and generators **MUST** be referenced
> by tag in order for the `slsa-verifier` to be able to verify the ref of the trusted builder/generator's
> reusable workflow. It also needs to be referred as `@vX.Y.Z`, because the build will fail if you reference it via a shorter tag like `@vX.Y` or `@vX`.
>
> This is contrary to the [GitHub best practice for third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) which recommends referencing by digest, but intentional due to limits in GitHub Actions.
> The desire to be able to verify reusable workflows pinned by hash, and the reas