### PR TITLE
Define is_view_ctor_property for all types ViewCtorProp can take

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2733,8 +2733,7 @@ resize(Kokkos::View<T, P...>& v, const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
 
 template <class I, class T, class... P>
 inline std::enable_if_t<
-    (Impl::is_view_ctor_property<I>::value ||
-     Kokkos::is_execution_space<I>::value) &&
+    Impl::is_view_ctor_property<I>::value &&
     (std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
                     Kokkos::LayoutLeft> ||
      std::is_same_v<typename Kokkos::View<T, P...>::array_layout,
@@ -2846,11 +2845,10 @@ inline void resize(const Impl::ViewCtorProp<ViewCtorArgs...>& arg_prop,
 }
 
 template <class I, class T, class... P>
-inline std::enable_if_t<Impl::is_view_ctor_property<I>::value ||
-                        Kokkos::is_execution_space<I>::value>
-resize(const I& arg_prop, Kokkos::View<T, P...>& v,
-       const typename Kokkos::View<T, P...>::array_layout& layout) {
-  impl_resize(arg_prop, v, layout);
+inline std::enable_if_t<Impl::is_view_ctor_property<I>::value> resize(
+    const I& arg_prop, Kokkos::View<T, P...>& v,
+    const typename Kokkos::View<T, P...>::array_layout& layout) {
+  impl_resize(Kokkos::view_alloc(arg_prop), v, layout);
 }
 
 template <class ExecutionSpace, class T, class... P>

--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -26,21 +26,6 @@ struct AccessorArg_t {
   size_t value{};
 };
 
-template <typename>
-struct is_view_ctor_property : public std::false_type {};
-
-template <>
-struct is_view_ctor_property<SequentialHostInit_t> : public std::true_type {};
-
-template <>
-struct is_view_ctor_property<WithoutInitializing_t> : public std::true_type {};
-
-template <>
-struct is_view_ctor_property<AllowPadding_t> : public std::true_type {};
-
-template <>
-struct is_view_ctor_property<AccessorArg_t> : public std::true_type {};
-
 //----------------------------------------------------------------------------
 /**\brief Whether a type can be used for a view label */
 
@@ -63,6 +48,30 @@ template <typename T>
 concept ViewLabel = is_view_label_v<T>;
 
 //----------------------------------------------------------------------------
+
+template <typename>
+struct is_view_ctor_property : public std::false_type {};
+
+template <>
+struct is_view_ctor_property<SequentialHostInit_t> : public std::true_type {};
+
+template <>
+struct is_view_ctor_property<WithoutInitializing_t> : public std::true_type {};
+
+template <>
+struct is_view_ctor_property<AllowPadding_t> : public std::true_type {};
+
+template <>
+struct is_view_ctor_property<AccessorArg_t> : public std::true_type {};
+
+template <ExecutionSpace ExecSpace>
+struct is_view_ctor_property<ExecSpace> : public std::true_type {};
+
+template <MemorySpace MemSpace>
+struct is_view_ctor_property<MemSpace> : public std::true_type {};
+
+template <ViewLabel Label>
+struct is_view_ctor_property<Label> : public std::true_type {};
 
 template <typename... P>
 struct ViewCtorProp;


### PR DESCRIPTION
Related to #9128. It makes sense for `is_view_ctor_property` to reflect all the types that be used for `ViewCtorProp`.
This allows cleaning up some constraints as well.
