### PR TITLE
Cuda: avoid batched RangePolicy path when StaticBatchSize is 1

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -99,7 +99,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     if constexpr (StaticBatchSize::batch_size != 1) {
       constexpr typename Policy::index_type batch_size =
           StaticBatchSize::batch_size;
-      nwork = range / batch_size + (range % batch_size == 0 ? 0 : 1);
+      nwork = (range + batch_size - 1) / batch_size;
     }
     cudaFuncAttributes attr =
         CudaParallelLaunch<ParallelFor, LaunchBounds>::get_cuda_func_attributes(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -8,6 +8,7 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 
 #include <Kokkos_Parallel.hpp>
@@ -91,7 +92,7 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     if constexpr (StaticBatchSize::batch_size != 1) {
       constexpr typename Policy::index_type batch_size =
           StaticBatchSize::batch_size;
-      nwork = (range + batch_size - 1) / batch_size;
+      nwork = (uint64_t(range) + batch_size - 1) / batch_size;
     }
     cudaFuncAttributes attr =
         CudaParallelLaunch<ParallelFor, LaunchBounds>::get_cuda_func_attributes(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -56,36 +56,51 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   Policy const& get_policy() const { return m_policy; }
 
   inline __device__ void operator()() const {
-    constexpr auto batch_size = Member(StaticBatchSize::batch_size);
-    const auto work_stride    = Member(blockDim.y) * gridDim.x;
-    const Member work_end     = m_policy.end();
+    const auto work_stride = Member(blockDim.y) * gridDim.x;
+    const Member work_end  = m_policy.end();
 
-    for (Member iwork = m_policy.begin() + threadIdx.y +
-                        static_cast<Member>(blockDim.y) * blockIdx.x;
-         iwork < work_end;
-         iwork =
-             iwork < static_cast<Member>(work_end - work_stride * batch_size)
-                 ? iwork + work_stride * batch_size
-                 : work_end) {
+    if constexpr (StaticBatchSize::batch_size == 1) {
+      for (Member iwork = m_policy.begin() + threadIdx.y +
+                          static_cast<Member>(blockDim.y) * blockIdx.x;
+           iwork < work_end;
+           iwork = iwork < static_cast<Member>(work_end - work_stride)
+                       ? iwork + work_stride
+                       : work_end) {
+        this->template exec_range<WorkTag>(iwork);
+      }
+    } else {
+      constexpr auto batch_size = Member(StaticBatchSize::batch_size);
+
+      for (Member iwork = m_policy.begin() + threadIdx.y +
+                          static_cast<Member>(blockDim.y) * blockIdx.x;
+           iwork < work_end;
+           iwork =
+               iwork < static_cast<Member>(work_end - work_stride * batch_size)
+                   ? iwork + work_stride * batch_size
+                   : work_end) {
 #if defined(KOKKOS_COMPILER_NVCC)
 #pragma unroll
 #endif
-      for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
-                         i < work_end - iwork;
-           i = (i < static_cast<Member>(work_end - work_stride - iwork))
-                   ? i + work_stride
-                   : work_end - iwork) {
-        this->template exec_range<WorkTag>(iwork + i);
+        for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
+                           i < work_end - iwork;
+             i = (i < static_cast<Member>(work_end - work_stride - iwork))
+                     ? i + work_stride
+                     : work_end - iwork) {
+          this->template exec_range<WorkTag>(iwork + i);
+        }
       }
     }
   }
 
   inline void execute() const {
-    constexpr typename Policy::index_type batch_size =
-        StaticBatchSize::batch_size;
-    const typename Policy::index_type nwork =
-        (m_policy.end() - m_policy.begin()) / batch_size +
-        ((m_policy.end() - m_policy.begin()) % batch_size == 0 ? 0 : 1);
+    const typename Policy::index_type range = m_policy.end() - m_policy.begin();
+    typename Policy::index_type nwork       = range;
+
+    if constexpr (StaticBatchSize::batch_size != 1) {
+      constexpr typename Policy::index_type batch_size =
+          StaticBatchSize::batch_size;
+      nwork = range / batch_size + (range % batch_size == 0 ? 0 : 1);
+    }
     cudaFuncAttributes attr =
         CudaParallelLaunch<ParallelFor, LaunchBounds>::get_cuda_func_attributes(
             m_policy.space().impl_internal_space_instance());

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -56,28 +56,20 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
   Policy const& get_policy() const { return m_policy; }
 
   inline __device__ void operator()() const {
-    const auto work_stride = Member(blockDim.y) * gridDim.x;
-    const Member work_end  = m_policy.end();
+    constexpr auto batch_size = Member(StaticBatchSize::batch_size);
+    const auto work_stride    = Member(blockDim.y) * gridDim.x;
+    const Member work_end     = m_policy.end();
 
-    if constexpr (StaticBatchSize::batch_size == 1) {
-      for (Member iwork = m_policy.begin() + threadIdx.y +
-                          static_cast<Member>(blockDim.y) * blockIdx.x;
-           iwork < work_end;
-           iwork = iwork < static_cast<Member>(work_end - work_stride)
-                       ? iwork + work_stride
-                       : work_end) {
+    for (Member iwork = m_policy.begin() + threadIdx.y +
+                        static_cast<Member>(blockDim.y) * blockIdx.x;
+         iwork < work_end;
+         iwork =
+             iwork < static_cast<Member>(work_end - work_stride * batch_size)
+                 ? iwork + work_stride * batch_size
+                 : work_end) {
+      if constexpr (batch_size == 1) {
         this->template exec_range<WorkTag>(iwork);
-      }
-    } else {
-      constexpr auto batch_size = Member(StaticBatchSize::batch_size);
-
-      for (Member iwork = m_policy.begin() + threadIdx.y +
-                          static_cast<Member>(blockDim.y) * blockIdx.x;
-           iwork < work_end;
-           iwork =
-               iwork < static_cast<Member>(work_end - work_stride * batch_size)
-                   ? iwork + work_stride * batch_size
-                   : work_end) {
+      } else {
 #if defined(KOKKOS_COMPILER_NVCC)
 #pragma unroll
 #endif


### PR DESCRIPTION
Add a dedicated CUDA path for `RangePolicy` when `StaticBatchSize::batch_size == 1`.

This avoids going through the batched/unrolled CUDA path in the default `batch_size == 1` case.

On local CUDA measurements, the current `StaticBatchSize<1>` path increases register pressure relative to the older non batched loop structure. A dedicated path for `batch_size == 1` removes that overhead.

## Register measurements

Using a local micro-benchmark, I observe cases such as:

- `4.7.2`: `128` registers
- `5.0.2`: `132` registers
- `5.1.0`: `132` registers
- patched build: `128` registers

and

- `4.7.2`: `164` registers
- `5.0.2`: `168` registers
- `5.1.0`: `168` registers
- patched build: `164` registers

Tested locally on an NVIDIA RTX 4000 Ada GPU with CUDA 13.1.

### Changelog Entry
Fix MDRange CUDA performance regression with static batch size 1 (Kokkos 5.0 PR: https://github.com/kokkos/kokkos/pull/8164)
