### PR TITLE
Duplicate source file accumulation in CMake test generation

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -392,8 +392,8 @@ foreach(PairDeviceSpace HIP-HostPinned;HIP-Managed;Cuda-HostPinned;Cuda-UVM;SYCL
       file(WRITE ${dir}/dummy.cpp "#include <Test${DEVICE}${SPACE}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
       configure_file(${dir}/dummy.cpp ${file})
       list(APPEND ${DEVICE}_SOURCES3 ${file})
+      list(APPEND ${DEVICE}_SOURCES ${file})
     endforeach()
-    list(APPEND ${DEVICE}_SOURCES ${${DEVICE}_SOURCES3})
   endif()
 endforeach()
 


### PR DESCRIPTION
This PR fixes in `core/unit_test/CMakeLists.txt` where test files were being in the master `${DEVICE}_SOURCES` lists, unnecessary bloating compile times. 

In nested `foreach` loop generating `PairDeviceSpace` tests, the `${DEVICE}_SOURCE3` variable acts as an accumulator across different memory spaces. However, at the end of the loop, the entire accumulated was being appended to the master list: 
Because the accumalator was never emptied between memory space iteratins, test generated in the firstiteration werebeing dumped into the masterlist multiple times.

*Fix:*
Instead of dumping the entire accumulator the generation script now appends `${file}` directly the master `${DEVICE}_SOURCES` list one-by-one from inside the inner loop


*Test:*
Built and ran `CoreUnitTest_Cuda3` to mathematically verify that the CUDA chunking system still successfully compiles both `HostPinned` and `UVM` tests without regression.
### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Unsure
-->
