### PR TITLE
[4.7.4] Do not specify alignment attribute with MSVC

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -207,7 +207,7 @@
 
 #ifndef KOKKOS_IMPL_ALIGN_PTR
 #if defined(_WIN32)
-#define KOKKOS_IMPL_ALIGN_PTR(size) __declspec(align_value(size))
+#define KOKKOS_IMPL_ALIGN_PTR(size)
 #else
 #define KOKKOS_IMPL_ALIGN_PTR(size) __attribute__((align_value(size)))
 #endif


### PR DESCRIPTION
Cherry-picking changes from #8414 into the 4.7.4 RC branch as per requested in #9046

cc @cgcgcg