### PR TITLE
core(graph): make HPX graph death test threadsafe

### DIFF
--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1310,6 +1310,7 @@ TEST(TEST_CATEGORY, execution_policy_with_default_execution_space_instance) {
   if (exec == TEST_EXECSPACE{}) {
     GTEST_SKIP();
   } else {
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH(graph.root_node().then_parallel_for(
                      Kokkos::RangePolicy(exec, 0, 1), NoOp{}),
                  "The execution space instance of the execution policy of a "


### PR DESCRIPTION
Fixes #9066

This PR switches the death test style to `threadsafe` before the `ASSERT_DEATH(...)` in `execution_policy_with_default_execution_space_instance`.