### PR TITLE
Enable opt-in >48KiB shared memory for CUDA

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -77,10 +77,11 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
     max_blocks_regs--;
 
   // Limits due to shared memory/SM
-  size_t const shmem_per_sm            = properties.sharedMemPerMultiprocessor;
-  size_t const shmem_per_block         = properties.sharedMemPerBlock;
+  size_t const shmem_per_sm = properties.sharedMemPerMultiprocessor;
+  size_t const shmem_per_block =
+      properties.sharedMemPerBlockOptin - properties.reservedSharedMemPerBlock;
   size_t const static_shmem            = attributes.sharedSizeBytes;
-  size_t const dynamic_shmem_per_block = attributes.maxDynamicSharedSizeBytes;
+  size_t const dynamic_shmem_per_block = shmem_per_block - static_shmem;
   size_t const total_shmem             = static_shmem + dynamic_shmem;
 
   int const max_blocks_shmem =

--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -31,6 +31,14 @@ inline int cuda_warp_per_sm_allocation_granularity(
   }
 }
 
+// sharedMemPerBlockOptin is the maximum available after opting in via
+// cudaFuncAttributeMaxDynamicSharedMemorySize; the driver reserves
+// reservedSharedMemPerBlock bytes, leaving this as the usable ceiling.
+inline size_t get_max_shared_mem_per_block(
+    cudaDeviceProp const& props) noexcept {
+  return props.sharedMemPerBlockOptin - props.reservedSharedMemPerBlock;
+}
+
 inline int cuda_max_warps_per_sm_registers(
     cudaDeviceProp const& properties, cudaFuncAttributes const& attributes) {
   // Maximum number of warps per sm as a function of register counts,
@@ -77,10 +85,9 @@ inline int cuda_max_active_blocks_per_sm(cudaDeviceProp const& properties,
     max_blocks_regs--;
 
   // Limits due to shared memory/SM
-  size_t const shmem_per_sm = properties.sharedMemPerMultiprocessor;
-  size_t const shmem_per_block =
-      properties.sharedMemPerBlockOptin - properties.reservedSharedMemPerBlock;
-  size_t const static_shmem            = attributes.sharedSizeBytes;
+  size_t const shmem_per_sm    = properties.sharedMemPerMultiprocessor;
+  size_t const shmem_per_block = get_max_shared_mem_per_block(properties);
+  size_t const static_shmem    = attributes.sharedSizeBytes;
   size_t const dynamic_shmem_per_block = shmem_per_block - static_shmem;
   size_t const total_shmem             = static_shmem + dynamic_shmem;
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -209,6 +209,10 @@ void CudaInternal::print_configuration(std::ostream &s) const {
       << '\n'
       << "  Shared Memory per Block: "
       << human_memory_size(prop.sharedMemPerBlock) << '\n'
+      << "  Shared Memory per Block (Optin): "
+      << human_memory_size(prop.sharedMemPerBlockOptin) << '\n'
+      << "  Reserved Shared Memory per Block: "
+      << human_memory_size(prop.reservedSharedMemPerBlock) << '\n'
       << "  Can access system allocated memory: " << prop.pageableMemoryAccess
       << '\n'
       << "    via Address Translation Service: "

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -128,9 +128,8 @@ inline bool is_empty_launch(dim3 const& grid, dim3 const& block) {
 }
 
 inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
-  int const maxShmemPerBlock =
-      cuda_instance->m_deviceProp.sharedMemPerBlockOptin -
-      cuda_instance->m_deviceProp.reservedSharedMemPerBlock;
+  int const maxShmemPerBlock = static_cast<int>(
+      get_max_shared_mem_per_block(cuda_instance->m_deviceProp));
   if (maxShmemPerBlock < shmem) {
     Kokkos::Impl::throw_runtime_exception(
         "CudaParallelLaunch (or graph node creation) FAILED: shared memory "

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -244,8 +244,10 @@ inline void configure_shmem_preference(const CudaInternal* cuda_instance,
   }
 }
 
+// Opt in to the maximum dynamic shared memory size when the request
+// exceeds the default limit.
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
-inline void ensure_sufficient_shmem(const CudaInternal* cuda_instance,
+inline void configure_max_dynamic_shmem(const CudaInternal* cuda_instance,
                                     const KernelFuncPtr& func, int shmem) {
   const auto& func_attr =
       get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
@@ -401,7 +403,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
                             CudaInternal const* cuda_instance) {
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
-    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+    Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
         cuda_instance, base_t::get_kernel_func(), shmem);
 
     (base_t::
@@ -430,7 +432,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
             cuda_instance->m_deviceProp, block_size, shmem, desired_occupancy);
       }
       Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+      Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
           cuda_instance, base_t::get_kernel_func(), shmem);
 
       void const* args[] = {&driver};
@@ -509,7 +511,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
-    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+    Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
         cuda_instance, base_t::get_kernel_func(), shmem);
 
     (base_t::
@@ -538,7 +540,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
             desired_occupancy);
       }
       Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+      Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
           cuda_instance, base_t::get_kernel_func(), shmem);
 
       auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(
@@ -649,7 +651,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
-    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+    Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
         cuda_instance, base_t::get_kernel_func(), shmem);
 
     // Invoke the driver function on the device

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -424,9 +424,6 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     KOKKOS_EXPECTS(!bool(graph_node));
 
     if (!Impl::is_empty_launch(grid, block)) {
-      Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
-          cuda_instance, base_t::get_kernel_func(), shmem);
       if constexpr (DriverType::Policy::
                         experimental_contains_desired_occupancy) {
         int desired_occupancy =
@@ -436,6 +433,9 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
             cuda_instance->m_cudaDev, base_t::get_kernel_func(),
             cuda_instance->m_deviceProp, block_size, shmem, desired_occupancy);
       }
+      Impl::check_shmem_request(cuda_instance, shmem);
+      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+          cuda_instance, base_t::get_kernel_func(), shmem);
 
       void const* args[] = {&driver};
 
@@ -532,9 +532,6 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     KOKKOS_EXPECTS(!bool(graph_node));
 
     if (!Impl::is_empty_launch(grid, block)) {
-      Impl::check_shmem_request(cuda_instance, shmem);
-      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
-          cuda_instance, base_t::get_kernel_func(), shmem);
       if constexpr (DriverType::Policy::
                         experimental_contains_desired_occupancy) {
         int desired_occupancy =
@@ -544,6 +541,9 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
             cuda_instance, base_t::get_kernel_func(), block_size, shmem,
             desired_occupancy);
       }
+      Impl::check_shmem_request(cuda_instance, shmem);
+      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+          cuda_instance, base_t::get_kernel_func(), shmem);
 
       auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(
           CudaSpace::impl_create(cuda_instance->m_cudaDev,

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -252,7 +252,13 @@ inline void configure_max_dynamic_shmem(const CudaInternal* cuda_instance,
   const auto& func_attr =
       get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
                                                                 func);
-  static int cached_max = func_attr.maxDynamicSharedSizeBytes;
+  const auto cuda_device = cuda_instance->m_cudaDev;
+  static std::map<int, int> cached_max_per_device;
+  if (cached_max_per_device.find(cuda_device) == cached_max_per_device.end()) {
+    cached_max_per_device.emplace(cuda_device,
+                                  func_attr.maxDynamicSharedSizeBytes);
+  }
+  int& cached_max = cached_max_per_device[cuda_device];
   if (shmem <= cached_max) return;
   KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_func_set_attribute_wrapper(
       func, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem)));

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -128,7 +128,9 @@ inline bool is_empty_launch(dim3 const& grid, dim3 const& block) {
 }
 
 inline void check_shmem_request(CudaInternal const* cuda_instance, int shmem) {
-  int const maxShmemPerBlock = cuda_instance->m_deviceProp.sharedMemPerBlock;
+  int const maxShmemPerBlock =
+      cuda_instance->m_deviceProp.sharedMemPerBlockOptin -
+      cuda_instance->m_deviceProp.reservedSharedMemPerBlock;
   if (maxShmemPerBlock < shmem) {
     Kokkos::Impl::throw_runtime_exception(
         "CudaParallelLaunch (or graph node creation) FAILED: shared memory "
@@ -240,6 +242,23 @@ inline void configure_shmem_preference(const CudaInternal* cuda_instance,
   if (cache_config_preference_cached != carveout) {
     cache_config_preference_cached = set_cache_config();
   }
+}
+
+template <class DriverType, class LaunchBounds, class KernelFuncPtr>
+inline void ensure_sufficient_shmem(const CudaInternal* cuda_instance,
+                                    const KernelFuncPtr& func, int shmem) {
+  const auto& func_attr =
+      get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
+                                                                func);
+  if (shmem <= func_attr.maxDynamicSharedSizeBytes) return;
+
+  auto set_max_shmem = [&] {
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_func_set_attribute_wrapper(
+        func, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem)));
+    return shmem;
+  };
+  static int cached_max = set_max_shmem();
+  if (cached_max < shmem) cached_max = set_max_shmem();
 }
 
 // </editor-fold> end Some helper functions for launch code readability }}}1
@@ -386,6 +405,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
                             CudaInternal const* cuda_instance) {
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
+    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+        cuda_instance, base_t::get_kernel_func(), shmem);
 
     (base_t::
          get_kernel_func())<<<grid, block, shmem, cuda_instance->m_stream>>>(
@@ -404,6 +425,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     if (!Impl::is_empty_launch(grid, block)) {
       Impl::check_shmem_request(cuda_instance, shmem);
+      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+          cuda_instance, base_t::get_kernel_func(), shmem);
       if constexpr (DriverType::Policy::
                         experimental_contains_desired_occupancy) {
         int desired_occupancy =
@@ -490,6 +513,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
+    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+        cuda_instance, base_t::get_kernel_func(), shmem);
 
     (base_t::
          get_kernel_func())<<<grid, block, shmem, cuda_instance->m_stream>>>(
@@ -508,6 +533,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     if (!Impl::is_empty_launch(grid, block)) {
       Impl::check_shmem_request(cuda_instance, shmem);
+      Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+          cuda_instance, base_t::get_kernel_func(), shmem);
       if constexpr (DriverType::Policy::
                         experimental_contains_desired_occupancy) {
         int desired_occupancy =
@@ -626,6 +653,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     // Set cuda device before launching kernel
     cuda_instance->set_cuda_device();
+    Impl::ensure_sufficient_shmem<DriverType, LaunchBounds>(
+        cuda_instance, base_t::get_kernel_func(), shmem);
 
     // Invoke the driver function on the device
     (base_t::

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -250,15 +250,11 @@ inline void ensure_sufficient_shmem(const CudaInternal* cuda_instance,
   const auto& func_attr =
       get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
                                                                 func);
-  if (shmem <= func_attr.maxDynamicSharedSizeBytes) return;
-
-  auto set_max_shmem = [&] {
-    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_func_set_attribute_wrapper(
-        func, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem)));
-    return shmem;
-  };
-  static int cached_max = set_max_shmem();
-  if (cached_max < shmem) cached_max = set_max_shmem();
+  static int cached_max = func_attr.maxDynamicSharedSizeBytes;
+  if (shmem <= cached_max) return;
+  KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_func_set_attribute_wrapper(
+      func, cudaFuncAttributeMaxDynamicSharedMemorySize, shmem)));
+  cached_max = shmem;
 }
 
 // </editor-fold> end Some helper functions for launch code readability }}}1

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -248,7 +248,7 @@ inline void configure_shmem_preference(const CudaInternal* cuda_instance,
 // exceeds the default limit.
 template <class DriverType, class LaunchBounds, class KernelFuncPtr>
 inline void configure_max_dynamic_shmem(const CudaInternal* cuda_instance,
-                                    const KernelFuncPtr& func, int shmem) {
+                                        const KernelFuncPtr& func, int shmem) {
   const auto& func_attr =
       get_cuda_kernel_func_attributes<DriverType, LaunchBounds>(cuda_instance,
                                                                 func);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -198,8 +198,9 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     // These potential scenarios are addressed in an ad-hoc fashion by the
     // 16KiB "shared memory fudge factor"; more robust solutions to this
     // are being considered in #9089.
-    constexpr size_t max_possible_team_size              = 1024;
-    constexpr size_t ad_hoc_shared_memory_overallocation = 16 * 1024;
+    constexpr size_t max_possible_team_size = 1024;
+    constexpr size_t ad_hoc_shared_memory_overallocation =
+        static_cast<size_t>(16) * 1024;
     constexpr size_t max_reserved_shared_mem_per_team =
         (max_possible_team_size + 2) * sizeof(double) + sizeof(int64_t) +
         ad_hoc_shared_memory_overallocation;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -993,8 +993,8 @@ class ParallelReduce<CombinedFunctorReducerType,
     // upon team size.
 
     auto const& dev_props = m_policy.space().cuda_device_prop();
-    const int maxShmemPerBlock = dev_props.sharedMemPerBlockOptin -
-                                 dev_props.reservedSharedMemPerBlock;
+    const int maxShmemPerBlock =
+        dev_props.sharedMemPerBlockOptin - dev_props.reservedSharedMemPerBlock;
     const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
     if (!Kokkos::has_single_bit<unsigned>(m_team_size) && !UseShflReduction) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -190,10 +190,19 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     // reductions. They also use one int64_t in static shared memory for a
     // shared ID. Furthermore, they use additional scratch memory in some
     // reduction scenarios, which depend on the size of the value_type and is
-    // NOT captured here.
-    constexpr size_t max_possible_team_size = 1024;
+    // NOT captured here. There is also the chance that RDC or the potential
+    // inclusion of CCCL/other libraries in the future could add extra static
+    // shared memory requirements that can't be captured without knowing
+    // details of the function itself.
+    //
+    // These potential scenarios are addressed in an ad-hoc fashion by the
+    // 16KiB "shared memory fudge factor"; more robust solutions to this
+    // are being considered in #9089.
+    constexpr size_t max_possible_team_size              = 1024;
+    constexpr size_t ad_hoc_shared_memory_overallocation = 16 * 1024;
     constexpr size_t max_reserved_shared_mem_per_team =
-        (max_possible_team_size + 2) * sizeof(double) + sizeof(int64_t);
+        (max_possible_team_size + 2) * sizeof(double) + sizeof(int64_t) +
+        ad_hoc_shared_memory_overallocation;
     // arbitrarily setting level 1 scratch limit to 20MB, for a
     // Volta V100 that would give us about 3.2GB for 2 teams per SM
     constexpr size_t max_l1_scratch_size =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -210,8 +210,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         static_cast<size_t>(80) * 1024 * 1024;
 
     auto const& props = Impl::CudaInternal::m_deviceProp;
-    size_t max_shmem =
-        props.sharedMemPerBlockOptin - props.reservedSharedMemPerBlock;
+    size_t max_shmem  = get_max_shared_mem_per_block(props);
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team
                        : max_l1_scratch_size);
   }
@@ -596,7 +595,7 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
 
     auto const& dev_props = m_policy.space().cuda_device_prop();
     const int maxShmemPerBlock =
-        dev_props.sharedMemPerBlockOptin - dev_props.reservedSharedMemPerBlock;
+        static_cast<int>(get_max_shared_mem_per_block(dev_props));
     const int shmem_size_total = m_shmem_begin + m_shmem_size;
     if (maxShmemPerBlock < shmem_size_total) {
       std::stringstream error;
@@ -994,7 +993,7 @@ class ParallelReduce<CombinedFunctorReducerType,
 
     auto const& dev_props = m_policy.space().cuda_device_prop();
     const int maxShmemPerBlock =
-        dev_props.sharedMemPerBlockOptin - dev_props.reservedSharedMemPerBlock;
+        static_cast<int>(get_max_shared_mem_per_block(dev_props));
     const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
     if (!Kokkos::has_single_bit<unsigned>(m_team_size) && !UseShflReduction) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -992,9 +992,9 @@ class ParallelReduce<CombinedFunctorReducerType,
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
 
-    auto const& dev_props_r    = m_policy.space().cuda_device_prop();
-    const int maxShmemPerBlock = dev_props_r.sharedMemPerBlockOptin -
-                                 dev_props_r.reservedSharedMemPerBlock;
+    auto const& dev_props = m_policy.space().cuda_device_prop();
+    const int maxShmemPerBlock = dev_props.sharedMemPerBlockOptin -
+                                 dev_props.reservedSharedMemPerBlock;
     const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
     if (!Kokkos::has_single_bit<unsigned>(m_team_size) && !UseShflReduction) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -199,7 +199,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     constexpr size_t max_l1_scratch_size =
         static_cast<size_t>(80) * 1024 * 1024;
 
-    auto const& props = Cuda().cuda_device_prop();
+    auto const& props = Impl::CudaInternal::m_deviceProp;
     size_t max_shmem =
         props.sharedMemPerBlockOptin - props.reservedSharedMemPerBlock;
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -199,7 +199,9 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     constexpr size_t max_l1_scratch_size =
         static_cast<size_t>(80) * 1024 * 1024;
 
-    size_t max_shmem = Cuda().cuda_device_prop().sharedMemPerBlock;
+    auto const& props = Cuda().cuda_device_prop();
+    size_t max_shmem =
+        props.sharedMemPerBlockOptin - props.reservedSharedMemPerBlock;
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team
                        : max_l1_scratch_size);
   }
@@ -582,8 +584,9 @@ class ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
                   static_cast<std::int64_t>(m_league_size))));
     }
 
+    auto const& dev_props = m_policy.space().cuda_device_prop();
     const int maxShmemPerBlock =
-        m_policy.space().cuda_device_prop().sharedMemPerBlock;
+        dev_props.sharedMemPerBlockOptin - dev_props.reservedSharedMemPerBlock;
     const int shmem_size_total = m_shmem_begin + m_shmem_size;
     if (maxShmemPerBlock < shmem_size_total) {
       std::stringstream error;
@@ -979,8 +982,9 @@ class ParallelReduce<CombinedFunctorReducerType,
     // Functor's reduce memory, team scan memory, and team shared memory depend
     // upon team size.
 
-    const int maxShmemPerBlock =
-        m_policy.space().cuda_device_prop().sharedMemPerBlock;
+    auto const& dev_props_r    = m_policy.space().cuda_device_prop();
+    const int maxShmemPerBlock = dev_props_r.sharedMemPerBlockOptin -
+                                 dev_props_r.reservedSharedMemPerBlock;
     const int shmem_size_total = m_team_begin + m_shmem_begin + m_shmem_size;
 
     if (!Kokkos::has_single_bit<unsigned>(m_team_size) && !UseShflReduction) {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -702,6 +702,14 @@ if(Kokkos_ENABLE_CUDA)
   kokkos_add_executable_and_test(CoreUnitTest_CudaGraphAtomicLocks SOURCES UnitTestMainInit.cpp ${file})
 
   kokkos_add_executable_and_test(
+    CoreUnitTest_CudaGraphScratch SOURCES UnitTestMainInit.cpp cuda/TestCuda_GraphScratch.cpp
+  )
+
+  kokkos_add_executable_and_test(
+    CoreUnitTest_CudaLargeScratch SOURCES UnitTestMainInit.cpp cuda/TestCuda_LargeScratch.cpp
+  )
+
+  kokkos_add_executable_and_test(
     CoreUnitTest_CudaTimingBased SOURCES UnitTestMainInit.cpp cuda/TestCuda_DebugSerialExecution.cpp
     cuda/TestCuda_DebugPinUVMSpace.cpp
   )

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1476,8 +1476,11 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), team_scratch_in_graph) {
     using functor_type = GraphScratchFunctor<exec_space>;
     using scratch_view = typename functor_type::scratch_view;
 
-    const int team_size     = std::min(32, ex.concurrency());
-    const int num_teams     = 2;
+    const int num_teams = 2;
+    const int team_size_max =
+        team_policy(num_teams, 1)
+            .team_size_max(functor_type{}, Kokkos::ParallelForTag());
+    const int team_size     = std::min(32, team_size_max);
     const int N             = num_teams * team_size;
     const int scratch_ints  = team_size;
     const int scratch_bytes = scratch_view::shmem_size(scratch_ints);

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1466,6 +1466,10 @@ struct GraphLBFunctor {
 
 // Test TeamPolicy with L0 scratch memory in graph nodes.
 TEST_F(TEST_CATEGORY_FIXTURE(graph), team_scratch_in_graph) {
+#ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
+  GTEST_SKIP() << "skipping since scratch memory is not yet implemented in the "
+                  "OpenACC backend";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using mem_space    = typename exec_space::memory_space;
   using team_policy  = Kokkos::TeamPolicy<exec_space>;

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1432,6 +1432,77 @@ TEST(TEST_CATEGORY, graph_then_tag) {
   ASSERT_TRUE(contains(exec, data, 5 * value_then));
 }
 
+// Functors for graph scratch/replay tests, at namespace scope for CUDA
+// compatibility.
+template <class ExecSpace>
+struct GraphScratchFunctor {
+  using mem_space   = typename ExecSpace::memory_space;
+  using team_policy = Kokkos::TeamPolicy<ExecSpace>;
+  using member_type = typename team_policy::member_type;
+  using scratch_view =
+      Kokkos::View<int*, typename ExecSpace::scratch_memory_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  Kokkos::View<int*, mem_space> out;
+  int scratch_elems;
+  KOKKOS_FUNCTION void operator()(const member_type& team) const {
+    scratch_view scratch(team.team_scratch(0), scratch_elems);
+    const int tid = team.team_rank();
+    scratch(tid)  = team.league_rank() * scratch_elems + tid + 1;
+    team.team_barrier();
+    out(team.league_rank() * scratch_elems + tid) = scratch(tid);
+  }
+};
+
+template <class ExecSpace>
+struct GraphLBFunctor {
+  using mem_space   = typename ExecSpace::memory_space;
+  using team_policy = Kokkos::TeamPolicy<ExecSpace, Kokkos::LaunchBounds<128>>;
+  using member_type = typename team_policy::member_type;
+  Kokkos::View<int*, mem_space> out;
+  KOKKOS_FUNCTION void operator()(const member_type& team) const {
+    if (team.team_rank() == 0) out(team.league_rank()) = team.league_rank() + 1;
+  }
+};
+
+// Test TeamPolicy with L0 scratch memory in graph nodes.
+TEST_F(TEST_CATEGORY_FIXTURE(graph), team_scratch_in_graph) {
+  using exec_space   = TEST_EXECSPACE;
+  using mem_space    = typename exec_space::memory_space;
+  using team_policy  = Kokkos::TeamPolicy<exec_space>;
+  using functor_type = GraphScratchFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+
+  const int team_size     = std::min(32, ex.concurrency());
+  const int num_teams     = 2;
+  const int N             = num_teams * team_size;
+  const int scratch_ints  = team_size;
+  const int scratch_bytes = scratch_view::shmem_size(scratch_ints);
+
+  Kokkos::View<int*, mem_space> result("result", N);
+
+  team_policy policy(num_teams, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+        root.then_parallel_for("TeamScratchGraph", policy,
+                               functor_type{result, scratch_ints});
+      });
+  graph.submit(ex);
+  ex.fence();
+
+  auto result_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
+  bool pass = true;
+  for (int i = 0; i < N; ++i) {
+    if (result_h(i) != i + 1) {
+      pass = false;
+      break;
+    }
+  }
+  ASSERT_TRUE(pass);
+}
+
 // Test that lvalue policies (stored in variables) work with then_parallel_for
 // and then_parallel_reduce. Before the remove_cvref_t fix in GraphNode.hpp,
 // passing any lvalue policy caused a compilation failure because the forwarding
@@ -1498,17 +1569,6 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), lvalue_policies_reduce) {
   graph2.submit(ex);
   ASSERT_TRUE(contains(ex, reduction_out2, 99));
 }
-
-template <class ExecSpace>
-struct GraphLBFunctor {
-  using mem_space   = typename ExecSpace::memory_space;
-  using team_policy = Kokkos::TeamPolicy<ExecSpace, Kokkos::LaunchBounds<128>>;
-  using member_type = typename team_policy::member_type;
-  Kokkos::View<int*, mem_space> out;
-  KOKKOS_FUNCTION void operator()(const member_type& team) const {
-    if (team.team_rank() == 0) out(team.league_rank()) = team.league_rank() + 1;
-  }
-};
 
 // Test TeamPolicy with LaunchBounds in graph nodes.
 TEST_F(TEST_CATEGORY_FIXTURE(graph), team_launch_bounds_in_graph) {

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1469,42 +1469,43 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), team_scratch_in_graph) {
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
   GTEST_SKIP() << "skipping since scratch memory is not yet implemented in the "
                   "OpenACC backend";
-#endif
-  using exec_space   = TEST_EXECSPACE;
-  using mem_space    = typename exec_space::memory_space;
-  using team_policy  = Kokkos::TeamPolicy<exec_space>;
-  using functor_type = GraphScratchFunctor<exec_space>;
-  using scratch_view = typename functor_type::scratch_view;
+#else
+    using exec_space   = TEST_EXECSPACE;
+    using mem_space    = typename exec_space::memory_space;
+    using team_policy  = Kokkos::TeamPolicy<exec_space>;
+    using functor_type = GraphScratchFunctor<exec_space>;
+    using scratch_view = typename functor_type::scratch_view;
 
-  const int team_size     = std::min(32, ex.concurrency());
-  const int num_teams     = 2;
-  const int N             = num_teams * team_size;
-  const int scratch_ints  = team_size;
-  const int scratch_bytes = scratch_view::shmem_size(scratch_ints);
+    const int team_size     = std::min(32, ex.concurrency());
+    const int num_teams     = 2;
+    const int N             = num_teams * team_size;
+    const int scratch_ints  = team_size;
+    const int scratch_bytes = scratch_view::shmem_size(scratch_ints);
 
-  Kokkos::View<int*, mem_space> result("result", N);
+    Kokkos::View<int*, mem_space> result("result", N);
 
-  team_policy policy(num_teams, team_size);
-  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+    team_policy policy(num_teams, team_size);
+    policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
 
-  auto graph = Kokkos::Experimental::create_graph(
-      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
-        root.then_parallel_for("TeamScratchGraph", policy,
-                               functor_type{result, scratch_ints});
-      });
-  graph.submit(ex);
-  ex.fence();
+    auto graph = Kokkos::Experimental::create_graph(
+        Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+          root.then_parallel_for("TeamScratchGraph", policy,
+                                 functor_type{result, scratch_ints});
+        });
+    graph.submit(ex);
+    ex.fence();
 
-  auto result_h =
-      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
-  bool pass = true;
-  for (int i = 0; i < N; ++i) {
-    if (result_h(i) != i + 1) {
-      pass = false;
-      break;
+    auto result_h =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
+    bool pass = true;
+    for (int i = 0; i < N; ++i) {
+      if (result_h(i) != i + 1) {
+        pass = false;
+        break;
+      }
     }
-  }
-  ASSERT_TRUE(pass);
+    ASSERT_TRUE(pass);
+#endif
 }
 
 // Test that lvalue policies (stored in variables) work with then_parallel_for

--- a/core/unit_test/TestLargeScratchFunctors.hpp
+++ b/core/unit_test/TestLargeScratchFunctors.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_LARGE_SCRATCH_FUNCTORS_HPP
+#define KOKKOS_TEST_LARGE_SCRATCH_FUNCTORS_HPP
+
+#include <Kokkos_Core.hpp>
+
+namespace Test {
+
+template <class ExecSpace>
+struct LargeScratchForFunctor {
+  using mem_space   = typename ExecSpace::memory_space;
+  using team_policy = Kokkos::TeamPolicy<ExecSpace>;
+  using member_type = typename team_policy::member_type;
+  using scratch_view =
+      Kokkos::View<double*, typename ExecSpace::scratch_memory_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  Kokkos::View<double*, mem_space> out;
+  int scratch_elems;
+  KOKKOS_FUNCTION void operator()(const member_type& team) const {
+    scratch_view scratch(team.team_scratch(0), scratch_elems);
+    for (int i = team.team_rank(); i < scratch_elems; i += team.team_size())
+      scratch(i) = i + 1.0;
+    team.team_barrier();
+    if (team.team_rank() == 0) {
+      double sum = 0;
+      for (int i = 0; i < scratch_elems; ++i) sum += scratch(i);
+      out(team.league_rank()) = sum;
+    }
+  }
+};
+
+template <class ExecSpace>
+struct LargeScratchReduceFunctor {
+  using mem_space   = typename ExecSpace::memory_space;
+  using team_policy = Kokkos::TeamPolicy<ExecSpace>;
+  using member_type = typename team_policy::member_type;
+  using scratch_view =
+      Kokkos::View<double*, typename ExecSpace::scratch_memory_space,
+                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  int scratch_elems;
+  KOKKOS_FUNCTION void operator()(const member_type& team, double& lsum) const {
+    scratch_view scratch(team.team_scratch(0), scratch_elems);
+    for (int i = team.team_rank(); i < scratch_elems; i += team.team_size())
+      scratch(i) = i + 1.0;
+    team.team_barrier();
+    if (team.team_rank() == 0) {
+      double team_sum = 0;
+      for (int i = 0; i < scratch_elems; ++i) team_sum += scratch(i);
+      lsum += team_sum;
+    }
+  }
+};
+
+}  // namespace Test
+
+#endif

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -203,20 +203,19 @@ void test_exceed_max_team_scratch_size_0() {
   policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, max_team_size_with_scratch);
   auto new_max_scratch_size = policy.scratch_size_max(level);
 
-  // FIXME need a tighter bound for Cuda and HIP, see #9089
 #ifdef KOKKOS_ENABLE_CUDA
   // due to the 16KiB "fudge factor" (see #9012) we need a large
   // rescale factor so this test still behaves as expected on, for ex,
-  // Pascal w/64KiB shared.
+  // Pascal w/64KiB shared. We do need a better way to handle this.
   auto oversize_factor = 2.0;
 #else
+  // FIXME test a tighter bound for HIP
   auto oversize_factor = 1.1;
 #endif
 
   ASSERT_THROW(
       {
         try {
-          // FIXME test a tighter bound for Cuda and HIP
           Kokkos::parallel_for(policy.set_scratch_size(
                                    level, Kokkos::PerTeam(new_max_scratch_size *
                                                           oversize_factor)),

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -203,14 +203,24 @@ void test_exceed_max_team_scratch_size_0() {
   policy = Kokkos::TeamPolicy<TEST_EXECSPACE>(1, max_team_size_with_scratch);
   auto new_max_scratch_size = policy.scratch_size_max(level);
 
+  // FIXME need a tighter bound for Cuda and HIP, see #9089
+#ifdef KOKKOS_ENABLE_CUDA
+  // due to the 16KiB "fudge factor" (see #9012) we need a large
+  // rescale factor so this test still behaves as expected on, for ex,
+  // Pascal w/64KiB shared.
+  auto oversize_factor = 2.0;
+#else
+  auto oversize_factor = 1.1;
+#endif
+
   ASSERT_THROW(
       {
         try {
           // FIXME test a tighter bound for Cuda and HIP
-          Kokkos::parallel_for(
-              policy.set_scratch_size(
-                  level, Kokkos::PerTeam(new_max_scratch_size * 1.1)),
-              dummy_functor);
+          Kokkos::parallel_for(policy.set_scratch_size(
+                                   level, Kokkos::PerTeam(new_max_scratch_size *
+                                                          oversize_factor)),
+                               dummy_functor);
         } catch (const std::runtime_error& e) {
           std::cmatch base_match;
           const char* regex_string =

--- a/core/unit_test/cuda/TestCuda_GraphScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_GraphScratch.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <TestCuda_Category.hpp>
+#include <TestGraph.hpp>
+#include <TestLargeScratchFunctors.hpp>
+
+namespace Test {
+
+// Large scratch graph tests only apply to CUDA (opt-in dynamic shared memory)
+TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_for) {
+  using exec_space   = TEST_EXECSPACE;
+  using mem_space    = typename exec_space::memory_space;
+  using functor_type = LargeScratchForFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+
+  const int scratch_elems = 8192;
+  const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
+  const int num_teams     = 2;
+  const int team_size     = 128;
+
+  Kokkos::View<double*, mem_space> result("result", num_teams);
+
+  Kokkos::TeamPolicy<exec_space> policy(num_teams, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+        root.then_parallel_for("LargeScratchGraphFor", policy,
+                               functor_type{result, scratch_elems});
+      });
+  graph.submit(ex);
+  ex.fence();
+
+  auto result_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
+  const double expected = scratch_elems * (scratch_elems + 1.0) / 2.0;
+  for (int i = 0; i < num_teams; ++i) {
+    ASSERT_DOUBLE_EQ(result_h(i), expected);
+  }
+}
+
+// Test 4: then_parallel_reduce with TeamPolicy requesting >48KiB scratch (graph
+// node)
+TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_reduce) {
+  using exec_space   = TEST_EXECSPACE;
+  using mem_space    = typename exec_space::memory_space;
+  using functor_type = LargeScratchReduceFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+  using view_type_d  = Kokkos::View<double, mem_space>;
+
+  const int scratch_elems = 8192;
+  const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
+  const int num_teams     = 2;
+  const int team_size     = 128;
+
+  view_type_d reduction_out("reduction_out");
+
+  Kokkos::TeamPolicy<exec_space> policy(num_teams, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+  auto graph = Kokkos::Experimental::create_graph(
+      Kokkos::Experimental::get_device_handle(ex), [&](auto root) {
+        root.then_parallel_for(1, set_functor{count, 0})
+            .then_parallel_reduce("LargeScratchGraphReduce", policy,
+                                  functor_type{scratch_elems}, reduction_out);
+      });
+  graph.submit(ex);
+  ex.fence();
+
+  double result = 0;
+  Kokkos::deep_copy(result, reduction_out);
+  const double expected =
+      num_teams * scratch_elems * (scratch_elems + 1.0) / 2.0;
+  ASSERT_DOUBLE_EQ(result, expected);
+}
+
+}  // namespace Test

--- a/core/unit_test/cuda/TestCuda_GraphScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_GraphScratch.cpp
@@ -9,6 +9,10 @@ namespace Test {
 
 // Large scratch graph tests only apply to CUDA (opt-in dynamic shared memory)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_for) {
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
+  GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "
+                  "Maxwell or Pascal";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using mem_space    = typename exec_space::memory_space;
   using functor_type = LargeScratchForFunctor<exec_space>;
@@ -43,6 +47,10 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_for) {
 // Test 4: then_parallel_reduce with TeamPolicy requesting >48KiB scratch (graph
 // node)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_reduce) {
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
+  GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "
+                  "Maxwell or Pascal";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using mem_space    = typename exec_space::memory_space;
   using functor_type = LargeScratchReduceFunctor<exec_space>;

--- a/core/unit_test/cuda/TestCuda_GraphScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_GraphScratch.cpp
@@ -44,8 +44,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_for) {
   }
 }
 
-// Test 4: then_parallel_reduce with TeamPolicy requesting >48KiB scratch (graph
-// node)
+// then_parallel_reduce with TeamPolicy requesting >48 KiB scratch (graph node)
 TEST_F(TEST_CATEGORY_FIXTURE(graph), large_scratch_graph_parallel_reduce) {
 #if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
   GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "

--- a/core/unit_test/cuda/TestCuda_LargeScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_LargeScratch.cpp
@@ -73,7 +73,8 @@ TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
   const int team_size = 128;
 
   for (auto scratch_kib : {48ul, 64ul, 80ul}) {
-    const int scratch_elems = static_cast<int>(scratch_kib * 1024 / sizeof(double));
+    const int scratch_elems =
+        static_cast<int>(scratch_kib * 1024 / sizeof(double));
     const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
 
     Kokkos::View<double*, mem_space> result("result", num_teams);

--- a/core/unit_test/cuda/TestCuda_LargeScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_LargeScratch.cpp
@@ -12,6 +12,10 @@
 namespace Test {
 
 TEST(TEST_CATEGORY, large_scratch_parallel_for) {
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
+  GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "
+                  "Maxwell or Pascal";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using mem_space    = typename exec_space::memory_space;
   using functor_type = LargeScratchForFunctor<exec_space>;
@@ -40,6 +44,10 @@ TEST(TEST_CATEGORY, large_scratch_parallel_for) {
 }
 
 TEST(TEST_CATEGORY, large_scratch_parallel_reduce) {
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
+  GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "
+                  "Maxwell or Pascal";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using functor_type = LargeScratchReduceFunctor<exec_space>;
   using scratch_view = typename functor_type::scratch_view;
@@ -62,8 +70,12 @@ TEST(TEST_CATEGORY, large_scratch_parallel_reduce) {
 }
 
 // Verify that the ensure_sufficient_shmem caching logic correctly
-// handles progressively increasing scratch sizes (48 -> 64 -> 80 KiB).
+// handles progressively increasing scratch sizes (32 -> 48 -> 64 -> 80 KiB).
 TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
+#if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)
+  GTEST_SKIP() << "Per-block dynamic shared memory >48 KiB is not supported on "
+                  "Maxwell or Pascal";
+#endif
   using exec_space   = TEST_EXECSPACE;
   using mem_space    = typename exec_space::memory_space;
   using functor_type = LargeScratchForFunctor<exec_space>;
@@ -72,7 +84,7 @@ TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
   const int num_teams = 2;
   const int team_size = 128;
 
-  for (auto scratch_kib : {48ul, 64ul, 80ul}) {
+  for (auto scratch_kib : {32ul, 48ul, 64ul, 80ul}) {
     const int scratch_elems =
         static_cast<int>(scratch_kib * 1024 / sizeof(double));
     const int scratch_bytes = scratch_view::shmem_size(scratch_elems);

--- a/core/unit_test/cuda/TestCuda_LargeScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_LargeScratch.cpp
@@ -72,8 +72,8 @@ TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
   const int num_teams = 2;
   const int team_size = 128;
 
-  for (int scratch_kib : {48, 64, 80}) {
-    const int scratch_elems = scratch_kib * 1024 / sizeof(double);
+  for (auto scratch_kib : {48ul, 64ul, 80ul}) {
+    const int scratch_elems = static_cast<int>(scratch_kib * 1024 / sizeof(double));
     const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
 
     Kokkos::View<double*, mem_space> result("result", num_teams);

--- a/core/unit_test/cuda/TestCuda_LargeScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_LargeScratch.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+#include <TestCuda_Category.hpp>
+#include <TestLargeScratchFunctors.hpp>
+
+// These tests exercise the dynamic shared memory opt-in
+// (cudaFuncAttributeMaxDynamicSharedMemorySize) which is CUDA-specific.
+
+namespace Test {
+
+TEST(TEST_CATEGORY, large_scratch_parallel_for) {
+  using exec_space   = TEST_EXECSPACE;
+  using mem_space    = typename exec_space::memory_space;
+  using functor_type = LargeScratchForFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+
+  const int scratch_elems = 8192;  // 8192 doubles = 64 KiB
+  const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
+  const int num_teams     = 2;
+  const int team_size     = 128;
+
+  Kokkos::View<double*, mem_space> result("result", num_teams);
+
+  Kokkos::TeamPolicy<exec_space> policy(num_teams, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+  Kokkos::parallel_for("LargeScratchFor", policy,
+                       functor_type{result, scratch_elems});
+  Kokkos::fence();
+
+  auto result_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
+  const double expected = scratch_elems * (scratch_elems + 1.0) / 2.0;
+  for (int i = 0; i < num_teams; ++i) {
+    ASSERT_DOUBLE_EQ(result_h(i), expected);
+  }
+}
+
+TEST(TEST_CATEGORY, large_scratch_parallel_reduce) {
+  using exec_space   = TEST_EXECSPACE;
+  using functor_type = LargeScratchReduceFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+
+  const int scratch_elems = 8192;
+  const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
+  const int num_teams     = 2;
+  const int team_size     = 128;
+
+  Kokkos::TeamPolicy<exec_space> policy(num_teams, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+  double result = 0;
+  Kokkos::parallel_reduce("LargeScratchReduce", policy,
+                          functor_type{scratch_elems}, result);
+
+  const double expected =
+      num_teams * scratch_elems * (scratch_elems + 1.0) / 2.0;
+  ASSERT_DOUBLE_EQ(result, expected);
+}
+
+// Verify that the ensure_sufficient_shmem caching logic correctly
+// handles progressively increasing scratch sizes (48 -> 64 -> 80 KiB).
+TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
+  using exec_space   = TEST_EXECSPACE;
+  using mem_space    = typename exec_space::memory_space;
+  using functor_type = LargeScratchForFunctor<exec_space>;
+  using scratch_view = typename functor_type::scratch_view;
+
+  const int num_teams = 2;
+  const int team_size = 128;
+
+  for (int scratch_kib : {48, 64, 80}) {
+    const int scratch_elems = scratch_kib * 1024 / sizeof(double);
+    const int scratch_bytes = scratch_view::shmem_size(scratch_elems);
+
+    Kokkos::View<double*, mem_space> result("result", num_teams);
+
+    Kokkos::TeamPolicy<exec_space> policy(num_teams, team_size);
+    policy.set_scratch_size(0, Kokkos::PerTeam(scratch_bytes));
+
+    Kokkos::parallel_for("ProgressiveScratch", policy,
+                         functor_type{result, scratch_elems});
+    Kokkos::fence();
+
+    auto result_h =
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, result);
+    const double expected = scratch_elems * (scratch_elems + 1.0) / 2.0;
+    for (int i = 0; i < num_teams; ++i) {
+      ASSERT_DOUBLE_EQ(result_h(i), expected)
+          << "Failed at scratch_kib=" << scratch_kib;
+    }
+  }
+}
+
+}  // namespace Test

--- a/core/unit_test/cuda/TestCuda_LargeScratch.cpp
+++ b/core/unit_test/cuda/TestCuda_LargeScratch.cpp
@@ -69,7 +69,7 @@ TEST(TEST_CATEGORY, large_scratch_parallel_reduce) {
   ASSERT_DOUBLE_EQ(result, expected);
 }
 
-// Verify that the ensure_sufficient_shmem caching logic correctly
+// Verify that the configure_max_dynamic_shmem caching logic correctly
 // handles progressively increasing scratch sizes (32 -> 48 -> 64 -> 80 KiB).
 TEST(TEST_CATEGORY, large_scratch_progressive_increase) {
 #if defined(KOKKOS_ARCH_MAXWELL) || defined(KOKKOS_ARCH_PASCAL)


### PR DESCRIPTION
This PR is gated on #9027 .

## Summary

- Enable CUDA kernels to use more than 48 KiB of dynamic shared memory per block by opting into `cudaFuncAttributeMaxDynamicSharedMemorySize` when a kernel's scratch request exceeds the default limit. This lets code take advantage of, for ex, the maximum of 96 KiB on Volta, 228 KiB on Hopper, ... and, as a portability enhancement, lets it match the 64 KiB on MI250 and MI300

## Dynamic shared memory opt-in

All shared memory ceilings now use `sharedMemPerBlockOptin - reservedSharedMemPerBlock` from `cudaDeviceProp` instead of the default `sharedMemPerBlock` (empirically/generally 48 KiB). The `reservedSharedMemPerBlock` correction could be "safely" ignored when the max was just 48 KiB because all modern NVIDIA GPUs have >> 48 KiB of shared memory available; we need to be more careful now.

A new `ensure_sufficient_shmem` helper calls `cudaFuncSetAttribute` with `cudaFuncAttributeMaxDynamicSharedMemorySize` when needed, using a static variable per kernel template instantiation to minimize API calls. This is applied in all `invoke_kernel` and `create_parallel_launch_graph_node` paths.

The `DesiredOccupancy` / `configure_shmem_preference` pipeline benefits automatically: when occupancy control inflates the shared memory request beyond 48 KiB, `ensure_sufficient_shmem` raises the limit transparently. (That said, I didn't overly test this workflow.)

## Test plan

New tests:
- `large_scratch_parallel_for`: TeamPolicy with 64 KiB L0 scratch (normal launch)
- `large_scratch_parallel_reduce`: TeamPolicy with 64 KiB L0 scratch (normal launch)
- `large_scratch_progressive_increase`: Increases scratch 48 → 64 → 80 KiB, verifying the caching logic handles repeated `cudaFuncSetAttribute` calls
- `large_scratch_graph_parallel_for`: 64 KiB scratch in a graph node via `then_parallel_for`
- `large_scratch_graph_parallel_reduce`: 64 KiB scratch in a graph node via `then_parallel_reduce`
- `team_scratch_in_graph`: TeamPolicy with scratch in graph nodes
