### PR TITLE
Resolve mismatch in View::extent and View::extent_int when querying extents larger than or equal to the rank of a view

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -330,11 +330,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_INLINE_FUNCTION constexpr int extent_int(size_t r) const {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    return static_cast<int>(base_t::extent(r));
-#else
-    return static_cast<int>(extent(r));
-#endif
+    return static_cast<int>(this->extent(r));
   }
   //----------------------------------------
   // Allow specializations to query their specialized map

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -330,7 +330,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_INLINE_FUNCTION constexpr int extent_int(size_t r) const {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    return static_cast<int>(base_t::extent(r));
+#else
     return static_cast<int>(extent(r));
+#endif
   }
   //----------------------------------------
   // Allow specializations to query their specialized map

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -330,7 +330,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_INLINE_FUNCTION constexpr int extent_int(size_t r) const {
-    return static_cast<int>(base_t::extent(r));
+    return static_cast<int>(extent(r));
   }
   //----------------------------------------
   // Allow specializations to query their specialized map


### PR DESCRIPTION
This resolves issue https://github.com/kokkos/kokkos/issues/9071.