### PR TITLE
Update kernel naming for Kokkos Tools

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1277,7 +1277,7 @@ struct ParallelConstructName {
           "/" + std::string(TypeInfo<std::remove_const_t<PolicyType>>::name());
 #else
       default_name = std::string(typeid(FunctorType).name()) + "/" +
-                     std::string(typeid(PolicyType).name());
+                     typeid(PolicyType).name();
 #endif
     }
   }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1264,45 +1264,28 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
 
 namespace Impl {
 
-template <typename FunctorType, typename TagType,
-          bool HasTag = !std::is_void_v<TagType>>
+template <typename FunctorType, typename PolicyType>
 struct ParallelConstructName;
 
-template <typename FunctorType, typename TagType>
-struct ParallelConstructName<FunctorType, TagType, true> {
+template <typename FunctorType, typename PolicyType>
+struct ParallelConstructName {
   ParallelConstructName(std::string const& label) : label_ref(label) {
     if (label.empty()) {
 #ifdef KOKKOS_ENABLE_IMPL_TYPEINFO
       default_name =
           std::string(TypeInfo<std::remove_const_t<FunctorType>>::name()) +
-          "/" + std::string(TypeInfo<TagType>::name());
+          "/" + std::string(TypeInfo<std::remove_const_t<PolicyType>>::name());
 #else
       default_name = std::string(typeid(FunctorType).name()) + "/" +
-                     typeid(TagType).name();
+                     std::string(typeid(PolicyType).name());
 #endif
     }
   }
-  std::string const& get() {
-    return (label_ref.empty()) ? default_name : label_ref;
-  }
-  std::string const& label_ref;
-  std::string default_name;
-};
 
-template <typename FunctorType, typename TagType>
-struct ParallelConstructName<FunctorType, TagType, false> {
-  ParallelConstructName(std::string const& label) : label_ref(label) {
-    if (label.empty()) {
-#ifdef KOKKOS_ENABLE_IMPL_TYPEINFO
-      default_name = TypeInfo<std::remove_const_t<FunctorType>>::name();
-#else
-      default_name = typeid(FunctorType).name();
-#endif
-    }
-  }
   std::string const& get() {
     return (label_ref.empty()) ? default_name : label_ref;
   }
+
   std::string const& label_ref;
   std::string default_name;
 };

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -194,8 +194,7 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type = std::remove_reference_t<decltype(policy)>;
-      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, Policy> name(label);
       label = name.get();
     }
     auto tuner_iter = [&]() {
@@ -220,8 +219,7 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type = std::remove_reference_t<decltype(policy)>;
-      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, Policy> name(label);
       label = name.get();
     }
     auto tuner_iter = [&]() {
@@ -411,8 +409,7 @@ void generic_report_results(const std::string& label_in, Map& map,
   if (should_tune(policy)) {
     std::string label = label_in;
     if (label_in.empty()) {
-      using policy_type = std::remove_reference_t<decltype(policy)>;
-      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, Policy> name(label);
       label = name.get();
     }
     auto tuner_iter = map[label];

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -195,8 +195,7 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
     std::string label = label_in;
     if (label_in.empty()) {
       using policy_type = std::remove_reference_t<decltype(policy)>;
-      using work_tag    = typename policy_type::work_tag;
-      Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
       label = name.get();
     }
     auto tuner_iter = [&]() {
@@ -222,8 +221,7 @@ auto generic_tune_policy(const std::string& label_in, Map& map,
     std::string label = label_in;
     if (label_in.empty()) {
       using policy_type = std::remove_reference_t<decltype(policy)>;
-      using work_tag    = typename policy_type::work_tag;
-      Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
       label = name.get();
     }
     auto tuner_iter = [&]() {
@@ -414,8 +412,7 @@ void generic_report_results(const std::string& label_in, Map& map,
     std::string label = label_in;
     if (label_in.empty()) {
       using policy_type = std::remove_reference_t<decltype(policy)>;
-      using work_tag    = typename policy_type::work_tag;
-      Kokkos::Impl::ParallelConstructName<Functor, work_tag> name(label);
+      Kokkos::Impl::ParallelConstructName<Functor, policy_type> name(label);
       label = name.get();
     }
     auto tuner_iter = map[label];
@@ -484,9 +481,7 @@ auto begin_parallel_for(const ExecPolicy& policy, FunctorType& functor,
       Kokkos::Tools::Impl::ToolResponse<ExecPolicy, FunctorType>;
   response_type response{policy};
   if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
+    Kokkos::Impl::ParallelConstructName<FunctorType, ExecPolicy> name(label);
     Kokkos::Tools::beginParallelFor(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);
@@ -529,9 +524,7 @@ auto begin_parallel_scan(const ExecPolicy& policy, FunctorType& functor,
       Kokkos::Tools::Impl::ToolResponse<ExecPolicy, FunctorType>;
   response_type response{policy};
   if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
+    Kokkos::Impl::ParallelConstructName<FunctorType, ExecPolicy> name(label);
     Kokkos::Tools::beginParallelScan(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);
@@ -573,9 +566,7 @@ auto begin_parallel_reduce(const ExecPolicy& policy, FunctorType& functor,
   using response_type = ToolResponse<ExecPolicy, FunctorType>;
   response_type response{policy};
   if (Kokkos::Tools::profileLibraryLoaded()) {
-    Kokkos::Impl::ParallelConstructName<FunctorType,
-                                        typename ExecPolicy::work_tag>
-        name(label);
+    Kokkos::Impl::ParallelConstructName<FunctorType, ExecPolicy> name(label);
     Kokkos::Tools::beginParallelReduce(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
         &kpID);

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -206,7 +206,6 @@ TEST(kokkosp, test_id_gen) {
 /**
  * Test that fencing and kernels yield events on the correct device ID's
  */
-/*
 TEST(kokkosp, test_kernel_sequence) {
   test_wrapper([&]() {
     Kokkos::DefaultExecutionSpace ex;
@@ -230,7 +229,6 @@ TEST(kokkosp, test_kernel_sequence) {
     num_instances += increment<Kokkos::DefaultExecutionSpace>::size;
   });
 }
-*/
 #ifdef KOKKOS_ENABLE_CUDA
 /**
  * CUDA ONLY: test that creating instances from streams leads to events

--- a/core/unit_test/tools/TestEventCorrectness.hpp
+++ b/core/unit_test/tools/TestEventCorrectness.hpp
@@ -206,6 +206,7 @@ TEST(kokkosp, test_id_gen) {
 /**
  * Test that fencing and kernels yield events on the correct device ID's
  */
+/*
 TEST(kokkosp, test_kernel_sequence) {
   test_wrapper([&]() {
     Kokkos::DefaultExecutionSpace ex;
@@ -229,6 +230,7 @@ TEST(kokkosp, test_kernel_sequence) {
     num_instances += increment<Kokkos::DefaultExecutionSpace>::size;
   });
 }
+*/
 #ifdef KOKKOS_ENABLE_CUDA
 /**
  * CUDA ONLY: test that creating instances from streams leads to events

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -54,7 +54,6 @@ void test_kernel_name_parallel_for() {
       get_parallel_for_kernel_name);
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
-
   {
     std::string const my_label = "my_parallel_for_range_policy";
 
@@ -64,7 +63,9 @@ void test_kernel_name_parallel_for() {
     ASSERT_EQ(last_parallel_for, my_label);
 
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
-    ASSERT_EQ(last_parallel_for, typeid_name(my_lambda));
+    ASSERT_EQ(last_parallel_for,
+              typeid_name(my_lambda) + "/" +
+                  typeid_name(Kokkos::RangePolicy<ExecutionSpace>{}));
     ASSERT_FALSE(last_parallel_for.starts_with("const "))
         << last_parallel_for << " is const-qualified";
 
@@ -77,7 +78,8 @@ void test_kernel_name_parallel_for() {
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                          my_lambda_with_tag);
     ASSERT_EQ(last_parallel_for,
-              typeid_name(my_lambda_with_tag) + "/" + typeid_name(WorkTag{}));
+              typeid_name(my_lambda_with_tag) + "/" +
+                  typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{}));
     ASSERT_FALSE(last_parallel_for.starts_with("const "))
         << last_parallel_for << " is const-qualified";
   }
@@ -122,7 +124,9 @@ void test_kernel_name_parallel_reduce() {
 
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                             my_lambda_with_tag, my_result);
-    auto const suffix = std::string("/") + typeid_name(WorkTag{});
+    auto const suffix =
+        std::string("/") +
+        typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{});
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());
     ASSERT_FALSE(last_parallel_reduce.starts_with("const "))
@@ -147,7 +151,9 @@ void test_kernel_name_parallel_scan() {
     ASSERT_EQ(last_parallel_scan, my_label);
 
     Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
-    ASSERT_EQ(last_parallel_scan, typeid_name(my_lambda));
+    ASSERT_EQ(last_parallel_scan,
+              typeid_name(my_lambda) + "/" +
+                  typeid_name(Kokkos::RangePolicy<ExecutionSpace>{}));
     ASSERT_FALSE(last_parallel_scan.starts_with("const "))
         << last_parallel_scan << " is const-qualified";
 
@@ -160,7 +166,8 @@ void test_kernel_name_parallel_scan() {
     Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
                           my_lambda_with_tag);
     ASSERT_EQ(last_parallel_scan,
-              typeid_name(my_lambda_with_tag) + "/" + typeid_name(WorkTag{}));
+              typeid_name(my_lambda_with_tag) + "/" +
+                  typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{}));
     ASSERT_FALSE(last_parallel_scan.starts_with("const "))
         << last_parallel_scan << " is const-qualified";
   }
@@ -178,23 +185,29 @@ TEST(kokkosp, kernel_name_parallel_scan) { test_kernel_name_parallel_scan(); }
 
 TEST(kokkosp, kernel_name_internal) {
   struct ThisType {};
+  struct MockPolicy {};
+  struct MockPolicyWithTag {
+    struct work_tag {};
+  };
   {
     std::string const label("my_label");
-    Kokkos::Impl::ParallelConstructName<ThisType, void> pcn(label);
+    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicy> pcn(label);
     ASSERT_EQ(pcn.get(), label);
     std::string const empty_label("");
-    Kokkos::Impl::ParallelConstructName<ThisType, void> empty_pcn(empty_label);
-    ASSERT_EQ(empty_pcn.get(), typeid_name(ThisType{}));
+    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicy> empty_pcn(
+        empty_label);
+    ASSERT_EQ(empty_pcn.get(),
+              typeid_name(ThisType{}) + "/" + typeid_name(MockPolicy{}));
   }
   {
     std::string const label("my_label");
-    Kokkos::Impl::ParallelConstructName<ThisType, WorkTag> pcn(label);
+    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicyWithTag> pcn(label);
     ASSERT_EQ(pcn.get(), label);
     std::string const empty_label("");
-    Kokkos::Impl::ParallelConstructName<ThisType, WorkTag> empty_pcn(
+    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicyWithTag> empty_pcn(
         empty_label);
     ASSERT_EQ(empty_pcn.get(),
-              typeid_name(ThisType{}) + "/" + typeid_name(WorkTag{}));
+              typeid_name(ThisType{}) + "/" + typeid_name(MockPolicyWithTag{}));
   }
 }
 

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -54,32 +54,30 @@ void test_kernel_name_parallel_for() {
       get_parallel_for_kernel_name);
 
   using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+
   {
     std::string const my_label = "my_parallel_for_range_policy";
 
     auto const my_lambda = KOKKOS_LAMBDA(int){};
-    Kokkos::parallel_for(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
-                         my_lambda);
+    auto const my_policy = Kokkos::RangePolicy<ExecutionSpace>(0, 1);
+    Kokkos::parallel_for(my_label, my_policy, my_lambda);
     ASSERT_EQ(last_parallel_for, my_label);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
+    Kokkos::parallel_for(my_policy, my_lambda);
     ASSERT_EQ(last_parallel_for,
-              typeid_name(my_lambda) + "/" +
-                  typeid_name(Kokkos::RangePolicy<ExecutionSpace>{}));
+              typeid_name(my_lambda) + "/" + typeid_name(my_policy));
     ASSERT_FALSE(last_parallel_for.starts_with("const "))
         << last_parallel_for << " is const-qualified";
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int){};
-    Kokkos::parallel_for(my_label,
-                         Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                         my_lambda_with_tag);
+    auto const my_policy_with_tag =
+        Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1);
+    Kokkos::parallel_for(my_label, my_policy_with_tag, my_lambda_with_tag);
     ASSERT_EQ(last_parallel_for, my_label);
 
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                         my_lambda_with_tag);
-    ASSERT_EQ(last_parallel_for,
-              typeid_name(my_lambda_with_tag) + "/" +
-                  typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{}));
+    Kokkos::parallel_for(my_policy_with_tag, my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_for, typeid_name(my_lambda_with_tag) + "/" +
+                                     typeid_name(my_policy_with_tag));
     ASSERT_FALSE(last_parallel_for.starts_with("const "))
         << last_parallel_for << " is const-qualified";
   }
@@ -98,12 +96,11 @@ void test_kernel_name_parallel_reduce() {
     float my_result;
 
     auto const my_lambda = KOKKOS_LAMBDA(int, float&){};
-    Kokkos::parallel_reduce(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
-                            my_lambda, my_result);
+    auto const my_policy = Kokkos::RangePolicy<ExecutionSpace>(0, 1);
+    Kokkos::parallel_reduce(my_label, my_policy, my_lambda, my_result);
     ASSERT_EQ(last_parallel_reduce, my_label);
 
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace>(0, 1),
-                            my_lambda, my_result);
+    Kokkos::parallel_reduce(my_policy, my_lambda, my_result);
 #ifndef KOKKOS_COMPILER_MSVC
     ASSERT_NE(last_parallel_reduce.find(typeid_name(my_lambda)),
               std::string::npos)
@@ -117,16 +114,14 @@ void test_kernel_name_parallel_reduce() {
         << last_parallel_reduce << " is const-qualified";
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
-    Kokkos::parallel_reduce(my_label,
-                            Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                            my_lambda_with_tag, my_result);
+    auto const my_policy_with_tag =
+        Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1);
+    Kokkos::parallel_reduce(my_label, my_policy_with_tag, my_lambda_with_tag,
+                            my_result);
     ASSERT_EQ(last_parallel_reduce, my_label);
 
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                            my_lambda_with_tag, my_result);
-    auto const suffix =
-        std::string("/") +
-        typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{});
+    Kokkos::parallel_reduce(my_policy_with_tag, my_lambda_with_tag, my_result);
+    auto const suffix = std::string("/") + typeid_name(my_policy_with_tag);
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());
     ASSERT_FALSE(last_parallel_reduce.starts_with("const "))
@@ -146,28 +141,25 @@ void test_kernel_name_parallel_scan() {
     std::string const my_label = "my_parallel_scan_range_policy";
 
     auto const my_lambda = KOKKOS_LAMBDA(int, float&, bool){};
-    Kokkos::parallel_scan(my_label, Kokkos::RangePolicy<ExecutionSpace>(0, 1),
-                          my_lambda);
+    auto const my_policy = Kokkos::RangePolicy<ExecutionSpace>(0, 1);
+    Kokkos::parallel_scan(my_label, my_policy, my_lambda);
     ASSERT_EQ(last_parallel_scan, my_label);
 
-    Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace>(0, 1), my_lambda);
+    Kokkos::parallel_scan(my_policy, my_lambda);
     ASSERT_EQ(last_parallel_scan,
-              typeid_name(my_lambda) + "/" +
-                  typeid_name(Kokkos::RangePolicy<ExecutionSpace>{}));
+              typeid_name(my_lambda) + "/" + typeid_name(my_policy));
     ASSERT_FALSE(last_parallel_scan.starts_with("const "))
         << last_parallel_scan << " is const-qualified";
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&, bool){};
-    Kokkos::parallel_scan(my_label,
-                          Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                          my_lambda_with_tag);
+    auto const my_policy_with_tag =
+        Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1);
+    Kokkos::parallel_scan(my_label, my_policy_with_tag, my_lambda_with_tag);
     ASSERT_EQ(last_parallel_scan, my_label);
 
-    Kokkos::parallel_scan(Kokkos::RangePolicy<ExecutionSpace, WorkTag>(0, 1),
-                          my_lambda_with_tag);
-    ASSERT_EQ(last_parallel_scan,
-              typeid_name(my_lambda_with_tag) + "/" +
-                  typeid_name(Kokkos::RangePolicy<ExecutionSpace, WorkTag>{}));
+    Kokkos::parallel_scan(my_policy_with_tag, my_lambda_with_tag);
+    ASSERT_EQ(last_parallel_scan, typeid_name(my_lambda_with_tag) + "/" +
+                                      typeid_name(my_policy_with_tag));
     ASSERT_FALSE(last_parallel_scan.starts_with("const "))
         << last_parallel_scan << " is const-qualified";
   }
@@ -184,31 +176,16 @@ TEST(kokkosp, kernel_name_parallel_reduce) {
 TEST(kokkosp, kernel_name_parallel_scan) { test_kernel_name_parallel_scan(); }
 
 TEST(kokkosp, kernel_name_internal) {
-  struct ThisType {};
+  struct MockFunctor {};
   struct MockPolicy {};
-  struct MockPolicyWithTag {
-    struct work_tag {};
-  };
-  {
-    std::string const label("my_label");
-    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicy> pcn(label);
-    ASSERT_EQ(pcn.get(), label);
-    std::string const empty_label("");
-    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicy> empty_pcn(
-        empty_label);
-    ASSERT_EQ(empty_pcn.get(),
-              typeid_name(ThisType{}) + "/" + typeid_name(MockPolicy{}));
-  }
-  {
-    std::string const label("my_label");
-    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicyWithTag> pcn(label);
-    ASSERT_EQ(pcn.get(), label);
-    std::string const empty_label("");
-    Kokkos::Impl::ParallelConstructName<ThisType, MockPolicyWithTag> empty_pcn(
-        empty_label);
-    ASSERT_EQ(empty_pcn.get(),
-              typeid_name(ThisType{}) + "/" + typeid_name(MockPolicyWithTag{}));
-  }
+  std::string const label("my_label");
+  Kokkos::Impl::ParallelConstructName<MockFunctor, MockPolicy> pcn(label);
+  ASSERT_EQ(pcn.get(), label);
+  std::string const empty_label("");
+  Kokkos::Impl::ParallelConstructName<MockFunctor, MockPolicy> empty_pcn(
+      empty_label);
+  ASSERT_EQ(empty_pcn.get(),
+            typeid_name(MockFunctor{}) + "/" + typeid_name(MockPolicy{}));
 }
 
 }  // namespace

--- a/core/unit_test/tools/TestKernelNames.cpp
+++ b/core/unit_test/tools/TestKernelNames.cpp
@@ -66,8 +66,16 @@ void test_kernel_name_parallel_for() {
     Kokkos::parallel_for(my_policy, my_lambda);
     ASSERT_EQ(last_parallel_for,
               typeid_name(my_lambda) + "/" + typeid_name(my_policy));
-    ASSERT_FALSE(last_parallel_for.starts_with("const "))
-        << last_parallel_for << " is const-qualified";
+    {
+      auto const pos = last_parallel_for.find('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_for.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_for.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int){};
     auto const my_policy_with_tag =
@@ -78,8 +86,16 @@ void test_kernel_name_parallel_for() {
     Kokkos::parallel_for(my_policy_with_tag, my_lambda_with_tag);
     ASSERT_EQ(last_parallel_for, typeid_name(my_lambda_with_tag) + "/" +
                                      typeid_name(my_policy_with_tag));
-    ASSERT_FALSE(last_parallel_for.starts_with("const "))
-        << last_parallel_for << " is const-qualified";
+    {
+      auto const pos = last_parallel_for.find('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_for.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_for.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
   }
 
   Kokkos::Tools::Experimental::set_begin_parallel_for_callback(nullptr);
@@ -110,8 +126,16 @@ void test_kernel_name_parallel_reduce() {
                             // but the name should still include the lambda as
                             // template parameter
 #endif
-    ASSERT_FALSE(last_parallel_reduce.starts_with("const "))
-        << last_parallel_reduce << " is const-qualified";
+    {
+      auto const pos = last_parallel_reduce.rfind('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_reduce.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_reduce.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&){};
     auto const my_policy_with_tag =
@@ -124,8 +148,16 @@ void test_kernel_name_parallel_reduce() {
     auto const suffix = std::string("/") + typeid_name(my_policy_with_tag);
     ASSERT_EQ(last_parallel_reduce.find(suffix),
               last_parallel_reduce.length() - suffix.length());
-    ASSERT_FALSE(last_parallel_reduce.starts_with("const "))
-        << last_parallel_reduce << " is const-qualified";
+    {
+      auto const pos = last_parallel_reduce.rfind('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_reduce.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_reduce.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
   }
 
   Kokkos::Tools::Experimental::set_begin_parallel_reduce_callback(nullptr);
@@ -148,8 +180,16 @@ void test_kernel_name_parallel_scan() {
     Kokkos::parallel_scan(my_policy, my_lambda);
     ASSERT_EQ(last_parallel_scan,
               typeid_name(my_lambda) + "/" + typeid_name(my_policy));
-    ASSERT_FALSE(last_parallel_scan.starts_with("const "))
-        << last_parallel_scan << " is const-qualified";
+    {
+      auto const pos = last_parallel_scan.find('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_scan.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_scan.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
 
     auto const my_lambda_with_tag = KOKKOS_LAMBDA(WorkTag, int, float&, bool){};
     auto const my_policy_with_tag =
@@ -160,8 +200,16 @@ void test_kernel_name_parallel_scan() {
     Kokkos::parallel_scan(my_policy_with_tag, my_lambda_with_tag);
     ASSERT_EQ(last_parallel_scan, typeid_name(my_lambda_with_tag) + "/" +
                                       typeid_name(my_policy_with_tag));
-    ASSERT_FALSE(last_parallel_scan.starts_with("const "))
-        << last_parallel_scan << " is const-qualified";
+    {
+      auto const pos = last_parallel_scan.find('/');
+      ASSERT_NE(pos, std::string::npos);
+      auto const functor_name = last_parallel_scan.substr(0, pos);
+      ASSERT_FALSE(functor_name.starts_with("const "))
+          << functor_name << " is const-qualified";
+      auto const policy_name = last_parallel_scan.substr(pos + 1);
+      ASSERT_FALSE(policy_name.starts_with("const "))
+          << policy_name << " is const-qualified";
+    }
   }
 
   Kokkos::Tools::Experimental::set_begin_parallel_scan_callback(nullptr);
@@ -186,6 +234,14 @@ TEST(kokkosp, kernel_name_internal) {
       empty_label);
   ASSERT_EQ(empty_pcn.get(),
             typeid_name(MockFunctor{}) + "/" + typeid_name(MockPolicy{}));
+  {
+    auto const name = empty_pcn.get();
+    auto const pos  = name.find('/');
+    ASSERT_NE(pos, std::string::npos);
+    auto const policy_name = name.substr(pos + 1);
+    ASSERT_FALSE(policy_name.starts_with("const "))
+        << policy_name << " is const-qualified";
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
This PR changes the way kernel names are generated for `Kokkos Tools`.
Instead of `Functor/Tag`, the name is now formatted as `Functor/Policy<Tag>`.

Before
```
-------------------------------------------------------------------------
Kernels: 

- Kokkos::View::initialization [Atest] via memset
 (ParFor)   6.236567 11 0.566961 27.126351 24.522262
- Kokkos::View::initialization [Btest] via memset
 (ParFor)   6.042563 11 0.549324 26.282517 23.759434
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>/NO_FLATENING_TAG
 (ParFor)   4.605142 1 4.605142 20.030362 18.107477
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>/FLATENING_TAG
 (ParFor)   1.266632 3 0.422211 5.509297 4.980412
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>/FLATENING_TAG
 (ParFor)   1.203197 3 0.401066 5.233384 4.730987
- Kokkos::ViewFill-1D
 (ParFor)   1.111746 22 0.050534 4.835610 4.371399
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>/NO_FLATENING_TAG
 (ParFor)   0.942170 6 0.157028 4.098029 3.704624
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>
 (ParFor)   0.818476 5 0.163695 3.560014 3.218258
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>
 (ParFor)   0.764315 8 0.095539 3.324437 3.005296

-------------------------------------------------------------------------
Summary:

Total Execution Time (incl. Kokkos + non-Kokkos):                  25.43227 seconds
Total Time in Kokkos kernels:                                      22.99081 seconds
   -> Time outside Kokkos kernels:                                  2.44146 seconds
   -> Percentage in Kokkos kernels:                                   90.40 %
Total Calls to Kokkos Kernels:                                           70
-------------------------------------------------------------------------

```
After
```
Kernels: 

- Kokkos::View::initialization [Btest] via memset
 (ParFor)   6.226052 11 0.566005 26.984567 24.490030
- Kokkos::View::initialization [Atest] via memset
 (ParFor)   6.046597 11 0.549691 26.206788 23.784150
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>/Kokkos::RangePolicy<NO_FLATENING_TAG, Kokkos::OpenMP>
 (ParFor)   4.649250 1 4.649250 20.150491 18.287717
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>/Kokkos::RangePolicy<FLATENING_TAG, Kokkos::OpenMP>
 (ParFor)   1.326919 3 0.442306 5.751049 5.219404
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>/Kokkos::RangePolicy<FLATENING_TAG, Kokkos::OpenMP>
 (ParFor)   1.273823 3 0.424608 5.520924 5.010552
- Kokkos::ViewFill-1D
 (ParFor)   1.080438 22 0.049111 4.682768 4.249878
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>/Kokkos::RangePolicy<NO_FLATENING_TAG, Kokkos::OpenMP>
 (ParFor)   0.893341 6 0.148890 3.871864 3.513937
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutLeft>/Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Left, Kokkos::Iterate::Left>, Kokkos::OpenMP>
 (ParFor)   0.789302 9 0.087700 3.420943 3.104701
- FunctorFlatenning<Kokkos::OpenMP, Kokkos::LayoutRight>/Kokkos::MDRangePolicy<Kokkos::Rank<2, Kokkos::Iterate::Right, Kokkos::Iterate::Right>, Kokkos::OpenMP>
 (ParFor)   0.786917 5 0.157383 3.410606 3.095319

-------------------------------------------------------------------------
Summary:

Total Execution Time (incl. Kokkos + non-Kokkos):                  25.42280 seconds
Total Time in Kokkos kernels:                                      23.07264 seconds
   -> Time outside Kokkos kernels:                                  2.35016 seconds
   -> Percentage in Kokkos kernels:                                   90.76 %
Total Calls to Kokkos Kernels:                                           71
-------------------------------------------------------------------------
```