### PR TITLE
simd: Fix a call to masked reduce with default parameters being ambiguous

### DIFF
--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -350,6 +350,7 @@ KOKKOS_FORCEINLINE_FUNCTION auto round_half_to_nearest_even(T const& x) {
 
 // common implementations of host only simd reductions:
 template <class T, class Abi, class BinaryOperation = std::plus<>>
+  requires requires(T x, BinaryOperation op) { op(x, x); }
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION T reduce(const basic_simd<T, Abi>& x,
                                                BinaryOperation binary_op = {}) {
   T result = x[0];

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -566,6 +566,7 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr basic_simd<T, simd_abi::scalar> condition(
 }
 
 template <class T, class BinaryOperation = std::plus<>>
+  requires requires(T x, BinaryOperation op) { op(x, x); }
 KOKKOS_FORCEINLINE_FUNCTION constexpr T reduce(
     Experimental::basic_simd<T, Experimental::simd_abi::scalar> const& x,
     BinaryOperation = {}) noexcept {

--- a/simd/unit_tests/include/SIMDTesting_Ops.hpp
+++ b/simd/unit_tests/include/SIMDTesting_Ops.hpp
@@ -611,6 +611,42 @@ class masked_reduce {
   }
 };
 
+class masked_reduce_default_params {
+ public:
+  template <typename T, typename U, typename MaskType>
+  auto on_host(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce(a, mask);
+  }
+  template <typename T, typename U, typename MaskType>
+  auto on_host_serial(T const& a, U, MaskType mask) const {
+    U result = Kokkos::Experimental::Impl::Identity<U, std::plus<>>();
+
+    if (Kokkos::Experimental::none_of(mask)) return result;
+
+    for (Kokkos::Experimental::Impl::simd_size_t i = 0; i < T::size(); ++i) {
+      if (mask[i]) result = result + a[i];
+    }
+    return result;
+  }
+
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device(T const& a, U, MaskType mask) const {
+    return Kokkos::Experimental::reduce(a, mask);
+  }
+  template <typename T, typename U, typename MaskType>
+  KOKKOS_INLINE_FUNCTION auto on_device_serial(T const& a, U,
+                                               MaskType mask) const {
+    U result = Kokkos::Experimental::Impl::Identity<U, std::plus<>>();
+
+    if (Kokkos::Experimental::none_of(mask)) return result;
+
+    for (Kokkos::Experimental::Impl::simd_size_t i = 0; i < T::size(); ++i) {
+      if (mask[i]) result = result + a[i];
+    }
+    return result;
+  }
+};
+
 #define KOKKOS_IMPL_SIMD_UNARY_TEST_OP(FUNC)                         \
   class FUNC##_op {                                                  \
    public:                                                           \

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -95,6 +95,8 @@ inline void host_check_all_reductions(const DataType (&args)[n]) {
   host_check_reduction_all_loaders<Abi>(masked_reduce<std::plus<>>(), n, args);
   host_check_reduction_all_loaders<Abi>(masked_reduce<std::multiplies<>>(), n,
                                         args);
+  host_check_reduction_all_loaders<Abi>(masked_reduce_default_params(), n,
+                                        args);
 }
 
 template <typename Abi, typename DataType>

--- a/simd/unit_tests/include/TestSIMD_Reductions.hpp
+++ b/simd/unit_tests/include/TestSIMD_Reductions.hpp
@@ -187,6 +187,8 @@ KOKKOS_INLINE_FUNCTION void device_check_all_reductions(
                                           args);
   device_check_reduction_all_loaders<Abi>(masked_reduce<std::multiplies<>>(), n,
                                           args);
+  device_check_reduction_all_loaders<Abi>(masked_reduce_default_params(), n,
+                                          args);
 }
 
 template <typename Abi, typename DataType>


### PR DESCRIPTION
Calling `reduce(simd, mask)` with an abi other than scalar would lead to the call being ambiguous, having `reduce(simd, mask, binary_op = std::plus<>(), identity = Identity<binary_op>())` and `reduce(simd, binary_op)` (with `binary_op` being deduced as the type of `mask`) as possible candidates.

This is fixed by adding a constraint on the `reduce(simd, binary_op)` overload to ensure that `binary_op` is a callable taking two arguments. Even though the scalar version was fine, I also added a constraint there for consistency.
I also added a test for this.