### PR TITLE
Guard some team parallel reduce tests when OpenACC is enabled

### DIFF
--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -1920,35 +1920,40 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelFor) {
 }
 
 TEST(TEST_CATEGORY, TeamThreadMDRangeParallelReduce) {
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_3D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_3D_TeamThreadMDRange<Right>(dims);
+#ifdef KOKKOS_ENABLE_OPENACC
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+#endif
+  {
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_TeamThreadMDRange<Left>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_3D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamThreadMDRange<Right>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_TeamThreadMDRange<Left>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamThreadMDRange<Right>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_TeamThreadMDRange<Left>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_6D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_6D_TeamThreadMDRange<Right>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_TeamThreadMDRange<Left>(dims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_7D_TeamThreadMDRange<Left>(smallDims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_7D_TeamThreadMDRange<Right>(smallDims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_7D_TeamThreadMDRange<Left>(smallDims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_7D_TeamThreadMDRange<Right>(smallDims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_8D_TeamThreadMDRange<Left>(smallDims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_8D_TeamThreadMDRange<Right>(smallDims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_8D_TeamThreadMDRange<Left>(smallDims);
+    TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_8D_TeamThreadMDRange<Right>(smallDims);
+  }
 }
 
 TEST(TEST_CATEGORY, ThreadVectorMDRangeParallelReduce) {
@@ -1991,30 +1996,35 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelReduce) {
     GTEST_SKIP() << "skipping because of bug in group_barrier implementation";
 #endif
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamVectorMDRange<Right>(dims);
+#ifdef KOKKOS_ENABLE_OPENACC
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+#endif
+  {
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_TeamVectorMDRange<Left>(dims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_4D_TeamVectorMDRange<Right>(dims);
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamVectorMDRange<Right>(dims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_TeamVectorMDRange<Left>(dims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_5D_TeamVectorMDRange<Right>(dims);
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_6D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_6D_TeamVectorMDRange<Right>(dims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_TeamVectorMDRange<Left>(dims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_6D_TeamVectorMDRange<Right>(dims);
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_7D_TeamVectorMDRange<Left>(smallDims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_7D_TeamVectorMDRange<Right>(smallDims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_7D_TeamVectorMDRange<Left>(smallDims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_7D_TeamVectorMDRange<Right>(smallDims);
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_8D_TeamVectorMDRange<Left>(smallDims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_8D_TeamVectorMDRange<Right>(smallDims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_8D_TeamVectorMDRange<Left>(smallDims);
+    TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
+        test_parallel_reduce_for_8D_TeamVectorMDRange<Right>(smallDims);
+  }
 }
 
 }  // namespace TeamMDRange

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -1921,7 +1921,10 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelFor) {
 
 TEST(TEST_CATEGORY, TeamThreadMDRangeParallelReduce) {
 #ifdef KOKKOS_ENABLE_OPENACC
-  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP()
+        << "Team level reductions are not fully implemented on OpenACC";
+  } else
 #endif
   {
     TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
@@ -1997,7 +2000,10 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelReduce) {
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENACC
-  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP()
+        << "Team level reductions are not fully implemented on OpenACC";
+  } else
 #endif
   {
     TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -1066,26 +1066,31 @@ TEST(TEST_CATEGORY, parallel_scan_with_reducers) {
   GTEST_SKIP() << "Failing KOKKOS_IMPL_32BIT";  // FIXME_32BIT
 #endif
 
-  checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
-            Kokkos::Prod<T, TEST_EXECSPACE>>()
-      .run();
-  checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
-            Kokkos::Prod<T, TEST_EXECSPACE>>()
-      .run();
+#ifdef KOKKOS_ENABLE_OPENACC
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+#endif
+  {
+    checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
+              Kokkos::Prod<T, TEST_EXECSPACE>>()
+        .run();
+    checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
+              Kokkos::Prod<T, TEST_EXECSPACE>>()
+        .run();
 
-  checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
-            Kokkos::Max<T, TEST_EXECSPACE>>()
-      .run();
-  checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
-            Kokkos::Max<T, TEST_EXECSPACE>>()
-      .run();
+    checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
+              Kokkos::Max<T, TEST_EXECSPACE>>()
+        .run();
+    checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
+              Kokkos::Max<T, TEST_EXECSPACE>>()
+        .run();
 
-  checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
-            Kokkos::Min<T, TEST_EXECSPACE>>()
-      .run();
-  checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
-            Kokkos::Min<T, TEST_EXECSPACE>>()
-      .run();
+    checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,
+              Kokkos::Min<T, TEST_EXECSPACE>>()
+        .run();
+    checkScan<TEST_EXECSPACE, ScanType::Inclusive, n, n_vector_range,
+              Kokkos::Min<T, TEST_EXECSPACE>>()
+        .run();
+  }
 
   (void)n;
   (void)n_vector_range;

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -1067,7 +1067,9 @@ TEST(TEST_CATEGORY, parallel_scan_with_reducers) {
 #endif
 
 #ifdef KOKKOS_ENABLE_OPENACC
-  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "Team level parallel_scan is not supported on OpenACC";
+  } else
 #endif
   {
     checkScan<TEST_EXECSPACE, ScanType::Exclusive, n, n_vector_range,

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -349,10 +349,16 @@ bool test_scalar(int nteams, int team_size, int test) {
         "Test::TeamVectorReduce", policy,
         functor_teamvector_reduce<Scalar, ExecutionSpace>(d_flag));
   } else if (test == 2) {
-    Kokkos::parallel_for(
-        "Test::TeamVectorReduceReducer",
-        Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
-        functor_teamvector_reduce_reducer<Scalar, ExecutionSpace>(d_flag));
+#ifdef KOKKOS_ENABLE_OPENACC
+    if constexpr (!std::is_same_v<ExecutionSpace,
+                                  Kokkos::Experimental::OpenACC>)
+#endif
+    {
+      Kokkos::parallel_for(
+          "Test::TeamVectorReduceReducer",
+          Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
+          functor_teamvector_reduce_reducer<Scalar, ExecutionSpace>(d_flag));
+    }
   }
 
   Kokkos::deep_copy(h_flag, d_flag);

--- a/core/unit_test/TestTeamVectorRange.hpp
+++ b/core/unit_test/TestTeamVectorRange.hpp
@@ -350,6 +350,7 @@ bool test_scalar(int nteams, int team_size, int test) {
         functor_teamvector_reduce<Scalar, ExecutionSpace>(d_flag));
   } else if (test == 2) {
 #ifdef KOKKOS_ENABLE_OPENACC
+    // FIXME_OPENACC team level reductions are not fully supported
     if constexpr (!std::is_same_v<ExecutionSpace,
                                   Kokkos::Experimental::OpenACC>)
 #endif
@@ -399,7 +400,15 @@ namespace Test {
 
 TEST(TEST_CATEGORY, team_teamvector_range) {
   ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(0)));
-  ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(1)));
-  ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(2)));
+#ifdef KOKKOS_ENABLE_OPENACC
+  // FIXME_OPENACC: the reduction tests below compile fine, but we get
+  // "Accelerator Fatal Error: call to cuCtxSynchronize returned error 700:
+  // Illegal address during kernel execution" at runtime
+  if constexpr (!std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>)
+#endif
+  {
+    ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(1)));
+    ASSERT_TRUE((TestTeamVectorRange::Test<TEST_EXECSPACE>(2)));
+  }
 }
 }  // namespace Test


### PR DESCRIPTION
#8976 uses some source files in the smoketest that were normally removed from the regular OpenACC test sources. Some of the code inside those files has been guarded in the original PR, but there were still some failures (see https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8976/27/stages/?start-byte=0&selected-node=240#log-240-292). This PR adds `#ifdefs` around some parallel reduce tests which won't compile on OpenACC.