### PR TITLE
core(cuda): tighten the condition on hooks workaround

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -694,7 +694,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 // Define the workaround here since this condition will be re-used.
 // We undef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND later.
 #if defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
-    (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA))
+    (defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 1600 && \
+     defined(KOKKOS_ENABLE_CUDA))
 #define KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND 1
 #endif
 #ifdef KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND

--- a/core/unit_test/TestViewMove.hpp
+++ b/core/unit_test/TestViewMove.hpp
@@ -163,7 +163,8 @@ TEST(TEST_CATEGORY, view_moved_from) {
 }
 
 #if !(defined(KOKKOS_COMPILER_NVCC) || defined(KOKKOS_COMPILER_NVHPC) || \
-      (defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)))
+      (defined(KOKKOS_COMPILER_CLANG) && KOKKOS_COMPILER_CLANG < 1600 && \
+       defined(KOKKOS_ENABLE_CUDA)))
 constexpr bool test_view_is_nothrow_move_constructible() {
   static_assert(
       std::is_nothrow_move_constructible_v<Kokkos::View<int*, TEST_EXECSPACE>>);


### PR DESCRIPTION
Follow up for:
- https://github.com/kokkos/kokkos/pull/8792

It appears the fix related to the `KOKKOS_IMPL_VIEW_HOOKS_NVCC_WORKAROUND` is no longer needed for `clang` as of version 16. 

I tested locally with clang 15 to 22, with different versions of cuda. I think the Kokkos CI tests with versions 15 and 17.  