### PR TITLE
Drop `Impl::ALL_t` alias that was marked as deprecated

### DIFF
--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -66,12 +66,10 @@ struct KokkosSliceToMDSpanSliceImpl {
 };
 
 template <>
-struct KokkosSliceToMDSpanSliceImpl<Kokkos::ALL_t> {
+struct KokkosSliceToMDSpanSliceImpl<ALL_t> {
   using type = full_extent_t;
   KOKKOS_FUNCTION
-  static constexpr decltype(auto) transform(Kokkos::ALL_t) {
-    return full_extent;
-  }
+  static constexpr decltype(auto) transform(ALL_t) { return full_extent; }
 };
 
 template <class T>

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -32,16 +32,6 @@ struct ALL_t {
   constexpr bool operator==(const ALL_t&) const { return true; }
 };
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-namespace Impl {
-// TODO This alias declaration forces us to fully qualify ALL_t inside the
-// Kokkos::Impl namespace to avoid deprecation warnings. Replace the
-// fully-qualified name when we remove Kokkos::Impl::ALL_t.
-using ALL_t KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::ALL_t instead!") =
-    Kokkos::ALL_t;
-}  // namespace Impl
-#endif
-
 inline constexpr Kokkos::ALL_t ALL{};
 
 namespace Impl {


### PR DESCRIPTION
Related to #8958