### PR TITLE
unreachable: Add `KOKKOS_IMPL_UNREACHABLE` macro

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -626,6 +626,7 @@ struct Random_UniqueIndex {
         (return DeviceType::execution_space::impl_hardware_thread_id();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 };
 
@@ -662,6 +663,7 @@ struct Random_UniqueIndex<
 
         return i;))
     KOKKOS_IF_ON_HOST(((void)locks_; return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 };
 

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -471,6 +471,7 @@ class OffsetView : public View<DataType, Properties...> {
     KOKKOS_IF_ON_HOST((return runtime_check_begins_ends_host(begins, ends);))
     KOKKOS_IF_ON_DEVICE(
         (return runtime_check_begins_ends_device(begins, ends);))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   // Constructor around unmanaged data after checking begins < ends for all

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -33,6 +33,7 @@ KOKKOS_FUNCTION constexpr auto dispatch_helper(T x) noexcept {
   KOKKOS_IF_ON_DEVICE((return Op<true, true>::do_compute(x);))
 #endif
 #endif
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 template <template <bool /*constant_evaluated*/, bool /*device*/> class Op,
@@ -40,11 +41,7 @@ template <template <bool /*constant_evaluated*/, bool /*device*/> class Op,
 KOKKOS_FUNCTION constexpr auto dispatch_helper_builtin(T x) noexcept {
   KOKKOS_IF_ON_HOST((return Op<false, false>::do_compute(x);))
   KOKKOS_IF_ON_DEVICE((return Op<false, true>::do_compute(x);))
-
-  // FIXME_NVHPC: erroneous warning about return from non-void function
-#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC)
-  return T();
-#endif
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 #if defined(KOKKOS_COMPILER_CLANG) || defined(KOKKOS_COMPILER_INTEL_LLVM) || \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -366,6 +366,21 @@
 #define KOKKOS_RESTRICT
 #endif
 
+// ---------------------------------------------------------------------------
+// Define macro for unreachable code:
+#if defined(__cpp_lib_unreachable)  // since C++23
+#include <utility>
+#define KOKKOS_IMPL_UNREACHABLE() std::unreachable()
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_unreachable)
+#define KOKKOS_IMPL_UNREACHABLE() __builtin_unreachable()
+#endif
+#endif
+
+#if !defined(KOKKOS_IMPL_UNREACHABLE)
+#define KOKKOS_IMPL_UNREACHABLE()
+#endif
+
 //----------------------------------------------------------------------------
 // Define Macro for alignment:
 

--- a/core/src/Kokkos_MathematicalFunctions.hpp
+++ b/core/src/Kokkos_MathematicalFunctions.hpp
@@ -285,10 +285,12 @@ using promote_3_t = typename promote_3<T, U, V>::type;
   KOKKOS_INLINE_FUNCTION bool FUNC(float x, float y) {                         \
     KOKKOS_IF_ON_DEVICE(return OP;)                                            \
     KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
+    KOKKOS_IMPL_UNREACHABLE();                                                 \
   }                                                                            \
   KOKKOS_INLINE_FUNCTION bool FUNC(double x, double y) {                       \
     KOKKOS_IF_ON_DEVICE(return OP;)                                            \
     KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
+    KOKKOS_IMPL_UNREACHABLE();                                                 \
   }                                                                            \
   inline bool FUNC(long double x, long double y) {                             \
     using std::FUNC;                                                           \
@@ -306,6 +308,7 @@ using promote_3_t = typename promote_3<T, U, V>::type;
     auto y         = static_cast<Promoted>(b);                                 \
     KOKKOS_IF_ON_DEVICE(return OP;)                                            \
     KOKKOS_IF_ON_HOST(using std::FUNC; return FUNC(x, y);)                     \
+    KOKKOS_IMPL_UNREACHABLE();                                                 \
   }                                                                            \
   template <class T1, class T2>                                                \
   inline std::enable_if_t<std::is_arithmetic_v<T1> &&                          \

--- a/core/src/Kokkos_MemoryPool.hpp
+++ b/core/src/Kokkos_MemoryPool.hpp
@@ -770,6 +770,7 @@ class MemoryPool {
       KOKKOS_IF_ON_DEVICE(
           (return SpaceAccessibility<DefaultExecutionSpace,
                                      base_memory_space>::accessible;))
+      KOKKOS_IMPL_UNREACHABLE();
     }();
 
     if (can_access_state_array) {

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -119,6 +119,7 @@ inline int OpenMP::impl_thread_pool_rank() noexcept {
   KOKKOS_IF_ON_HOST((return omp_get_thread_num();))
 
   KOKKOS_IF_ON_DEVICE((return -1;))
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 inline int OpenMP::impl_thread_pool_size(int depth) const {
@@ -130,6 +131,7 @@ int OpenMP::impl_hardware_thread_id() noexcept {
   KOKKOS_IF_ON_HOST((return omp_get_thread_num();))
 
   KOKKOS_IF_ON_DEVICE((return -1;))
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 namespace Tools {

--- a/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_UniqueToken.hpp
@@ -44,6 +44,7 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
     KOKKOS_IF_ON_HOST((return m_count;))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief acquire value such that 0 <= value < size()
@@ -65,6 +66,7 @@ class UniqueToken<OpenMP, UniqueTokenScope::Instance> {
          return result.first;))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief release a value acquired by generate
@@ -96,6 +98,7 @@ class UniqueToken<OpenMP, UniqueTokenScope::Global> {
         (return Kokkos::Impl::OpenMPInternal::max_hardware_threads();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief acquire value such that 0 <= value < size()
@@ -106,6 +109,7 @@ class UniqueToken<OpenMP, UniqueTokenScope::Global> {
     KOKKOS_IF_ON_HOST((return omp_get_thread_num();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief release a value acquired by generate

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -202,6 +202,8 @@ class ThreadsExecTeamMember {
         team_fan_out();
 
         return accum;))
+
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   template <typename ReducerType>
@@ -328,6 +330,7 @@ class ThreadsExecTeamMember {
         team_fan_out();
 
         return *work_value;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /** \brief  Intra-team exclusive prefix sum with team_rank() ordering.

--- a/core/src/Threads/Kokkos_Threads_UniqueToken.hpp
+++ b/core/src/Threads/Kokkos_Threads_UniqueToken.hpp
@@ -65,6 +65,7 @@ class UniqueToken<Threads, UniqueTokenScope::Instance> {
         }))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief release a value acquired by generate
@@ -95,6 +96,8 @@ class UniqueToken<Threads, UniqueTokenScope::Global> {
     KOKKOS_IF_ON_HOST((return Threads::impl_thread_pool_size();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief acquire value such that 0 <= value < size()
@@ -103,6 +106,8 @@ class UniqueToken<Threads, UniqueTokenScope::Global> {
     KOKKOS_IF_ON_HOST((return Threads::impl_thread_pool_rank();))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   /// \brief release a value acquired by generate

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -105,6 +105,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 uint64_t clock_tic() noexcept {
   KOKKOS_IF_ON_DEVICE((return clock_tic_device();))
   KOKKOS_IF_ON_HOST((return clock_tic_host();))
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_HostThreadTeam.hpp
+++ b/core/src/impl/Kokkos_HostThreadTeam.hpp
@@ -646,6 +646,7 @@ class HostThreadTeamMember {
     KOKKOS_IF_ON_DEVICE(((void)value; (void)global;
                          Kokkos::abort("HostThreadTeamMember team_scan\n");
                          return T();))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 };
 

--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -116,6 +116,7 @@ class SharedAllocationRecord<void, void> {
   static KOKKOS_FUNCTION int tracking_enabled() {
     KOKKOS_IF_ON_HOST(return t_tracking_enabled;)
     KOKKOS_IF_ON_DEVICE(return 0;)
+    KOKKOS_IMPL_UNREACHABLE();
   }
 #if defined(__EDG__)
 #pragma pop
@@ -503,6 +504,7 @@ class SharedAllocationRecord
         (return new SharedAllocationRecord(arg_space, arg_label, arg_alloc);))
     KOKKOS_IF_ON_DEVICE(
         ((void)arg_space; (void)arg_label; (void)arg_alloc; return nullptr;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   template <typename ExecutionSpace>
@@ -514,6 +516,7 @@ class SharedAllocationRecord
                                            arg_alloc);))
     KOKKOS_IF_ON_DEVICE(((void)exec_space; (void)arg_space; (void)arg_label;
                          (void)arg_alloc; return nullptr;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 };
 
@@ -593,6 +596,7 @@ union SharedAllocationTracker {
                        return (tmp ? tmp->use_count() : 0);))
 
     KOKKOS_IF_ON_DEVICE((return 0;))
+    KOKKOS_IMPL_UNREACHABLE();
   }
 
   KOKKOS_INLINE_FUNCTION bool has_record() const {

--- a/core/unit_test/TestExecSpaceThreadSafety.hpp
+++ b/core/unit_test/TestExecSpaceThreadSafety.hpp
@@ -15,18 +15,12 @@ import kokkos.core;
 
 namespace {
 
-#ifdef KOKKOS_COMPILER_NVHPC
-#define THREAD_SAFETY_TEST_UNREACHABLE() __builtin_unreachable()
-#else
-#define THREAD_SAFETY_TEST_UNREACHABLE() static_assert(true)
-#endif
-
 #ifdef KOKKOS_ENABLE_OPENACC  // FIXME_OPENACC
 #define KOKKOS_TEST_SKIP_IF_OPENACC()                                       \
   GTEST_SKIP()                                                              \
       << "skipping OpenACC test since unsupported host-side atomics cause " \
          "race conditions during shared allocation reference counting";     \
-  THREAD_SAFETY_TEST_UNREACHABLE();
+  KOKKOS_IMPL_UNREACHABLE();
 #else
 #define KOKKOS_TEST_SKIP_IF_OPENACC()
 #endif

--- a/core/unit_test/TestSubView_a.hpp
+++ b/core/unit_test/TestSubView_a.hpp
@@ -66,9 +66,7 @@ TEST(TEST_CATEGORY_DEATH, view_subview_wrong_extents) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
-#ifdef KOKKOS_COMPILER_NVHPC
-  __builtin_unreachable();
-#endif
+  KOKKOS_IMPL_UNREACHABLE();
 #endif
 
   TestViewSubview::test_subview_extents<1, TEST_EXECSPACE>();

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -82,18 +82,12 @@ struct DynamicRank<0> {
   using type = int;
 };
 
-#ifdef KOKKOS_COMPILER_NVHPC
-#define VIEW_CTOR_TEST_UNREACHABLE() __builtin_unreachable()
-#else
-#define VIEW_CTOR_TEST_UNREACHABLE() static_assert(true)
-#endif
-
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
-  VIEW_CTOR_TEST_UNREACHABLE();
+  KOKKOS_IMPL_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, DynamicRank>();  // dim = 0, dynamic = 0
@@ -122,7 +116,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
-  VIEW_CTOR_TEST_UNREACHABLE();
+  KOKKOS_IMPL_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, StaticRank>();  // dim = 0, dynamic = 0
@@ -151,7 +145,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
-  VIEW_CTOR_TEST_UNREACHABLE();
+  KOKKOS_IMPL_UNREACHABLE();
 #endif
 
   test_matching_arguments_rank<0, 0, MixedRank>();  // dim = 0, dynamic = 0
@@ -183,7 +177,7 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
 
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
-  VIEW_CTOR_TEST_UNREACHABLE();
+  KOKKOS_IMPL_UNREACHABLE();
 #endif
 
   // clang-format off
@@ -209,7 +203,5 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
 
 #undef CHECK_DEATH
 #undef CHECK_DEATH_UNMANAGED
-
-#undef VIEW_CTOR_TEST_UNREACHABLE
 
 }  // namespace Test

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -100,7 +100,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION static vls_bool_t get_pred(
   } else if constexpr (nbits == 64) {
     return svwhilele_b64(0, static_cast<std::int32_t>(lane));
   } else {
-    __builtin_unreachable();
+    KOKKOS_IMPL_UNREACHABLE();
   }
 }
 


### PR DESCRIPTION
Add a portable `KOKKOS_IMPL_UNREACHABLE()` macro, useful for suppressing warnings/errors like
```
error: non-void function does not return a value in all control paths [-Werror,-Wreturn-type]
```
and for providing optimization hints to compilers. Particularly useful for backends where `KOKKOS_IF_ON_HOST`/`KOKKOS_IF_ON_DEVICE` are resolved at compile time.

Insert `KOKKOS_IMPL_UNREACHABLE` after all pairs of `KOKKOS_IF_ON_HOST`/`KOKKOS_IF_ON_DEVICE` which always return or always abort.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

Split from #9100.

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
Not required, not a public-facing macro. A changelog entry would be required if this is renamed to `KOKKOS_UNREACHABLE`.
