### PR TITLE
core(graph): ensure that the `get_device_handle` query returns the device associated with the node execution policy

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -106,11 +106,9 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   using Policy       = PolicyType;
   using graph_kernel = GraphNodeKernelImpl;
 
-  // TODO Ensure the execution space of the graph is the same as the one
-  //      attached to the policy?
   // TODO @graph kernel name info propagation
   template <class PolicyDeduced, class... ArgsDeduced>
-  GraphNodeKernelImpl(std::string label_, Cuda const&, Functor arg_functor,
+  GraphNodeKernelImpl(std::string label_, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
       // This is super ugly, but it works for now and is the most minimal change
       // to the codebase for now...
@@ -118,11 +116,9 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
                (ArgsDeduced&&)args...),
         label(std::move(label_)) {}
 
-  // FIXME @graph Forward through the instance once that works in the backends
   template <class PolicyDeduced>
-  GraphNodeKernelImpl(Kokkos::Cuda const& ex, Functor arg_functor,
-                      PolicyDeduced&& arg_policy)
-      : GraphNodeKernelImpl("[unlabeled]", ex, std::move(arg_functor),
+  GraphNodeKernelImpl(Functor arg_functor, PolicyDeduced&& arg_policy)
+      : GraphNodeKernelImpl("[unlabeled]", std::move(arg_functor),
                             (PolicyDeduced&&)arg_policy) {}
 
   void set_cuda_graph_ptr(cudaGraph_t* arg_graph_ptr) {

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -83,16 +83,15 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
  public:
   template <typename PolicyDeduced, typename... ArgsDeduced>
-  GraphNodeKernelImpl(std::string label_, HIP const&, Functor arg_functor,
+  GraphNodeKernelImpl(std::string label_, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
       : base_t(std::move(arg_functor), (PolicyDeduced&&)arg_policy,
                (ArgsDeduced&&)args...),
         label(std::move(label_)) {}
 
   template <typename PolicyDeduced>
-  GraphNodeKernelImpl(Kokkos::HIP const& exec_space, Functor arg_functor,
-                      PolicyDeduced&& arg_policy)
-      : GraphNodeKernelImpl("[unlabeled]", exec_space, std::move(arg_functor),
+  GraphNodeKernelImpl(Functor arg_functor, PolicyDeduced&& arg_policy)
+      : GraphNodeKernelImpl("[unlabeled]", std::move(arg_functor),
                             (PolicyDeduced&&)arg_policy) {}
 
   void set_hip_graph_ptr(hipGraph_t* arg_graph_ptr) {

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -132,7 +132,8 @@ class GraphNodeRef {
   // TODO kernel name propagation and exposure
 
   template <class NextKernelDeduced>
-  auto _then_kernel(NextKernelDeduced&& arg_kernel) const {
+  auto _then_kernel(const device_handle_t& device_handle,
+                    NextKernelDeduced&& arg_kernel) const {
     static_assert(
         Kokkos::Impl::is_graph_kernel_v<std::remove_cvref_t<NextKernelDeduced>>,
         "Kokkos internal error");
@@ -148,8 +149,7 @@ class GraphNodeRef {
         m_graph_impl,
         Kokkos::Impl::GraphAccess::make_node_shared_ptr<
             typename return_t::node_impl_t>(
-            m_node_impl->get_device_handle(),
-            Kokkos::Impl::_graph_node_kernel_ctor_tag{},
+            device_handle, Kokkos::Impl::_graph_node_kernel_ctor_tag{},
             (NextKernelDeduced&&)arg_kernel,
             // *this is the predecessor
             Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
@@ -235,13 +235,14 @@ class GraphNodeRef {
                                         std::remove_cvref_t<Functor>>;
     auto graph_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_ptr))
-    auto full_props = Kokkos::Impl::with_properties_if_unset(
-        std::forward<Props>(props), graph_ptr->get_device_handle(),
-        "[unlabeled]");
-    return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        std::forward<Policy>(policy), std::forward<Functor>(functor)});
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_ptr->get_device_handle(),
+            "[unlabeled]");
+    return this->_then_kernel(
+        device_handle, next_kernel_t{std::move(label), device_handle.m_exec,
+                                     std::forward<Policy>(policy),
+                                     std::forward<Functor>(functor)});
   }
 
   template <typename Props, typename Functor>
@@ -378,7 +379,7 @@ class GraphNodeRef {
           m_graph_impl,
           Kokkos::Impl::GraphAccess::make_node_shared_ptr<
               typename return_t::node_impl_t>(
-              m_node_impl->get_device_handle(),
+              Kokkos::Experimental::get_device_handle(exec),
               Kokkos::Impl::_graph_node_capture_ctor_tag{},
               std::forward<Functor>(functor),
               Kokkos::Impl::_graph_node_predecessor_ctor_tag{}, *this));
@@ -410,15 +411,16 @@ class GraphNodeRef {
 
     auto graph_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_ptr))
-    auto full_props =
-        with_properties_if_unset(std::forward<Props>(props),
-                                 graph_ptr->get_device_handle(), "[unlabeled]");
+
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_ptr->get_device_handle(),
+            "[unlabeled]");
 
     using policy_type = std::remove_cvref_t<Policy>;
     auto policy       = Experimental::require(
-        policy_type(
-            Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
-            Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        policy_type(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+                          device_handle.m_exec),
         Kokkos::Impl::KernelInGraphProperty{});
 
     using next_policy_t = decltype(policy);
@@ -426,10 +428,9 @@ class GraphNodeRef {
         Kokkos::Impl::GraphNodeKernelImpl<ExecutionSpace, next_policy_t,
                                           std::decay_t<Functor>,
                                           Kokkos::ParallelForTag>;
-    return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        (Functor&&)functor, std::move(policy)});
+    return this->_then_kernel(
+        std::move(device_handle),
+        next_kernel_t{std::move(label), (Functor&&)functor, std::move(policy)});
   }
 
   template <class Policy, class Functor>
@@ -498,10 +499,6 @@ class GraphNodeRef {
     // needs static assertion of constraint:
     //   DataParallelReductionFunctor<Functor, ReturnType>
 
-    auto full_props = with_properties_if_unset(
-        std::forward<Props>(props), graph_impl_ptr->get_device_handle(),
-        "[unlabeled]");
-
     // This is also just an expectation, but it's one that we expect the user
     // to interact with (even in release mode), so we should throw an exception
     // with an explanation rather than just doing a contract assertion.
@@ -556,11 +553,15 @@ class GraphNodeRef {
     // End of Kokkos reducer disaster
     //----------------------------------------
 
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_impl_ptr->get_device_handle(),
+            "[unlabeled]");
+
     using policy_type = std::remove_cvref_t<Policy>;
     auto policy       = Experimental::require(
-        policy_type(
-            Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
-            Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        policy_type(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+                          device_handle.m_exec),
         Kokkos::Impl::KernelInGraphProperty{});
 
     using passed_reducer_type = typename return_value_adapter::reducer_type;
@@ -587,12 +588,12 @@ class GraphNodeRef {
                                           decltype(functor_reducer),
                                           Kokkos::ParallelReduceTag>;
 
-    return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        std::move(functor_reducer), std::move(policy),
-        return_value_adapter::return_value(return_value,
-                                           std::forward<Functor>(functor))});
+    return this->_then_kernel(
+        std::move(device_handle),
+        next_kernel_t{std::move(label), std::move(functor_reducer),
+                      std::move(policy),
+                      return_value_adapter::return_value(
+                          return_value, std::forward<Functor>(functor))});
   }
 
   template <class Policy, class Functor, class ReturnType>

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -80,17 +80,16 @@ class GraphNodeKernelImpl<Kokkos::SYCL, PolicyType, Functor, PatternTag,
       typename PatternImplSpecializationFromTag<PatternTag, Functor, Policy,
                                                 Args..., Kokkos::SYCL>::type;
 
-  // TODO use the name and executionspace
+  // TODO use the name
   template <typename PolicyDeduced, typename... ArgsDeduced>
-  GraphNodeKernelImpl(std::string, Kokkos::SYCL const&, Functor arg_functor,
+  GraphNodeKernelImpl(std::string, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
       : base_t(std::move(arg_functor), (PolicyDeduced&&)arg_policy,
                (ArgsDeduced&&)args...) {}
 
   template <typename PolicyDeduced>
-  GraphNodeKernelImpl(Kokkos::SYCL const& exec_space, Functor arg_functor,
-                      PolicyDeduced&& arg_policy)
-      : GraphNodeKernelImpl("", exec_space, std::move(arg_functor),
+  GraphNodeKernelImpl(Functor arg_functor, PolicyDeduced&& arg_policy)
+      : GraphNodeKernelImpl("[unlabeled]", std::move(arg_functor),
                             (PolicyDeduced&&)arg_policy) {}
 
   void set_sycl_graph_ptr(

--- a/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
+++ b/core/src/impl/Kokkos_Default_GraphNodeKernel.hpp
@@ -71,18 +71,16 @@ class GraphNodeKernelImpl
 
   // TODO @graph kernel name info propagation
   template <class PolicyDeduced, class... ArgsDeduced>
-  GraphNodeKernelImpl(std::string const &, ExecutionSpace const &,
-                      Functor arg_functor, PolicyDeduced &&arg_policy,
-                      ArgsDeduced &&...args)
+  GraphNodeKernelImpl(std::string const &, Functor arg_functor,
+                      PolicyDeduced &&arg_policy, ArgsDeduced &&...args)
       : execute_kernel_vtable_base_t(arg_policy.space()),
         base_t(std::move(arg_functor), (PolicyDeduced &&)arg_policy,
                (ArgsDeduced &&)args...) {}
 
-  // FIXME @graph Forward through the instance once that works in the backends
   template <class PolicyDeduced, class... ArgsDeduced>
-  GraphNodeKernelImpl(ExecutionSpace const &ex, Functor arg_functor,
-                      PolicyDeduced &&arg_policy, ArgsDeduced &&...args)
-      : GraphNodeKernelImpl("", ex, std::move(arg_functor),
+  GraphNodeKernelImpl(Functor arg_functor, PolicyDeduced &&arg_policy,
+                      ArgsDeduced &&...args)
+      : GraphNodeKernelImpl("[unlabeled]", std::move(arg_functor),
                             (PolicyDeduced &&)arg_policy,
                             (ArgsDeduced &&)args...) {
     // FIXME This constructor seem unused.

--- a/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
+++ b/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
@@ -76,60 +76,37 @@ constexpr bool is_node_props_v = is_node_props<T>::value;
 template <typename T>
 concept NodeProperties = is_node_props_v<T>;
 
-template <typename Prop, NodeProperties Props>
-  requires Props::template
-has<Prop> [[nodiscard]] constexpr decltype(auto) get_property(
-    const Props& props) {
-  return static_cast<const NodeCtorProp<Prop>&>(props).m_value;
+template <typename Prop, typename PropsContainer>
+  requires(NodeProperties<std::remove_cvref_t<PropsContainer>> &&
+           std::remove_cvref_t<PropsContainer>::template has<Prop>)
+[[nodiscard]] constexpr decltype(auto) get_property(PropsContainer&& props) {
+  using base_t = std::conditional_t<
+      std::is_const_v<std::remove_reference_t<PropsContainer>>,
+      const NodeCtorProp<Prop>, NodeCtorProp<Prop>>;
+  return Kokkos::Impl::forward_like<PropsContainer>(
+      static_cast<base_t&>(props).m_value);
 }
 
-template <typename Prop, NodeProperties Props>
-  requires Props::template
-has<Prop> [[nodiscard]] constexpr decltype(auto) extract_property(
-    Props& props) {
-  return std::move(static_cast<NodeCtorProp<Prop>&>(props).m_value);
-}
-
-struct WithProperty {
-  template <typename... Props, typename Property>
-    requires(sizeof...(Props) > 0)
-  [[nodiscard]] static constexpr decltype(auto) set(
-      NodeCtorProps<Props...> props, Property&& property) {
-    using NewNodeCtorProps =
-        typename NodeCtorProps<Props...,
-                               std::remove_cvref_t<Property>>::uniform_type;
-    return NewNodeCtorProps{extract_property<Props>(props)...,
-                            std::forward<Property>(property)};
-  }
-
-  template <typename Property>
-  [[nodiscard]] static constexpr decltype(auto) set(NodeCtorProps<>,
-                                                    Property&& prop) {
-    return typename NodeCtorProps<std::remove_cvref_t<Property>>::uniform_type{
-        std::forward<Property>(prop)};
-  }
-};
-
-template <NodeProperties Props>
-[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
-    Props node_props) noexcept {
-  return node_props;
-}
-
-template <NodeProperties Props, typename Property, typename... Properties>
-[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
-    Props node_props, [[maybe_unused]] Property&& property,
-    Properties&&... properties) {
-  if constexpr (!Props::template has<typename Kokkos::Impl::NodeCtorProp<
-                    std::remove_cvref_t<Property>>::value_type>) {
-    return with_properties_if_unset(
-        WithProperty::set(std::move(node_props),
-                          std::forward<Property>(property)),
-        std::forward<Properties>(properties)...);
-  } else {
-    return with_properties_if_unset(std::move(node_props),
-                                    std::forward<Properties>(properties)...);
-  }
+template <typename... Props, typename PropsContainer, typename... Defaults>
+  requires(NodeProperties<std::remove_cvref_t<PropsContainer>> &&
+           (std::convertible_to<Defaults, Props> && ...))
+[[nodiscard]] constexpr auto get_properties_or(PropsContainer&& props,
+                                               Defaults&&... defaults)
+    -> std::tuple<Props...> {
+  using props_container_t = std::remove_cvref_t<PropsContainer>;
+  constexpr bool is_base_const =
+      std::is_const_v<std::remove_reference_t<PropsContainer>>;
+  return {[&]() -> decltype(auto) {
+    if constexpr (props_container_t::template has<Props>) {
+      using base_t =
+          std::conditional_t<is_base_const, const NodeCtorProp<Props>,
+                             NodeCtorProp<Props>>;
+      return Kokkos::Impl::forward_like<PropsContainer>(
+          static_cast<base_t&>(props).m_value);
+    } else {
+      return std::forward<Defaults>(defaults);
+    }
+  }()...};
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -76,7 +76,7 @@ struct GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
   // </editor-fold> end no other constructors }}}2
   //----------------------------------------------------------------------------
 
-  device_handle_t get_device_handle() const {
+  const device_handle_t& get_device_handle() const {
     return this->device_handle_storage_base_t::instance();
   }
 

--- a/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeThenImpl.hpp
@@ -49,8 +49,7 @@ struct GraphNodeThenImpl
   template <typename Label, typename T>
   GraphNodeThenImpl(Label&& label_, const ExecutionSpace& exec, ThenPolicyType,
                     T&& functor)
-      : base_t(std::forward<Label>(label_), exec,
-               wrapper_t{std::forward<T>(functor)},
+      : base_t(std::forward<Label>(label_), wrapper_t{std::forward<T>(functor)},
                inner_policy_t(exec, 0, 1)) {}
 };
 

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -50,6 +50,30 @@ KOKKOS_FUNCTION constexpr std::underlying_type_t<E> to_underlying(
   return static_cast<std::underlying_type_t<E>>(e);
 }
 
+#if defined(__cpp_lib_forward_like)
+// since C++23
+using std::forward_like;
+#else
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2445r0.pdf
+template <typename T, typename U>
+using override_ref_t = std::conditional_t<std::is_rvalue_reference_v<T>,
+                                          std::remove_reference_t<U> &&, U &>;
+
+template <typename T, typename U>
+using copy_const_t =
+    std::conditional_t<std::is_const_v<std::remove_reference_t<T>>, U const, U>;
+
+template <typename T, typename U>
+using forward_like_t =
+    override_ref_t<T &&, copy_const_t<T, std::remove_reference_t<U>>>;
+
+template <typename T>
+[[nodiscard]] constexpr auto forward_like(auto &&x) noexcept
+    -> forward_like_t<T, decltype(x)> {
+  return static_cast<forward_like_t<T, decltype(x)>>(x);
+}
+#endif
+
 #if defined(__cpp_lib_is_scoped_enum)
 // since C++23
 using std::is_scoped_enum;

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1650,4 +1650,56 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), team_launch_bounds_in_graph) {
   }
 }
 
+// Ensure that node properties can be passed by const ref.
+TEST_F(TEST_CATEGORY_FIXTURE(graph), property_by_const_ref) {
+  Kokkos::Experimental::Graph<TEST_EXECSPACE> graph{};
+
+  const auto node_props = Kokkos::Experimental::node_props(
+      "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+
+  auto node_then = graph.root_node().then(node_props, NoOp{});
+  auto node_pfor = node_then.then_parallel_for(
+      node_props, Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), NoOp{});
+  auto node_pred = node_pfor.then_parallel_reduce(
+      node_props, Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
+      NoOpReduceFunctor<TEST_EXECSPACE, int>{}, count);
+}
+
+// Check that node device handles are correct.
+TEST_F(TEST_CATEGORY_FIXTURE(graph), node_device_handle) {
+  const auto [exec_A, exec_B, exec_C, exec_D] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1, 1, 1, 1);
+
+  const auto device_handle_A = Kokkos::Experimental::get_device_handle(exec_A);
+  const auto device_handle_B = Kokkos::Experimental::get_device_handle(exec_B);
+  const auto device_handle_C = Kokkos::Experimental::get_device_handle(exec_C);
+  const auto device_handle_D = Kokkos::Experimental::get_device_handle(exec_D);
+
+  Kokkos::Experimental::Graph<TEST_EXECSPACE> graph{};
+
+  const auto node_A = graph.root_node().then_parallel_for(
+      Kokkos::Experimental::node_props(device_handle_A),
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), NoOp{});
+  const auto node_B =
+      node_A.then(Kokkos::Experimental::node_props(device_handle_B), NoOp{});
+  const auto node_C =
+      node_A.then(Kokkos::Experimental::node_props(device_handle_C), NoOp{});
+  const auto node_D =
+      Kokkos::Experimental::when_all(node_B, node_C)
+          .then(Kokkos::Experimental::node_props(device_handle_D), NoOp{});
+
+  ASSERT_EQ(
+      Kokkos::Impl::GraphAccess::get_node_ptr(node_A)->get_device_handle(),
+      device_handle_A);
+  ASSERT_EQ(
+      Kokkos::Impl::GraphAccess::get_node_ptr(node_B)->get_device_handle(),
+      device_handle_B);
+  ASSERT_EQ(
+      Kokkos::Impl::GraphAccess::get_node_ptr(node_C)->get_device_handle(),
+      device_handle_C);
+  ASSERT_EQ(
+      Kokkos::Impl::GraphAccess::get_node_ptr(node_D)->get_device_handle(),
+      device_handle_D);
+}
+
 }  // end namespace Test

--- a/core/unit_test/TestGraphNodeCtorProps.hpp
+++ b/core/unit_test/TestGraphNodeCtorProps.hpp
@@ -117,69 +117,45 @@ TEST(TEST_CATEGORY, node_props_label_device_handle) {
       Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
 }
 
-TEST(TEST_CATEGORY, node_props_with_properties_if_unset) {
-  {
-    const auto props_label_device_handle_old = Kokkos::Experimental::node_props(
-        "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
-    const auto props_label_device_handle_new =
-        Kokkos::Impl::with_properties_if_unset(props_label_device_handle_old,
-                                               "another label");
+TEST(TEST_CATEGORY, node_props_get_properties_or) {
+  const auto device_handle =
+      Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{});
 
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle_old),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle_new),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+  auto empty              = Kokkos::Experimental::node_props();
+  auto prop_label         = Kokkos::Experimental::node_props("label");
+  auto prop_device_handle = Kokkos::Experimental::node_props(device_handle);
+  auto props = Kokkos::Experimental::node_props("label", device_handle);
 
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle_old),
-        "label");
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle_new),
-        "label");
-  }
+  using device_handle_t = Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>;
 
   {
-    const auto props_empty = Kokkos::Experimental::node_props();
-    const auto props_label_device_handle =
-        Kokkos::Impl::with_properties_if_unset(
-            props_empty, "label", Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
-
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
-
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle),
-        "label");
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
-            props_label_device_handle),
-        Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+    const auto [d_h, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(empty), device_handle, "[unlabeled]");
+    ASSERT_EQ(d_h, device_handle);
+    ASSERT_EQ(label, "[unlabeled]");
   }
-}
-
-TEST(TEST_CATEGORY, node_props_get_property) {
-  auto props = Kokkos::Experimental::node_props(
-      "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
-
-  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
-  ASSERT_EQ(
-      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
-          props),
-      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
-
-  const auto label = Kokkos::Impl::extract_property<std::string>(props);
-
-  ASSERT_EQ(label, "label");
-  ASSERT_TRUE(Kokkos::Impl::get_property<std::string>(props).empty());
+  {
+    const auto [d_h, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(prop_label), device_handle, "[unlabeled]");
+    ASSERT_EQ(d_h, device_handle);
+    ASSERT_EQ(label, "label");
+  }
+  {
+    const auto [d_h, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(prop_device_handle), device_handle, "[unlabeled]");
+    ASSERT_EQ(d_h, device_handle);
+    ASSERT_EQ(label, "[unlabeled]");
+  }
+  {
+    const auto [label, d_h] =
+        Kokkos::Impl::get_properties_or<std::string, device_handle_t>(
+            std::move(props), "[unlabeled]", device_handle);
+    ASSERT_EQ(d_h, device_handle);
+    ASSERT_EQ(label, "label");
+  }
 }
 
 }  // end namespace


### PR DESCRIPTION
When selecting the device a node should run on, both the node execution policy (if relevant) and the `get_device_handle` should agree.

The main change of this PR is the removal of the execution space instance from all `GraphNodeKernelImpl` constructors, since we mandate it be the same as the one in the execution policy.

I've also cleaned the node properties helpers, it's much cleaner now. There is only `get_properties_or` that is used in the code, which will properly "extract" the properties when the incoming properties are *rvalues*.

### Changelog Entry

It think it is a required change log entry (big bug fix).