### PR TITLE
[5.1.1]  1  Fix for issue #9087: Provide ROCM_PATH to rocthrust

### DIFF
--- a/cmake/Modules/FindTPLROCTHRUST.cmake
+++ b/cmake/Modules/FindTPLROCTHRUST.cmake
@@ -1,4 +1,4 @@
-find_package(rocthrust REQUIRED)
+find_package(rocthrust REQUIRED PATHS ${ROCM_PATH} $ENV{ROCM_PATH})
 kokkos_create_imported_tpl(ROCTHRUST INTERFACE LINK_LIBRARIES roc::rocthrust)
 
 # Export ROCTHRUST as a Kokkos dependency


### PR DESCRIPTION
Cherry-pick of #9101 onto `release-candidate-5.1.1`.

Original PR: https://github.com/kokkos/kokkos/pull/9101