### PR TITLE
Fix: Add bounds check to prevent OOB access in tuner dimension indexing

### DIFF
--- a/core/src/Kokkos_Tuners.hpp
+++ b/core/src/Kokkos_Tuners.hpp
@@ -184,7 +184,11 @@ template <class RootType, class Subtype>
 struct DimensionValueExtractor<ValueHierarchyNode<RootType, Subtype>> {
   static RootType get(const ValueHierarchyNode<RootType, Subtype>& dimension,
                       double fraction_to_traverse) {
-    size_t index = dimension.root_values.size() * fraction_to_traverse;
+    // Clamp the index to size - 1 to prevent out-of-bounds access
+    // if an external tuning tool returns a fraction >= 1.0
+    size_t size = dimension.root_values.size();
+    size_t index =
+        std::min(size - 1, static_cast<size_t>(size * fraction_to_traverse));
     return dimension.get_root_value(index);
   }
 };
@@ -220,7 +224,11 @@ struct GetMultidimensionalPoint<ValueHierarchyNode<ValueType, Subtype>, double,
       std::declval<std::tuple<ValueType>>(), std::declval<sub_tuple>()));
   static return_type build(const node_type& in, double fraction_to_traverse,
                            Indices... indices) {
-    size_t index         = in.sub_values.size() * fraction_to_traverse;
+    // Clamp the index to size - 1 to prevent out-of-bounds access
+    // if an external tuning tool returns a fraction >= 1.0
+    size_t size = in.sub_values.size();
+    size_t index =
+        std::min(size - 1, static_cast<size_t>(size * fraction_to_traverse));
     auto dimension_value = std::make_tuple(
         DimensionValueExtractor<node_type>::get(in, fraction_to_traverse));
     return std::tuple_cat(dimension_value,

--- a/core/unit_test/tools/TestBuiltinTuners.cpp
+++ b/core/unit_test/tools/TestBuiltinTuners.cpp
@@ -76,6 +76,17 @@ TEST(kokkosp, builtin_tuner) {
   EXPECT_EQ(std::get<0>(begin_point), 1);
   auto end_point = new_team_tuner.get_point(0.9, 0.0, 0.0);
   EXPECT_EQ(std::get<0>(end_point), 5);
+  // Test boundary: fractions near or at 1.0 must clamp to last element, not
+  // go out of bounds. A tuning tool could return such values due to
+  // floating-point rounding.
+  auto near_boundary_point =
+      new_team_tuner.get_point(0.999999999999999, 0.0, 0.0);
+  EXPECT_EQ(std::get<0>(near_boundary_point), 5);
+  auto boundary_point = new_team_tuner.get_point(1.0, 0.0, 0.0);
+  EXPECT_EQ(std::get<0>(boundary_point), 5);
+  // Value slightly over 1.0
+  auto over_boundary_point = new_team_tuner.get_point(1.01, 0.0, 0.0);
+  EXPECT_EQ(std::get<0>(over_boundary_point), 5);
   for (int x = 0; x < 10000; ++x) {
     auto config                 = new_team_tuner.begin();
     [[maybe_unused]] int option = std::get<0>(config);


### PR DESCRIPTION
DimensionValueExtractor::get() and GetMultidimensionalPoint::build() compute a vector index from a floating-point fraction via:
  size_t index = size * fraction_to_traverse;

When fraction_to_traverse >= 1.0 (possible due to floating-point rounding or a misbehaving tuning tool), this produces index == size, which is out of bounds and causes a segmentation fault.

Add a guard to clamp the index to size - 1 when it exceeds the valid range. Also add a regression test that passes fraction=1.0 directly to verify the boundary is handled correctly.

Tested: Without fix → segfault (exit code 139). With fix → all tests pass.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
