### PR TITLE
Diagnose when deep_copy view arguments are identical

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1074,6 +1074,24 @@ void deep_copy_rank0(ExecSpace exec_space, DstView dst, SrcView src) {
       Kokkos::RangePolicy<ExecSpace>(exec_space, 0, 1),
       KOKKOS_LAMBDA(int) { dst() = src(); });
 }
+
+// pass the addresses of the view objects
+inline void check_deep_copy_view_arguments_are_distinct(void const* dst,
+                                                        void const* src) {
+  if (dst != src) return;
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  if (Kokkos::show_warnings()) {
+    log_warning(
+        "Kokkos WARNING: deep_copy() source and destination View arguments "
+        "are identical\n");
+  }
+#else
+  abort(
+      "Kokkos ERROR: deep_copy() source and destination View arguments "
+      "are identical\n");
+#endif
+}
 }  // namespace Impl
 
 template <class DT, class... DP, class ST, class... SP>
@@ -1084,6 +1102,9 @@ inline void deep_copy(
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
           unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>* = nullptr) {
+  Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
+                                                    std::addressof(src));
+
   using dst_type = View<DT, DP...>;
   using src_type = View<ST, SP...>;
 
@@ -1159,6 +1180,9 @@ inline void deep_copy(
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
+  Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
+                                                    std::addressof(src));
+
   using dst_type         = View<DT, DP...>;
   using src_type         = View<ST, SP...>;
   using dst_memory_space = typename dst_type::memory_space;
@@ -2325,6 +2349,9 @@ inline void deep_copy(
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) == unsigned(0) &&
           unsigned(ViewTraits<ST, SP...>::rank) == unsigned(0)))>* = nullptr) {
+  Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
+                                                    std::addressof(src));
+
   using src_traits = ViewTraits<ST, SP...>;
   using dst_traits = ViewTraits<DT, DP...>;
 
@@ -2383,6 +2410,9 @@ inline void deep_copy(
          std::is_void_v<typename ViewTraits<ST, SP...>::specialize> &&
          (unsigned(ViewTraits<DT, DP...>::rank) != 0 ||
           unsigned(ViewTraits<ST, SP...>::rank) != 0))>* = nullptr) {
+  Impl::check_deep_copy_view_arguments_are_distinct(std::addressof(dst),
+                                                    std::addressof(src));
+
   using dst_type = View<DT, DP...>;
   using src_type = View<ST, SP...>;
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1080,13 +1080,7 @@ inline void check_deep_copy_view_arguments_are_distinct(void const* dst,
                                                         void const* src) {
   if (dst != src) return;
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  if (Kokkos::show_warnings()) {
-    log_warning(
-        "Kokkos WARNING: deep_copy() source and destination View arguments "
-        "are identical\n");
-  }
-#else
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
   abort(
       "Kokkos ERROR: deep_copy() source and destination View arguments "
       "are identical\n");

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -124,6 +124,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
       Crs
       DeepCopy_Assignment
       DeepCopy_Narrowing
+      DeepCopy_SameArgument
       DeepCopyAlignment
       ExecSpacePartitioning
       ExecSpaceThreadSafety

--- a/core/unit_test/TestDeepCopy_SameArgument.hpp
+++ b/core/unit_test/TestDeepCopy_SameArgument.hpp
@@ -12,33 +12,14 @@ import kokkos.core;
 
 namespace {
 
-#define KOKKOS_TEST_EXPECT_WARNING(CODE, SUBSTRING)                       \
-  do {                                                                    \
-    ::testing::internal::CaptureStderr();                                 \
-    CODE;                                                                 \
-    auto captured = ::testing::internal::GetCapturedStderr();             \
-    if (Kokkos::show_warnings()) {                                        \
-      EXPECT_FALSE(captured.empty());                                     \
-      EXPECT_NE(captured.find(SUBSTRING), std::string::npos) << captured; \
-    } else {                                                              \
-      EXPECT_TRUE(captured.empty()) << captured;                          \
-    }                                                                     \
-  } while (false)
-
 template <class View>
 void test_deep_copy_same_argument(View v) {
   auto v_h = Kokkos::create_mirror_view(v);
   EXPECT_NO_THROW(Kokkos::deep_copy(v, v_h));
   EXPECT_NO_THROW(Kokkos::deep_copy(v_h, v));
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(v, v),
-                             "Kokkos WARNING: deep_copy() source and "
-                             "destination View arguments are identical");
-
-  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(v_h, v_h),
-                             "Kokkos WARNING: deep_copy() source and "
-                             "destination View arguments are identical");
-
+  EXPECT_NO_THROW(Kokkos::deep_copy(v, v));
+  EXPECT_NO_THROW(Kokkos::deep_copy(v_h, v_h));
 #else
   EXPECT_DEATH(Kokkos::deep_copy(v, v),
                "Kokkos ERROR: deep_copy\\(\\) source and "
@@ -52,14 +33,8 @@ void test_deep_copy_same_argument(View v) {
   EXPECT_NO_THROW(Kokkos::deep_copy(exec, v, v_h));
   EXPECT_NO_THROW(Kokkos::deep_copy(exec, v_h, v));
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(exec, v, v),
-                             "Kokkos WARNING: deep_copy() source and "
-                             "destination View arguments are identical");
-
-  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(exec, v_h, v_h),
-                             "Kokkos WARNING: deep_copy() source and "
-                             "destination View arguments are identical");
-
+  EXPECT_NO_THROW(Kokkos::deep_copy(exec, v, v));
+  EXPECT_NO_THROW(Kokkos::deep_copy(exec, v_h, v_h));
 #else
   EXPECT_DEATH(Kokkos::deep_copy(exec, v, v),
                "Kokkos ERROR: deep_copy\\(\\) source and "

--- a/core/unit_test/TestDeepCopy_SameArgument.hpp
+++ b/core/unit_test/TestDeepCopy_SameArgument.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+namespace {
+
+#define KOKKOS_TEST_EXPECT_WARNING(CODE, SUBSTRING)                       \
+  do {                                                                    \
+    ::testing::internal::CaptureStderr();                                 \
+    CODE;                                                                 \
+    auto captured = ::testing::internal::GetCapturedStderr();             \
+    if (Kokkos::show_warnings()) {                                        \
+      EXPECT_FALSE(captured.empty());                                     \
+      EXPECT_NE(captured.find(SUBSTRING), std::string::npos) << captured; \
+    } else {                                                              \
+      EXPECT_TRUE(captured.empty()) << captured;                          \
+    }                                                                     \
+  } while (false)
+
+template <class View>
+void test_deep_copy_same_argument(View v) {
+  auto v_h = Kokkos::create_mirror_view(v);
+  EXPECT_NO_THROW(Kokkos::deep_copy(v, v_h));
+  EXPECT_NO_THROW(Kokkos::deep_copy(v_h, v));
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(v, v),
+                             "Kokkos WARNING: deep_copy() source and "
+                             "destination View arguments are identical");
+
+  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(v_h, v_h),
+                             "Kokkos WARNING: deep_copy() source and "
+                             "destination View arguments are identical");
+
+#else
+  EXPECT_DEATH(Kokkos::deep_copy(v, v),
+               "Kokkos ERROR: deep_copy\\(\\) source and "
+               "destination View arguments are identical");
+  EXPECT_DEATH(Kokkos::deep_copy(v_h, v_h),
+               "Kokkos ERROR: deep_copy\\(\\) source and "
+               "destination View arguments are identical");
+#endif
+
+  TEST_EXECSPACE exec;
+  EXPECT_NO_THROW(Kokkos::deep_copy(exec, v, v_h));
+  EXPECT_NO_THROW(Kokkos::deep_copy(exec, v_h, v));
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(exec, v, v),
+                             "Kokkos WARNING: deep_copy() source and "
+                             "destination View arguments are identical");
+
+  KOKKOS_TEST_EXPECT_WARNING(Kokkos::deep_copy(exec, v_h, v_h),
+                             "Kokkos WARNING: deep_copy() source and "
+                             "destination View arguments are identical");
+
+#else
+  EXPECT_DEATH(Kokkos::deep_copy(exec, v, v),
+               "Kokkos ERROR: deep_copy\\(\\) source and "
+               "destination View arguments are identical");
+  EXPECT_DEATH(Kokkos::deep_copy(exec, v_h, v_h),
+               "Kokkos ERROR: deep_copy\\(\\) source and "
+               "destination View arguments are identical");
+#endif
+}
+
+TEST(TEST_CATEGORY_DEATH, deep_copy_same_view) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  test_deep_copy_same_argument(Kokkos::View<double, TEST_EXECSPACE>("v0"));
+  test_deep_copy_same_argument(Kokkos::View<int*, TEST_EXECSPACE>("v1", 10));
+}
+
+}  // namespace

--- a/core/unit_test/TestViewCopy_a.hpp
+++ b/core/unit_test/TestViewCopy_a.hpp
@@ -68,17 +68,12 @@ TEST(TEST_CATEGORY, view_copy_tests) {
       typename TEST_EXECSPACE::memory_space>::accessible;
 
   // Contiguous copies
-  { Kokkos::deep_copy(defaulted, defaulted); }
   {
     Kokkos::deep_copy(a, 0);
     ASSERT_TRUE(run_check(a, 0));
   }
   {
     Kokkos::deep_copy(a, 1);
-    ASSERT_TRUE(run_check(a, 1));
-  }
-  {
-    Kokkos::deep_copy(a, a);
     ASSERT_TRUE(run_check(a, 1));
   }
   {
@@ -180,17 +175,12 @@ TEST(TEST_CATEGORY, view_copy_tests) {
   }
 
   // Contiguous copies
-  { Kokkos::deep_copy(dev, defaulted, defaulted); }
   {
     Kokkos::deep_copy(dev, a, 0);
     ASSERT_TRUE(run_check(a, 0));
   }
   {
     Kokkos::deep_copy(dev, a, 1);
-    ASSERT_TRUE(run_check(a, 1));
-  }
-  {
-    Kokkos::deep_copy(dev, a, a);
     ASSERT_TRUE(run_check(a, 1));
   }
   {
@@ -259,17 +249,12 @@ TEST(TEST_CATEGORY, view_copy_tests) {
   }
 
   // Contiguous copies
-  { Kokkos::deep_copy(host, defaulted, defaulted); }
   {
     Kokkos::deep_copy(host, a, 0);
     ASSERT_TRUE(run_check(a, 0));
   }
   {
     Kokkos::deep_copy(host, a, 1);
-    ASSERT_TRUE(run_check(a, 1));
-  }
-  {
-    Kokkos::deep_copy(host, a, a);
     ASSERT_TRUE(run_check(a, 1));
   }
   {


### PR DESCRIPTION
Proposed resolution for #8978 
```C++
deep_copy(v, v);  // Was silently doing nothing
                  // Now considered a precondition violation
```