### PR TITLE
Simplify RangePolicy deduction guide

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1392,7 +1392,7 @@ RangePolicy() -> RangePolicy<>;
 RangePolicy(int64_t, int64_t) -> RangePolicy<>;
 RangePolicy(int64_t, int64_t, ChunkSize const&) -> RangePolicy<>;
 RangePolicy(const DefaultExecutionSpace&, int64_t, int64_t, ChunkSize const&)
-    -> RangePolicy<>;
+    -> RangePolicy<DefaultExecutionSpace>;
 template <Impl::ExecutionTypeConcept Exec>
 RangePolicy(const Exec&, int64_t, int64_t, ChunkSize const&)
     -> RangePolicy<Exec>;
@@ -1400,7 +1400,8 @@ RangePolicy(const Exec&, int64_t, int64_t, ChunkSize const&)
 // Instances for both execution space and team handle specializations.
 // Must be callable on device.
 KOKKOS_DEDUCTION_GUIDE RangePolicy(const DefaultExecutionSpace&, int64_t,
-                                   int64_t) -> RangePolicy<>;
+                                   int64_t)
+    -> RangePolicy<DefaultExecutionSpace>;
 template <Impl::ExecutionTypeConcept Exec>
 KOKKOS_DEDUCTION_GUIDE RangePolicy(const Exec&, int64_t, int64_t)
     -> RangePolicy<Exec>;

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1388,12 +1388,11 @@ concept ExecutionTypeConcept = ExecutionSpace<ExecType> || TeamHandle<ExecType>;
 // Deduction guide
 
 // Instances for the execution space specialization
-RangePolicy() -> RangePolicy<DefaultExecutionSpace>;
-RangePolicy(int64_t, int64_t) -> RangePolicy<DefaultExecutionSpace>;
-RangePolicy(int64_t, int64_t, ChunkSize const&)
-    -> RangePolicy<DefaultExecutionSpace>;
+RangePolicy() -> RangePolicy<>;
+RangePolicy(int64_t, int64_t) -> RangePolicy<>;
+RangePolicy(int64_t, int64_t, ChunkSize const&) -> RangePolicy<>;
 RangePolicy(const DefaultExecutionSpace&, int64_t, int64_t, ChunkSize const&)
-    -> RangePolicy<DefaultExecutionSpace>;
+    -> RangePolicy<>;
 template <Impl::ExecutionTypeConcept Exec>
 RangePolicy(const Exec&, int64_t, int64_t, ChunkSize const&)
     -> RangePolicy<Exec>;
@@ -1401,8 +1400,7 @@ RangePolicy(const Exec&, int64_t, int64_t, ChunkSize const&)
 // Instances for both execution space and team handle specializations.
 // Must be callable on device.
 KOKKOS_DEDUCTION_GUIDE RangePolicy(const DefaultExecutionSpace&, int64_t,
-                                   int64_t)
-    -> RangePolicy<DefaultExecutionSpace>;
+                                   int64_t) -> RangePolicy<>;
 template <Impl::ExecutionTypeConcept Exec>
 KOKKOS_DEDUCTION_GUIDE RangePolicy(const Exec&, int64_t, int64_t)
     -> RangePolicy<Exec>;

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -77,19 +77,27 @@ struct TestRangePolicyCTAD {
 
   [[maybe_unused]] static inline auto rpdesi64i64 =
       Kokkos::RangePolicy(des, i64, i64);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi64i64)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpdesi64i64)>);
 
   [[maybe_unused]] static inline auto rpdesi32i32 =
       Kokkos::RangePolicy(des, i32, i32);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi32i32)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpdesi32i32)>);
 
   [[maybe_unused]] static inline auto rpnesi64i64 =
       Kokkos::RangePolicy(nes, i64, i64);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi64i64)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpnesi64i64)>);
 
   [[maybe_unused]] static inline auto rpnesi32i32 =
       Kokkos::RangePolicy(nes, i32, i32);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi32i32)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpnesi32i32)>);
 
   [[maybe_unused]] static inline auto rpsesi64i64 =
       Kokkos::RangePolicy(ses, i64, i64);
@@ -105,19 +113,27 @@ struct TestRangePolicyCTAD {
 
   [[maybe_unused]] static inline auto rpdesi64i64cs =
       Kokkos::RangePolicy(des, i64, i64, cs);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi64i64cs)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpdesi64i64cs)>);
 
   [[maybe_unused]] static inline auto rpdesi32i32cs =
       Kokkos::RangePolicy(des, i32, i32, cs);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi32i32cs)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpdesi32i32cs)>);
 
   [[maybe_unused]] static inline auto rpnesi64i64cs =
       Kokkos::RangePolicy(nes, i64, i64, cs);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi64i64cs)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpnesi64i64cs)>);
 
   [[maybe_unused]] static inline auto rpnesi32i32cs =
       Kokkos::RangePolicy(nes, i32, i32, cs);
-  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi32i32cs)>);
+  static_assert(
+      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
+                     decltype(rpnesi32i32cs)>);
 
   [[maybe_unused]] static inline auto rpsesi64i64cs =
       Kokkos::RangePolicy(ses, i64, i64, cs);

--- a/core/unit_test/TestRangePolicyCTAD.cpp
+++ b/core/unit_test/TestRangePolicyCTAD.cpp
@@ -39,83 +39,57 @@ struct TestRangePolicyCTAD {
   // RangePolicy()
 
   [[maybe_unused]] static inline auto rp = Kokkos::RangePolicy{};
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rp)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rp)>);
 
   // RangePolicy(index_type, index_type)
 
   [[maybe_unused]] static inline auto rpi64i64 = Kokkos::RangePolicy(i64, i64);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi64i64)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi64i64)>);
 
   [[maybe_unused]] static inline auto rpi64i32 = Kokkos::RangePolicy(i64, i32);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi64i32)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi64i32)>);
 
   [[maybe_unused]] static inline auto rpi32i64 = Kokkos::RangePolicy(i32, i64);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi32i64)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi32i64)>);
 
   [[maybe_unused]] static inline auto rpi32i32 = Kokkos::RangePolicy(i32, i32);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi32i32)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi32i32)>);
 
   // RangePolicy(index_type, index_type, ChunkSize)
 
   [[maybe_unused]] static inline auto rpi64i64cs =
       Kokkos::RangePolicy(i64, i64, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi64i64cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi64i64cs)>);
 
   [[maybe_unused]] static inline auto rpi64i32cs =
       Kokkos::RangePolicy(i64, i32, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi64i32cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi64i32cs)>);
 
   [[maybe_unused]] static inline auto rpi32i64cs =
       Kokkos::RangePolicy(i32, i64, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi32i64cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi32i64cs)>);
 
   [[maybe_unused]] static inline auto rpi32i32cs =
       Kokkos::RangePolicy(i32, i32, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpi32i32cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpi32i32cs)>);
 
   // RangePolicy(execution_space, index_type, index_type)
 
   [[maybe_unused]] static inline auto rpdesi64i64 =
       Kokkos::RangePolicy(des, i64, i64);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpdesi64i64)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi64i64)>);
 
   [[maybe_unused]] static inline auto rpdesi32i32 =
       Kokkos::RangePolicy(des, i32, i32);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpdesi32i32)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi32i32)>);
 
   [[maybe_unused]] static inline auto rpnesi64i64 =
       Kokkos::RangePolicy(nes, i64, i64);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpnesi64i64)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi64i64)>);
 
   [[maybe_unused]] static inline auto rpnesi32i32 =
       Kokkos::RangePolicy(nes, i32, i32);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpnesi32i32)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi32i32)>);
 
   [[maybe_unused]] static inline auto rpsesi64i64 =
       Kokkos::RangePolicy(ses, i64, i64);
@@ -131,27 +105,19 @@ struct TestRangePolicyCTAD {
 
   [[maybe_unused]] static inline auto rpdesi64i64cs =
       Kokkos::RangePolicy(des, i64, i64, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpdesi64i64cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi64i64cs)>);
 
   [[maybe_unused]] static inline auto rpdesi32i32cs =
       Kokkos::RangePolicy(des, i32, i32, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpdesi32i32cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpdesi32i32cs)>);
 
   [[maybe_unused]] static inline auto rpnesi64i64cs =
       Kokkos::RangePolicy(nes, i64, i64, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpnesi64i64cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi64i64cs)>);
 
   [[maybe_unused]] static inline auto rpnesi32i32cs =
       Kokkos::RangePolicy(nes, i32, i32, cs);
-  static_assert(
-      std::is_same_v<Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>,
-                     decltype(rpnesi32i32cs)>);
+  static_assert(std::is_same_v<Kokkos::RangePolicy<>, decltype(rpnesi32i32cs)>);
 
   [[maybe_unused]] static inline auto rpsesi64i64cs =
       Kokkos::RangePolicy(ses, i64, i64, cs);


### PR DESCRIPTION
In the deduction guide for `RangePolicy`, we do not have to explicitly pass the `DefaultExecutionSpace` template, since `Impl::PolicyTraits<>::execution_type` will correctly map to `DefaultExecutionSpace`, and the correct specialization for `RangePolicy` will be chosen, namely
```
template <>
class RangePolicy 
    : public Impl::ImplRangePolicy<Impl::PolicyTraits<>::execution_type> {
 
};
```

Explicitly passing in `DefaultExecutionSpace` as template in deduction guide was introduced in an early iteration of https://github.com/kokkos/kokkos/pull/8367 (before the TeamHandle trait was introduced). Then, it was necessary to explicitly pass this template since we required either a `TeamHandle` or `ExecSpace` template existed. That is no longer the case.

What is in develop isn't incorrect, it just isn't necessary.