### PR TITLE
quadruple max team scratch

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -197,7 +197,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     // arbitrarily setting level 1 scratch limit to 20MB, for a
     // Volta V100 that would give us about 3.2GB for 2 teams per SM
     constexpr size_t max_l1_scratch_size =
-        static_cast<size_t>(20) * 1024 * 1024;
+        static_cast<size_t>(80) * 1024 * 1024;
 
     size_t max_shmem = Cuda().cuda_device_prop().sharedMemPerBlock;
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team

--- a/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
+++ b/core/src/HIP/Kokkos_HIP_TeamPolicyInternal.hpp
@@ -160,7 +160,7 @@ class TeamPolicyInternal<HIP, Properties...>
     // arbitrarily setting level 1 scratch limit to 20MB, for a
     // MI250 that would give us about 4.4GB for 2 teams per CU
     constexpr size_t max_l1_scratch_size =
-        static_cast<size_t>(20 * 1024 * 1024);
+        static_cast<size_t>(80 * 1024 * 1024);
 
     size_t max_shmem = HIP().hip_device_prop().sharedMemPerBlock;
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -86,7 +86,7 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
 
   inline static int scratch_size_max(int level) {
     return (level == 0 ? 1024 * 32 :  // Roughly L1 size
-                20 * 1024 * 1024);    // Limit to keep compatibility with CUDA
+                80 * 1024 * 1024);    // Limit to keep compatibility with CUDA
   }
 
   //----------------------------------------

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -117,7 +117,7 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
         (max_possible_team_size + 2) * sizeof(double);
     // arbitrarily setting level 1 scratch limit to 20MB
     constexpr size_t max_l1_scratch_size =
-        static_cast<size_t>(20) * 1024 * 1024;
+        static_cast<size_t>(80) * 1024 * 1024;
 
     size_t max_shmem = sycl_instance.m_maxShmemPerBlock;
     return (level == 0 ? max_shmem - max_reserved_shared_mem_per_team

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -99,7 +99,7 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   }  // Use arbitrary large number, is meant as a vectorizable length
 
   inline static int scratch_size_max(int level) {
-    return (level == 0 ? 1024 * 32 : 20 * 1024 * 1024);
+    return (level == 0 ? 1024 * 32 : 80 * 1024 * 1024);
   }
   /** \brief  Specify league size, request team size */
   TeamPolicyInternal(const execution_space& space, int league_size_request,

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -640,7 +640,7 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
 
   inline static int scratch_size_max(int level) {
     return (level == 0 ? 1024 * 32 :  // Roughly L1 size
-                20 * 1024 * 1024);    // Limit to keep compatibility with CUDA
+                80 * 1024 * 1024);    // Limit to keep compatibility with CUDA
   }
 
   //----------------------------------------


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

This MR comes from a discussion with @crtrott . Here I quadruple the max team scratch size for level 1 scratch for each backend. This is motivated by the fact that the available memory on the average architecture has roughly quadrupled since the original max scratch size was chosen. 

@crtrott and I also discussed a longer term solution where scratch limits are changed to reflect a fraction of of available machine memory, given that the number of teams used may very with application and problem. So this should be viewed as an intermediate solution.

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

  - Unsure
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
