### PR TITLE
Use -Werror=all-warnings in SNL Cuda CI

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -42,7 +42,7 @@ jobs:
             -DKokkos_ARCH_HOPPER90=ON \
             -DKokkos_ARCH_NATIVE=ON \
             -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_CXX_FLAGS="-Werror" \
+            -DCMAKE_CXX_FLAGS="-Werror=all-warnings -Werror" \
             -DBUILD_SHARED_LIBS=OFF \
             -DKokkos_ENABLE_COMPILER_WARNINGS=ON \
             -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
@@ -70,7 +70,7 @@ jobs:
         run: |
           cmake -S ${PWD}/example/build_cmake_installed_different_compiler -B build_examples \
             -DCMAKE_CXX_STANDARD=20 \
-            -DCMAKE_CXX_FLAGS="-Werror" \
+            -DCMAKE_CXX_FLAGS="-Werror=all-warnings -Werror" \
             -DKokkos_ROOT=${PWD}/install
           cmake --build build_examples --parallel -j36
 


### PR DESCRIPTION
As reported in https://kokkosteam.slack.com/archives/C07JRFJ1XCN/p1775736190528439, we didn't error out for Cuda device warnings.