### PR TITLE
core(graph): HIP/CUDA driver storage allocation only synchronizes the stream

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -16,6 +16,7 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <Cuda/Kokkos_Cuda.hpp>
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -134,12 +135,22 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   cudaGraphNode_t* get_cuda_graph_node_ptr() const { return m_graph_node_ptr; }
   cudaGraph_t const* get_cuda_graph_ptr() const { return m_graph_ptr; }
 
-  base_t* allocate_driver_memory_buffer(const CudaSpace& mem) const {
+  base_t* allocate_driver_memory_buffer(
+      [[maybe_unused]] const CudaInternal& cuda_instance) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
+
+    const auto& exec = this->get_policy().space();
+
+    KOKKOS_EXPECTS(cuda_instance.m_cudaDev == exec.cuda_device());
+    KOKKOS_EXPECTS(cuda_instance.m_stream == exec.cuda_stream());
+
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
+    auto mem =
+        Kokkos::CudaSpace::impl_create(exec.cuda_device(), exec.cuda_stream());
     m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
-        static_cast<base_t*>(mem.allocate(alloc_label.c_str(), sizeof(base_t))),
+        static_cast<base_t*>(
+            mem.allocate(exec, alloc_label.c_str(), sizeof(base_t))),
         DriverStorageDeleter{.label = alloc_label, .mem = mem});
     KOKKOS_ENSURES(m_driver_storage != nullptr)
     return m_driver_storage.get();
@@ -167,16 +178,13 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
 // <editor-fold desc="get_cuda_graph_*() helper functions"> {{{1
 
 template <class KernelType>
-auto* allocate_driver_storage_for_kernel(const CudaSpace& mem,
+auto* allocate_driver_storage_for_kernel(const CudaInternal& cuda_instance,
                                          KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
   auto const& kernel_as_graph_kernel =
       static_cast<graph_node_kernel_t const&>(kernel);
-  // TODO @graphs we need to somehow indicate the need for a fence in the
-  //              destructor of the GraphImpl object (so that we don't have to
-  //              just always do it)
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer(mem);
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer(cuda_instance);
 }
 
 template <class KernelType>

--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -16,7 +16,6 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <Cuda/Kokkos_Cuda.hpp>
-#include <Cuda/Kokkos_Cuda_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -135,23 +134,20 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   cudaGraphNode_t* get_cuda_graph_node_ptr() const { return m_graph_node_ptr; }
   cudaGraph_t const* get_cuda_graph_ptr() const { return m_graph_ptr; }
 
-  base_t* allocate_driver_memory_buffer(
-      [[maybe_unused]] const CudaInternal& cuda_instance) const {
+  base_t* allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
 
     const auto& exec = this->get_policy().space();
-
-    KOKKOS_EXPECTS(cuda_instance.m_cudaDev == exec.cuda_device());
-    KOKKOS_EXPECTS(cuda_instance.m_stream == exec.cuda_stream());
 
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
     auto mem =
         Kokkos::CudaSpace::impl_create(exec.cuda_device(), exec.cuda_stream());
+    auto* ptr = static_cast<base_t*>(
+        mem.allocate(exec, alloc_label.c_str(), sizeof(base_t)));
     m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
-        static_cast<base_t*>(
-            mem.allocate(exec, alloc_label.c_str(), sizeof(base_t))),
-        DriverStorageDeleter{.label = alloc_label, .mem = mem});
+        ptr, DriverStorageDeleter{.label = std::move(alloc_label),
+                                  .mem   = std::move(mem)});
     KOKKOS_ENSURES(m_driver_storage != nullptr)
     return m_driver_storage.get();
   }
@@ -178,33 +174,24 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
 // <editor-fold desc="get_cuda_graph_*() helper functions"> {{{1
 
 template <class KernelType>
-auto* allocate_driver_storage_for_kernel(const CudaInternal& cuda_instance,
-                                         KernelType const& kernel) {
+auto const& get_graph_node_kernel(KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer(cuda_instance);
+  return static_cast<graph_node_kernel_t const&>(kernel);
 }
 
 template <class KernelType>
 auto const& get_cuda_graph_from_kernel(KernelType const& kernel) {
-  using graph_node_kernel_t =
-      typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  cudaGraph_t const* graph_ptr = kernel_as_graph_kernel.get_cuda_graph_ptr();
+  cudaGraph_t const* graph_ptr =
+      get_graph_node_kernel(kernel).get_cuda_graph_ptr();
   KOKKOS_EXPECTS(graph_ptr != nullptr);
   return *graph_ptr;
 }
 
 template <class KernelType>
 auto& get_cuda_graph_node_from_kernel(KernelType const& kernel) {
-  using graph_node_kernel_t =
-      typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  auto* graph_node_ptr = kernel_as_graph_kernel.get_cuda_graph_node_ptr();
+  auto* graph_node_ptr =
+      get_graph_node_kernel(kernel).get_cuda_graph_node_ptr();
   KOKKOS_EXPECTS(graph_node_ptr != nullptr);
   return *graph_node_ptr;
 }

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -548,10 +548,8 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
       Impl::configure_max_dynamic_shmem<DriverType, LaunchBounds>(
           cuda_instance, base_t::get_kernel_func(), shmem);
 
-      auto* driver_ptr = Impl::allocate_driver_storage_for_kernel(
-          CudaSpace::impl_create(cuda_instance->m_cudaDev,
-                                 cuda_instance->m_stream),
-          driver);
+      auto* driver_ptr =
+          Impl::allocate_driver_storage_for_kernel(*cuda_instance, driver);
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl

--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunch.hpp
@@ -479,7 +479,9 @@ template <class DriverType, unsigned int MaxThreadsPerBlock,
 struct CudaParallelLaunchKernelFunc<
     DriverType, Kokkos::LaunchBounds<MaxThreadsPerBlock, MinBlocksPerSM>,
     CudaLaunchMechanism::GlobalMemory> {
-  static void* get_kernel_func() {
+  static std::decay_t<decltype(cuda_parallel_launch_global_memory<
+                               DriverType, MaxThreadsPerBlock, MinBlocksPerSM>)>
+  get_kernel_func() {
     return cuda_parallel_launch_global_memory<DriverType, MaxThreadsPerBlock,
                                               MinBlocksPerSM>;
   }
@@ -549,7 +551,7 @@ struct CudaParallelLaunchKernelInvoker<DriverType, LaunchBounds,
           cuda_instance, base_t::get_kernel_func(), shmem);
 
       auto* driver_ptr =
-          Impl::allocate_driver_storage_for_kernel(*cuda_instance, driver);
+          get_graph_node_kernel(driver).allocate_driver_memory_buffer();
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -12,6 +12,7 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
+#include <HIP/Kokkos_HIP_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -107,12 +108,22 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
 
-  base_t* allocate_driver_memory_buffer(const HIPSpace& mem) const {
+  base_t* allocate_driver_memory_buffer(
+      [[maybe_unused]] const HIPInternal& hip_instance) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
+
+    const auto& exec = this->get_policy().space();
+
+    KOKKOS_EXPECTS(hip_instance.m_hipDev == exec.hip_device());
+    KOKKOS_EXPECTS(hip_instance.m_stream == exec.hip_stream());
+
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
+    auto mem =
+        Kokkos::HIPSpace::impl_create(exec.hip_device(), exec.hip_stream());
     m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
-        static_cast<base_t*>(mem.allocate(alloc_label.c_str(), sizeof(base_t))),
+        static_cast<base_t*>(
+            mem.allocate(exec, alloc_label.c_str(), sizeof(base_t))),
         DriverStorageDeleter{.label = alloc_label, .mem = mem});
     KOKKOS_ENSURES(m_driver_storage != nullptr);
     return m_driver_storage.get();
@@ -145,14 +156,13 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
           Kokkos::ParallelReduceTag>> {};
 
 template <typename KernelType>
-auto* allocate_driver_storage_for_kernel(const HIPSpace& mem,
+auto* allocate_driver_storage_for_kernel(const HIPInternal& hip_instance,
                                          KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
   auto const& kernel_as_graph_kernel =
       static_cast<graph_node_kernel_t const&>(kernel);
-
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer(mem);
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer(hip_instance);
 }
 
 template <typename KernelType>

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -12,7 +12,6 @@
 #include <Kokkos_Parallel_Reduce.hpp>
 
 #include <HIP/Kokkos_HIP_GraphNode_Impl.hpp>
-#include <HIP/Kokkos_HIP_Instance.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -108,23 +107,20 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
 
-  base_t* allocate_driver_memory_buffer(
-      [[maybe_unused]] const HIPInternal& hip_instance) const {
+  base_t* allocate_driver_memory_buffer() const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
 
     const auto& exec = this->get_policy().space();
-
-    KOKKOS_EXPECTS(hip_instance.m_hipDev == exec.hip_device());
-    KOKKOS_EXPECTS(hip_instance.m_stream == exec.hip_stream());
 
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
     auto mem =
         Kokkos::HIPSpace::impl_create(exec.hip_device(), exec.hip_stream());
+    auto* ptr = static_cast<base_t*>(
+        mem.allocate(exec, alloc_label.c_str(), sizeof(base_t)));
     m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
-        static_cast<base_t*>(
-            mem.allocate(exec, alloc_label.c_str(), sizeof(base_t))),
-        DriverStorageDeleter{.label = alloc_label, .mem = mem});
+        ptr, DriverStorageDeleter{.label = std::move(alloc_label),
+                                  .mem   = std::move(mem)});
     KOKKOS_ENSURES(m_driver_storage != nullptr);
     return m_driver_storage.get();
   }
@@ -156,22 +152,16 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
           Kokkos::ParallelReduceTag>> {};
 
 template <typename KernelType>
-auto* allocate_driver_storage_for_kernel(const HIPInternal& hip_instance,
-                                         KernelType const& kernel) {
+auto const& get_graph_node_kernel(KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer(hip_instance);
+  return static_cast<graph_node_kernel_t const&>(kernel);
 }
 
 template <typename KernelType>
 auto const& get_hip_graph_from_kernel(KernelType const& kernel) {
-  using graph_node_kernel_t =
-      typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  hipGraph_t const* graph_ptr = kernel_as_graph_kernel.get_hip_graph_ptr();
+  hipGraph_t const* graph_ptr =
+      get_graph_node_kernel(kernel).get_hip_graph_ptr();
   KOKKOS_EXPECTS(graph_ptr != nullptr);
 
   return *graph_ptr;
@@ -179,11 +169,7 @@ auto const& get_hip_graph_from_kernel(KernelType const& kernel) {
 
 template <typename KernelType>
 auto& get_hip_graph_node_from_kernel(KernelType const& kernel) {
-  using graph_node_kernel_t =
-      typename get_graph_node_kernel_type<KernelType>::type;
-  auto const& kernel_as_graph_kernel =
-      static_cast<graph_node_kernel_t const&>(kernel);
-  auto* graph_node_ptr = kernel_as_graph_kernel.get_hip_graph_node_ptr();
+  auto* graph_node_ptr = get_graph_node_kernel(kernel).get_hip_graph_node_ptr();
   KOKKOS_EXPECTS(graph_node_ptr != nullptr);
 
   return *graph_node_ptr;

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -437,9 +437,8 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
     KOKKOS_EXPECTS(!graph_node);
 
     if (!Impl::is_empty_launch(grid, block)) {
-      auto *driver_ptr = Impl::allocate_driver_storage_for_kernel(
-          HIPSpace::impl_create(hip_instance->m_hipDev, hip_instance->m_stream),
-          driver);
+      auto *driver_ptr =
+          Impl::allocate_driver_storage_for_kernel(*hip_instance, driver);
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -438,7 +438,7 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     if (!Impl::is_empty_launch(grid, block)) {
       auto *driver_ptr =
-          Impl::allocate_driver_storage_for_kernel(*hip_instance, driver);
+          get_graph_node_kernel(driver).allocate_driver_memory_buffer();
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -45,6 +45,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
 
   ParallelFor() = delete;
 
+  Policy const& get_policy() const { return m_policy; }
+
   inline __device__ void operator()() const {
     constexpr auto batch_size = Member(StaticBatchSize::batch_size);
     const auto work_stride    = Member(blockDim.y) * gridDim.x;

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -770,6 +770,9 @@ if(Kokkos_ENABLE_HIP)
   kokkos_add_executable_and_test(
     CoreUnitTest_HIPInterOpStreamsMultiGPU SOURCES UnitTestMainInit.cpp hip/TestHIP_InterOp_StreamsMultiGPU.cpp
   )
+  kokkos_add_executable_and_test(
+    CoreUnitTest_HIPInterOpGraphMultiGPU SOURCES UnitTestMainInit.cpp hip/TestHIP_InterOp_GraphMultiGPU.cpp
+  )
 endif()
 
 if(Kokkos_ENABLE_SYCL)

--- a/core/unit_test/cuda/TestCuda_InterOp_GraphMultiGPU.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_GraphMultiGPU.cpp
@@ -103,4 +103,53 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), then) {
   }
 }
 
+// FIXME Copy/pasted from TestGraph.hpp.
+template <typename ViewType, size_t Count>
+struct SizedFunctor {
+ public:
+  static constexpr size_t count = Count;
+
+  ViewType data;
+
+  SizedFunctor(ViewType data_) : data(std::move(data_)) {}
+
+  KOKKOS_FUNCTION void operator()() const { ++data(); }
+
+ private:
+  std::byte unused[count] = {};
+};
+
+// Create a graph with a then node on the first device that is not the default
+// device. It should exercise the global launch mechanism.
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu),
+       then_force_global_launch_on_non_default_device) {
+  using view_t = Kokkos::View<int, Kokkos::CudaSpace>;
+  using functor_t =
+      SizedFunctor<view_t, Kokkos::Impl::CudaTraits::ConstantMemoryUsage + 1>;
+
+  const auto exec_it = std::ranges::find_if(
+      this->execs, [default_device_id = Kokkos::Cuda().cuda_device()](
+                       const Kokkos::Cuda& exec) {
+        return exec.cuda_device() != default_device_id;
+      });
+  ASSERT_NE(exec_it, std::cend(this->execs));
+
+  const view_t data(Kokkos::view_alloc(
+      "data on device " + std::to_string(exec_it->cuda_device()), *exec_it));
+
+  const auto device_handle = Kokkos::Experimental::get_device_handle(*exec_it);
+
+  const auto graph = Kokkos::Experimental::create_graph(
+      device_handle, [&](const auto& root) { root.then(functor_t(data)); });
+
+  graph.submit(*exec_it);
+
+  int value = 0;
+
+  Kokkos::deep_copy(*exec_it, value, data);
+  exec_it->fence();
+
+  ASSERT_EQ(value, 1);
+}
+
 }  // namespace

--- a/core/unit_test/hip/TestHIP_InterOp_GraphMultiGPU.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_GraphMultiGPU.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Graph.hpp"
+#include "impl/Kokkos_DeviceManagement.hpp"
+#include "TestHIP_Category.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace {
+
+class TEST_CATEGORY_FIXTURE(multi_gpu) : public ::testing::Test {
+ public:
+  using graph_t = Kokkos::Experimental::Graph<Kokkos::HIP>;
+
+ public:
+  void SetUp() override {
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipGetDeviceCount(&num_devices));
+
+    if (num_devices < 2)
+      GTEST_SKIP()
+          << "Skipping multi-gpu testing since current machine only has "
+          << num_devices << " GPU.";
+
+    execs.reserve(num_devices);
+
+    for (int idevice = 0; idevice < num_devices; ++idevice) {
+      KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(idevice));
+      hipStream_t stream = nullptr;
+      KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamCreate(&stream));
+      execs.push_back(Kokkos::HIP(stream));
+    }
+  }
+
+  void TearDown() override {
+    while (!execs.empty()) {
+      const auto stream = execs.back().hip_stream();
+      execs.pop_back();
+      KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamDestroy(stream));
+    }
+  }
+
+ protected:
+  int num_devices;
+  std::vector<Kokkos::HIP> execs;
+};
+
+template <typename ViewType>
+struct ThenFunctor {
+  ViewType data;
+
+  KOKKOS_FUNCTION void operator()() const { ++data(); }
+};
+
+// Create a graph with a then node on any device but the default one.
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), then_on_non_default_device) {
+  using view_t = Kokkos::View<int, Kokkos::HIPSpace>;
+
+  const auto exec_it = std::ranges::find_if(
+      this->execs, [default_device_id =
+                        Kokkos::HIP().hip_device()](const Kokkos::HIP& exec) {
+        return exec.hip_device() != default_device_id;
+      });
+  ASSERT_NE(exec_it, std::cend(this->execs));
+
+  const view_t data(Kokkos::view_alloc(
+      "data on device " + std::to_string(exec_it->hip_device()), *exec_it));
+
+  const auto device_handle = Kokkos::Experimental::get_device_handle(*exec_it);
+
+  const auto graph = Kokkos::Experimental::create_graph(
+      device_handle,
+      [&](const auto& root) { root.then(ThenFunctor<view_t>{.data = data}); });
+
+  graph.submit(*exec_it);
+
+  int value = 0;
+
+  Kokkos::deep_copy(*exec_it, value, data);
+  exec_it->fence();
+
+  ASSERT_EQ(value, 1);
+}
+
+}  // namespace

--- a/core/unit_test/hip/TestHIP_InterOp_GraphMultiGPU.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_GraphMultiGPU.cpp
@@ -47,16 +47,29 @@ class TEST_CATEGORY_FIXTURE(multi_gpu) : public ::testing::Test {
   std::vector<Kokkos::HIP> execs;
 };
 
-template <typename ViewType>
-struct ThenFunctor {
+// FIXME Copy/pasted from TestGraph.hpp.
+template <typename ViewType, size_t Count>
+struct SizedFunctor {
+ public:
+  static constexpr size_t count = Count;
+
   ViewType data;
 
+  SizedFunctor(ViewType data_) : data(std::move(data_)) {}
+
   KOKKOS_FUNCTION void operator()() const { ++data(); }
+
+ private:
+  std::byte unused[count] = {};
 };
 
-// Create a graph with a then node on any device but the default one.
-TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), then_on_non_default_device) {
+// Create a graph with a then node on the first device that is not the default
+// device. It should exercise the global launch mechanism.
+TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu),
+       then_force_global_launch_on_non_default_device) {
   using view_t = Kokkos::View<int, Kokkos::HIPSpace>;
+  using functor_t =
+      SizedFunctor<view_t, Kokkos::Impl::HIPTraits::ConstantMemoryUsage + 1>;
 
   const auto exec_it = std::ranges::find_if(
       this->execs, [default_device_id =
@@ -71,8 +84,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(multi_gpu), then_on_non_default_device) {
   const auto device_handle = Kokkos::Experimental::get_device_handle(*exec_it);
 
   const auto graph = Kokkos::Experimental::create_graph(
-      device_handle,
-      [&](const auto& root) { root.then(ThenFunctor<view_t>{.data = data}); });
+      device_handle, [&](const auto& root) { root.then(functor_t(data)); });
 
   graph.submit(*exec_it);
 


### PR DESCRIPTION
This PR ensures that the CUDA/HIP graph node driver storage is allocated with:
```c++
mem.allocate(exec, ...);
```
to ensure that when `KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC`/`KOKKOS_ENABLE_IMPL_HIP_MALLOC_ASYNC` is defined, it only synchronizes the underlying stream, instead of the whole device.

This is aligned with the user expectation that creating a graph node should not interfere with operations running on other streams.

Since `GraphNodeKernelImpl` derives from `PatternImplSpecializationFromTag`, it means the node stores the execution policy until it is destroyed. Therefore, it is safe to use the underlying stream to deallocate upon destruction.

This PR adds a consistency check that the `[cuda|hip]_instance` passed to `allocate_driver_storage_for_kernel` uses the same stream/device as the execution space instance stored in the node execution policy.


<details>

<summary>Old PR description</summary>

This PR changes how CUDA and HIP driver storage for kernel nodes are stored, switching from a `shared_ptr` to a `unique_ptr` (as a reminder, the driver storage is only used for global launch). It avoids the extra cost of the `shared_ptr`.

It fixes the deallocation of the driver for HIP. Indeed, it was always using the default `HIPSpace` instance, bound to the default device, which is a mismatch with the allocation that may happen on any device (the one of the node) [*think of stream-ordered allocation on a given device*]. I've added a test that creates a graph on a non-default device (I did not make it a multi-GPU graph yet because I don't think it is officially supported for now).

Finally, it fixes both CUDA and HIP to use:
```c++
mem.allocate(exec, alloc_label.c_str(), sizeof(base_t)))
```
instead of
```c++
mem.allocate(alloc_label.c_str(), sizeof(base_t)))
```
to avoid a device synchronization.

I've created:
- #9140 

because of the "round-trip" needed to create a pair of `CudaSpace` and `Cuda` from a `CudaInternal`, which incurs additional API calls through the `CudaInternal` already knows everything needed.

</details>

### Changelog Entry

This is probably sufficiently minor fix that it does not deserve the changelog noise.