### PR TITLE
Remove untracked deprecated code 4

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -603,16 +603,6 @@ class DynRankView : private View<DataType*******, Properties...> {
   using view_type::span;
   using view_type::span_is_contiguous;  // FIXME: not tested
   using view_type::stride;              // FIXME: not tested
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  using view_type::stride_0;  // FIXME: not tested
-  using view_type::stride_1;  // FIXME: not tested
-  using view_type::stride_2;  // FIXME: not tested
-  using view_type::stride_3;  // FIXME: not tested
-  using view_type::stride_4;  // FIXME: not tested
-  using view_type::stride_5;  // FIXME: not tested
-  using view_type::stride_6;  // FIXME: not tested
-  using view_type::stride_7;  // FIXME: not tested
-#endif
   using view_type::use_count;
 
 #ifdef KOKKOS_ENABLE_CUDA

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -331,19 +331,6 @@ class DynamicView : public Kokkos::ViewTraits<DataType, P...> {
     return r == 0 ? size() : 1;
   }
 
-  // clang-format off
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead") KOKKOS_FUNCTION constexpr size_t stride_0() const { return stride(0); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead") KOKKOS_FUNCTION constexpr size_t stride_1() const { return stride(1); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead") KOKKOS_FUNCTION constexpr size_t stride_2() const { return stride(2); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead") KOKKOS_FUNCTION constexpr size_t stride_3() const { return stride(3); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead") KOKKOS_FUNCTION constexpr size_t stride_4() const { return stride(4); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead") KOKKOS_FUNCTION constexpr size_t stride_5() const { return stride(5); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead") KOKKOS_FUNCTION constexpr size_t stride_6() const { return stride(6); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead") KOKKOS_FUNCTION constexpr size_t stride_7() const { return stride(7); }
-#endif
-  // clang-format on
-
   template <typename iType>
   KOKKOS_INLINE_FUNCTION void stride(iType* const s) const {
     *s = 0;

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1115,23 +1115,6 @@ KOKKOS_INLINE_FUNCTION
   return Kokkos::Experimental::Impl::subview_offset(src, args...);
 }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-namespace Experimental {
-template <class D, class... P, class... Args>
-KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::subview instead")
-KOKKOS_INLINE_FUNCTION
-    typename Kokkos::Experimental::Impl::GetOffsetViewTypeFromViewType<
-        typename Kokkos::Impl::ViewMapping<
-            void /* deduce subview type from source view traits */
-            ,
-            ViewTraits<D, P...>, Args...>::type>::type
-    subview(const Kokkos::Experimental::OffsetView<D, P...>& src,
-            Args... args) {
-  return Kokkos::subview(src, args...);
-}
-}  // namespace Experimental
-#endif
-
 }  // namespace Kokkos
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -921,20 +921,8 @@ class UnorderedMap {
                    std::is_same_v<std::remove_const_t<SValue>, value_type>>
   deep_copy_view(
       UnorderedMap<SKey, SValue, SDevice, Hasher, EqualTo> const &src) {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_4
     // To deep copy UnorderedMap, capacity must be identical
     KOKKOS_EXPECTS(capacity() == src.capacity());
-#else
-    if (capacity() != src.capacity()) {
-      allocate_view(src);
-#ifdef KOKKOS_ENABLE_DEPRECATION_WARNINGS
-      Kokkos::Impl::log_warning(
-          "Warning: deep_copy_view() allocating views is deprecated. Must call "
-          "with UnorderedMaps of identical capacity, or use "
-          "create_copy_view().\n");
-#endif
-    }
-#endif
 
     if (m_hash_lists.data() != src.m_hash_lists.data()) {
       Kokkos::deep_copy(m_available_indexes, src.m_available_indexes);

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -292,19 +292,6 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
         base_t::mapping());
   }
 
-  // clang-format off
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead") KOKKOS_FUNCTION constexpr size_t stride_0() const { return stride(0); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead") KOKKOS_FUNCTION constexpr size_t stride_1() const { return stride(1); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead") KOKKOS_FUNCTION constexpr size_t stride_2() const { return stride(2); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead") KOKKOS_FUNCTION constexpr size_t stride_3() const { return stride(3); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead") KOKKOS_FUNCTION constexpr size_t stride_4() const { return stride(4); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead") KOKKOS_FUNCTION constexpr size_t stride_5() const { return stride(5); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead") KOKKOS_FUNCTION constexpr size_t stride_6() const { return stride(6); }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead") KOKKOS_FUNCTION constexpr size_t stride_7() const { return stride(7); }
-#endif
-  // clang-format on
-
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
                                                     size_t>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -312,25 +312,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     // base class doesn't have constraint
     // FIXME: Eventually we need to deprecate this behavior and just use
     // BasicView implementation
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    using LayoutType = typename mdspan_type::layout_type;
-    if (r >= static_cast<iType>(rank())) {
-      if constexpr (rank() == 0) return 1;
-      if constexpr (std::is_same_v<LayoutType, layout_right> ||
-                    Impl::IsLayoutRightPadded<LayoutType>::value) {
-        return 1;
-      }
-      if constexpr (std::is_same_v<LayoutType, layout_left> ||
-                    Impl::IsLayoutLeftPadded<LayoutType>::value) {
-        return base_t::stride(rank() - 1) * extent(rank() - 1);
-      }
-      if constexpr (std::is_same_v<LayoutType, layout_stride>) {
-        return 0;
-      }
-    }
-#else
     KOKKOS_ASSERT(r < static_cast<iType>(rank()));
-#endif
     return base_t::stride(r);
   }
 

--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -374,41 +374,6 @@ class View : public ViewTraits<DataType, Properties...> {
            m_map.dimension_6() * m_map.dimension_7();
   }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(0) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_0() const {
-    return m_map.stride_0();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(1) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_1() const {
-    return m_map.stride_1();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(2) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_2() const {
-    return m_map.stride_2();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(3) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_3() const {
-    return m_map.stride_3();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(4) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_4() const {
-    return m_map.stride_4();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(5) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_5() const {
-    return m_map.stride_5();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(6) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_6() const {
-    return m_map.stride_6();
-  }
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use stride(7) instead")
-  KOKKOS_INLINE_FUNCTION constexpr size_t stride_7() const {
-    return m_map.stride_7();
-  }
-#endif
-
   template <typename iType>
   KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<std::is_integral_v<iType>,
                                                     size_t>

--- a/core/src/View/Kokkos_ViewTraits.hpp
+++ b/core/src/View/Kokkos_ViewTraits.hpp
@@ -559,14 +559,6 @@ struct ViewTraits {
                       decltype(customize_view_arguments(
                           Impl::ViewArguments<value_type, array_layout,
                                               device_type, memory_traits>()))>;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  KOKKOS_DEPRECATED static constexpr bool is_hostspace =
-      std::is_same_v<MemorySpace, HostSpace>;
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use !MemoryTraits::is_unmanaged instead.")
-  static constexpr bool is_managed = !MemoryTraits::is_unmanaged;
-  KOKKOS_DEPRECATED_WITH_COMMENT("Use MemoryTraits::is_random_access instead.")
-  static constexpr bool is_random_access = MemoryTraits::is_random_access;
-#endif
   //------------------------------------
 };
 

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -95,12 +95,6 @@ void test_left_stride(Extents... extents) {
     expected_stride *= view.extent(i);
   }
   ASSERT_EQ(all_strides[view_type::rank()], expected_stride);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  for (size_t i = view_type::rank(); i < size_t(8); ++i) {
-    ASSERT_EQ(view.stride(i), view.stride(view_type::rank() - 1) *
-                                  view.extent(view_type::rank() - 1));
-  }
-#endif
 }
 
 template <typename DataType, typename... Extents>
@@ -118,11 +112,6 @@ void test_right_stride(Extents... extents) {
     expected_stride *= view.extent(i);
   }
   ASSERT_EQ(all_strides[view_type::rank()], expected_stride);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-  for (size_t i = view_type::rank(); i < size_t(8); ++i) {
-    ASSERT_EQ(view.stride(i), size_t(1));
-  }
-#endif
 }
 
 template <typename DataType, typename... Extents>
@@ -148,11 +137,6 @@ void test_stride_stride(Extents... extents) {
     }
     ASSERT_EQ(all_strides[view_type::rank()],
               max_stride * view.extent(max_stride_idx));
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    for (size_t i = view_type::rank(); i < size_t(8); ++i) {
-      ASSERT_EQ(view.stride(i), size_t(0));
-    }
-#endif
   };
 
   Kokkos::View<DataType, Kokkos::LayoutRight, Kokkos::HostSpace> view_right(

--- a/core/unit_test/TestViewMapping_subview.hpp
+++ b/core/unit_test/TestViewMapping_subview.hpp
@@ -154,14 +154,6 @@ struct TestViewMappingSubview {
     ASSERT_EQ(Da.stride(2), Db.stride(1));
     ASSERT_EQ(Da.stride(3), Db.stride(2));
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
-    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
-    ASSERT_EQ(Da.stride_1(), Db.stride_0());  // NOLINT
-    ASSERT_EQ(Da.stride_2(), Db.stride_1());  // NOLINT
-    ASSERT_EQ(Da.stride_3(), Db.stride_2());  // NOLINT
-    KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
-#endif
-
     long error_count = -1;
     Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 1), *this,
                             error_count);


### PR DESCRIPTION
Still woking on #8958, almost there.  This batch contains a medley of deprecated code 4.

* `UnorderedMap::create_copy_view()` with internal view not properly sized (deprecated since 4.4 in #6812)
* `View::stride(i)` with `i >= rank()` (deprecated since 4.7 in #7984)
* `View::stride_N()` (deprecated since 5.0 in #8109)
* `ViewTraits::is_{hostspace,managed,random_access}` (deprecated since 5.0 in #8294)
* `Experimental::subview(OffsetView)` (deprecated in 5.0 in #8287)