### PR TITLE
Clang ice unittest workaround

### DIFF
--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -136,7 +136,7 @@ struct Foo {
 // separate noinline device function breaks the inlining chain.
 #if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
 KOKKOS_FUNCTION
-    __attribute__((noinline))
+__attribute__((noinline))
 #else
 KOKKOS_FUNCTION
 #endif

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -128,6 +128,20 @@ struct Foo {
   int use_count() { return ptr.use_count(); }
 };
 
+// Workaround for clang 21.x MachineLICM ICE (llvm.org/PR???): when Foo's copy
+// assignment (which contains a HostSharedPtr) is fully inlined into
+// cuda_parallel_launch_local_memory via exec_range, the MachineLICM pass
+// crashes with a null pointer dereference. Keeping the assignment in a
+// separate noinline device function breaks the inlining chain.
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
+KOKKOS_FUNCTION __attribute__((noinline))
+#else
+KOKKOS_FUNCTION
+#endif
+void assign_foo(Foo* dst, const Foo& src) noexcept {
+  *dst = src;
+}
+
 template <class DevMemSpace, class HostMemSpace>
 void host_shared_ptr_test_reference_counting() {
   using ExecSpace = typename DevMemSpace::execution_space;
@@ -190,7 +204,7 @@ void host_shared_ptr_test_reference_counting() {
     fp_h() = Foo();
     Kokkos::parallel_for(
         Kokkos::RangePolicy<ExecSpace>(0, 1),
-        KOKKOS_LAMBDA(int) { fp_d() = f1; });
+        KOKKOS_LAMBDA(int) { assign_foo(fp_d.data(), f1); });
     Kokkos::fence();
     Kokkos::deep_copy(fp_h, fp_d);
 

--- a/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
+++ b/core/unit_test/TestHostSharedPtrAccessOnDevice.hpp
@@ -128,17 +128,20 @@ struct Foo {
   int use_count() { return ptr.use_count(); }
 };
 
-// Workaround for clang 21.x MachineLICM ICE (llvm.org/PR???): when Foo's copy
+// Workaround for clang 19/20/21/22 MachineLICM ICE
+// (https://github.com/llvm/llvm-project/issues/190853): when Foo's copy
 // assignment (which contains a HostSharedPtr) is fully inlined into
 // cuda_parallel_launch_local_memory via exec_range, the MachineLICM pass
-// crashes with a null pointer dereference. Keeping the assignment in a
+// crashes. Keeping the assignment in a
 // separate noinline device function breaks the inlining chain.
 #if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
-KOKKOS_FUNCTION __attribute__((noinline))
+KOKKOS_FUNCTION
+    __attribute__((noinline))
 #else
 KOKKOS_FUNCTION
 #endif
-void assign_foo(Foo* dst, const Foo& src) noexcept {
+    void
+    assign_foo(Foo* dst, const Foo& src) noexcept {
   *dst = src;
 }
 

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -42,17 +42,19 @@ struct NestedView {
   }
 };
 
-// Workaround for clang 21.x MachineLICM ICE: NestedView::operator=(View) holds
-// View reference-counting machinery that crashes MachineLICM when inlined into
-// cuda_parallel_launch_local_memory. A noinline wrapper breaks the chain.
+// Workaround for clang 19/20/21/22 MachineLICM ICE: NestedView::operator=(View)
+// crashes MachineLICM when inlined into cuda_parallel_launch_local_memory. A
+// noinline wrapper breaks the chain.
 template <class Space>
 #if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
-KOKKOS_FUNCTION __attribute__((noinline))
+KOKKOS_FUNCTION
+    __attribute__((noinline))
 #else
 KOKKOS_FUNCTION
 #endif
-void assign_nested_view(NestedView<Space> &dst,
-                        const Kokkos::View<int *, Space> &src) {
+    void
+    assign_nested_view(NestedView<Space> &dst,
+                       const Kokkos::View<int *, Space> &src) {
   dst = src;
 }
 

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -42,6 +42,20 @@ struct NestedView {
   }
 };
 
+// Workaround for clang 21.x MachineLICM ICE: NestedView::operator=(View) holds
+// View reference-counting machinery that crashes MachineLICM when inlined into
+// cuda_parallel_launch_local_memory. A noinline wrapper breaks the chain.
+template <class Space>
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
+KOKKOS_FUNCTION __attribute__((noinline))
+#else
+KOKKOS_FUNCTION
+#endif
+void assign_nested_view(NestedView<Space> &dst,
+                        const Kokkos::View<int *, Space> &src) {
+  dst = src;
+}
+
 template <class Space>
 struct NestedViewFunctor {
   Kokkos::View<NestedView<Space> *, Space> nested;
@@ -52,7 +66,7 @@ struct NestedViewFunctor {
       : nested(arg_nested), array(arg_array) {}
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i) const { nested[i] = array; }
+  void operator()(int i) const { assign_nested_view(nested[i], array); }
 };
 
 template <class Space>


### PR DESCRIPTION
Alternate to #8984 
Rather than implementing a block on inlining the RangePolicy for every case, this PR implements a workaround in the unit test implementation.   