### PR TITLE
(Partial) Remove code guarded by KOKKOS_ENABLE_DEPRECATED_CODE_4 in Kokkos 4.7

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -31,7 +31,6 @@ import kokkos.functional;
 
 #include <cstdint>
 
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
 #if defined(KOKKOS_COMPILER_GNU) && !defined(__PGIC__) && \
     !defined(__CUDA_ARCH__)
 
@@ -45,12 +44,6 @@ import kokkos.functional;
 #define KOKKOS_IMPL_NONTEMPORAL_PREFETCH_LOAD(addr) ((void)0)
 #define KOKKOS_IMPL_NONTEMPORAL_PREFETCH_STORE(addr) ((void)0)
 
-#endif
-#else
-#define KOKKOS_IMPL_NONTEMPORAL_PREFETCH_LOAD(addr) \
-  KOKKOS_NONTEMPORAL_PREFETCH_LOAD(addr)
-#define KOKKOS_IMPL_NONTEMPORAL_PREFETCH_STORE(addr) \
-  KOKKOS_NONTEMPORAL_PREFETCH_STORE(addr)
 #endif
 
 namespace Kokkos {

--- a/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
+++ b/core/src/Kokkos_Atomics_Desul_Wrapper.hpp
@@ -18,22 +18,6 @@ static_assert(false,
 
 namespace Kokkos {
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#if defined(KOKKOS_COMPILER_GNU) && !defined(__PGIC__) && \
-    !defined(__CUDA_ARCH__)
-
-#define KOKKOS_NONTEMPORAL_PREFETCH_LOAD(addr) __builtin_prefetch(addr, 0, 0)
-#define KOKKOS_NONTEMPORAL_PREFETCH_STORE(addr) __builtin_prefetch(addr, 1, 0)
-
-#else
-
-#define KOKKOS_NONTEMPORAL_PREFETCH_LOAD(addr) ((void)0)
-#define KOKKOS_NONTEMPORAL_PREFETCH_STORE(addr) ((void)0)
-
-#endif
-#endif
-// ============================================================
-
 #ifdef KOKKOS_ENABLE_ATOMICS_BYPASS
 #define KOKKOS_DESUL_MEM_SCOPE desul::MemoryScopeCaller()
 #else

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -369,55 +369,6 @@
 //----------------------------------------------------------------------------
 // Define Macro for alignment:
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#ifndef KOKKOS_MEMORY_ALIGNMENT
-#define KOKKOS_IMPL_MEMORY_ALIGNMENT 64
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-#define KOKKOS_MEMORY_ALIGNMENT                                         \
-  [] {                                                                  \
-    int memory_alignment                                                \
-        [[deprecated("KOKKOS_MEMORY_ALIGNMENT macro is deprecated")]] = \
-            KOKKOS_IMPL_MEMORY_ALIGNMENT;                               \
-    return memory_alignment;                                            \
-  }();
-#else
-#define KOKKOS_MEMORY_ALIGNMENT KOKKOS_IMPL_MEMORY_ALIGNMENT
-#endif
-#else
-#define KOKKOS_IMPL_MEMORY_ALIGNMENT KOKKOS_MEMORY_ALIGNMENT
-#endif
-#else  // KOKKOS_ENABLE_DEPRECATED_CODE_4
-#ifdef KOKKOS_MEMORY_ALIGNMENT
-static_assert(false,
-              "External definition of KOKKOS_MEMORY_ALIGNMENT is not allowed");
-#endif
-#endif
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-#ifndef KOKKOS_MEMORY_ALIGNMENT_THRESHOLD
-#define KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD 1
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-#define KOKKOS_MEMORY_ALIGNMENT_THRESHOLD                            \
-  [] {                                                               \
-    int memory_alignment [[deprecated(                               \
-        "KOKKOS_MEMORY_ALIGNMENT_THRESHOLD macro is deprecated")]] = \
-        KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD;                      \
-    return memory_alignment;                                         \
-  }();
-#else
-#define KOKKOS_MEMORY_ALIGNMENT_THRESHOLD KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD
-#endif
-#else
-#define KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD KOKKOS_MEMORY_ALIGNMENT_THRESHOLD
-#endif
-#else  // KOKKOS_ENABLE_DEPRECATED_CODE_4
-#ifdef KOKKOS_MEMORY_ALIGNMENT_THRESHOLD
-static_assert(
-    false,
-    "External definition of KOKKOS_MEMORY_ALIGNMENT_THRESHOLD is not allowed");
-#endif
-#endif
-
 #if !defined(KOKKOS_IMPL_ALIGN_PTR)
 #define KOKKOS_IMPL_ALIGN_PTR(size) /* */
 #endif

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -57,16 +57,8 @@ struct MemoryTraits {
 
 namespace Kokkos {
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<>;
-#endif
-using MemoryUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-using MemoryRandomAccess =
-    Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>;
-#else
+using MemoryUnmanaged    = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 using MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::RandomAccess>;
-#endif
 
 }  // namespace Kokkos
 
@@ -81,14 +73,8 @@ namespace Impl {
  *  Enable compatibility of views from different devices with static stride.
  *  Use compiler flag to enable overwrites.
  */
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-inline constexpr unsigned MEMORY_ALIGNMENT = KOKKOS_IMPL_MEMORY_ALIGNMENT;
-inline constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD =
-    KOKKOS_IMPL_MEMORY_ALIGNMENT_THRESHOLD;
-#else
 inline constexpr unsigned MEMORY_ALIGNMENT           = 64;
 inline constexpr unsigned MEMORY_ALIGNMENT_THRESHOLD = 1;
-#endif
 static_assert(has_single_bit(MEMORY_ALIGNMENT),
               "MEMORY_ALIGNMENT must be a power of 2");
 

--- a/core/src/Kokkos_MemoryTraits.hpp
+++ b/core/src/Kokkos_MemoryTraits.hpp
@@ -57,6 +57,9 @@ struct MemoryTraits {
 
 namespace Kokkos {
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
+using MemoryManaged KOKKOS_DEPRECATED = Kokkos::MemoryTraits<>;
+#endif
 using MemoryUnmanaged    = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 using MemoryRandomAccess = Kokkos::MemoryTraits<Kokkos::RandomAccess>;
 


### PR DESCRIPTION
(Partial fix for #8958)

* KOKKOS_MEMORY_ALIGNMENT[_THRESHOLD]
~~* MemoryManaged~~
* KOKKOS_NONTEMPORAL_PREFETCH_{LOAD,STORE}

I searched for usage on GitHub and MemoryManaged is still used notably in E3SM and SUNDIALS so I think we might want to delay the removal til 5.3.