### PR TITLE
Disable hip.graph_capture for ROCm before 7.2

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -229,8 +229,6 @@ AMD-MI300A:
     - export CTEST_BUILD_NAME="AMD-MI300A"
     - export HSA_XNACK=1
     - export KOKKOS_DEVICE_ID=3
-    # FIXME Reenable hip.graph_capture for rocm 7 testing
-    - export GTEST_FILTER="-hip.graph_capture"
     - ctest -VV
       -D CDASH_MODEL=${CDASH_MODEL}
       -D GITHUB_PR_ID="${GITHUB_PR_ID}"

--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -136,10 +136,6 @@ pipeline {
                             args '-v /tmp/ccache.kokkos:/tmp/ccache --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES --env NODE_NAME=${env.NODE_NAME} --env STAGE_NAME=${env.STAGE_NAME}'
                         }
                     }
-                    environment {
-                        // FIXME Reenable hip.graph_capture for rocm 7 testing
-                        GTEST_FILTER = '-hip.graph_capture'
-                    }
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
@@ -424,8 +420,6 @@ pipeline {
                         OMP_MAX_ACTIVE_LEVELS = 3
                         OMP_PLACES = 'threads'
                         OMP_PROC_BIND = 'spread'
-                        // FIXME Reenable hip.graph_capture for rocm 7 testing
-                        GTEST_FILTER = '-hip.graph_capture'
                     }
                     steps {
                         sh 'ccache --zero-stats'
@@ -471,8 +465,7 @@ pipeline {
                     }
                     environment {
                         // FIXME hip_hostpinned.view_allocation_large_rank test returns a wrong value
-                        // FIXME Reenable hip.graph_capture for rocm 7 testing
-                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank:hip.graph_capture'
+                        GTEST_FILTER = '-hip_hostpinned.view_allocation_large_rank'
                     }
                     steps {
                         sh 'ccache --zero-stats'

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1099,6 +1099,13 @@ void test_graph_capture() {
 }
 
 TEST(TEST_CATEGORY, graph_capture) {
+#if defined(KOKKOS_ENABLE_HIP) && \
+    (HIP_VERSION_MAJOR < 7 ||     \
+     (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR < 2))
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>)
+    GTEST_SKIP() << "The test has only been fixed in ROCm 7.2 to run reliably.";
+#endif
+
   if constexpr (GraphNodeTypes<TEST_EXECSPACE>::support_capture) {
     test_graph_capture<TEST_EXECSPACE>();
   } else {


### PR DESCRIPTION
The CI working group discussed in https://github.com/kokkos/development/blob/main/meeting_notes/wg-ci/2026/2026_03_23.md that `hip.graph_capture` should be skipped before ROCm 7.2.
Related to https://github.com/kokkos/kokkos/issues/8359.