### PR TITLE
[5.1.1]  0  Resolve mismatch in View::extent and View::extent_int when querying extents larger than or equal to the rank of a view

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -373,7 +373,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   KOKKOS_INLINE_FUNCTION constexpr int extent_int(size_t r) const {
-    return static_cast<int>(base_t::extent(r));
+    return static_cast<int>(this->extent(r));
   }
   //----------------------------------------
   // Allow specializations to query their specialized map


### PR DESCRIPTION
Cherry-pick of #9072 onto `release-candidate-5.1.1`.

Original PR: https://github.com/kokkos/kokkos/pull/9072