### PR TITLE
Remove MemorySpaceAccess::deepcopy

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -190,9 +190,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
                          Kokkos::Cuda::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -190,7 +190,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
                          Kokkos::Cuda::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -190,6 +190,9 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
                          Kokkos::Cuda::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -322,9 +322,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaSpace> {
 #else
   enum : bool { accessible = true };
 #endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -332,9 +329,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaUVMSpace> {
   // HostSpace::execution_space != CudaUVMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -342,9 +336,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaHostPinnedSpace> {
   // HostSpace::execution_space == CudaHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -353,9 +344,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -363,9 +351,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaUVMSpace> {
   // CudaSpace::execution_space == CudaUVMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -373,9 +358,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -386,9 +368,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // Cuda cannot access HostSpace
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -399,9 +378,6 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaSpace> {
 
   // CudaUVMSpace::execution_space can access CudaSpace
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -409,9 +385,6 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaUVMSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaUVMSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -422,27 +395,18 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from Cuda
   enum : bool { accessible = true };   // CudaHostPinnedSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -322,7 +322,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaSpace> {
 #else
   enum : bool { accessible = true };
 #endif
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -330,7 +329,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaUVMSpace> {
   // HostSpace::execution_space != CudaUVMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -338,7 +336,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaHostPinnedSpace> {
   // HostSpace::execution_space == CudaHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -347,7 +344,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -355,7 +351,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaUVMSpace> {
   // CudaSpace::execution_space == CudaUVMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -363,7 +358,6 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -374,7 +368,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // Cuda cannot access HostSpace
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -385,7 +378,6 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaSpace> {
 
   // CudaUVMSpace::execution_space can access CudaSpace
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -393,7 +385,6 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaUVMSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaUVMSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -404,21 +395,18 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from Cuda
   enum : bool { accessible = true };   // CudaHostPinnedSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------

--- a/core/src/Cuda/Kokkos_CudaSpace.hpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.hpp
@@ -322,6 +322,9 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaSpace> {
 #else
   enum : bool { accessible = true };
 #endif
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -329,6 +332,9 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaUVMSpace> {
   // HostSpace::execution_space != CudaUVMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -336,6 +342,9 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::CudaHostPinnedSpace> {
   // HostSpace::execution_space == CudaHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -344,6 +353,9 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -351,6 +363,9 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaUVMSpace> {
   // CudaSpace::execution_space == CudaUVMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -358,6 +373,9 @@ struct MemorySpaceAccess<Kokkos::CudaSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -368,6 +386,9 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // Cuda cannot access HostSpace
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -378,6 +399,9 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaSpace> {
 
   // CudaUVMSpace::execution_space can access CudaSpace
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -385,6 +409,9 @@ struct MemorySpaceAccess<Kokkos::CudaUVMSpace, Kokkos::CudaHostPinnedSpace> {
   // CudaUVMSpace::execution_space != CudaHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // CudaUVMSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -395,18 +422,27 @@ template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from Cuda
   enum : bool { accessible = true };   // CudaHostPinnedSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::CudaHostPinnedSpace, Kokkos::CudaUVMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -106,6 +106,9 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HIP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 }  // namespace Impl
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -106,9 +106,6 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HIP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 }  // namespace Impl
 

--- a/core/src/HIP/Kokkos_HIP.hpp
+++ b/core/src/HIP/Kokkos_HIP.hpp
@@ -106,7 +106,6 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HIP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 }  // namespace Impl
 

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -283,7 +283,6 @@ struct MemorySpaceAccess<HostSpace, HIPSpace> {
 #else
   enum : bool { accessible = true };
 #endif
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -291,7 +290,6 @@ struct MemorySpaceAccess<HostSpace, HIPHostPinnedSpace> {
   // HostSpace::execution_space == HIPHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -299,7 +297,6 @@ struct MemorySpaceAccess<HostSpace, HIPManagedSpace> {
   // HostSpace::execution_space != HIPManagedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -308,7 +305,6 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -316,7 +312,6 @@ struct MemorySpaceAccess<HIPSpace, HIPHostPinnedSpace> {
   // HIPSpace::execution_space != HIPHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // HIPSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -324,7 +319,6 @@ struct MemorySpaceAccess<HIPSpace, HIPManagedSpace> {
   // HIPSpace::execution_space == HIPManagedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -335,21 +329,18 @@ template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HostSpace> {
   enum : bool { assignable = false };  // Cannot access from HIP
   enum : bool { accessible = true };   // HIPHostPinnedSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPManagedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -360,21 +351,18 @@ template <>
 struct MemorySpaceAccess<HIPManagedSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // HIPHostPinnedSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPHostPinnedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -283,9 +283,6 @@ struct MemorySpaceAccess<HostSpace, HIPSpace> {
 #else
   enum : bool { accessible = true };
 #endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -293,9 +290,6 @@ struct MemorySpaceAccess<HostSpace, HIPHostPinnedSpace> {
   // HostSpace::execution_space == HIPHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -303,9 +297,6 @@ struct MemorySpaceAccess<HostSpace, HIPManagedSpace> {
   // HostSpace::execution_space != HIPManagedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -314,9 +305,6 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -324,9 +312,6 @@ struct MemorySpaceAccess<HIPSpace, HIPHostPinnedSpace> {
   // HIPSpace::execution_space != HIPHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // HIPSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -334,9 +319,6 @@ struct MemorySpaceAccess<HIPSpace, HIPManagedSpace> {
   // HIPSpace::execution_space == HIPManagedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -347,27 +329,18 @@ template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HostSpace> {
   enum : bool { assignable = false };  // Cannot access from HIP
   enum : bool { accessible = true };   // HIPHostPinnedSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPManagedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 //----------------------------------------
@@ -378,27 +351,18 @@ template <>
 struct MemorySpaceAccess<HIPManagedSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // HIPHostPinnedSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPHostPinnedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/HIP/Kokkos_HIP_Space.hpp
+++ b/core/src/HIP/Kokkos_HIP_Space.hpp
@@ -283,6 +283,9 @@ struct MemorySpaceAccess<HostSpace, HIPSpace> {
 #else
   enum : bool { accessible = true };
 #endif
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -290,6 +293,9 @@ struct MemorySpaceAccess<HostSpace, HIPHostPinnedSpace> {
   // HostSpace::execution_space == HIPHostPinnedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -297,6 +303,9 @@ struct MemorySpaceAccess<HostSpace, HIPManagedSpace> {
   // HostSpace::execution_space != HIPManagedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -305,6 +314,9 @@ template <>
 struct MemorySpaceAccess<HIPSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -312,6 +324,9 @@ struct MemorySpaceAccess<HIPSpace, HIPHostPinnedSpace> {
   // HIPSpace::execution_space != HIPHostPinnedSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // HIPSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -319,6 +334,9 @@ struct MemorySpaceAccess<HIPSpace, HIPManagedSpace> {
   // HIPSpace::execution_space == HIPManagedSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -329,18 +347,27 @@ template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HostSpace> {
   enum : bool { assignable = false };  // Cannot access from HIP
   enum : bool { accessible = true };   // HIPHostPinnedSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPHostPinnedSpace, HIPManagedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 //----------------------------------------
@@ -351,18 +378,27 @@ template <>
 struct MemorySpaceAccess<HIPManagedSpace, HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // HIPHostPinnedSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<HIPManagedSpace, HIPHostPinnedSpace> {
   enum : bool { assignable = false };  // different exec_space
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -473,7 +473,6 @@ struct MemorySpaceAccess<Kokkos::Experimental::HPX::memory_space,
                          Kokkos::Experimental::HPX::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 template <>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -473,9 +473,6 @@ struct MemorySpaceAccess<Kokkos::Experimental::HPX::memory_space,
                          Kokkos::Experimental::HPX::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 
 template <>

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -473,6 +473,9 @@ struct MemorySpaceAccess<Kokkos::Experimental::HPX::memory_space,
                          Kokkos::Experimental::HPX::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 
 template <>

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -46,21 +46,18 @@ template <typename OtherSpace>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, OtherSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <typename OtherSpace>
 struct MemorySpaceAccess<OtherSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -46,27 +46,18 @@ template <typename OtherSpace>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, OtherSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <typename OtherSpace>
 struct MemorySpaceAccess<OtherSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_AnonymousSpace.hpp
+++ b/core/src/Kokkos_AnonymousSpace.hpp
@@ -46,18 +46,27 @@ template <typename OtherSpace>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, OtherSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <typename OtherSpace>
 struct MemorySpaceAccess<OtherSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::AnonymousSpace, Kokkos::AnonymousSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -390,8 +390,11 @@ struct SpaceAccessibility {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   enum KOKKOS_DEPRECATED {
     deepcopy = !std::is_same_v<
-        typename AccessSpace::execution_space::scratch_memory_space,
-        MemorySpace>
+                   typename MemorySpace::execution_space::scratch_memory_space,
+                   MemorySpace> &&
+               !std::is_same_v<
+                   typename AccessSpace::execution_space::scratch_memory_space,
+                   typename AccessSpace::memory_space>
   };
 #endif
 

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -320,6 +320,13 @@ struct MemorySpaceAccess {
    *         DstExecSpace can access SrcMemorySpace.
    */
   enum { accessible = assignable };
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  /**\brief  Does a DeepCopy capability exist
+   *         to DstMemorySpace from SrcMemorySpace
+   */
+  enum { deepcopy = assignable };
+#endif
 };
 
 }  // namespace Impl
@@ -385,6 +392,11 @@ struct SpaceAccessibility {
   enum {
     assignable = is_memory_space<AccessSpace>::value && mem_access::assignable
   };
+
+  /**\brief  Can deep copy to AccessSpace::memory_Space from MemorySpace ?  */
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum KOKKOS_DEPRECATED { deepcopy = mem_access::deepcopy };
+#endif
 
   // What intercessory space for AccessSpace::execution_space
   // to be able to access MemorySpace?

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -320,13 +320,6 @@ struct MemorySpaceAccess {
    *         DstExecSpace can access SrcMemorySpace.
    */
   enum { accessible = assignable };
-
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  /**\brief  Does a DeepCopy capability exist
-   *         to DstMemorySpace from SrcMemorySpace
-   */
-  enum { deepcopy = assignable };
-#endif
 };
 
 }  // namespace Impl
@@ -395,7 +388,11 @@ struct SpaceAccessibility {
 
   /**\brief  Can deep copy to AccessSpace::memory_Space from MemorySpace ?  */
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum KOKKOS_DEPRECATED { deepcopy = mem_access::deepcopy };
+  enum KOKKOS_DEPRECATED {
+    deepcopy = !std::is_same_v<
+        typename AccessSpace::execution_space::scratch_memory_space,
+        MemorySpace>
+  };
 #endif
 
   // What intercessory space for AccessSpace::execution_space

--- a/core/src/Kokkos_Concepts.hpp
+++ b/core/src/Kokkos_Concepts.hpp
@@ -320,11 +320,6 @@ struct MemorySpaceAccess {
    *         DstExecSpace can access SrcMemorySpace.
    */
   enum { accessible = assignable };
-
-  /**\brief  Does a DeepCopy capability exist
-   *         to DstMemorySpace from SrcMemorySpace
-   */
-  enum { deepcopy = assignable };
 };
 
 }  // namespace Impl
@@ -390,9 +385,6 @@ struct SpaceAccessibility {
   enum {
     assignable = is_memory_space<AccessSpace>::value && mem_access::assignable
   };
-
-  /**\brief  Can deep copy to AccessSpace::memory_Space from MemorySpace ?  */
-  enum { deepcopy = mem_access::deepcopy };
 
   // What intercessory space for AccessSpace::execution_space
   // to be able to access MemorySpace?

--- a/core/src/NextSilicon/Kokkos_NextSilicon.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.hpp
@@ -78,9 +78,6 @@ struct MemorySpaceAccess<Experimental::NextSiliconSharedSpace,
                          Experimental::NextSilicon::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/NextSilicon/Kokkos_NextSilicon.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.hpp
@@ -78,7 +78,9 @@ struct MemorySpaceAccess<Experimental::NextSiliconSharedSpace,
                          Experimental::NextSilicon::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   enum : bool { deepcopy = true };
+#endif
 };
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/NextSilicon/Kokkos_NextSiliconSpace.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSiliconSpace.hpp
@@ -97,9 +97,6 @@ struct MemorySpaceAccess<Kokkos::Experimental::NextSiliconSharedSpace,
   };  // This is a lie, because NextSilicon can access HostSpace. Set this way
       // so the HostMirror of NextSiliconSharedSpace uses the host execution
       // space.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -110,9 +107,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace,
     accessible = true
   };  // Unlike <NextSiliconSharedSpace, HostSpace>, this is true so that
       // HostMirror uses NextSiliconSharedSpace as the memory space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/NextSilicon/Kokkos_NextSiliconSpace.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSiliconSpace.hpp
@@ -97,7 +97,9 @@ struct MemorySpaceAccess<Kokkos::Experimental::NextSiliconSharedSpace,
   };  // This is a lie, because NextSilicon can access HostSpace. Set this way
       // so the HostMirror of NextSiliconSharedSpace uses the host execution
       // space.
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -108,7 +110,9 @@ struct MemorySpaceAccess<Kokkos::HostSpace,
     accessible = true
   };  // Unlike <NextSiliconSharedSpace, HostSpace>, this is true so that
       // HostMirror uses NextSiliconSharedSpace as the memory space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   enum : bool { deepcopy = true };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -79,7 +79,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -92,7 +91,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -100,7 +98,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -79,6 +79,9 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -91,6 +94,9 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 
 template <>
@@ -98,6 +104,9 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = true};
+#endif
 };
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACCSpace.hpp
@@ -79,9 +79,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::HostSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -94,9 +91,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
   enum : bool { assignable = false };
   enum : bool { accessible = false };
 #endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 
 template <>
@@ -104,9 +98,6 @@ struct Kokkos::Impl::MemorySpaceAccess<Kokkos::Experimental::OpenACCSpace,
                                        Kokkos::Experimental::OpenACCSpace> {
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = true};
-#endif
 };
 /*--------------------------------------------------------------------------*/
 

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -154,6 +154,9 @@ struct MemorySpaceAccess<Kokkos::OpenMP::memory_space,
                          Kokkos::OpenMP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -154,7 +154,6 @@ struct MemorySpaceAccess<Kokkos::OpenMP::memory_space,
                          Kokkos::OpenMP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 }  // namespace Impl

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -154,9 +154,6 @@ struct MemorySpaceAccess<Kokkos::OpenMP::memory_space,
                          Kokkos::OpenMP::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -168,9 +168,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -178,9 +175,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLSharedUSMSpace> {
   // HostSpace::execution_space != SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -189,18 +183,12 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -209,9 +197,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
   // SYCLDeviceUSMSpace::execution_space == SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -220,9 +205,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLDeviceUSMSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 //----------------------------------------
@@ -233,9 +215,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // SYCL cannot access HostSpace
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -248,9 +227,6 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace,
 
   // SYCLSharedUSMSpace::execution_space can access SYCLDeviceUSMSpace
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -259,36 +235,24 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLSharedUSMSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from SYCL
   enum : bool { accessible = true };   // SYCLHostUSMSpace::execution_space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLSharedUSMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = true };
-#endif
 };
 
 template <>
@@ -296,9 +260,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
                          Kokkos::ScratchMemorySpace<Kokkos::SYCL>> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -168,6 +168,9 @@ template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -175,6 +178,9 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLSharedUSMSpace> {
   // HostSpace::execution_space != SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -183,12 +189,18 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -197,6 +209,9 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
   // SYCLDeviceUSMSpace::execution_space == SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -205,6 +220,9 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLDeviceUSMSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 //----------------------------------------
@@ -215,6 +233,9 @@ template <>
 struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // SYCL cannot access HostSpace
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -227,6 +248,9 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace,
 
   // SYCLSharedUSMSpace::execution_space can access SYCLDeviceUSMSpace
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -235,24 +259,36 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLSharedUSMSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from SYCL
   enum : bool { accessible = true };   // SYCLHostUSMSpace::execution_space
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLSharedUSMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = true };
+#endif
 };
 
 template <>
@@ -260,6 +296,9 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
                          Kokkos::ScratchMemorySpace<Kokkos::SYCL>> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/SYCL/Kokkos_SYCL_Space.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Space.hpp
@@ -168,7 +168,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -176,7 +175,6 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLSharedUSMSpace> {
   // HostSpace::execution_space != SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -185,14 +183,12 @@ struct MemorySpaceAccess<Kokkos::HostSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -201,7 +197,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
   // SYCLDeviceUSMSpace::execution_space == SYCLSharedUSMSpace::execution_space
   enum : bool { assignable = true };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -210,7 +205,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLDeviceUSMSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 //----------------------------------------
@@ -221,7 +215,6 @@ template <>
 struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };
   enum : bool { accessible = false };  // SYCL cannot access HostSpace
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -234,7 +227,6 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace,
 
   // SYCLSharedUSMSpace::execution_space can access SYCLDeviceUSMSpace
   enum : bool { accessible = true };
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -243,28 +235,24 @@ struct MemorySpaceAccess<Kokkos::SYCLSharedUSMSpace, Kokkos::SYCLHostUSMSpace> {
   // SYCLHostUSMSpace::execution_space
   enum : bool { assignable = false };
   enum : bool { accessible = true };  // SYCLSharedUSMSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::HostSpace> {
   enum : bool { assignable = false };  // Cannot access from SYCL
   enum : bool { accessible = true };   // SYCLHostUSMSpace::execution_space
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLDeviceUSMSpace> {
   enum : bool { assignable = false };  // Cannot access from Host
   enum : bool { accessible = false };
-  enum : bool { deepcopy = true };
 };
 
 template <>
 struct MemorySpaceAccess<Kokkos::SYCLHostUSMSpace, Kokkos::SYCLSharedUSMSpace> {
   enum : bool { assignable = false };  // different execution_space
   enum : bool { accessible = true };   // same accessibility
-  enum : bool { deepcopy = true };
 };
 
 template <>
@@ -272,7 +260,6 @@ struct MemorySpaceAccess<Kokkos::SYCLDeviceUSMSpace,
                          Kokkos::ScratchMemorySpace<Kokkos::SYCL>> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 }  // namespace Impl

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -215,9 +215,6 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
                          Kokkos::Serial::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool{deepcopy = false};
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -215,7 +215,6 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
                          Kokkos::Serial::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 }  // namespace Impl

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -215,6 +215,9 @@ struct MemorySpaceAccess<Kokkos::Serial::memory_space,
                          Kokkos::Serial::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool{deepcopy = false};
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -142,9 +142,6 @@ struct MemorySpaceAccess<Kokkos::Threads::memory_space,
                          Kokkos::Threads::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  enum : bool { deepcopy = false };
-#endif
 };
 
 }  // namespace Impl

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -142,6 +142,9 @@ struct MemorySpaceAccess<Kokkos::Threads::memory_space,
                          Kokkos::Threads::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  enum : bool { deepcopy = false };
+#endif
 };
 
 }  // namespace Impl

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -142,7 +142,6 @@ struct MemorySpaceAccess<Kokkos::Threads::memory_space,
                          Kokkos::Threads::scratch_memory_space> {
   enum : bool { assignable = false };
   enum : bool { accessible = true };
-  enum : bool { deepcopy = false };
 };
 
 }  // namespace Impl


### PR DESCRIPTION
It seems `MemorySpaceAccess::deepcopy` was never used.