### PR TITLE
Remove deprecated code path disabling enforcement of RangePolicy preconditions

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -237,14 +237,7 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
                         std::to_string(m_begin) +
                         ") is greater than the upper bound (" +
                         std::to_string(m_end) + ").\n";
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
       Kokkos::abort(msg.c_str());
-#endif
-      m_begin = 0;
-      m_end   = 0;
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-      Kokkos::Impl::log_warning(msg);
-#endif
     }
   }
 
@@ -253,44 +246,35 @@ class RangePolicy : public Impl::PolicyTraits<Properties...> {
   static void check_conversion_safety([[maybe_unused]] const IndexType bound) {
     // Checking that the round-trip conversion preserves input index value
     if constexpr (std::is_convertible_v<member_type, IndexType>) {
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_4) || \
-    defined(KOKKOS_ENABLE_DEPRECATION_WARNINGS)
-      bool warn = false;
+      bool error = false;
 
       if constexpr (std::is_arithmetic_v<member_type> &&
                     (std::is_signed_v<IndexType> !=
                      std::is_signed_v<member_type>)) {
         // check signed to unsigned
         if constexpr (std::is_signed_v<IndexType>)
-          warn |= (bound < static_cast<IndexType>(
-                               std::numeric_limits<member_type>::min()));
+          error |= (bound < static_cast<IndexType>(
+                                std::numeric_limits<member_type>::min()));
 
         // check unsigned to signed
         if constexpr (std::is_signed_v<member_type>)
-          warn |= (bound > static_cast<IndexType>(
-                               std::numeric_limits<member_type>::max()));
+          error |= (bound > static_cast<IndexType>(
+                                std::numeric_limits<member_type>::max()));
       }
 
       // check narrowing
-      warn |=
+      error |=
           (static_cast<IndexType>(static_cast<member_type>(bound)) != bound);
 
-      if (warn) {
+      if (error) {
         std::string msg =
             "Kokkos::RangePolicy bound type error: an unsafe implicit "
             "conversion is performed on a bound (" +
             std::to_string(bound) +
             "), which may not preserve its original value.\n";
 
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
         Kokkos::abort(msg.c_str());
-#endif
-
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-        Kokkos::Impl::log_warning(msg);
-#endif
       }
-#endif
     }
   }
 

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -76,46 +76,12 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
   std::string msg =
       "Kokkos::RangePolicy bounds error: The lower bound (100) is greater than "
       "the upper bound (90).\n";
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   // escape the parentheses in the regex to match the error message
   msg = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
   ASSERT_DEATH({ (void)Policy(100, 90); }, msg);
 
   ASSERT_DEATH({ (void)Policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10)); },
                msg);
-#else
-
-  if (!Kokkos::show_warnings()) {
-    GTEST_SKIP() << "Kokkos warning messages are disabled";
-  }
-
-  {
-    ::testing::internal::CaptureStderr();
-    Policy policy(100, 90);
-    ASSERT_EQ((int)policy.begin(), 0);
-    ASSERT_EQ((int)policy.end(), 0);
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg);
-#else
-    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-    (void)msg;
-#endif
-  }
-
-  {
-    ::testing::internal::CaptureStderr();
-    Policy policy(TEST_EXECSPACE(), 100, 90, ChunkSize(10));
-    ASSERT_EQ((int)policy.begin(), 0);
-    ASSERT_EQ((int)policy.end(), 0);
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    ASSERT_EQ(::testing::internal::GetCapturedStderr(), msg);
-#else
-    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-    (void)msg;
-#endif
-  }
-
-#endif
 }
 
 struct W {  // round-trip conversion check for narrowing should "fire"
@@ -138,19 +104,7 @@ TEST(TEST_CATEGORY_DEATH, range_policy_round_trip_conversion_fires) {
   [[maybe_unused]] std::string msg =
       "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is "
       "performed";
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   ASSERT_DEATH((void)Policy(0, W(&n)), msg);
-#else
-  ::testing::internal::CaptureStderr();
-  (void)Policy(0, W(&n));
-  auto s = std::string(::testing::internal::GetCapturedStderr());
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-  if (Kokkos::show_warnings()) {
-    ASSERT_NE(s.find(msg), std::string::npos) << msg;
-  } else
-#endif
-    ASSERT_TRUE(s.empty());
-#endif
 }
 
 struct B {  // round-trip conversion would not compile
@@ -182,7 +136,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_check_sign_changes) {
   [[maybe_unused]] std::string msg =
       "Kokkos::RangePolicy bound type error: an unsafe implicit conversion is "
       "performed";
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   {
     std::int64_t n = std::numeric_limits<std::int64_t>::max();
     ASSERT_DEATH((void)UInt32Policy(0, n), msg);
@@ -191,30 +144,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_check_sign_changes) {
     std::int64_t n = std::numeric_limits<std::int64_t>::min();
     ASSERT_DEATH((void)UInt32Policy(n, 0), msg);
   }
-#else
-  {
-    ::testing::internal::CaptureStderr();
-    std::int64_t n = std::numeric_limits<std::int64_t>::max();
-    (void)UInt32Policy(0, n);
-    auto s = std::string(::testing::internal::GetCapturedStderr());
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    if (Kokkos::show_warnings()) {
-      ASSERT_NE(s.find(msg), std::string::npos) << msg;
-    }
-#endif
-  }
-  {
-    ::testing::internal::CaptureStderr();
-    std::int64_t n = std::numeric_limits<std::int64_t>::min();
-    (void)UInt32Policy(n, 0);
-    auto s = std::string(::testing::internal::GetCapturedStderr());
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    if (Kokkos::show_warnings()) {
-      ASSERT_NE(s.find(msg), std::string::npos) << msg;
-    }
-#endif
-  }
-#endif
 }
 
 TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
@@ -230,7 +159,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   [[maybe_unused]] auto get_error_msg = [](auto str, auto val) {
     return str.insert(str.find("(") + 1, std::to_string(val).c_str());
   };
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   std::string expected = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
@@ -254,43 +182,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
     ASSERT_DEATH({ (void)UIntPolicy(test_val, 10, Kokkos::ChunkSize(2)); },
                  get_error_msg(expected, test_val));
   }
-
-#else
-  {
-    ::testing::internal::CaptureStderr();
-    int test_val = -1;
-    UIntPolicy policy(test_val, 10);
-    ASSERT_EQ(policy.begin(), 0u);
-    ASSERT_EQ(policy.end(), 0u);
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    if (Kokkos::show_warnings()) {
-      auto s = std::string(::testing::internal::GetCapturedStderr());
-      ASSERT_EQ(s.substr(0, s.find("\n") + 1), get_error_msg(msg, test_val));
-    }
-#else
-    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-    (void)msg;
-    (void)get_error_msg;
-#endif
-  }
-  {
-    ::testing::internal::CaptureStderr();
-    unsigned test_val = std::numeric_limits<unsigned>::max();
-    IntPolicy policy(0u, test_val);
-    ASSERT_EQ(policy.begin(), 0);
-    ASSERT_EQ(policy.end(), 0);
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-    if (Kokkos::show_warnings()) {
-      auto s = std::string(::testing::internal::GetCapturedStderr());
-      ASSERT_EQ(s.substr(0, s.find("\n") + 1), get_error_msg(msg, test_val));
-    }
-#else
-    ASSERT_TRUE(::testing::internal::GetCapturedStderr().empty());
-    (void)msg;
-    (void)get_error_msg;
-#endif
-  }
-#endif
 }
 
 constexpr bool test_chunk_size_explicit() {


### PR DESCRIPTION
Working towards https://github.com/kokkos/kokkos/issues/8958
