### PR TITLE
Add constexpr to inner tile direction branch

### DIFF
--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -489,7 +489,7 @@ struct DeviceIterateTile {
         bool in_bounds      = true;
 
         // LL
-        if (PolicyType::inner_direction == Iterate::Left) {
+        if constexpr (PolicyType::inner_direction == Iterate::Left) {
           for (int i = 0; i < PolicyType::rank; ++i) {
             m_offset[i] =
                 (tile_idx % m_policy.m_tile_end[i]) * m_policy.m_tile[i] +


### PR DESCRIPTION
Make tile direction branch `(PolicyType::inner_direction == Iterate::Left)` `constexpr`