### PR TITLE
[4.7.03]: Disable MallocAsync for ROCm

### DIFF
--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -89,7 +89,21 @@ kokkos_enable_option(
   HIP_MULTIPLE_KERNEL_INSTANTIATIONS OFF
   "Whether multiple kernels are instantiated at compile time - improve performance but increase compile time"
 )
-kokkos_enable_option(IMPL_HIP_MALLOC_ASYNC ${KOKKOS_ENABLE_HIP} "Whether to enable hipMallocAsync")
+# FIXME_HIP
+if(KOKKOS_ENABLE_HIP)
+  #here just for the version, can be removed with the fixme as it will be found by our TPL processing
+  find_package(hip REQUIRED PATHS ${ROCM_PATH} $ENV{ROCM_PATH})
+endif()
+if(hip_VERSION VERSION_GREATER_EQUAL 7.0.0)
+  set(HIP_MALLOC_ASYNC_DEFAULT OFF)
+else()
+  set(HIP_MALLOC_ASYNC_DEFAULT ${KOKKOS_ENABLE_HIP})
+endif()
+kokkos_enable_option(IMPL_HIP_MALLOC_ASYNC ${HIP_MALLOC_ASYNC_DEFAULT} "Whether to enable hipMallocAsync")
+if((hip_VERSION VERSION_GREATER_EQUAL 7.0.0) AND Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC)
+  message(WARNING "Using Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC is problematic with ROCm 7")
+endif()
+
 kokkos_enable_option(OPENACC_FORCE_HOST_AS_DEVICE OFF "Whether to force to use host as a target device for OpenACC")
 
 # This option will go away eventually, but allows fallback to old implementation when needed.

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -89,18 +89,8 @@ kokkos_enable_option(
   HIP_MULTIPLE_KERNEL_INSTANTIATIONS OFF
   "Whether multiple kernels are instantiated at compile time - improve performance but increase compile time"
 )
-# FIXME_HIP
-if(KOKKOS_ENABLE_HIP)
-  #here just for the version, can be removed with the fixme as it will be found by our TPL processing
-  find_package(hip REQUIRED PATHS ${ROCM_PATH} $ENV{ROCM_PATH})
-endif()
-if(hip_VERSION VERSION_GREATER_EQUAL 7.0.0)
-  set(HIP_MALLOC_ASYNC_DEFAULT OFF)
-else()
-  set(HIP_MALLOC_ASYNC_DEFAULT ${KOKKOS_ENABLE_HIP})
-endif()
-kokkos_enable_option(IMPL_HIP_MALLOC_ASYNC ${HIP_MALLOC_ASYNC_DEFAULT} "Whether to enable hipMallocAsync")
-if((hip_VERSION VERSION_GREATER_EQUAL 7.0.0) AND Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC)
+kokkos_enable_option(IMPL_HIP_MALLOC_ASYNC OFF "Whether to enable hipMallocAsync")
+if(Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC)
   message(WARNING "Using Kokkos_ENABLE_IMPL_HIP_MALLOC_ASYNC is problematic with ROCm 7")
 endif()
 


### PR DESCRIPTION
~~Cherry-picking #8746.~~
Trying `find_package(hip)` doesn't seem to work well with `ROCm` 5. Without setting `GPU_TARGETS` we are compiling for more architectures than intended and that even breaks compiling our unit tests. Therefore, this pull request now disables `hipMallocAsync` by default unconditionally.