### PR TITLE
Fix View equality to compare extents only up to rank

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1496,7 +1496,7 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
                         typename rhs_traits::array_layout> &&
          std::is_same_v<typename lhs_traits::memory_space,
                         typename rhs_traits::memory_space> &&
-         View<LT, LP...>::rank() == View<RT, RP...>::rank() &&
+         lhs_view::rank() == rhs_view::rank() &&
          lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
          Kokkos::Impl::view_equal_extents_impl(
              lhs, rhs, std::make_index_sequence<lhs_view::rank()>{});

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -115,6 +115,12 @@ KOKKOS_INLINE_FUNCTION constexpr auto ptr_from_data_handle(
   static_assert(std::is_pointer_v<HandleType>);
   return handle;
 }
+
+template <class LView, class RView, size_t... I>
+KOKKOS_INLINE_FUNCTION constexpr bool view_equal_extents_impl(
+    const LView& lhs, const RView& rhs, std::index_sequence<I...>) {
+  return ((lhs.extent(I) == rhs.extent(I)) && ...);
+}
 }  // namespace Impl
 
 template <class DataType, class... Properties>
@@ -1490,10 +1496,8 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
                         typename rhs_traits::memory_space> &&
          View<LT, LP...>::rank() == View<RT, RP...>::rank() &&
          lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
-         lhs.extent(0) == rhs.extent(0) && lhs.extent(1) == rhs.extent(1) &&
-         lhs.extent(2) == rhs.extent(2) && lhs.extent(3) == rhs.extent(3) &&
-         lhs.extent(4) == rhs.extent(4) && lhs.extent(5) == rhs.extent(5) &&
-         lhs.extent(6) == rhs.extent(6) && lhs.extent(7) == rhs.extent(7);
+         Kokkos::Impl::view_equal_extents_impl(
+             lhs, rhs, std::make_index_sequence<lhs_view::rank()>{});
 }
 
 template <class LT, class... LP, class RT, class... RP>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1496,8 +1496,8 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
                         typename rhs_traits::array_layout> &&
          std::is_same_v<typename lhs_traits::memory_space,
                         typename rhs_traits::memory_space> &&
-         lhs_view::rank() == rhs_view::rank() &&
-         lhs.data() == rhs.data() && lhs.span() == rhs.span() &&
+         lhs_view::rank() == rhs_view::rank() && lhs.data() == rhs.data() &&
+         lhs.span() == rhs.span() &&
          Kokkos::Impl::view_equal_extents_impl(
              lhs, rhs, std::make_index_sequence<lhs_view::rank()>{});
 }

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1487,6 +1487,8 @@ KOKKOS_INLINE_FUNCTION bool operator==(const View<LT, LP...>& lhs,
   // Same data, layout, dimensions
   using lhs_traits = ViewTraits<LT, LP...>;
   using rhs_traits = ViewTraits<RT, RP...>;
+  using lhs_view   = View<LT, LP...>;
+  using rhs_view   = View<RT, RP...>;
 
   return std::is_same_v<typename lhs_traits::const_value_type,
                         typename rhs_traits::const_value_type> &&

--- a/core/unit_test/view/TestViewEqualityOperator.hpp
+++ b/core/unit_test/view/TestViewEqualityOperator.hpp
@@ -113,14 +113,12 @@ void test_view_equality_operator() {
   }
 
   {
-    using v_t =
-        Kokkos::View<T[3][5], Kokkos::LayoutLeft, TEST_EXECSPACE>;
-    using col_t =
-        Kokkos::View<T[3], Kokkos::LayoutLeft, TEST_EXECSPACE,
-                     Kokkos::MemoryUnmanaged>;
+    using v_t   = Kokkos::View<T[3][5], Kokkos::LayoutLeft, TEST_EXECSPACE>;
+    using col_t = Kokkos::View<T[3], Kokkos::LayoutLeft, TEST_EXECSPACE,
+                               Kokkos::MemoryUnmanaged>;
 
     v_t v_0("A_layoutleft_extent_rank_eq");
-    auto col_0    = Kokkos::subview(v_0, Kokkos::ALL, 0);
+    auto col_0 = Kokkos::subview(v_0, Kokkos::ALL, 0);
     col_t alias_to_col_0(col_0.data());
     ASSERT_TRUE(check_equal(col_0, alias_to_col_0));
   }

--- a/core/unit_test/view/TestViewEqualityOperator.hpp
+++ b/core/unit_test/view/TestViewEqualityOperator.hpp
@@ -111,6 +111,19 @@ void test_view_equality_operator() {
         v_0.data());
     ASSERT_TRUE(check_equal(v_0, v_1));
   }
+
+  {
+    using v_t =
+        Kokkos::View<T[3][5], Kokkos::LayoutLeft, TEST_EXECSPACE>;
+    using col_t =
+        Kokkos::View<T[3], Kokkos::LayoutLeft, TEST_EXECSPACE,
+                     Kokkos::MemoryUnmanaged>;
+
+    v_t v_0("A_layoutleft_extent_rank_eq");
+    auto col_0    = Kokkos::subview(v_0, Kokkos::ALL, 0);
+    col_t alias_to_col_0(col_0.data());
+    ASSERT_TRUE(check_equal(col_0, alias_to_col_0));
+  }
 }
 
 TEST(TEST_CATEGORY, view_equality_operator) { test_view_equality_operator(); }


### PR DESCRIPTION
Similar idea to https://github.com/kokkos/kokkos/pull/9074.

This is another step toward allowing deprecation for checking View::extent(r) or View::extent_int(r) for r >= View::rank(), see https://github.com/kokkos/kokkos/issues/9071/