### PR TITLE
Update Kokkos version in README.md for 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ To start learning about Kokkos:
 
 The latest release of Kokkos can be obtained from the [GitHub releases page](https://github.com/kokkos/kokkos/releases/latest).
 
-The current release is [5.0.2](https://github.com/kokkos/kokkos/releases/tag/5.0.2).
+The current release is [5.1.0](https://github.com/kokkos/kokkos/releases/tag/5.1.0).
 
 ```bash
-curl -OJ -L https://github.com/kokkos/kokkos/releases/download/5.0.2/kokkos-5.0.2.tar.gz
+curl -OJ -L https://github.com/kokkos/kokkos/releases/download/5.1.0/kokkos-5.1.0.tar.gz
 # Or with wget
-wget https://github.com/kokkos/kokkos/releases/download/5.0.2/kokkos-5.0.2.tar.gz
+wget https://github.com/kokkos/kokkos/releases/download/5.1.0/kokkos-5.1.0.tar.gz
 # Or with git
-git clone --depth=2 --branch 5.0.2 https://github.com/kokkos/kokkos.git
+git clone --depth=2 --branch 5.1.0 https://github.com/kokkos/kokkos.git
 ```
 
 To clone the latest development version of Kokkos from GitHub:


### PR DESCRIPTION
IIRC, we discussed adding `latest` tag before but for now this makes sure the latest version listed is up-to-date.