### PR TITLE
Fix compilation on MAXWELL50 using CUDAToolkit 12.4.131

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -306,9 +306,9 @@ cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
 
-#endif  // !KOKKOS_BHALF_T_IS_FLOAT
+#endif // KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80
 
-#endif
+#endif // !KOKKOS_BHALF_T_IS_FLOAT
 
 }  // namespace Kokkos::Experimental
 

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -306,9 +306,9 @@ cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
 
-#endif // KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80
+#endif  // KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80
 
-#endif // !KOKKOS_BHALF_T_IS_FLOAT
+#endif  // !KOKKOS_BHALF_T_IS_FLOAT
 
 }  // namespace Kokkos::Experimental
 

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -101,7 +101,7 @@ cast_from_half(half_t val) {
 
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
 
-// if architecture is older than Amper
+// if architecture is older than Ampere
 #if KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80
 
 KOKKOS_INLINE_FUNCTION

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -4,6 +4,8 @@
 #ifndef KOKKOS_CUDA_HALF_HPP_
 #define KOKKOS_CUDA_HALF_HPP_
 
+#ifdef _CUDACC_
+
 #include <Kokkos_Half.hpp>
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 
@@ -299,5 +301,7 @@ cast_from_bhalf(bhalf_t val) {
 #endif
 
 }  // namespace Kokkos::Experimental
+
+#endif
 
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -4,8 +4,6 @@
 #ifndef KOKKOS_CUDA_HALF_HPP_
 #define KOKKOS_CUDA_HALF_HPP_
 
-#ifdef _CUDACC_
-
 #include <Kokkos_Half.hpp>
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 
@@ -14,6 +12,9 @@
 namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(half_t val) { return val; }
 
@@ -94,9 +95,15 @@ cast_from_half(half_t val) {
   return static_cast<T>(cast_from_half<unsigned long long>(val));
 }
 
+#endif  // !KOKKOS_HALF_T_IS_FLOAT
+
 /************************** bhalf conversions *********************************/
-// if architecture is older than Ampere
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+
+// if architecture is older than Amper
 #if KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80
+
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
@@ -298,10 +305,11 @@ KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
 cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(cast_from_bhalf<unsigned long long>(val));
 }
+
+#endif  // !KOKKOS_BHALF_T_IS_FLOAT
+
 #endif
 
 }  // namespace Kokkos::Experimental
-
-#endif
 
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -2907,11 +2907,15 @@ KE::half_t ref_test_fallback_half(KE::half_t) {
   // When SYCL is enabled, half_t is available on both the GPU and the CPU.
   return KE::half_t(0.f);
 #elif defined(KOKKOS_ENABLE_CUDA)
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && KOKKOS_HALF_T_IS_FLOAT
+  return KE::half_t(1.f);
+#else
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
     return KE::half_t(0.f);
   } else {
     return KE::half_t(1.f);
   }
+#endif
 #elif defined(KOKKOS_ENABLE_HIP)
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::HIP>) {
     return KE::half_t(0.f);

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -409,10 +409,13 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
                                Kokkos::HostSpace>) {
     GTEST_SKIP() << "Disabling for host backends";
   }
+// NVC++ warned about unreachable code without the
+// if/else construct here
 #ifndef KOKKOS_ENABLE_LARGE_MEM_TESTS
   GTEST_SKIP() << "skipping for GPUs with not enough memory";
-#endif
+#else
   test_large_parallel_for_reduce();
+#endif
 }
 #endif
 

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -409,6 +409,9 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
                                Kokkos::HostSpace>) {
     GTEST_SKIP() << "Disabling for host backends";
   }
+#ifdef KOKKOS_ARCH_MAXWELL50
+  GTEST_SKIP() << "skipping for Maxwell50 devices (not enough memory)";
+#endif
   test_large_parallel_for_reduce();
 }
 #endif

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -409,8 +409,8 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
                                Kokkos::HostSpace>) {
     GTEST_SKIP() << "Disabling for host backends";
   }
-#ifdef KOKKOS_ARCH_MAXWELL50
-  GTEST_SKIP() << "skipping for Maxwell50 devices (not enough memory)";
+#ifndef KOKKOS_ENABLE_LARGE_MEM_TESTS
+  GTEST_SKIP() << "skipping for GPUs with not enough memory";
 #endif
   test_large_parallel_for_reduce();
 }

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -299,6 +299,9 @@ TEST(TEST_CATEGORY, view_allocation_large_rank) {
 #ifdef KOKKOS_IMPL_32BIT
   GTEST_SKIP() << "skipping for 32-bit builds";
 #endif
+#ifndef KOKKOS_ENABLE_LARGE_MEM_TESTS
+  GTEST_SKIP() << "skipping for GPUs with not enough memory";
+#endif
   using ExecutionSpace = typename TEST_EXECSPACE::execution_space;
   using MemorySpace    = typename TEST_EXECSPACE::memory_space;
   constexpr int dim    = 15;

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -293,15 +293,15 @@ struct TestViewAllocationLargeRank {
 
 // Orin and other Jetson devices come with smaller memory capacity, 8GB total
 TEST(TEST_CATEGORY, view_allocation_large_rank) {
-#ifdef KOKKOS_ARCH_AMPERE87
-  GTEST_SKIP() << "skipping for Jetson devices that have only 8GB memory";
-#endif
 #ifdef KOKKOS_IMPL_32BIT
   GTEST_SKIP() << "skipping for 32-bit builds";
 #endif
+// NVC++ warned about unreachable code without the
+// if/else construct here. Not worrying about 32bit
+// since we are not testing with NVHPC on those
 #ifndef KOKKOS_ENABLE_LARGE_MEM_TESTS
   GTEST_SKIP() << "skipping for GPUs with not enough memory";
-#endif
+#else
   using ExecutionSpace = typename TEST_EXECSPACE::execution_space;
   using MemorySpace    = typename TEST_EXECSPACE::memory_space;
   constexpr int dim    = 15;
@@ -315,6 +315,7 @@ TEST(TEST_CATEGORY, view_allocation_large_rank) {
   auto result =
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, v_single);
   ASSERT_EQ(result(0, 0, 0, 0, 0, 0, 0, 0), 42);
+#endif
 }
 
 template <typename ExecSpace, typename ViewType>


### PR DESCRIPTION
Fixes #9070

~Compilation is fixed adding `_CUDACC_` around declarations in `core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp`.~
Compilation is fixed using`KOKKOS_HALF_T_IS_FLOAT` and `KOKKOS_BHALF_T_IS_FLOAT` as guards for declarations in `core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp`

Also fix two unit tests:
- `cuda.mathematical_functions_impl_half_fallback`
Since MAXWELL50 does not support `halft_t` it is treated as `float`
- `cuda.large_parallel_for_reduce`
Test is skipped on MAXWELL50 since this device has really low memory

One test still fails : `cuda.mixed_then_host_device_nodes`.
```
[ RUN      ] cuda.mixed_then_host_device_nodes
/home/delpino/src/kokkos/core/unit_test/TestGraph.hpp:1286: Failure
Expected equality of these values:
  counter(0)
    Which is: 4
  6u
    Which is: 6
[  FAILED  ] cuda.mixed_then_host_device_nodes (2 ms)
```
Strangely, if I replace
```c++
root.then     (node_props("node A", dev_handle), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node A - device", exec))}})
    .then_host("node B",       functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - node B - host"))}})
    .then     (node_props("node C", std::move(dev_handle)), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node C - device", exec))}});
```
 by
 ```c++
root.then     (node_props("node A", dev_handle), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node A - device", exec))}})
     .then_host("node B",       functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - node B - host"))}});

root.then     (node_props("node C", std::move(dev_handle)), functor_d_t{{counter, view_d_t(Kokkos::view_alloc("internal buffer - node C - device", exec))}});
```
the test succeeds if launched standalone
```shell
./core/unit_test/Kokkos_CoreUnitTest_Cuda1 --gtest_filter="cuda.mixed_then_host_device_nodes"
```
but not launching the whole testsuite.
