### PR TITLE
Fix for issue #9087: Provide ROCM_PATH to rocthrust

### DIFF
--- a/cmake/Modules/FindTPLROCTHRUST.cmake
+++ b/cmake/Modules/FindTPLROCTHRUST.cmake
@@ -1,4 +1,4 @@
-find_package(rocthrust REQUIRED)
+find_package(rocthrust REQUIRED PATHS ${ROCM_PATH} $ENV{ROCM_PATH})
 kokkos_create_imported_tpl(ROCTHRUST INTERFACE LINK_LIBRARIES roc::rocthrust)
 
 # Export ROCTHRUST as a Kokkos dependency


### PR DESCRIPTION
### Related issues / PRs

Issue: https://github.com/kokkos/kokkos/issues/9087

Original PR: https://github.com/kokkos/kokkos/pull/9088

### Changelog Entry

Provide ROCM_PATH as search path for rocthrust, using the same structure as in FindTPLROCM.cmake.
Change from original PR: Now with signoff.