### PR TITLE
Fix: Correct type reference in IndexTypeTrait error reporting

### DIFF
--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -47,7 +47,7 @@ struct IndexTypePolicyMixin<Kokkos::IndexType<IntegralIndexType>,
   static constexpr auto show_index_type_error_in_compilation_message =
       show_extra_index_type_erroneously_given_to_execution_policy<
           std::conditional_t<base_t::index_type_is_defaulted, void,
-                             typename base_t::schedule_type>>{};
+                             typename base_t::index_type>>{};
   static_assert(base_t::index_type_is_defaulted,
                 "Kokkos Error: More than one index type given. Search "
                 "compiler output for 'show_extra_index_type' to see the "
@@ -65,7 +65,7 @@ struct IndexTypePolicyMixin : AnalyzeNextTrait {
   static constexpr auto show_index_type_error_in_compilation_message =
       show_extra_index_type_erroneously_given_to_execution_policy<
           std::conditional_t<base_t::index_type_is_defaulted, void,
-                             typename base_t::schedule_type>>{};
+                             typename base_t::index_type>>{};
   static_assert(base_t::index_type_is_defaulted,
                 "Kokkos Error: More than one index type given. Search "
                 "compiler output for 'show_extra_index_type' to see the "


### PR DESCRIPTION
Currently, if a user erroneously provides multiple index types to an execution policy, the compile-time error trap attempts to query base_t::schedule_type instead of base_t::index_type. This causes the compiler to crash with an unhelpful missing type error rather than triggering the intended readable static_assert.

This PR corrects the reference to ensure the proper Kokkos error message is displayed.

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
