### PR TITLE
[5.1.1]  0  simd: Fix compile failures when ranges are not available

### DIFF
--- a/simd/src/Kokkos_SIMD.hpp
+++ b/simd/src/Kokkos_SIMD.hpp
@@ -236,9 +236,9 @@ simd_unchecked_load(const T* ptr,
   return simd_unchecked_load<basic_simd<T, simd_abi::scalar>>(ptr, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
@@ -246,9 +246,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
@@ -256,9 +256,9 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                                 flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
@@ -268,9 +268,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                            flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
@@ -279,9 +279,9 @@ KOKKOS_FORCEINLINE_FUNCTION auto unchecked_gather_from(
                                                                 indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
@@ -289,9 +289,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
       basic_simd<T, simd_abi::Impl::host_fixed_native<T>>>(in, indices, flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> flag = simd_flag_default) {
@@ -299,9 +299,9 @@ KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
                                                               flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::NonScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
@@ -311,9 +311,9 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION auto partial_gather_from(
                                                            flag);
 }
 
-template <std::ranges::contiguous_range R, Impl::SimdIntegral I,
-          typename... Flags, typename T = std::ranges::range_value_t<R>>
-  requires std::ranges::sized_range<R> &&
+template <Impl::Ranges::contiguous_range R, Impl::SimdIntegral I,
+          typename... Flags, typename T = Impl::Ranges::range_value_t<R>>
+  requires Impl::Ranges::sized_range<R> &&
            Impl::ScalarAbi<simd_abi::Impl::host_fixed_native<T>>
 KOKKOS_FORCEINLINE_FUNCTION auto partial_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -3466,7 +3466,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm256_i32gather_pd(std::ranges::data(in), idx, 8));
+      return V(_mm256_i32gather_pd(Impl::Ranges::data(in), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3478,7 +3478,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256d mmask =
           static_cast<__m256d>(basic_simd_mask<double, abi_type>{mask});
       return V(_mm256_mask_i32gather_pd(_mm256_set1_pd(value_type{}),
-                                        std::ranges::data(in), idx, mmask, 8));
+                                        Impl::Ranges::data(in), idx, mmask, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3515,7 +3515,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm_i32gather_ps(std::ranges::data(in), idx, 4));
+      return V(_mm_i32gather_ps(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3527,7 +3527,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m128 mmask =
           static_cast<__m128>(basic_simd_mask<float, abi_type>{mask});
       return V(_mm_mask_i32gather_ps(_mm_set1_ps(value_type{}),
-                                     std::ranges::data(in), idx, mmask, 4));
+                                     Impl::Ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3564,7 +3564,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx2_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_ps(std::ranges::data(in), idx, 4));
+      return V(_mm256_i32gather_ps(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3576,7 +3576,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256 mmask =
           static_cast<__m256>(basic_simd_mask<float, abi_type>{mask});
       return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}),
-                                        std::ranges::data(in), idx, mmask, 4));
+                                        Impl::Ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3613,7 +3613,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<4>, {
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
-      return V(_mm_i32gather_epi32(std::ranges::data(in), idx, 4));
+      return V(_mm_i32gather_epi32(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3625,7 +3625,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m128i mmask =
           static_cast<__m128i>(basic_simd_mask<std::int32_t, abi_type>{mask});
       return V(_mm_mask_i32gather_epi32(_mm_set1_epi32(value_type{}),
-                                        std::ranges::data(in), idx, mmask, 4));
+                                        Impl::Ranges::data(in), idx, mmask, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3662,7 +3662,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx2_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_epi32(std::ranges::data(in), idx, 4));
+      return V(_mm256_i32gather_epi32(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3674,7 +3674,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256i mmask =
           static_cast<__m256i>(basic_simd_mask<std::int32_t, abi_type>{mask});
       return V(_mm256_mask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
-                                           std::ranges::data(in), idx, mmask,
+                                           Impl::Ranges::data(in), idx, mmask,
                                            4));
     })
 
@@ -3713,7 +3713,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
       return V(_mm256_i32gather_epi64(
-          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, 8));
+          reinterpret_cast<long long const*>(Impl::Ranges::data(in)), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3726,8 +3726,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
       return V(_mm256_mask_i32gather_epi64(
           _mm256_set1_epi64x(value_type{}),
-          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, mmask,
-          8));
+          reinterpret_cast<long long const*>(Impl::Ranges::data(in)), idx,
+          mmask, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3765,7 +3765,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
       __m128i idx = static_cast<__m128i>(
           basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>>{indices});
       return V(_mm256_i32gather_epi64(
-          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, 8));
+          reinterpret_cast<long long const*>(Impl::Ranges::data(in)), idx, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3778,8 +3778,8 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           static_cast<__m256i>(basic_simd_mask<std::int64_t, abi_type>{mask});
       return V(_mm256_mask_i32gather_epi64(
           _mm256_set1_epi64x(value_type{}),
-          reinterpret_cast<long long const*>(std::ranges::data(in)), idx, mmask,
-          8));
+          reinterpret_cast<long long const*>(Impl::Ranges::data(in)), idx,
+          mmask, 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -4015,7 +4015,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_pd(idx, std::ranges::data(in), 8));
+      return V(_mm512_i32gather_pd(idx, Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4025,7 +4025,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm512_mask_i32gather_pd(_mm512_set1_pd(value_type{}),
                                         static_cast<__mmask8>(mask), idx,
-                                        std::ranges::data(in), 8));
+                                        Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4040,15 +4040,15 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_pd(std::ranges::data(out), idx, static_cast<__m512d>(v),
-                           8);
+      _mm512_i32scatter_pd(Impl::Ranges::data(out), idx,
+                           static_cast<__m512d>(v), 8);
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     double, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_pd(std::ranges::data(out),
+      _mm512_mask_i32scatter_pd(Impl::Ranges::data(out),
                                 static_cast<__mmask8>(mask), idx,
                                 static_cast<__m512d>(v), 8);
     })
@@ -4065,7 +4065,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_ps(std::ranges::data(in), idx, 4));
+      return V(_mm256_i32gather_ps(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4076,7 +4076,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
       __m256 on = _mm256_castsi256_ps(_mm256_set1_epi32(-1));
       __m256 m  = _mm256_maskz_mov_ps(static_cast<__mmask8>(mask), on);
       return V(_mm256_mask_i32gather_ps(_mm256_set1_ps(value_type{}),
-                                        std::ranges::data(in), idx, m, 4));
+                                        Impl::Ranges::data(in), idx, m, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4091,7 +4091,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_ps(std::ranges::data(out), idx, static_cast<__m256>(v),
+      _mm256_i32scatter_ps(Impl::Ranges::data(out), idx, static_cast<__m256>(v),
                            4);
     })
 
@@ -4099,7 +4099,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_ps(std::ranges::data(out),
+      _mm256_mask_i32scatter_ps(Impl::Ranges::data(out),
                                 static_cast<__mmask8>(mask), idx,
                                 static_cast<__m256>(v), 4);
     })
@@ -4116,7 +4116,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_ps(idx, std::ranges::data(in), 4));
+      return V(_mm512_i32gather_ps(idx, Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4126,7 +4126,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_ps(_mm512_set1_ps(value_type{}),
                                         static_cast<__mmask16>(mask), idx,
-                                        std::ranges::data(in), 4));
+                                        Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4141,7 +4141,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_ps(std::ranges::data(out), idx, static_cast<__m512>(v),
+      _mm512_i32scatter_ps(Impl::Ranges::data(out), idx, static_cast<__m512>(v),
                            4);
     })
 
@@ -4149,7 +4149,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     float, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_ps(std::ranges::data(out),
+      _mm512_mask_i32scatter_ps(Impl::Ranges::data(out),
                                 static_cast<__mmask16>(mask), idx,
                                 static_cast<__m512>(v), 4);
     })
@@ -4166,7 +4166,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm256_i32gather_epi32(std::ranges::data(in), idx, 4));
+      return V(_mm256_i32gather_epi32(Impl::Ranges::data(in), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4176,7 +4176,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                             static_cast<__mmask8>(mask), idx,
-                                            std::ranges::data(in), 4));
+                                            Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4191,7 +4191,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_epi32(std::ranges::data(out), idx,
+      _mm256_i32scatter_epi32(Impl::Ranges::data(out), idx,
                               static_cast<__m256i>(v), 4);
     })
 
@@ -4199,7 +4199,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_epi32(std::ranges::data(out),
+      _mm256_mask_i32scatter_epi32(Impl::Ranges::data(out),
                                    static_cast<__mmask8>(mask), idx,
                                    static_cast<__m256i>(v), 4);
     })
@@ -4216,7 +4216,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_epi32(idx, std::ranges::data(in), 4));
+      return V(_mm512_i32gather_epi32(idx, Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4226,7 +4226,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                            static_cast<__mmask16>(mask), idx,
-                                           std::ranges::data(in), 4));
+                                           Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4241,7 +4241,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_epi32(std::ranges::data(out), idx,
+      _mm512_i32scatter_epi32(Impl::Ranges::data(out), idx,
                               static_cast<__m512i>(v), 4);
     })
 
@@ -4249,7 +4249,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_epi32(std::ranges::data(out),
+      _mm512_mask_i32scatter_epi32(Impl::Ranges::data(out),
                                    static_cast<__mmask16>(mask), idx,
                                    static_cast<__m512i>(v), 4);
     })
@@ -4267,7 +4267,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm256_i32gather_epi32(
-          reinterpret_cast<const int*>(std::ranges::data(in)), idx, 4));
+          reinterpret_cast<const int*>(Impl::Ranges::data(in)), idx, 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4277,7 +4277,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm256_mmask_i32gather_epi32(_mm256_set1_epi32(value_type{}),
                                             static_cast<__mmask8>(mask), idx,
-                                            std::ranges::data(in), 4));
+                                            Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4292,7 +4292,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_i32scatter_epi32(std::ranges::data(out), idx,
+      _mm256_i32scatter_epi32(Impl::Ranges::data(out), idx,
                               static_cast<__m256i>(v), 4);
     })
 
@@ -4300,7 +4300,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm256_mask_i32scatter_epi32(std::ranges::data(out),
+      _mm256_mask_i32scatter_epi32(Impl::Ranges::data(out),
                                    static_cast<__mmask8>(mask), idx,
                                    static_cast<__m256i>(v), 4);
     })
@@ -4317,7 +4317,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      return V(_mm512_i32gather_epi32(idx, std::ranges::data(in), 4));
+      return V(_mm512_i32gather_epi32(idx, Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4327,7 +4327,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
       return V(_mm512_mask_i32gather_epi32(_mm512_set1_epi32(value_type{}),
                                            static_cast<__mmask16>(mask), idx,
-                                           std::ranges::data(in), 4));
+                                           Impl::Ranges::data(in), 4));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4342,7 +4342,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_i32scatter_epi32(std::ranges::data(out), idx,
+      _mm512_i32scatter_epi32(Impl::Ranges::data(out), idx,
                               static_cast<__m512i>(v), 4);
     })
 
@@ -4350,7 +4350,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint32_t, simd_abi::avx512_fixed_size<16>, {
       __m512i idx = static_cast<__m512i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>>{indices});
-      _mm512_mask_i32scatter_epi32(std::ranges::data(out),
+      _mm512_mask_i32scatter_epi32(Impl::Ranges::data(out),
                                    static_cast<__mmask16>(mask), idx,
                                    static_cast<__m512i>(v), 4);
     })
@@ -4367,7 +4367,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_epi64(idx, std::ranges::data(in), 8));
+      return V(_mm512_i32gather_epi64(idx, Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4377,7 +4377,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
                                            static_cast<__mmask8>(mask), idx,
-                                           std::ranges::data(in), 8));
+                                           Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4392,7 +4392,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_epi64(std::ranges::data(out), idx,
+      _mm512_i32scatter_epi64(Impl::Ranges::data(out), idx,
                               static_cast<__m512i>(v), 8);
     })
 
@@ -4400,7 +4400,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::int64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_epi64(std::ranges::data(out),
+      _mm512_mask_i32scatter_epi64(Impl::Ranges::data(out),
                                    static_cast<__mmask8>(mask), idx,
                                    static_cast<__m512i>(v), 8);
     })
@@ -4417,7 +4417,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      return V(_mm512_i32gather_epi64(idx, std::ranges::data(in), 8));
+      return V(_mm512_i32gather_epi64(idx, Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -4427,7 +4427,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
       return V(_mm512_mask_i32gather_epi64(_mm512_set1_epi64(value_type{}),
                                            static_cast<__mmask8>(mask), idx,
-                                           std::ranges::data(in), 8));
+                                           Impl::Ranges::data(in), 8));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -4442,7 +4442,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_i32scatter_epi64(std::ranges::data(out), idx,
+      _mm512_i32scatter_epi64(Impl::Ranges::data(out), idx,
                               static_cast<__m512i>(v), 8);
     })
 
@@ -4450,7 +4450,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
     std::uint64_t, simd_abi::avx512_fixed_size<8>, {
       __m256i idx = static_cast<__m256i>(
           basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>>{indices});
-      _mm512_mask_i32scatter_epi64(std::ranges::data(out),
+      _mm512_mask_i32scatter_epi64(Impl::Ranges::data(out),
                                    static_cast<__mmask8>(mask), idx,
                                    static_cast<__m512i>(v), 8);
     })

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -12,12 +12,12 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 #include <impl/Kokkos_SIMD_Impl_Macros.hpp>
+#include <impl/Kokkos_SIMD_RangesCtorSupport.hpp>
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <utility>
 #include <type_traits>
-#include <ranges>
 
 namespace Kokkos {
 

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -3553,7 +3553,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_float64_t>(
-          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b64(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3562,7 +3562,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_float64_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3578,7 +3578,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b64(), Impl::Ranges::data(out), idx,
                           static_cast<vls_float64_t>(v));
     })
 
@@ -3587,8 +3587,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_float64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_float64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3605,7 +3606,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_float32_t>(
-          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b32(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3614,7 +3615,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_float32_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3630,7 +3631,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b32(), Impl::Ranges::data(out), idx,
                           static_cast<vls_float32_t>(v));
     })
 
@@ -3639,8 +3640,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_float32_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_float32_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3657,7 +3659,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_int32_t>(
-          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b32(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3666,7 +3668,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_int32_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3682,7 +3684,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b32(), Impl::Ranges::data(out), idx,
                           static_cast<vls_int32_t>(v));
     })
 
@@ -3691,8 +3693,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_int32_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_int32_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3709,7 +3712,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint32_t>(
-          svld1_gather_index(svptrue_b32(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b32(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3718,7 +3721,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint32_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3734,7 +3737,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b32(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b32(), Impl::Ranges::data(out), idx,
                           static_cast<vls_uint32_t>(v));
     })
 
@@ -3743,8 +3746,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int32_t idx = static_cast<vls_int32_t>(
           basic_simd<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_uint32_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_uint32_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3761,7 +3765,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_int64_t>(
-          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b64(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3770,7 +3774,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_int64_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3786,7 +3790,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b64(), Impl::Ranges::data(out), idx,
                           static_cast<vls_int64_t>(v));
     })
 
@@ -3795,8 +3799,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_int64_t idx = static_cast<vls_int64_t>(
           basic_simd<std::int64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_int64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_int64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(
@@ -3813,7 +3818,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint64_t>(
-          svld1_gather_index(svptrue_b64(), std::ranges::data(in), idx)));
+          svld1_gather_index(svptrue_b64(), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
@@ -3822,7 +3827,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_GATHER_FROM_WITH_MASK(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
       return V(static_cast<vls_uint64_t>(svld1_gather_index(
-          static_cast<vls_bool_t>(mask), std::ranges::data(in), idx)));
+          static_cast<vls_bool_t>(mask), Impl::Ranges::data(in), idx)));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_GATHER_FROM(
@@ -3838,7 +3843,7 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO(
       vls_uint64_t idx = static_cast<vls_uint64_t>(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(svptrue_b64(), std::ranges::data(out), idx,
+      svst1_scatter_index(svptrue_b64(), Impl::Ranges::data(out), idx,
                           static_cast<vls_uint64_t>(v));
     })
 
@@ -3847,8 +3852,9 @@ KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_UNCHECKED_SCATTER_TO_WITH_MASK(
       vls_uint64_t idx = static_cast<vls_uint64_t>(
           basic_simd<std::uint64_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>{indices});
-      svst1_scatter_index(static_cast<vls_bool_t>(mask), std::ranges::data(out),
-                          idx, static_cast<vls_uint64_t>(v));
+      svst1_scatter_index(static_cast<vls_bool_t>(mask),
+                          Impl::Ranges::data(out), idx,
+                          static_cast<vls_uint64_t>(v));
     })
 
 KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_PARTIAL_SCATTER_TO(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -518,9 +518,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void simd_partial_store(
   }
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
@@ -528,9 +528,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
   return basic_simd<T, simd_abi::scalar>(in[indices[0]]);
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
@@ -540,18 +540,18 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V unchecked_gather_from(
   return basic_simd<T, simd_abi::scalar>(val);
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const I& indices, simd_flags<Flags...> = simd_flag_default) {
   return unchecked_gather_from<V>(in, indices);
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
     R&& in, const typename I::mask_type& mask, const I& indices,
@@ -559,9 +559,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr V partial_gather_from(
   return unchecked_gather_from<V>(in, mask, indices);
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
     const V& v, R&& out, const I& indices,
@@ -569,9 +569,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
   out[indices[0]] = v[0];
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
     const V& v, R&& out, const typename I::mask_type& mask, const I& indices,
@@ -579,9 +579,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void unchecked_scatter_to(
   out[indices[0]] = (mask[0]) ? v[0] : typename V::value_type{};
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
     const V& v, R&& out, const I& indices,
@@ -589,9 +589,9 @@ KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
   unchecked_scatter_to<V>(v, out, indices);
 }
 
-template <Impl::SimdVecType V, std::ranges::contiguous_range R,
+template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,
           Impl::SimdIntegral I, typename... Flags>
-  requires std::ranges::sized_range<R> &&
+  requires Impl::Ranges::sized_range<R> &&
            std::same_as<typename V::abi_type, simd_abi::scalar>
 KOKKOS_FORCEINLINE_FUNCTION constexpr void partial_scatter_to(
     const V& v, R&& out, const typename I::mask_type& mask, const I& indices,

--- a/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
+++ b/simd/src/impl/Kokkos_SIMD_Impl_Macros.hpp
@@ -6,9 +6,9 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM(PREFIX, DATA_TYPE,    \
                                                     ABI_TYPE, EXPR)       \
-  template <Impl::SimdVecType V, std::ranges::contiguous_range R,         \
+  template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,        \
             Impl::SimdIntegral I, typename... Flags>                      \
-    requires std::ranges::sized_range<R> &&                               \
+    requires Impl::Ranges::sized_range<R> &&                              \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
       R&& in, const I& indices,                                           \
@@ -28,9 +28,9 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_GATHER_FROM_WITH_MASK(            \
     PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                    \
-  template <Impl::SimdVecType V, std::ranges::contiguous_range R,         \
+  template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,        \
             Impl::SimdIntegral I, typename... Flags>                      \
-    requires std::ranges::sized_range<R> &&                               \
+    requires Impl::Ranges::sized_range<R> &&                              \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>             \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr V PREFIX##_gather_from( \
       R&& in, const typename I::mask_type& mask, const I& indices,        \
@@ -50,9 +50,9 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO(PREFIX, DATA_TYPE,       \
                                                    ABI_TYPE, EXPR)          \
-  template <Impl::SimdVecType V, std::ranges::contiguous_range R,           \
+  template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,          \
             Impl::SimdIntegral I, typename... Flags>                        \
-    requires std::ranges::sized_range<R> &&                                 \
+    requires Impl::Ranges::sized_range<R> &&                                \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
       const V& v, R&& out, const I& indices,                                \
@@ -71,9 +71,9 @@
 
 #define KOKKOS_SIMD_IMPL_MEMORY_PERMUTE_SCATTER_TO_WITH_MASK(               \
     PREFIX, DATA_TYPE, ABI_TYPE, EXPR)                                      \
-  template <Impl::SimdVecType V, std::ranges::contiguous_range R,           \
+  template <Impl::SimdVecType V, Impl::Ranges::contiguous_range R,          \
             Impl::SimdIntegral I, typename... Flags>                        \
-    requires std::ranges::sized_range<R> &&                                 \
+    requires Impl::Ranges::sized_range<R> &&                                \
              std::same_as<V, basic_simd<DATA_TYPE, ABI_TYPE>>               \
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr void PREFIX##_scatter_to( \
       const V& v, R&& out, const typename I::mask_type& mask,               \

--- a/simd/src/impl/Kokkos_SIMD_RangesCtorSupport.hpp
+++ b/simd/src/impl/Kokkos_SIMD_RangesCtorSupport.hpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_SIMD_RANGES_HPP
+#define KOKKOS_SIMD_RANGES_HPP
+
+#include <Kokkos_Macros.hpp>
+
+// FIXME: Some of the compiler versions we support come with standard
+// library implementations which don't fully support C++20 ranges:
+// - LLVM Clang 14, 15
+// - AppleClang 14
+// This file implements the minimal set of functionality to make the SIMD type
+// ctors that take ranges work for types which otherwise would rely on ranges
+// interop (e.g. standard containers).
+#if defined(__cpp_lib_ranges) && (__cpp_lib_ranges >= 201911L)
+#define KOKKOS_IMPL_COMPILER_SUPPORTS_CXX20_RANGES
+#endif
+
+#if defined(KOKKOS_IMPL_COMPILER_SUPPORTS_CXX20_RANGES)
+#include <ranges>
+
+namespace Kokkos::Experimental::Impl::Ranges {
+using std::ranges::contiguous_range;
+using std::ranges::data;
+using std::ranges::range_value_t;
+using std::ranges::sized_range;
+}  // namespace Kokkos::Experimental::Impl::Ranges
+#else
+#include <iterator>
+
+namespace Kokkos::Experimental::Impl::Ranges {
+
+// Use another nested Impl namespace to prevent accidental explicit
+// usage of these symbols in the SIMD code - we want to only use
+// the minimal set necessary for the constructors that take ranges
+namespace Impl {
+// We need to rely on ADL but "using" declarations cannot be used inside a
+// requires clause, we use an immediately-invoked lambda returning the requires
+// clause as an alternative.
+template <class R>
+concept range = []() {
+  using std::begin;
+  using std::end;
+  return requires(R& r) {
+    begin(r);
+    end(r);
+  };
+}();
+
+inline constexpr auto begin = []<range R>(R&& r) {
+  using std::begin;
+  return begin(r);
+};
+
+template <class R>
+using iterator_t = decltype(begin(std::declval<R&>()));
+
+template <class R>
+using range_reference_t = decltype(*std::declval<iterator_t<R>&>());
+}  // namespace Impl
+
+inline constexpr auto data = []<Impl::range R>(R&& r) {
+  using std::data;
+  return data(r);
+};
+
+template <class R>
+concept sized_range = Impl::range<R> && []() {
+  using std::size;
+  return requires(R& r) { size(r); };
+}();
+
+template <class R>
+concept contiguous_range =
+    Impl::range<R> && requires(R& r, Impl::iterator_t<R>& it) {
+      { ++it } -> std::same_as<Impl::iterator_t<R>&>;
+      { --it } -> std::same_as<Impl::iterator_t<R>&>;
+      { it + 2 } -> std::same_as<Impl::iterator_t<R> >;
+      { it - 2 } -> std::same_as<Impl::iterator_t<R> >;
+      { it += 2 } -> std::same_as<Impl::iterator_t<R>&>;
+      { it -= 2 } -> std::same_as<Impl::iterator_t<R>&>;
+      {
+        it - it
+      } -> std::same_as<typename std::iterator_traits<
+          std::remove_cvref_t<Impl::iterator_t<R> > >::difference_type>;
+      { *it } -> std::same_as<Impl::range_reference_t<R> >;
+      { it[0] } -> std::same_as<Impl::range_reference_t<R> >;
+      { it < it } -> std::same_as<bool>;
+      { it > it } -> std::same_as<bool>;
+      { it <= it } -> std::same_as<bool>;
+      { it >= it } -> std::same_as<bool>;
+      requires std::is_same_v<decltype(data(r)),
+                              std::add_pointer_t<Impl::range_reference_t<R> > >;
+    };
+
+template <Impl::range R>
+using range_value_t = typename std::iterator_traits<
+    std::remove_cvref_t<Impl::iterator_t<R> > >::value_type;
+
+}  // namespace Kokkos::Experimental::Impl::Ranges
+#endif
+
+#endif


### PR DESCRIPTION
Cherry-pick of #9065 onto `release-candidate-5.1.1`.

Original PR: https://github.com/kokkos/kokkos/pull/9065