### PR TITLE
Make is_assignable more robust

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -62,9 +62,9 @@ struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
 
  public:
   // Example:
-  //   extents<int, dynamic_extent> is always assignable to extents<int,
-  //   dynamic_extent> extents<int, dynamic_extent> may be assignable to
-  //   extents<int, 2>, need runtime check
+  //   - extents<int, dynamic_extent> is always assignable to extents<int,
+  //     dynamic_extent> extents<int, dynamic_extent> may be assignable to
+  //   - extents<int, 2>, need runtime check
 
   // is it always (statically known)  assignable
   constexpr static bool value =
@@ -76,13 +76,12 @@ struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
     if constexpr ((dst_t::rank() == 0) || value) {
       return true;
     } else {
-      using rank_type   = typename dst_t::rank_type;
-      bool return_value = true;
+      using rank_type = typename dst_t::rank_type;
       for (rank_type r = 0; r < dst_t::rank(); r++)
-        return_value =
-            return_value && (dst_t::static_extent(r) == dynamic_extent ||
-                             dst_t::static_extent(r) == src.extent(r));
-      return return_value;
+        if (!(dst_t::static_extent(r) == dynamic_extent ||
+              dst_t::static_extent(r) == src.extent(r)))
+          return false;
+      return true;
     }
   }
 };

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -115,10 +115,10 @@ struct is_assignable_impl<View<ViewTDst...>, View<ViewTSrc...>, true> {
 
 // Don't remove const from destination, since you can't assign
 // to a 'const View<...>'
-template <class View1, class View2>
+template <class DstView, class SrcView>
 using is_always_assignable = Impl::is_assignable_impl<
-    std::remove_reference_t<std::remove_volatile_t<View1> >,
-    std::remove_cvref_t<View2> >;
+    std::remove_volatile_t<std::remove_reference_t<DstView> >,
+    std::remove_cvref_t<SrcView> >;
 
 template <class T1, class T2>
 inline constexpr bool is_always_assignable_v =
@@ -126,10 +126,16 @@ inline constexpr bool is_always_assignable_v =
 
 // FIXME: this should be a device callable function
 template <class... ViewTDst, class... ViewTSrc>
-constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
+constexpr bool is_assignable(Kokkos::View<ViewTDst...>& dst,
                              const Kokkos::View<ViewTSrc...>& src) {
   return is_always_assignable<View<ViewTDst...>,
                               View<ViewTSrc...> >::impl_runtime_value(dst, src);
+}
+
+template <class... ViewTDst, class... ViewTSrc>
+constexpr bool is_assignable(const Kokkos::View<ViewTDst...>&,
+                             const Kokkos::View<ViewTSrc...>&) {
+  return false;
 }
 
 namespace Impl {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -39,55 +39,97 @@ template <class ParentView>
 struct ViewTracker;
 } /* namespace Impl */
 
-template <class T1, class T2>
-struct is_always_assignable_impl;
+namespace Impl {
 
-template <class... ViewTDst, class... ViewTSrc>
-struct is_always_assignable_impl<Kokkos::View<ViewTDst...>,
-                                 Kokkos::View<ViewTSrc...> > {
-  using dst_mdspan = typename Kokkos::View<ViewTDst...>::mdspan_type;
-  using src_mdspan = typename Kokkos::View<ViewTSrc...>::mdspan_type;
+template <class TDst, class TSrc, bool same_rank = TDst::rank() == TSrc::rank()>
+struct is_assignable_impl {
+  // is it always (statically known) assignable
+  constexpr static bool value = false;
 
-  constexpr static bool value =
-      std::is_constructible_v<dst_mdspan, src_mdspan> &&
-      static_cast<int>(Kokkos::View<ViewTDst...>::rank_dynamic) >=
-          static_cast<int>(Kokkos::View<ViewTSrc...>::rank_dynamic);
+  // runtime check
+  KOKKOS_FUNCTION
+  static constexpr bool impl_runtime_value(const TDst&, const TSrc&) {
+    return false;
+  }
 };
 
+template <class IdxDst, size_t... ExtsDst, class IdxSrc, size_t... ExtsSrc>
+struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
+                          extents<IdxSrc, ExtsSrc...>, true> {
+ private:
+  using dst_t = extents<IdxDst, ExtsDst...>;
+  using src_t = extents<IdxSrc, ExtsSrc...>;
+
+ public:
+  // Example:
+  //   extents<int, dynamic_extent> is always assignable to extents<int,
+  //   dynamic_extent> extents<int, dynamic_extent> may be assignable to
+  //   extents<int, 2>, need runtime check
+
+  // is it always (statically known)  assignable
+  constexpr static bool value =
+      ((ExtsDst == dynamic_extent || ExtsDst == ExtsSrc) && ... && true);
+
+  // runtime check
+  KOKKOS_FUNCTION
+  static constexpr bool impl_runtime_value(const dst_t&, const src_t& src) {
+    if constexpr ((dst_t::rank() == 0) || value) {
+      return true;
+    } else {
+      using rank_type   = typename dst_t::rank_type;
+      bool return_value = true;
+      for (rank_type r = 0; r < dst_t::rank(); r++)
+        return_value =
+            return_value && (dst_t::static_extent(r) == dynamic_extent ||
+                             dst_t::static_extent(r) == src.extent(r));
+      return return_value;
+    }
+  }
+};
+
+template <class... ViewTDst, class... ViewTSrc>
+struct is_assignable_impl<View<ViewTDst...>, View<ViewTSrc...>, true> {
+ private:
+  using dst_t                = View<ViewTDst...>;
+  using src_t                = View<ViewTSrc...>;
+  using dst_mdspan           = typename View<ViewTDst...>::mdspan_type;
+  using src_mdspan           = typename View<ViewTSrc...>::mdspan_type;
+  using is_assignable_exts_t = is_assignable_impl<typename dst_t::extents_type,
+                                                  typename src_t::extents_type>;
+
+ public:
+  // is it always (statically known) assignable
+  constexpr static bool value =
+      std::is_constructible_v<dst_mdspan, src_mdspan> &&
+      is_assignable_exts_t::value;
+
+  // runtime check
+  KOKKOS_FUNCTION
+  static constexpr bool impl_runtime_value(const dst_t& dst, const src_t& src) {
+    return std::is_constructible_v<dst_mdspan, src_mdspan> &&
+           is_assignable_exts_t::impl_runtime_value(dst.extents(),
+                                                    src.extents());
+  }
+};
+}  // namespace Impl
+
+// Don't remove const from destination, since you can't assign
+// to a 'const View<...>'
 template <class View1, class View2>
-using is_always_assignable = is_always_assignable_impl<
-    std::remove_reference_t<View1>,
-    std::remove_const_t<std::remove_reference_t<View2> > >;
+using is_always_assignable = Impl::is_assignable_impl<
+    std::remove_reference_t<std::remove_volatile_t<View1> >,
+    std::remove_cvref_t<View2> >;
 
 template <class T1, class T2>
 inline constexpr bool is_always_assignable_v =
     is_always_assignable<T1, T2>::value;
 
+// FIXME: this should be a device callable function
 template <class... ViewTDst, class... ViewTSrc>
 constexpr bool is_assignable(const Kokkos::View<ViewTDst...>& dst,
                              const Kokkos::View<ViewTSrc...>& src) {
-  using dst_mdspan = typename Kokkos::View<ViewTDst...>::mdspan_type;
-  using src_mdspan = typename Kokkos::View<ViewTSrc...>::mdspan_type;
-
-  return is_always_assignable_v<Kokkos::View<ViewTDst...>,
-                                Kokkos::View<ViewTSrc...> > ||
-         (std::is_constructible_v<dst_mdspan, src_mdspan> &&
-          ((dst_mdspan::rank_dynamic() >= 1) ||
-           (dst.static_extent(0) == src.extent(0))) &&
-          ((dst_mdspan::rank_dynamic() >= 2) ||
-           (dst.static_extent(1) == src.extent(1))) &&
-          ((dst_mdspan::rank_dynamic() >= 3) ||
-           (dst.static_extent(2) == src.extent(2))) &&
-          ((dst_mdspan::rank_dynamic() >= 4) ||
-           (dst.static_extent(3) == src.extent(3))) &&
-          ((dst_mdspan::rank_dynamic() >= 5) ||
-           (dst.static_extent(4) == src.extent(4))) &&
-          ((dst_mdspan::rank_dynamic() >= 6) ||
-           (dst.static_extent(5) == src.extent(5))) &&
-          ((dst_mdspan::rank_dynamic() >= 7) ||
-           (dst.static_extent(6) == src.extent(6))) &&
-          ((dst_mdspan::rank_dynamic() == 8) ||
-           (dst.static_extent(7) == src.extent(7))));
+  return is_always_assignable<View<ViewTDst...>,
+                              View<ViewTSrc...> >::impl_runtime_value(dst, src);
 }
 
 namespace Impl {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -29,6 +29,26 @@ class ViewMapping;
 #include <View/Kokkos_ViewMapping.hpp>
 #include <Kokkos_MinMax.hpp>
 
+namespace Kokkos {
+template <class DataType, class... Properties>
+struct ViewTraits;
+
+template <class DataType, class... Properties>
+class View;
+
+template <class>
+struct is_view : public std::false_type {};
+
+template <class D, class... P>
+struct is_view<View<D, P...> > : public std::true_type {};
+
+template <class D, class... P>
+struct is_view<const View<D, P...> > : public std::true_type {};
+
+template <class T>
+inline constexpr bool is_view_v = is_view<T>::value;
+}  // namespace Kokkos
+
 // Class to provide a uniform type
 namespace Kokkos {
 namespace Impl {
@@ -42,20 +62,20 @@ struct ViewTracker;
 namespace Impl {
 
 template <class TDst, class TSrc, bool same_rank = TDst::rank() == TSrc::rank()>
-struct is_assignable_impl {
+struct is_assignable_extents {
   // is it always (statically known) assignable
   constexpr static bool value = false;
 
   // runtime check
   KOKKOS_FUNCTION
-  static constexpr bool impl_runtime_value(const TDst&, const TSrc&) {
+  static constexpr bool runtime_value(const TDst&, const TSrc&) {
     return false;
   }
 };
 
 template <class IdxDst, size_t... ExtsDst, class IdxSrc, size_t... ExtsSrc>
-struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
-                          extents<IdxSrc, ExtsSrc...>, true> {
+struct is_assignable_extents<extents<IdxDst, ExtsDst...>,
+                             extents<IdxSrc, ExtsSrc...>, true> {
  private:
   using dst_t = extents<IdxDst, ExtsDst...>;
   using src_t = extents<IdxSrc, ExtsSrc...>;
@@ -72,7 +92,7 @@ struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
 
   // runtime check
   KOKKOS_FUNCTION
-  static constexpr bool impl_runtime_value(const dst_t&, const src_t& src) {
+  static constexpr bool runtime_value(const dst_t&, const src_t& src) {
     if constexpr ((dst_t::rank() == 0) || value) {
       return true;
     } else {
@@ -86,36 +106,35 @@ struct is_assignable_impl<extents<IdxDst, ExtsDst...>,
   }
 };
 
+template <class TDst, class TSrc, bool same_rank = TDst::rank() == TSrc::rank()>
+struct is_assignable_view {
+  // is it always (statically known) assignable
+  constexpr static bool value = false;
+};
+
 template <class... ViewTDst, class... ViewTSrc>
-struct is_assignable_impl<View<ViewTDst...>, View<ViewTSrc...>, true> {
+struct is_assignable_view<View<ViewTDst...>, View<ViewTSrc...>, true> {
  private:
-  using dst_t                = View<ViewTDst...>;
-  using src_t                = View<ViewTSrc...>;
-  using dst_mdspan           = typename View<ViewTDst...>::mdspan_type;
-  using src_mdspan           = typename View<ViewTSrc...>::mdspan_type;
-  using is_assignable_exts_t = is_assignable_impl<typename dst_t::extents_type,
-                                                  typename src_t::extents_type>;
+  using dst_t      = View<ViewTDst...>;
+  using src_t      = View<ViewTSrc...>;
+  using dst_mdspan = typename View<ViewTDst...>::mdspan_type;
+  using src_mdspan = typename View<ViewTSrc...>::mdspan_type;
+  using is_assignable_exts_t =
+      is_assignable_extents<typename dst_t::extents_type,
+                            typename src_t::extents_type>;
 
  public:
   // is it always (statically known) assignable
   constexpr static bool value =
       std::is_constructible_v<dst_mdspan, src_mdspan> &&
       is_assignable_exts_t::value;
-
-  // runtime check
-  KOKKOS_FUNCTION
-  static constexpr bool impl_runtime_value(const dst_t& dst, const src_t& src) {
-    return std::is_constructible_v<dst_mdspan, src_mdspan> &&
-           is_assignable_exts_t::impl_runtime_value(dst.extents(),
-                                                    src.extents());
-  }
 };
 }  // namespace Impl
 
 // Don't remove const from destination, since you can't assign
 // to a 'const View<...>'
 template <class DstView, class SrcView>
-using is_always_assignable = Impl::is_assignable_impl<
+using is_always_assignable = Impl::is_assignable_view<
     std::remove_volatile_t<std::remove_reference_t<DstView> >,
     std::remove_cvref_t<SrcView> >;
 
@@ -124,16 +143,21 @@ inline constexpr bool is_always_assignable_v =
     is_always_assignable<T1, T2>::value;
 
 // FIXME: this should be a device callable function
-template <class... ViewTDst, class... ViewTSrc>
-constexpr bool is_assignable(Kokkos::View<ViewTDst...>& dst,
-                             const Kokkos::View<ViewTSrc...>& src) {
-  return is_always_assignable<View<ViewTDst...>,
-                              View<ViewTSrc...> >::impl_runtime_value(dst, src);
+template <class DstView, class SrcView>
+  requires(is_view_v<DstView> && is_view_v<SrcView> &&
+           !std::is_const_v<DstView>)
+constexpr bool is_assignable(DstView& dst, const SrcView& src) {
+  using is_assignable_exts_t =
+      Impl::is_assignable_extents<typename DstView::extents_type,
+                                  typename SrcView::extents_type>;
+  return std::is_constructible_v<typename DstView::mdspan_type,
+                                 typename SrcView::mdspan_type> &&
+         is_assignable_exts_t::runtime_value(dst.extents(), src.extents());
 }
 
-template <class... ViewTDst, class... ViewTSrc>
-constexpr bool is_assignable(const Kokkos::View<ViewTDst...>&,
-                             const Kokkos::View<ViewTSrc...>&) {
+template <class DstView, class SrcView>
+  requires(is_view_v<DstView> && is_view_v<SrcView> && std::is_const_v<DstView>)
+constexpr bool is_assignable(DstView&, const SrcView&) {
   return false;
 }
 
@@ -163,24 +187,6 @@ KOKKOS_INLINE_FUNCTION constexpr auto ptr_from_data_handle(
   return handle;
 }
 }  // namespace Impl
-
-template <class DataType, class... Properties>
-struct ViewTraits;
-
-template <class DataType, class... Properties>
-class View;
-
-template <class>
-struct is_view : public std::false_type {};
-
-template <class D, class... P>
-struct is_view<View<D, P...> > : public std::true_type {};
-
-template <class D, class... P>
-struct is_view<const View<D, P...> > : public std::true_type {};
-
-template <class T>
-inline constexpr bool is_view_v = is_view<T>::value;
 
 // FIXME spurious warnings like
 // error: 'SR.14123' may be used uninitialized [-Werror=maybe-uninitialized]

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -145,9 +145,55 @@ TEST(TEST_CATEGORY, view_is_assignable) {
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType&>);
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType const>);
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType const&>);
+  static_assert(
+      is_always_assignable_v<SomeViewType, volatile SomeViewType const&>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType&>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const&>);
+  static_assert(
+      is_always_assignable_v<SomeViewType&, volatile SomeViewType const&>);
+  static_assert(is_always_assignable_v<volatile SomeViewType&, SomeViewType>);
+
+  // Check assignment to const qualified Views is false
+  static_assert(!is_always_assignable_v<SomeViewType const, SomeViewType>);
+  static_assert(!is_always_assignable_v<SomeViewType const&, SomeViewType>);
+  static_assert(
+      !is_always_assignable_v<volatile SomeViewType const&, SomeViewType>);
+  {
+    SomeViewType non_const_view("V", 10);
+    const SomeViewType const_view;
+    ASSERT_FALSE(Kokkos::is_assignable(const_view, non_const_view));
+  }
+
+  // Rank mismatch: is_always_assignable_v must be false (consteval false case)
+  using RankMismatchView1D = View<int*, left, d_exec>;
+  using RankMismatchView2D = View<int**, left, d_exec>;
+  static_assert(
+      !is_always_assignable_v<RankMismatchView1D, RankMismatchView2D>);
+  static_assert(
+      !is_always_assignable_v<RankMismatchView2D, RankMismatchView1D>);
+
+  // Rank mismatch: is_assignable must compile and return false (not cause a
+  // compile error due to a non-static impl_runtime_value in the primary
+  // template of is_assignable_impl)
+  {
+    RankMismatchView1D v1d;
+    RankMismatchView2D v2d("v2d", 10, 10);
+    ASSERT_FALSE(Kokkos::is_assignable(v1d, v2d));
+    ASSERT_FALSE(Kokkos::is_assignable(v2d, v1d));
+  }
+
+  // CV-qualified element types: adding const to the element type is allowed;
+  // removing const is not
+  using ConstElementView = View<const int*, left, d_exec>;
+  static_assert(is_always_assignable_v<ConstElementView, SomeViewType>);
+  static_assert(!is_always_assignable_v<SomeViewType, ConstElementView>);
+  {
+    ConstElementView cv;
+    SomeViewType v("v", 10);
+    ASSERT_TRUE(Kokkos::is_assignable(cv, v));
+    ASSERT_FALSE(Kokkos::is_assignable(v, cv));
+  }
 }
 }  // namespace Test

--- a/core/unit_test/TestViewIsAssignable.hpp
+++ b/core/unit_test/TestViewIsAssignable.hpp
@@ -145,26 +145,21 @@ TEST(TEST_CATEGORY, view_is_assignable) {
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType&>);
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType const>);
   static_assert(is_always_assignable_v<SomeViewType, SomeViewType const&>);
-  static_assert(
-      is_always_assignable_v<SomeViewType, volatile SomeViewType const&>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType&>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const>);
   static_assert(is_always_assignable_v<SomeViewType&, SomeViewType const&>);
-  static_assert(
-      is_always_assignable_v<SomeViewType&, volatile SomeViewType const&>);
-  static_assert(is_always_assignable_v<volatile SomeViewType&, SomeViewType>);
 
+#ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY
   // Check assignment to const qualified Views is false
   static_assert(!is_always_assignable_v<SomeViewType const, SomeViewType>);
   static_assert(!is_always_assignable_v<SomeViewType const&, SomeViewType>);
-  static_assert(
-      !is_always_assignable_v<volatile SomeViewType const&, SomeViewType>);
   {
     SomeViewType non_const_view("V", 10);
     const SomeViewType const_view;
     ASSERT_FALSE(Kokkos::is_assignable(const_view, non_const_view));
   }
+#endif
 
   // Rank mismatch: is_always_assignable_v must be false (consteval false case)
   using RankMismatchView1D = View<int*, left, d_exec>;


### PR DESCRIPTION
- don't rely on View::extent(r) returning 1 for r >= rank
- make the check more robust not relying on all dynamic extents coming first (in prep for later View changes)
- support checks for CV qualified types properly
  - note this changes (arguably fixes) assignability for const types (see below)!
- expanded testing to check this a bit more robustly 

This is part of preparation for deprecating View::extent(r) calls with r>=rank.

I pulled this out since it's a complicated enough change on its own to think through. 

There is one possibly breaking change in this:

```c++
auto foo(const Kokkos::View<int*> a, const Kokkos::View<int*> b) {
   return Kokkos::is_assignable(a,b); 
}
```

This returned `true` before, now returns `false` since you can't assign `b` to `a` since `a` is `const`. 

Regarding the purpose of this function/type_trait: it does take precondition violations (like assigning `View<int*>("A",10)` to `View<int[5]>`) into account. So for example:

```c++
is_always_assignable_v<View<int[5]>,View<int*>> // false
is_assignable(View<int[5]>(), View<int*>("A",5)) // true
is_assignable(View<int[5]>(), View<int*>("A",10)) // false
```

While `std::is_assignable_v<View<int[5]>,View<int*>>` is `false`.