### PR TITLE
Add functions to create stream on every available devices

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -709,7 +709,7 @@ std::vector<Kokkos::Cuda> create_device_space() {
     KOKKOS_IMPL_CUDA_SAFE_CALL(::cudaSetDevice(device));
     KOKKOS_IMPL_CUDA_SAFE_CALL(::cudaStreamCreate(&stream));
 
-    spaces.emplace_back(Kokkos::Cuda(stream));
+    spaces.emplace_back(stream);
   }
 
   return spaces;

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -28,6 +28,7 @@ import kokkos.core;
 #include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>
 #include <impl/Kokkos_ExecSpaceManager.hpp>
+#include <impl/Kokkos_DeviceManagement.hpp>
 
 /*--------------------------------------------------------------------------*/
 /* Standard 'C' libraries */
@@ -697,6 +698,22 @@ KOKKOS_IMPL_EXPORT std::map<int, std::mutex>
     CudaInternal::constantMemMutexPerDevice = {};
 
 }  // namespace Impl
+
+std::vector<Kokkos::Cuda> create_device_space() {
+  std::vector<Kokkos::Cuda> spaces;
+  auto devices = ::Kokkos::Impl::get_visible_devices();
+  spaces.reserve(devices.size());
+
+  for (auto device : devices) {
+    ::cudaStream_t stream;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(::cudaSetDevice(device));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(::cudaStreamCreate(&stream));
+
+    spaces.emplace_back(Kokkos::Cuda(stream));
+  }
+
+  return spaces;
+}
 
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.hpp
@@ -348,5 +348,7 @@ std::vector<Cuda> impl_partition_space(const Cuda& base_instance,
 }
 }  // namespace Experimental::Impl
 
+std::vector<Kokkos::Cuda> create_device_space();
+
 }  // Namespace Kokkos
 #endif

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -396,7 +396,7 @@ std::vector<Kokkos::HIP> create_device_space() {
     KOKKOS_IMPL_HIP_SAFE_CALL(::hipSetDevice(device));
     KOKKOS_IMPL_HIP_SAFE_CALL(::hipStreamCreate(&stream));
 
-    spaces.emplace_back(Kokkos::HIP(stream));
+    spaces.emplace_back(stream);
   }
 
   return spaces;

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -385,6 +385,23 @@ Kokkos::HIP::size_type *hip_internal_scratch_flags(const HIP &instance,
 }
 
 }  // namespace Impl
+
+std::vector<Kokkos::HIP> create_device_space() {
+  std::vector<Kokkos::HIP> spaces;
+  auto devices = ::Kokkos::Impl::get_visible_devices();
+  spaces.reserve(devices.size());
+
+  for (auto device : devices) {
+    ::hipStream_t stream;
+    KOKKOS_IMPL_HIP_SAFE_CALL(::hipSetDevice(device));
+    KOKKOS_IMPL_HIP_SAFE_CALL(::hipStreamCreate(&stream));
+
+    spaces.emplace_back(Kokkos::HIP(stream));
+  }
+
+  return spaces;
+}
+
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/core/src/HIP/Kokkos_HIP_Instance.hpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.hpp
@@ -350,6 +350,9 @@ std::vector<HIP> impl_partition_space(const HIP &base_instance,
   return instances;
 }
 }  // namespace Experimental::Impl
+
+std::vector<Kokkos::HIP> create_device_space();
+
 }  // namespace Kokkos
 
 #endif

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -347,10 +347,9 @@ std::vector<Kokkos::SYCL> create_device_space() {
 
   auto sycl_devices = Impl::get_sycl_devices();
 
-  KOKKOS_ASSERT(sycl_devices.size() >= devices.size());
-
   for (const int& device : devices) {
-    sycl::queue queue(sycl_devices[device], sycl::property::queue::in_order());
+    sycl::queue queue(sycl_devices.at(device),
+                      sycl::property::queue::in_order());
     spaces.emplace_back(Kokkos::SYCL(queue));
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -338,4 +338,20 @@ template class SYCLInternal::USMObjectMem<sycl::usm::alloc::device>;
 template class SYCLInternal::USMObjectMem<sycl::usm::alloc::host>;
 
 }  // namespace Impl
+
+std::vector<Kokkos::SYCL> create_device_space() {
+  std::vector<Kokkos::SYCL> spaces;
+  std::vector<int> devices = ::Kokkos::Impl::get_visible_devices();
+  spaces.reserve(devices.size());
+
+  auto sycl_devices = Impl::get_sycl_devices();
+
+  for (const int& device : devices) {
+    sycl::queue queue(sycl_devices[device], sycl::property::queue::in_order());
+    spaces.emplace_back(Kokkos::SYCL(queue));
+  }
+
+  return spaces;
+}
+
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -14,6 +14,7 @@ import kokkos.core; // kokkos_malloc
 
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_Error.hpp>
+#include <impl/Kokkos_DeviceManagement.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -345,6 +346,8 @@ std::vector<Kokkos::SYCL> create_device_space() {
   spaces.reserve(devices.size());
 
   auto sycl_devices = Impl::get_sycl_devices();
+
+  KOKKOS_ASSERT(sycl_devices.size() >= devices.size());
 
   for (const int& device : devices) {
     sycl::queue queue(sycl_devices[device], sycl::property::queue::in_order());

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -10,6 +10,7 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
+#include <impl/Kokkos_DeviceManagement.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -305,6 +306,9 @@ auto make_sycl_function_wrapper(const Functor& functor, Storage& storage) {
   return SYCLFunctionWrapper<Functor, Storage>(functor, storage);
 }
 }  // namespace Impl
+
+std::vector<Kokkos::SYCL> create_device_space();
+
 }  // namespace Kokkos
 
 #if defined(SYCL_DEVICE_COPYABLE) && defined(KOKKOS_ARCH_INTEL_GPU)

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -10,7 +10,6 @@
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
-#include <impl/Kokkos_DeviceManagement.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -48,10 +48,10 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), managed_views) {
 
   Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
                                             100);
-  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
-                                           100);
+  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v1", execs[1]),
+                                            100);
 
-  test_policies(execs[0], view0, execs[1], view);
+  test_policies(execs[0], view0, execs[1], view1);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {

--- a/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_StreamsMultiGPU.cpp
@@ -30,79 +30,56 @@ struct StreamsAndDevices {
   }
 };
 
-std::array<TEST_EXECSPACE, 2> get_execution_spaces(
-    const StreamsAndDevices &streams_and_devices) {
-  TEST_EXECSPACE exec0(streams_and_devices.streams[0]);
-  TEST_EXECSPACE exec1(streams_and_devices.streams[1]);
-
-  // Must return void to use ASSERT_EQ
-  [&]() {
-    ASSERT_EQ(exec0.cuda_device(), streams_and_devices.devices[0]);
-    ASSERT_EQ(exec1.cuda_device(), streams_and_devices.devices[1]);
-  }();
-
-  return {exec0, exec1};
-}
-
 struct TEST_CATEGORY_FIXTURE(multi_gpu) : public ::testing::Test {
-  StreamsAndDevices sd;
-
   void SetUp() override {
-    if (sd.devices[0] == sd.devices[1])
+    auto execs = Kokkos::create_device_space();
+    if (execs.size() <= 1) {
       GTEST_SKIP() << "Skipping Cuda multi-gpu testing since current machine "
                       "only contains a single GPU.\n";
+    }
+
+    ASSERT_GE(execs.size(), 2);
+    ASSERT_NE(execs[0].cuda_device(), execs[1].cuda_device());
   }
 };
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), managed_views) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    Kokkos::View<int *, TEST_EXECSPACE> view0(
-        Kokkos::view_alloc("v0", execs[0]), 100);
-    Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
-                                             100);
+  Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
+                                            100);
+  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
+                                           100);
 
-    test_policies(execs[0], view0, execs[1], view);
-  }
+  test_policies(execs[0], view0, execs[1], view);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[0].cuda_device()));
-    int *p0;
-    void *p0_void_ptr = nullptr;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p0_void_ptr, sizeof(int) * 100));
-    p0 = static_cast<int *>(p0_void_ptr);
-    Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[0].cuda_device()));
+  int *p0;
+  void *p0_void_ptr = nullptr;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p0_void_ptr, sizeof(int) * 100));
+  p0 = static_cast<int *>(p0_void_ptr);
+  Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
 
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[1].cuda_device()));
-    int *p;
-    void *p_void_ptr = nullptr;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p_void_ptr, sizeof(int) * 100));
-    p = static_cast<int *>(p_void_ptr);
-    Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(execs[1].cuda_device()));
+  int *p;
+  void *p_void_ptr = nullptr;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc(&p_void_ptr, sizeof(int) * 100));
+  p = static_cast<int *>(p_void_ptr);
+  Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
 
-    test_policies(execs[0], view0, execs[1], view);
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p0));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p));
-  }
+  test_policies(execs[0], view0, execs[1], view);
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p0));
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(p));
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), scratch_space) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    test_scratch(execs[0], execs[1]);
-  }
+  test_scratch(execs[0], execs[1]);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), stream_sync_semantics_raw_cuda) {

--- a/core/unit_test/hip/TestHIP_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_StreamsMultiGPU.cpp
@@ -30,74 +30,57 @@ struct StreamsAndDevices {
   }
 };
 
-std::array<TEST_EXECSPACE, 2> get_execution_spaces(
-    const StreamsAndDevices &streams_and_devices) {
-  TEST_EXECSPACE exec0(streams_and_devices.streams[0]);
-  TEST_EXECSPACE exec1(streams_and_devices.streams[1]);
-
-  EXPECT_EQ(exec0.hip_device(), streams_and_devices.devices[0]);
-  EXPECT_EQ(exec1.hip_device(), streams_and_devices.devices[1]);
-
-  return {exec0, exec1};
-}
-
 struct TEST_CATEGORY_FIXTURE(multi_gpu) : public ::testing::Test {
   StreamsAndDevices sd;
 
   void SetUp() override {
-    if (sd.devices[0] == sd.devices[1])
+    auto execs = Kokkos::create_device_space();
+
+    if (execs.size() <= 1) {
       GTEST_SKIP() << "Skipping HIP multi-gpu testing since current machine "
                       "only contains a single GPU.\n";
+    }
+
+    ASSERT_GE(execs.size(), 2);
+    ASSERT_NE(execs[0].hip_device(), execs[1].hip_device());
   }
 };
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), managed_views) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    Kokkos::View<int *, TEST_EXECSPACE> view0(
-        Kokkos::view_alloc("v0", execs[0]), 100);
-    Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
-                                             100);
+  Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
+                                            100);
+  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
+                                           100);
 
-    test_policies(execs[0], view0, execs[1], view);
-  }
+  test_policies(execs[0], view0, execs[1], view);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(execs[0].hip_device()));
-    int *p0;
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMalloc(reinterpret_cast<void **>(&p0), sizeof(int) * 100));
-    Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(execs[0].hip_device()));
+  int *p0;
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      hipMalloc(reinterpret_cast<void **>(&p0), sizeof(int) * 100));
+  Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
 
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(execs[1].hip_device()));
-    int *p;
-    KOKKOS_IMPL_HIP_SAFE_CALL(
-        hipMalloc(reinterpret_cast<void **>(&p), sizeof(int) * 100));
-    Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(execs[1].hip_device()));
+  int *p;
+  KOKKOS_IMPL_HIP_SAFE_CALL(
+      hipMalloc(reinterpret_cast<void **>(&p), sizeof(int) * 100));
+  Kokkos::View<int *, TEST_EXECSPACE> view(p, 100);
 
-    test_policies(execs[0], view0, execs[1], view);
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(p0));
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(p));
-  }
+  test_policies(execs[0], view0, execs[1], view);
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(p0));
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(p));
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), scratch_space) {
-  StreamsAndDevices streams_and_devices;
-  {
-    std::array<TEST_EXECSPACE, 2> execs =
-        get_execution_spaces(streams_and_devices);
+  auto execs = Kokkos::create_device_space();
 
-    test_scratch(execs[0], execs[1]);
-  }
+  test_scratch(execs[0], execs[1]);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), stream_sync_semantics_raw_hip) {

--- a/core/unit_test/hip/TestHIP_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_StreamsMultiGPU.cpp
@@ -51,10 +51,10 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), managed_views) {
 
   Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
                                             100);
-  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
-                                           100);
+  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v1", execs[1]),
+                                            100);
 
-  test_policies(execs[0], view0, execs[1], view);
+  test_policies(execs[0], view0, execs[1], view1);
 }
 
 TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), unmanaged_views) {

--- a/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
@@ -9,31 +9,40 @@ namespace {
 TEST(sycl_multi_gpu, managed_views) {
   auto execs = ::Kokkos::create_device_space();
 
-  Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
+  auto execs0 = execs.front();
+  auto execs1 = execs.back();
+
+  Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs0),
                                             100);
-  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v1", execs[1]),
+  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v1", execs1),
                                             100);
 
-  test_policies(execs[0], view0, execs[1], view1);
+  test_policies(execs0, view0, execs1, view1);
 }
 
 TEST(sycl_multi_gpu, unmanaged_views) {
   auto execs = ::Kokkos::create_device_space();
 
-  int *p0 = sycl::malloc_device<int>(100, execs[0].sycl_queue());
+  auto execs0 = execs.front();
+  auto execs1 = execs.back();
+
+  int *p0 = sycl::malloc_device<int>(100, execs0.sycl_queue());
   Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
 
-  int *p1 = sycl::malloc_device<int>(100, execs[1].sycl_queue());
+  int *p1 = sycl::malloc_device<int>(100, execs1.sycl_queue());
   Kokkos::View<int *, TEST_EXECSPACE> view1(p1, 100);
 
-  test_policies(execs[0], view0, execs[1], view1);
-  sycl::free(p0, execs[0].sycl_queue());
-  sycl::free(p1, execs[1].sycl_queue());
+  test_policies(execs0, view0, execs1, view1);
+  sycl::free(p0, execs0.sycl_queue());
+  sycl::free(p1, execs1.sycl_queue());
 }
 
 TEST(sycl_multi_gpu, scratch_space) {
   auto execs = ::Kokkos::create_device_space();
 
-  test_scratch(execs[0], execs[1]);
+  auto execs0 = execs.front();
+  auto execs1 = execs.back();
+
+  test_scratch(execs0, execs1);
 }
 }  // namespace

--- a/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
@@ -6,31 +6,19 @@
 
 namespace {
 
-std::array<TEST_EXECSPACE, 2> get_execution_spaces() {
-  std::vector<sycl::device> gpu_devices =
-      sycl::device::get_devices(sycl::info::device_type::gpu);
-
-  TEST_EXECSPACE exec0(
-      sycl::queue{gpu_devices.front(), sycl::property::queue::in_order()});
-  TEST_EXECSPACE exec1(
-      sycl::queue{gpu_devices.back(), sycl::property::queue::in_order()});
-
-  return {exec0, exec1};
-}
-
 TEST(sycl_multi_gpu, managed_views) {
-  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+  auto execs = ::Kokkos::create_device_space();
 
   Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
                                             100);
-  Kokkos::View<int *, TEST_EXECSPACE> view(Kokkos::view_alloc("v", execs[1]),
-                                           100);
+  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v", execs[1]),
+                                            100);
 
-  test_policies(execs[0], view0, execs[1], view);
+  test_policies(execs[0], view0, execs[1], view1);
 }
 
 TEST(sycl_multi_gpu, unmanaged_views) {
-  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+  auto execs = ::Kokkos::create_device_space();
 
   int *p0 = sycl::malloc_device<int>(100, execs[0].sycl_queue());
   Kokkos::View<int *, TEST_EXECSPACE> view0(p0, 100);
@@ -44,7 +32,7 @@ TEST(sycl_multi_gpu, unmanaged_views) {
 }
 
 TEST(sycl_multi_gpu, scratch_space) {
-  std::array<TEST_EXECSPACE, 2> execs = get_execution_spaces();
+  auto execs = ::Kokkos::create_device_space();
 
   test_scratch(execs[0], execs[1]);
 }

--- a/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_StreamsMultiGPU.cpp
@@ -11,7 +11,7 @@ TEST(sycl_multi_gpu, managed_views) {
 
   Kokkos::View<int *, TEST_EXECSPACE> view0(Kokkos::view_alloc("v0", execs[0]),
                                             100);
-  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v", execs[1]),
+  Kokkos::View<int *, TEST_EXECSPACE> view1(Kokkos::view_alloc("v1", execs[1]),
                                             100);
 
   test_policies(execs[0], view0, execs[1], view1);


### PR DESCRIPTION
This PR adds a function to ease the creation of stream in multi device configuration for GPU backends: the new function `create_device_space` returns a vector of execution space, one for each device.

If the `KOKKOS_VISIBLE_DEVICES` environment variable is set, it will only consider the GPUs set in it.