### PR TITLE
[4.7.4] Add a missing sstream include in Kokkos_ViewLegacy.hpp

### DIFF
--- a/core/src/View/Kokkos_ViewLegacy.hpp
+++ b/core/src/View/Kokkos_ViewLegacy.hpp
@@ -26,6 +26,7 @@ static_assert(false,
 #include <string>
 #include <algorithm>
 #include <initializer_list>
+#include <sstream>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_HostSpace.hpp>


### PR DESCRIPTION
Cherry pick #8659

I think this is reasonable since it was a clear oversight.