### PR TITLE
Fix silent state mutation in tuning variable ID registry

### DIFF
--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -29,7 +29,6 @@
 #include <unordered_set>
 #include <vector>
 #include <sstream>
-#include <iostream>
 
 namespace {
 void warn_cmd_line_arg_ignored_when_kokkos_tools_disabled(char const* arg) {
@@ -1023,13 +1022,13 @@ static size_t& get_context_counter() {
 }
 static size_t& get_variable_counter() {
   static size_t x;
-  return ++x;
+  return x;
 }
 
 size_t get_new_context_id() { return ++get_context_counter(); }
 size_t get_current_context_id() { return get_context_counter(); }
 void decrement_current_context_id() { --get_context_counter(); }
-size_t get_new_variable_id() { return get_variable_counter(); }
+size_t get_new_variable_id() { return ++get_variable_counter(); }
 
 size_t declare_output_type(const std::string& variableName, VariableInfo info) {
   size_t variableId = get_new_variable_id();


### PR DESCRIPTION
Previously, get_variable_counter() used a pre-increment (++x) inside the getter itself, unlike get_context_counter() which correctly just returned the reference. 

- Changed get_variable_counter() to strictly return the static reference x without mutation.
- Moved the incrementing logic ++get_variable_counter() out to the wrapper function get_new_variable_id() to perfectly match the design pattern used by the context ID factory.

Validation:
```
4/47 Test  7: Kokkos_CoreUnitTest_TuningBuiltins ... Passed

5/47 Test  8: Kokkos_CoreUnitTest_TuningBasics ..... Passed

6/47 Test  9: Kokkos_CoreUnitTest_CategoricalTuner . Passed

7/47 Test 10: Kokkos_CoreUnitTest_KokkosP .......... Passed

8/47 Test 11: Kokkos_CoreUnitTest_ToolIndependence . Passed
```

### Related issues / PRs

None.

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
