### PR TITLE
[HPX] Fix CI: team reduce buffer fix, unregister finalized execution spaces

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -16,6 +16,7 @@ import kokkos.core;
 #include <HPX/Kokkos_HPX.hpp>
 
 #include <impl/Kokkos_ExecSpaceManager.hpp>
+#include <impl/Kokkos_Error.hpp>
 
 #include <hpx/condition_variable.hpp>
 #include <hpx/init.hpp>
@@ -167,6 +168,13 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
       const int clamped   = (requested > 0 && available > 0)
                                 ? std::min(requested, available)
                                 : requested;
+      if (clamped != requested) {
+        Kokkos::Impl::log_warning("Requested " + std::to_string(requested) +
+                                  " threads, but HPX only allows " +
+                                  std::to_string(available) +
+                                  "; Setting the number of threads to " +
+                                  std::to_string(clamped) + ".");
+      }
       i.cfg.emplace_back("hpx.os_threads=" + std::to_string(clamped));
     }
     int argc_hpx     = 1;
@@ -189,9 +197,6 @@ void HPX::impl_finalize() {
   m_default_instance_data = nullptr;
 
   if (m_hpx_initialized) {
-    // Draining the instance sender (fence + ~instance_data) may run HPX work
-    // that stops the runtime before we get here, in which case
-    // get_runtime_ptr() is already null. Only finalize/stop when still active.
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {
 #if HPX_VERSION_FULL >= 0x010900

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -117,15 +117,18 @@ void HPX::impl_instance_fence(const std::string &name) const {
 }
 
 void HPX::impl_static_fence(const std::string &name) {
+  // Check if runtime still valid and return if not.
+  if (hpx::get_runtime_ptr() == nullptr) return;
+
   Kokkos::Tools::Experimental::Impl::profile_fence_event<
       Kokkos::Experimental::HPX>(
       name,
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::
           GlobalDeviceSynchronization,
       [&]() {
-        auto &s = HPX().impl_get_sender();
-
-        std::unique_lock<hpx::spinlock> l(HPX().impl_get_sender_mutex());
+        auto &s = m_default_instance_data.m_sender;
+        std::unique_lock<hpx::spinlock> l(
+            m_default_instance_data.m_sender_mutex);
 
         // This is a loose fence. Any work scheduled before this will be waited
         // for, but work scheduled while waiting may also be waited for.

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -78,7 +78,7 @@ std::atomic<uint32_t> HPX::m_next_instance_id{HPX::impl_default_instance_id() +
 uint32_t HPX::m_active_parallel_region_count{0};
 hpx::spinlock HPX::m_active_parallel_region_count_mutex;
 hpx::condition_variable_any HPX::m_active_parallel_region_count_cond;
-HPX::instance_data HPX::m_default_instance_data;
+Kokkos::Impl::HostSharedPtr<HPX::instance_data> HPX::m_default_instance_data;
 
 void HPX::print_configuration(std::ostream &os, const bool) const {
   os << "Host Parallel Execution Space\n";
@@ -126,9 +126,9 @@ void HPX::impl_static_fence(const std::string &name) {
       Kokkos::Tools::Experimental::SpecialSynchronizationCases::
           GlobalDeviceSynchronization,
       [&]() {
-        auto &s = m_default_instance_data.m_sender;
+        auto &s = m_default_instance_data->m_sender;
         std::unique_lock<hpx::spinlock> l(
-            m_default_instance_data.m_sender_mutex);
+            m_default_instance_data->m_sender_mutex);
 
         // This is a loose fence. Any work scheduled before this will be waited
         // for, but work scheduled while waiting may also be waited for.
@@ -173,9 +173,18 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
 
     m_hpx_initialized = true;
   }
+
+  // Create the default instance data.
+  m_default_instance_data = Kokkos::Impl::HostSharedPtr(new instance_data());
 }
 
 void HPX::impl_finalize() {
+  m_default_instance_data->fence(
+      "Kokkos::Experimental::HPX: fence "
+      "to drain internal sender on finalize");
+
+  m_default_instance_data = nullptr;
+
   if (m_hpx_initialized) {
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -117,9 +117,6 @@ void HPX::impl_instance_fence(const std::string &name) const {
 }
 
 void HPX::impl_static_fence(const std::string &name) {
-  // Check if runtime still valid and return if not.
-  if (hpx::get_runtime_ptr() == nullptr) return;
-
   Kokkos::Tools::Experimental::Impl::profile_fence_event<
       Kokkos::Experimental::HPX>(
       name,

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -163,8 +163,14 @@ void HPX::impl_initialize(InitializationSettings const &settings) {
   if (rt == nullptr) {
     hpx::init_params i;
     if (settings.has_num_threads()) {
-      i.cfg.emplace_back("hpx.os_threads=" +
-                         std::to_string(settings.get_num_threads()));
+      // HPX throws if asked to oversubscribe beyond available processing units.
+      // KOKKOS_NUM_THREADS can be larger than what HPX allows, so clamp.
+      const int requested = settings.get_num_threads();
+      const int available = hpx::threads::hardware_concurrency();
+      const int clamped   = (requested > 0 && available > 0)
+                                ? std::min(requested, available)
+                                : requested;
+      i.cfg.emplace_back("hpx.os_threads=" + std::to_string(clamped));
     }
     int argc_hpx     = 1;
     char name[]      = "kokkos_hpx";
@@ -186,6 +192,9 @@ void HPX::impl_finalize() {
   m_default_instance_data = nullptr;
 
   if (m_hpx_initialized) {
+    // Draining the instance sender (fence + ~instance_data) may run HPX work
+    // that stops the runtime before we get here, in which case
+    // get_runtime_ptr() is already null. Only finalize/stop when still active.
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {
 #if HPX_VERSION_FULL >= 0x010900
@@ -194,11 +203,8 @@ void HPX::impl_finalize() {
       hpx::apply([]() { hpx::finalize(); });
 #endif
       hpx::stop();
-    } else {
-      Kokkos::abort(
-          "Kokkos::Experimental::HPX::impl_finalize: Kokkos started "
-          "HPX but something else already stopped HPX\n");
     }
+    m_hpx_initialized = false;
   }
 }
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -124,7 +124,12 @@ class HPX {
     instance_data() = default;
     // NOLINTNEXTLINE(bugprone-exception-escape)
     ~instance_data() {
-      fence("Kokkos::Experimental::HPX: fence on destruction");
+      // The HPX runtime may already be shut down (e.g. if finalization is
+      // triggered while draining work). Avoid calling into HPX when the runtime
+      // is no longer active.
+      if (hpx::get_runtime_ptr() != nullptr) {
+        fence("Kokkos::Experimental::HPX: fence on destruction");
+      }
     }
     instance_data(uint32_t instance_id) : m_instance_id(instance_id) {}
     instance_data(uint32_t instance_id,
@@ -137,11 +142,13 @@ class HPX {
     instance_data &operator=(instance_data)         = delete;
 
     void fence(const std::string &name) {
+      if (hpx::get_runtime_ptr() == nullptr) return;
       std::lock_guard<hpx::spinlock> l(m_sender_mutex);
       fence_locked(name);
     }
 
     void fence_locked(const std::string &name) {
+      if (hpx::get_runtime_ptr() == nullptr) return;
       Kokkos::Tools::Experimental::Impl::profile_fence_event<
           Kokkos::Experimental::HPX>(
           name,
@@ -1579,7 +1586,7 @@ class ParallelReduce<CombinedFunctorReducerType,
     const auto buffer_size = std::min(nchunks, num_worker_threads);
     buffer.resize(buffer_size, value_size + m_shared);
 
-    for (int t = 0; t < num_worker_threads; ++t) {
+    for (int t = 0; t < buffer_size; ++t) {
       reducer.init(reinterpret_cast<pointer_type>(buffer.get(t)));
     }
   }
@@ -1618,8 +1625,11 @@ class ParallelReduce<CombinedFunctorReducerType,
     hpx_thread_buffer &buffer    = m_policy.space().impl_get_buffer();
     const ReducerType &reducer   = m_functor_reducer.get_reducer();
     const int num_worker_threads = m_policy.space().concurrency();
+    const auto nchunks =
+        get_num_chunks(0, m_policy.chunk_size(), m_policy.league_size());
+    const auto buffer_size = std::min(nchunks, num_worker_threads);
     const pointer_type ptr = reinterpret_cast<pointer_type>(buffer.get(0));
-    for (int t = 1; t < num_worker_threads; ++t) {
+    for (int t = 1; t < buffer_size; ++t) {
       reducer.join(ptr, reinterpret_cast<pointer_type>(buffer.get(t)));
     }
 

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -124,12 +124,7 @@ class HPX {
     instance_data() = default;
     // NOLINTNEXTLINE(bugprone-exception-escape)
     ~instance_data() {
-      // The HPX runtime may already be shut down (e.g. if finalization is
-      // triggered while draining work). Avoid calling into HPX when the runtime
-      // is no longer active.
-      if (hpx::get_runtime_ptr() != nullptr) {
-        fence("Kokkos::Experimental::HPX: fence on destruction");
-      }
+      fence("Kokkos::Experimental::HPX: fence on destruction");
     }
     instance_data(uint32_t instance_id) : m_instance_id(instance_id) {}
     instance_data(uint32_t instance_id,
@@ -142,20 +137,17 @@ class HPX {
     instance_data &operator=(instance_data)         = delete;
 
     void fence(const std::string &name) {
-      if (hpx::get_runtime_ptr() == nullptr) return;
       std::lock_guard<hpx::spinlock> l(m_sender_mutex);
       fence_locked(name);
     }
 
     void fence_locked(const std::string &name) {
-      if (hpx::get_runtime_ptr() == nullptr) return;
       Kokkos::Tools::Experimental::Impl::profile_fence_event<
           Kokkos::Experimental::HPX>(
           name,
           Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{m_instance_id},
           [&]() {
             auto &s = m_sender;
-
             hpx::this_thread::experimental::sync_wait(std::move(s));
             s = hpx::execution::experimental::unique_any_sender<>(
                 hpx::execution::experimental::just());

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -162,8 +162,7 @@ class HPX {
     hpx::spinlock m_sender_mutex;
   };
 
-  static void default_instance_deleter(instance_data *) {}
-  static instance_data m_default_instance_data;
+  static Kokkos::Impl::HostSharedPtr<instance_data> m_default_instance_data;
   Kokkos::Impl::HostSharedPtr<instance_data> m_instance_data;
 
  public:
@@ -183,8 +182,7 @@ class HPX {
       : m_instance_data(
             (Kokkos::Impl::check_execution_space_constructor_precondition(
                  name()),
-             Kokkos::Impl::HostSharedPtr<instance_data>(
-                 &m_default_instance_data, &default_instance_deleter))) {}
+             m_default_instance_data)) {}
 
 #pragma GCC diagnostic pop
 
@@ -198,8 +196,7 @@ class HPX {
              mode == instance_mode::independent
                  ? (Kokkos::Impl::HostSharedPtr<instance_data>(
                        new instance_data(m_next_instance_id++)))
-                 : Kokkos::Impl::HostSharedPtr<instance_data>(
-                       &m_default_instance_data, &default_instance_deleter))) {}
+                 : m_default_instance_data)) {}
   explicit HPX(hpx::execution::experimental::unique_any_sender<> &&sender)
       : m_instance_data(
             (Kokkos::Impl::check_execution_space_constructor_precondition(

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -218,8 +218,14 @@ void Kokkos::Impl::ExecSpaceManager::initialize_spaces(
 }
 
 void Kokkos::Impl::ExecSpaceManager::finalize_spaces() {
-  for (auto& to_finalize : exec_space_factory_list) {
-    to_finalize.second->finalize();
+  // Finalize and remove each backend immediately. Otherwise a later finalize()
+  // (or code it runs, e.g. deallocation) can call Kokkos::fence(), which
+  // dispatches static_fence() to every entry still in the map — including
+  // backends already torn down.
+  for (auto it = exec_space_factory_list.begin();
+       it != exec_space_factory_list.end();) {
+    it->second->finalize();
+    it = exec_space_factory_list.erase(it);
   }
 }
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -552,6 +552,10 @@ endif()
 
 if(Kokkos_ENABLE_HPX)
   kokkos_add_executable_and_test(CoreUnitTest_HPX SOURCES UnitTestMainInit.cpp ${HPX_SOURCES})
+  kokkos_add_executable_and_test(
+    CoreUnitTest_HPXDefaultInstanceFencesOnFinalize SOURCES UnitTestMain.cpp
+    hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
+  )
   kokkos_add_executable_and_test(CoreUnitTest_HPXInterOp SOURCES UnitTestMain.cpp hpx/TestHPX_InterOp.cpp)
   kokkos_add_executable_and_test(
     CoreUnitTest_HPX_IndependentInstances

--- a/core/unit_test/hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
+++ b/core/unit_test/hpx/TestHPX_DefaultInstanceFencesOnFinalize.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+#include <TestHPX_Category.hpp>
+
+#include "tools/include/ToolTestingUtilities.hpp"
+
+namespace Test {
+
+// Test whether the HPX default instance fences on finalize.
+TEST(hpx, default_instance_fences_on_finalize) {
+  Kokkos::Test::Tools::listen_tool_events(
+      Kokkos::Test::Tools::Config::DisableAll(),
+      Kokkos::Test::Tools::Config::EnableFences());
+
+  auto success = Kokkos::Test::Tools::validate_existence(
+      [&]() {
+        Kokkos::initialize();
+        {
+          const Kokkos::Experimental::HPX exec{};
+
+          Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 100),
+                               KOKKOS_LAMBDA(const auto){});
+        }
+        Kokkos::finalize();
+      },
+      [&](Kokkos::Test::Tools::BeginFenceEvent event) {
+        return Kokkos::Test::Tools::MatchDiagnostic{
+            event.descriptor().find("fence on destruction") !=
+            std::string::npos};
+      });
+
+  ASSERT_TRUE(success);
+
+  Kokkos::Test::Tools::listen_tool_events(
+      Kokkos::Test::Tools::Config::DisableAll());
+}
+
+}  // namespace Test


### PR DESCRIPTION
Pulls in / supersedes https://github.com/kokkos/kokkos/pull/8992


Changes to fix CI right now:
- Fixes team parallel_reduce buffer indexing (CI fix)
- Clamps host thread count for HPX startup (CI fix)
- Unregisters execution spaces from ExecSpaceManager as each backend is finalized so Kokkos::fence() does not call into already-torn-down backends (CI fix)


More changes that could address issues in the future:
- `static instance_data m_default_instance_data` is now heap-allocated and we should not need to provide a custom deallocator (default_instance_deleter). @msimberg can you verify this change please? I do not see a reason for a static lifetime management right now.
- Removes default_instance_deleter

Unit test
- Adds a unit test for default-instance fences on finalize (from https://github.com/kokkos/kokkos/pull/8992)
