### PR TITLE
MDRangePolicy: skip grid-stride loop when not needed (HIP and CUDA)

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -80,9 +80,7 @@ class ParallelForMDRange<FunctorType, UseStride,
   const array_type m_extent;  // tile_size * num_tiles
 
  public:
-  ParallelForMDRange()                                     = delete;
-  ParallelForMDRange(ParallelForMDRange const&)            = default;
-  ParallelForMDRange& operator=(ParallelForMDRange const&) = delete;
+  ParallelForMDRange() = delete;
 
   Policy const& get_policy() const { return m_policy; }
 

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -64,14 +64,10 @@ class ParallelForMDRange<FunctorType, UseStride,
   using array_index_type = typename Policy::array_index_type;
   using array_type       = typename Policy::point_type;
 
-  using DeviceIteratePattern = std::conditional_t<
-      UseStride,
+  using DeviceIteratePattern =
       Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                  FunctorType, Policy::inner_direction,
-                                  typename Policy::work_tag>,
-      Kokkos::Impl::DeviceIterateNoStride<
-          Policy::rank, array_index_type, index_type, FunctorType,
-          Policy::inner_direction, typename Policy::work_tag>>;
+                                  Policy::inner_direction, UseStride,
+                                  FunctorType, typename Policy::work_tag>;
 
   const FunctorType m_functor;
   const Policy m_policy;
@@ -108,7 +104,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
   using LaunchBounds     = typename Policy::launch_bounds;
-  using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using MaxGridSize      = Kokkos::Array<array_index_type, 3>;
   using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
@@ -129,7 +125,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
 
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                FunctorType, Policy::inner_direction,
+                                Policy::inner_direction, true, FunctorType,
                                 typename Policy::work_tag>(m_lower, m_upper,
                                                            m_extent, m_functor)
         .exec_range();
@@ -178,59 +174,10 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     check_grid_sizes(grid);
     check_block_sizes(block);
 
-    // Check if the grid covers the full iteration space (no stride needed).
-    using comp_t = std::common_type_t<index_type, array_index_type>;
+    const bool need_grid_stride =
+        Kokkos::Impl::need_grid_stride_loop(m_max_grid_size, block, m_extent);
 
-    const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
-    const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);
-    const comp_t max_grid_z = static_cast<comp_t>(m_max_grid_size[2]);
-    const comp_t bx         = static_cast<comp_t>(block.x);
-    const comp_t by         = static_cast<comp_t>(block.y);
-    const comp_t bz         = static_cast<comp_t>(block.z);
-
-    bool need_grid_stride = true;
-    if constexpr (Policy::rank == 1) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 2) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 3) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[2])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 4) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[3])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 5) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
-                                   static_cast<comp_t>(m_extent[3]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 6) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
-                                   static_cast<comp_t>(m_extent[3]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4]) *
-                                   static_cast<comp_t>(m_extent[5])) {
-        need_grid_stride = false;
-      }
-    }
-
-    // launch the kernel
+    // Use this kernel for graph capture if the policy is a graph kernel
     if constexpr (Policy::is_graph_kernel::value) {
       CudaParallelLaunch<ParallelFor, LaunchBounds>(
           *this, grid, block, 0,
@@ -258,12 +205,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_max_grid_size({
-            static_cast<index_type>(
-                m_policy.space().cuda_device_prop().maxGridSize[0]),
-            static_cast<index_type>(
-                m_policy.space().cuda_device_prop().maxGridSize[1]),
-            static_cast<index_type>(
-                m_policy.space().cuda_device_prop().maxGridSize[2]),
+            m_policy.space().cuda_device_prop().maxGridSize[0],
+            m_policy.space().cuda_device_prop().maxGridSize[1],
+            m_policy.space().cuda_device_prop().maxGridSize[2],
         }) {
     // Initialize begins and ends based on layout
     // Swap the fastest indexes to x dimension

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -5,7 +5,6 @@
 #define KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP
 
 #include <Kokkos_Macros.hpp>
-#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
 
@@ -18,8 +17,7 @@
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <impl/KokkosExp_IterateTileGPU.hpp>
 
-namespace Kokkos {
-namespace Impl {
+namespace Kokkos::Impl {
 
 template <typename ParallelType, typename Policy, typename LaunchBounds>
 int max_tile_size_product_helper(const Policy& pol, const LaunchBounds&) {
@@ -48,6 +46,59 @@ int max_tile_size_product_helper(const Policy& pol, const LaunchBounds&) {
       max_threads_per_sm,
       static_cast<int>(Kokkos::Impl::CudaTraits::MaxHierarchicalParallelism));
 }
+
+// Device closure for MDRange ParallelFor on CUDA.
+// Selects between stride and no-stride iteration patterns at compile time
+template <typename FunctorType, bool UseStride, typename... Traits>
+class ParallelForMDRange;
+
+template <typename FunctorType, bool UseStride, typename... Traits>
+class ParallelForMDRange<FunctorType, UseStride,
+                         Kokkos::MDRangePolicy<Traits...>> {
+ public:
+  using Policy       = Kokkos::MDRangePolicy<Traits...>;
+  using functor_type = FunctorType;
+
+ private:
+  using index_type       = typename Policy::index_type;
+  using array_index_type = typename Policy::array_index_type;
+  using array_type       = typename Policy::point_type;
+
+  using DeviceIteratePattern = std::conditional_t<
+      UseStride,
+      Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
+                                  FunctorType, Policy::inner_direction,
+                                  typename Policy::work_tag>,
+      Kokkos::Impl::DeviceIterateNoStride<
+          Policy::rank, array_index_type, index_type, FunctorType,
+          Policy::inner_direction, typename Policy::work_tag>>;
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+  const array_type m_lower;
+  const array_type m_upper;
+  const array_type m_extent;  // tile_size * num_tiles
+
+ public:
+  ParallelForMDRange()                                     = delete;
+  ParallelForMDRange(ParallelForMDRange const&)            = default;
+  ParallelForMDRange& operator=(ParallelForMDRange const&) = delete;
+
+  Policy const& get_policy() const { return m_policy; }
+
+  inline __device__ void operator()() const {
+    DeviceIteratePattern(m_lower, m_upper, m_extent, m_functor).exec_range();
+  }
+
+  ParallelForMDRange(FunctorType const& arg_functor, const Policy& arg_policy,
+                     const array_type& lower, const array_type& upper,
+                     const array_type& extent)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_lower(lower),
+        m_upper(upper),
+        m_extent(extent) {}
+};
 
 template <class FunctorType, class... Traits>
 class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
@@ -128,9 +179,78 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     // ensure we don't exceed the capability of the device
     check_grid_sizes(grid);
     check_block_sizes(block);
+
+    // Check if the grid covers the full iteration space (no stride needed).
+    using comp_t = std::common_type_t<std::make_unsigned_t<index_type>,
+                                      std::make_unsigned_t<array_index_type>,
+                                      unsigned int>;
+
+    const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
+    const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);
+    const comp_t max_grid_z = static_cast<comp_t>(m_max_grid_size[2]);
+    const comp_t bx         = static_cast<comp_t>(block.x);
+    const comp_t by         = static_cast<comp_t>(block.y);
+    const comp_t bz         = static_cast<comp_t>(block.z);
+
+    bool need_grid_stride = true;
+    if constexpr (Policy::rank == 2) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 3) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[2])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 4) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[3])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 5) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
+                                   static_cast<comp_t>(m_extent[3]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 6) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
+                                   static_cast<comp_t>(m_extent[3]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4]) *
+                                   static_cast<comp_t>(m_extent[5])) {
+        need_grid_stride = false;
+      }
+    }
+
     // launch the kernel
-    CudaParallelLaunch<ParallelFor, LaunchBounds>(
-        *this, grid, block, 0, m_policy.space().impl_internal_space_instance());
+    if constexpr (Policy::is_graph_kernel::value) {
+      CudaParallelLaunch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance());
+    } else {
+      // launch the kernel with or without grid stride
+      if (need_grid_stride) {
+        using ClosureType = ParallelForMDRange<FunctorType, true, Policy>;
+        ClosureType closure(m_functor, m_policy, m_lower, m_upper, m_extent);
+        CudaParallelLaunch<ClosureType, LaunchBounds>(
+            closure, grid, block, 0,
+            m_policy.space().impl_internal_space_instance());
+      } else {
+        using ClosureType = ParallelForMDRange<FunctorType, false, Policy>;
+        ClosureType closure(m_functor, m_policy, m_lower, m_upper, m_extent);
+        CudaParallelLaunch<ClosureType, LaunchBounds>(
+            closure, grid, block, 0,
+            m_policy.space().impl_internal_space_instance());
+      }
+    }
   }  // end execute
 
   //  inline
@@ -229,6 +349,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   static int max_tile_size_product(const Policy& pol, const Functor&) {
     return max_tile_size_product_helper<ParallelReduce>(pol, LaunchBounds{});
   }
+
   Policy const& get_policy() const { return m_policy; }
   inline __device__ void exec_range(reference_type update) const {
     Kokkos::Impl::Reduce::DeviceIterateTile<Policy::rank, Policy, FunctorType,
@@ -412,8 +533,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_policy, m_functor_reducer.get_functor());
   }
 };
-}  // namespace Impl
-}  // namespace Kokkos
-#endif
 
-#endif
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -181,9 +181,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     check_block_sizes(block);
 
     // Check if the grid covers the full iteration space (no stride needed).
-    using comp_t = std::common_type_t<std::make_unsigned_t<index_type>,
-                                      std::make_unsigned_t<array_index_type>,
-                                      unsigned int>;
+    using comp_t = std::common_type_t<index_type, array_index_type>;
 
     const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
     const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -189,7 +189,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, Kokkos::Cuda> {
     const comp_t bz         = static_cast<comp_t>(block.z);
 
     bool need_grid_stride = true;
-    if constexpr (Policy::rank == 2) {
+    if constexpr (Policy::rank == 1) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 2) {
       if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
           (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
         need_grid_stride = false;

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP
 
 #include <Kokkos_Macros.hpp>
+#if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
 
@@ -479,5 +480,6 @@ class ParallelReduce<CombinedFunctorReducerType,
 };
 
 }  // namespace Kokkos::Impl
+#endif
 
 #endif  // KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -109,7 +109,11 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     const comp_t bz         = static_cast<comp_t>(block.z);
 
     bool need_grid_stride = true;
-    if constexpr (Policy::rank == 2) {
+    if constexpr (Policy::rank == 1) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 2) {
       if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
           (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
         need_grid_stride = false;

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -30,14 +30,10 @@ class ParallelForMDRange<FunctorType, UseStride,
   using index_type       = typename Policy::index_type;
   using array_type       = typename Policy::point_type;
 
-  using DeviceIteratePattern = std::conditional_t<
-      UseStride,
+  using DeviceIteratePattern =
       Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                  FunctorType, Policy::inner_direction,
-                                  typename Policy::work_tag>,
-      Kokkos::Impl::DeviceIterateNoStride<
-          Policy::rank, array_index_type, index_type, FunctorType,
-          Policy::inner_direction, typename Policy::work_tag>>;
+                                  Policy::inner_direction, UseStride,
+                                  FunctorType, typename Policy::work_tag>;
 
   const FunctorType m_functor;
   const array_type m_lower;
@@ -70,7 +66,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
   using LaunchBounds     = typename Policy::launch_bounds;
-  using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using MaxGridSize      = Kokkos::Array<array_index_type, 3>;
   using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
@@ -86,7 +82,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
 
   inline __device__ void operator()() const {
     Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                FunctorType, Policy::inner_direction,
+                                Policy::inner_direction, true, FunctorType,
                                 typename Policy::work_tag>(m_lower, m_upper,
                                                            m_extent, m_functor)
         .exec_range();
@@ -98,57 +94,8 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
     const auto [grid, block] =
         Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
 
-    // Check if the grid covers the full iteration space (no stride needed).
-    using comp_t = std::common_type_t<index_type, array_index_type>;
-
-    const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
-    const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);
-    const comp_t max_grid_z = static_cast<comp_t>(m_max_grid_size[2]);
-    const comp_t bx         = static_cast<comp_t>(block.x);
-    const comp_t by         = static_cast<comp_t>(block.y);
-    const comp_t bz         = static_cast<comp_t>(block.z);
-
-    bool need_grid_stride = true;
-    if constexpr (Policy::rank == 1) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 2) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 3) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[2])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 4) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[3])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 5) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
-                                   static_cast<comp_t>(m_extent[3]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4])) {
-        need_grid_stride = false;
-      }
-    } else if constexpr (Policy::rank == 6) {
-      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
-                                   static_cast<comp_t>(m_extent[1]) &&
-          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
-                                   static_cast<comp_t>(m_extent[3]) &&
-          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4]) *
-                                   static_cast<comp_t>(m_extent[5])) {
-        need_grid_stride = false;
-      }
-    }
+    const bool need_grid_stride =
+        Kokkos::Impl::need_grid_stride_loop(m_max_grid_size, block, m_extent);
 
     if constexpr (Policy::is_graph_kernel::value) {
       hip_parallel_launch<ParallelFor, LaunchBounds>(
@@ -176,12 +123,9 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
       : m_functor(arg_functor),
         m_policy(arg_policy),
         m_max_grid_size({
-            static_cast<index_type>(
-                m_policy.space().hip_device_prop().maxGridSize[0]),
-            static_cast<index_type>(
-                m_policy.space().hip_device_prop().maxGridSize[1]),
-            static_cast<index_type>(
-                m_policy.space().hip_device_prop().maxGridSize[2]),
+            m_policy.space().hip_device_prop().maxGridSize[0],
+            m_policy.space().hip_device_prop().maxGridSize[1],
+            m_policy.space().hip_device_prop().maxGridSize[2],
         }) {
     // Initialize begins and ends based on layout
     // Swap the fastest indexes to x dimension

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -45,9 +45,7 @@ class ParallelForMDRange<FunctorType, UseStride,
   const array_type m_extent;  // tile_size * num_tiles
 
  public:
-  ParallelForMDRange()                                     = delete;
-  ParallelForMDRange(ParallelForMDRange const&)            = default;
-  ParallelForMDRange& operator=(ParallelForMDRange const&) = delete;
+  ParallelForMDRange() = delete;
 
   inline __device__ void operator()() const {
     DeviceIteratePattern(m_lower, m_upper, m_extent, m_functor).exec_range();

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -11,8 +11,55 @@
 #include <KokkosExp_MDRangePolicy.hpp>
 #include <impl/KokkosExp_IterateTileGPU.hpp>
 
-namespace Kokkos {
-namespace Impl {
+namespace Kokkos::Impl {
+
+// Device closure for MDRange ParallelFor on HIP.
+// Selects between stride and no-stride iteration patterns at compile time.
+template <typename FunctorType, bool UseStride, typename... Traits>
+class ParallelForMDRange;
+
+template <typename FunctorType, bool UseStride, typename... Traits>
+class ParallelForMDRange<FunctorType, UseStride,
+                         Kokkos::MDRangePolicy<Traits...>> {
+ public:
+  using Policy       = Kokkos::MDRangePolicy<Traits...>;
+  using functor_type = FunctorType;
+
+ private:
+  using array_index_type = typename Policy::array_index_type;
+  using index_type       = typename Policy::index_type;
+  using array_type       = typename Policy::point_type;
+
+  using DeviceIteratePattern = std::conditional_t<
+      UseStride,
+      Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
+                                  FunctorType, Policy::inner_direction,
+                                  typename Policy::work_tag>,
+      Kokkos::Impl::DeviceIterateNoStride<
+          Policy::rank, array_index_type, index_type, FunctorType,
+          Policy::inner_direction, typename Policy::work_tag>>;
+
+  const FunctorType m_functor;
+  const array_type m_lower;
+  const array_type m_upper;
+  const array_type m_extent;  // tile_size * num_tiles
+
+ public:
+  ParallelForMDRange()                                     = delete;
+  ParallelForMDRange(ParallelForMDRange const&)            = default;
+  ParallelForMDRange& operator=(ParallelForMDRange const&) = delete;
+
+  inline __device__ void operator()() const {
+    DeviceIteratePattern(m_lower, m_upper, m_extent, m_functor).exec_range();
+  }
+
+  ParallelForMDRange(FunctorType const& arg_functor, const array_type& lower,
+                     const array_type& upper, const array_type& extent)
+      : m_functor(arg_functor),
+        m_lower(lower),
+        m_upper(upper),
+        m_extent(extent) {}
+};
 
 // ParallelFor
 template <class FunctorType, class... Traits>
@@ -48,15 +95,81 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   }
 
   inline void execute() const {
-    using ClosureType = ParallelFor<FunctorType, Policy, HIP>;
     if (m_policy.m_num_tiles == 0) return;
 
     const auto [grid, block] =
         Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
 
-    hip_parallel_launch<ClosureType, LaunchBounds>(
-        *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),
-        false);
+    // Check if the grid covers the full iteration space (no stride needed).
+    using comp_t = std::common_type_t<std::make_unsigned_t<index_type>,
+                                      std::make_unsigned_t<array_index_type>,
+                                      unsigned int>;
+
+    const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
+    const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);
+    const comp_t max_grid_z = static_cast<comp_t>(m_max_grid_size[2]);
+    const comp_t bx         = static_cast<comp_t>(block.x);
+    const comp_t by         = static_cast<comp_t>(block.y);
+    const comp_t bz         = static_cast<comp_t>(block.z);
+
+    bool need_grid_stride = true;
+    if constexpr (Policy::rank == 2) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 3) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[2])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 4) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[3])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 5) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
+                                   static_cast<comp_t>(m_extent[3]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 6) {
+      if ((max_grid_x * bx) >= static_cast<comp_t>(m_extent[0]) *
+                                   static_cast<comp_t>(m_extent[1]) &&
+          (max_grid_y * by) >= static_cast<comp_t>(m_extent[2]) *
+                                   static_cast<comp_t>(m_extent[3]) &&
+          (max_grid_z * bz) >= static_cast<comp_t>(m_extent[4]) *
+                                   static_cast<comp_t>(m_extent[5])) {
+        need_grid_stride = false;
+      }
+    }
+
+    if constexpr (Policy::is_graph_kernel::value) {
+      hip_parallel_launch<ParallelFor, LaunchBounds>(
+          *this, grid, block, 0,
+          m_policy.space().impl_internal_space_instance(), false);
+    } else {
+      // launch the kernel
+      if (need_grid_stride) {
+        using ClosureType = ParallelForMDRange<FunctorType, true, Policy>;
+        ClosureType closure(m_functor, m_lower, m_upper, m_extent);
+        hip_parallel_launch<ClosureType, LaunchBounds>(
+            closure, grid, block, 0,
+            m_policy.space().impl_internal_space_instance(), false);
+      } else {
+        using ClosureType = ParallelForMDRange<FunctorType, false, Policy>;
+        ClosureType closure(m_functor, m_lower, m_upper, m_extent);
+        hip_parallel_launch<ClosureType, LaunchBounds>(
+            closure, grid, block, 0,
+            m_policy.space().impl_internal_space_instance(), false);
+      }
+    }
   }  // end execute
 
   ParallelFor(FunctorType const& arg_functor, Policy const& arg_policy)
@@ -99,7 +212,6 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
   }
 };
 
-}  // namespace Impl
-}  // namespace Kokkos
+}  // namespace Kokkos::Impl
 
-#endif
+#endif  // KOKKOS_HIP_PARALLEL_FOR_MDRANGE_HPP

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_MDRange.hpp
@@ -101,9 +101,7 @@ class ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>, HIP> {
         Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
 
     // Check if the grid covers the full iteration space (no stride needed).
-    using comp_t = std::common_type_t<std::make_unsigned_t<index_type>,
-                                      std::make_unsigned_t<array_index_type>,
-                                      unsigned int>;
+    using comp_t = std::common_type_t<index_type, array_index_type>;
 
     const comp_t max_grid_x = static_cast<comp_t>(m_max_grid_size[0]);
     const comp_t max_grid_y = static_cast<comp_t>(m_max_grid_size[1]);

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -83,7 +83,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         const index_type n_global_z = item.get_group_range(0);
 
         Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                    FunctorType, Policy::inner_direction,
+                                    Policy::inner_direction, true, FunctorType,
                                     typename Policy::work_tag>(
             lower_bound, upper_bound, extent, functor_wrapper.get_functor(),
             {n_global_x, n_global_y, n_global_z},

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -179,9 +179,9 @@ struct DeviceIterateNoStride {
   KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
       std::index_sequence<R...>, Idxs... idxs) const {
     if constexpr (Layout == Iterate::Left) {
-      return ((idxs < m_upper[R]) && ...);
+      return ((idxs < static_cast<index_type>(m_upper[R])) && ...);
     } else {
-      return ((idxs < m_upper[Rank - 1 - R]) && ...);
+      return ((idxs < static_cast<index_type>(m_upper[Rank - 1 - R])) && ...);
     }
   }
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -225,7 +225,7 @@ bool need_grid_stride_loop(const Kokkos::Array<array_type, 3>& max_grid_size,
 // 3. Bounds check against m_upper to filter out-of-bounds iterations.
 //
 template <int Rank, typename array_index_type, typename index_type,
-          Kokkos::Iterate Layout, bool grid_stride, typename Functor,
+          Kokkos::Iterate IterateDir, bool grid_stride, typename Functor,
           typename Tag>
 struct DeviceIterate {
   using array_type = Kokkos::Array<array_index_type, Rank>;
@@ -386,46 +386,47 @@ struct DeviceIterate {
     }
   }
 
-  // Packed: returns flat hardware thread index (unpacking happens in iterate())
-  // Unpacked: hardware thread index (blockIdx * blockDim + threadIdx)
-  template <unsigned R>
+  // \brief Returns the global thread index for dimension RIdx
+  // Packed: returns flat hardware thread ID (unpacking happens in iterate())
+  // Unpacked: returns global thread index (blockIdx * blockDim + threadIdx)
+  // \tparam RIdx rank index
+  // \return global thread index
+  template <unsigned RIdx>
   KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
   my_thIdx() const noexcept {
-    static_assert(R < 6);
-    if constexpr (is_packed_index<R>()) {
-      if constexpr (R == 0 || R == 1) {
+    static_assert(RIdx < 6);
+    if constexpr (Rank < 4) {
+      // No packed index
+      if constexpr (RIdx == 0) {
         return blockIdx.x * blockDim.x + threadIdx.x;
-      } else if constexpr (R == 2 || R == 3) {
+      } else if constexpr (RIdx == 1) {
         return blockIdx.y * blockDim.y + threadIdx.y;
-      } else if constexpr (R == 4 || R == 5) {
+      } else if constexpr (RIdx == 2) {
         return blockIdx.z * blockDim.z + threadIdx.z;
       }
-    } else {
-      // No packed index
-      if constexpr (Rank < 4) {
-        if constexpr (R == 0) {
+    } else {  // Ranks 4, 5, 6
+      if constexpr (is_packed_index<RIdx>()) {
+        if constexpr (RIdx == 0 || RIdx == 1) {
           return blockIdx.x * blockDim.x + threadIdx.x;
-        } else if constexpr (R == 1) {
+        } else if constexpr (RIdx == 2 || RIdx == 3) {
           return blockIdx.y * blockDim.y + threadIdx.y;
-        } else if constexpr (R == 2) {
+        } else if constexpr (RIdx == 4 || RIdx == 5) {
           return blockIdx.z * blockDim.z + threadIdx.z;
         }
-      } else {
-        // Mix of packed and unpacked for Rank 4 and 5
-        if constexpr (R == 2) {
+      } else {  // Unpacked indices of Ranks 4 and 5
+        if constexpr (RIdx == 2) {
           return blockIdx.y * blockDim.y + threadIdx.y;
-        } else if constexpr (R == 3 || R == 4) {
+        } else if constexpr (RIdx == 3 || RIdx == 4) {
           return blockIdx.z * blockDim.z + threadIdx.z;
         }
       }
     }
-    return index_type{0};
   }
 
   template <size_t... R, typename... Idxs>
   KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
       std::index_sequence<R...>, Idxs... idxs) const {
-    if constexpr (Layout == Iterate::Left) {
+    if constexpr (IterateDir == Iterate::Left) {
       return ((idxs < static_cast<index_type>(m_upper[R])) && ...);
     } else {
       return ((idxs < static_cast<index_type>(m_upper[Rank - 1 - R])) && ...);
@@ -471,7 +472,7 @@ struct DeviceIterate {
         const index_type id_2 = idx / m_extent[rankIdx1] + m_lower[rankIdx2];
 
         if (id_1 < m_upper[rankIdx1] && id_2 < m_upper[rankIdx2]) {
-          if constexpr (Layout == Iterate::Left) {
+          if constexpr (IterateDir == Iterate::Left) {
             iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2,
                     idxs...);
           } else {
@@ -480,7 +481,7 @@ struct DeviceIterate {
           }
         }
       } else {
-        if constexpr (Layout == Iterate::Left) {
+        if constexpr (IterateDir == Iterate::Left) {
           iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
         } else {
           iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);
@@ -510,14 +511,14 @@ struct DeviceIterate {
       const index_type id_1 = thIdx % m_extent[rankIdx1] + m_lower[rankIdx1];
       const index_type id_2 = thIdx / m_extent[rankIdx1] + m_lower[rankIdx2];
 
-      if constexpr (Layout == Iterate::Left) {
+      if constexpr (IterateDir == Iterate::Left) {
         iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2, idxs...);
       } else {
         iterate(std::integral_constant<unsigned, R - 2>(), idxs..., id_2, id_1);
       }
     } else {
       const index_type idx = thIdx + m_lower[rankIdx];
-      if constexpr (Layout == Iterate::Left) {
+      if constexpr (IterateDir == Iterate::Left) {
         iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
       } else {
         iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -50,151 +50,6 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
 }
 
 // ------------------------------------------------------------------------- //
-// ParallelFor iteration pattern without stride
-// When the backend API is sufficient for iterating over the ND-range
-//
-template <int Rank, typename array_index_type, typename index_type,
-          typename Functor, Kokkos::Iterate Layout, typename Tag>
-struct DeviceIterateNoStride {
-  using array_type = Kokkos::Array<array_index_type, Rank>;
-
- private:
-  const array_type m_lower;
-  const array_type m_upper;
-  const array_type m_extent;  // tile_size * num_tiles
-  const Functor& m_functor;
-
-#ifdef KOKKOS_ENABLE_SYCL
-  const EmulateCUDADim3<index_type> gridDim;
-  const EmulateCUDADim3<index_type> blockDim;
-  const EmulateCUDADim3<index_type> blockIdx;
-  const EmulateCUDADim3<index_type> threadIdx;
-#endif
-
- public:
-#ifdef KOKKOS_ENABLE_SYCL
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateNoStride(
-      const array_type& lower, const array_type& upper,
-      const array_type& extent, const Functor& functor,
-      const EmulateCUDADim3<index_type> gridDim_,
-      const EmulateCUDADim3<index_type> blockDim_,
-      const EmulateCUDADim3<index_type> blockIdx_,
-      const EmulateCUDADim3<index_type> threadIdx_)
-      : m_lower(lower),
-        m_upper(upper),
-        m_extent(extent),
-        m_functor(functor),
-        gridDim(gridDim_),
-        blockDim(blockDim_),
-        blockIdx(blockIdx_),
-        threadIdx(threadIdx_) {}
-#else
-  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateNoStride(const array_type& lower,
-                                                    const array_type& upper,
-                                                    const array_type& extent,
-                                                    const Functor& functor)
-      : m_lower(lower), m_upper(upper), m_extent(extent), m_functor(functor) {}
-#endif
-
-  KOKKOS_IMPL_DEVICE_FUNCTION
-  void exec_range() const { iterate(std::integral_constant<unsigned, Rank>()); }
-
- private:
-  // Runtime expression to determine if Dim is part of a packed pair
-  // Packing occurs on consecutive dimension pairs for rank > 3
-  template <unsigned Dim>
-  KOKKOS_IMPL_DEVICE_FUNCTION static consteval bool is_packed_index() {
-    return ((Dim == 0 || Dim == 1) && Rank > 3) ||
-           ((Dim == 2 || Dim == 3) && Rank > 4) ||
-           ((Dim == 4 || Dim == 5) && Rank > 5);
-  }
-
-  // Packed: returns flat hardware thread index (unpacking happens in iterate())
-  // Unpacked: hardware thread index (blockIdx * blockDim + threadIdx)
-  template <unsigned R>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_thIdx() const noexcept {
-    static_assert(R < 6);
-    if constexpr (is_packed_index<R>()) {
-      if constexpr (R == 0 || R == 1) {
-        return blockIdx.x * blockDim.x + threadIdx.x;
-      } else if constexpr (R == 2 || R == 3) {
-        return blockIdx.y * blockDim.y + threadIdx.y;
-      } else if constexpr (R == 4 || R == 5) {
-        return blockIdx.z * blockDim.z + threadIdx.z;
-      }
-    } else {
-      // No packed index
-      if constexpr (Rank < 4) {
-        if constexpr (R == 0) {
-          return blockIdx.x * blockDim.x + threadIdx.x;
-        } else if constexpr (R == 1) {
-          return blockIdx.y * blockDim.y + threadIdx.y;
-        } else if constexpr (R == 2) {
-          return blockIdx.z * blockDim.z + threadIdx.z;
-        }
-      } else {
-        // Mix of packed and unpacked for Rank 4 and 5
-        if constexpr (R == 2) {
-          return blockIdx.y * blockDim.y + threadIdx.y;
-        } else if constexpr (R == 3 || R == 4) {
-          return blockIdx.z * blockDim.z + threadIdx.z;
-        }
-      }
-    }
-    return index_type{0};
-  }
-
-  template <unsigned R, typename... Idxs>
-  KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
-      std::integral_constant<unsigned, R>, Idxs... idxs) const {
-    constexpr unsigned rankIdx = R - 1;
-    const index_type thIdx     = my_thIdx<rankIdx>();
-
-    if constexpr (is_packed_index<rankIdx>()) {
-      static_assert(R >= 2);
-      // Unpack two consecutive indices
-      constexpr unsigned rankId1 = (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
-      constexpr unsigned rankId2 = (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
-
-      const index_type id_1 = thIdx % m_extent[rankId1] + m_lower[rankId1];
-      const index_type id_2 = thIdx / m_extent[rankId1] + m_lower[rankId2];
-
-      if constexpr (Layout == Iterate::Left) {
-        iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2, idxs...);
-      } else {
-        iterate(std::integral_constant<unsigned, R - 2>(), idxs..., id_2, id_1);
-      }
-    } else {
-      const index_type idx = thIdx + m_lower[rankIdx];
-      if constexpr (Layout == Iterate::Left) {
-        iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
-      } else {
-        iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);
-      }
-    }
-  }
-
-  template <size_t... R, typename... Idxs>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
-      std::index_sequence<R...>, Idxs... idxs) const {
-    if constexpr (Layout == Iterate::Left) {
-      return ((idxs < static_cast<index_type>(m_upper[R])) && ...);
-    } else {
-      return ((idxs < static_cast<index_type>(m_upper[Rank - 1 - R])) && ...);
-    }
-  }
-
-  template <typename... Idxs>
-  KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
-      std::integral_constant<unsigned, 0u>, Idxs... idxs) const {
-    if (check_bounds(std::make_index_sequence<Rank>{}, idxs...)) {
-      Impl::_tag_invoke<Tag>(m_functor, idxs...);
-    }
-  }
-};
-
-// ------------------------------------------------------------------------- //
 // Compute GPU launch parameters (grid/block dimensions) for MDRangePolicy
 //
 // Ranks 1-3: Direct mapping - each policy dimension maps to one GPU dimension.
@@ -312,6 +167,51 @@ auto compute_device_launch_params(
 #endif
 }
 
+#ifndef KOKKOS_ENABLE_SYCL
+// Check if the grid covers the full iteration space (no grid stride needed)
+template <size_t Rank, typename array_type>
+bool need_grid_stride_loop(const Kokkos::Array<array_type, 3>& max_grid_size,
+                           const dim3& block,
+                           const Kokkos::Array<array_type, Rank>& m_extent) {
+  bool need_grid_stride = true;
+  if constexpr (Rank == 1) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0]) {
+      need_grid_stride = false;
+    }
+  } else if constexpr (Rank == 2) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0] &&
+        (max_grid_size[1] * block.y) >= m_extent[1]) {
+      need_grid_stride = false;
+    }
+  } else if constexpr (Rank == 3) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0] &&
+        (max_grid_size[1] * block.y) >= m_extent[1] &&
+        (max_grid_size[2] * block.z) >= m_extent[2]) {
+      need_grid_stride = false;
+    }
+  } else if constexpr (Rank == 4) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0] * m_extent[1] &&
+        (max_grid_size[1] * block.y) >= m_extent[2] &&
+        (max_grid_size[2] * block.z) >= m_extent[3]) {
+      need_grid_stride = false;
+    }
+  } else if constexpr (Rank == 5) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0] * m_extent[1] &&
+        (max_grid_size[1] * block.y) >= m_extent[2] * m_extent[3] &&
+        (max_grid_size[2] * block.z) >= m_extent[4]) {
+      need_grid_stride = false;
+    }
+  } else if constexpr (Rank == 6) {
+    if ((max_grid_size[0] * block.x) >= m_extent[0] * m_extent[1] &&
+        (max_grid_size[1] * block.y) >= m_extent[2] * m_extent[3] &&
+        (max_grid_size[2] * block.z) >= m_extent[4] * m_extent[5]) {
+      need_grid_stride = false;
+    }
+  }
+  return need_grid_stride;
+}
+#endif
+
 // ------------------------------------------------------------------------- //
 // ParallelFor iteration pattern - maps GPU threads to N-D iteration space
 //
@@ -325,7 +225,8 @@ auto compute_device_launch_params(
 // 3. Bounds check against m_upper to filter out-of-bounds iterations.
 //
 template <int Rank, typename array_index_type, typename index_type,
-          typename Functor, Kokkos::Iterate Layout, typename Tag>
+          Kokkos::Iterate Layout, bool grid_stride, typename Functor,
+          typename Tag>
 struct DeviceIterate {
   using array_type = Kokkos::Array<array_index_type, Rank>;
 
@@ -485,6 +386,52 @@ struct DeviceIterate {
     }
   }
 
+  // Packed: returns flat hardware thread index (unpacking happens in iterate())
+  // Unpacked: hardware thread index (blockIdx * blockDim + threadIdx)
+  template <unsigned R>
+  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
+  my_thIdx() const noexcept {
+    static_assert(R < 6);
+    if constexpr (is_packed_index<R>()) {
+      if constexpr (R == 0 || R == 1) {
+        return blockIdx.x * blockDim.x + threadIdx.x;
+      } else if constexpr (R == 2 || R == 3) {
+        return blockIdx.y * blockDim.y + threadIdx.y;
+      } else if constexpr (R == 4 || R == 5) {
+        return blockIdx.z * blockDim.z + threadIdx.z;
+      }
+    } else {
+      // No packed index
+      if constexpr (Rank < 4) {
+        if constexpr (R == 0) {
+          return blockIdx.x * blockDim.x + threadIdx.x;
+        } else if constexpr (R == 1) {
+          return blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 2) {
+          return blockIdx.z * blockDim.z + threadIdx.z;
+        }
+      } else {
+        // Mix of packed and unpacked for Rank 4 and 5
+        if constexpr (R == 2) {
+          return blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 3 || R == 4) {
+          return blockIdx.z * blockDim.z + threadIdx.z;
+        }
+      }
+    }
+    return index_type{0};
+  }
+
+  template <size_t... R, typename... Idxs>
+  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
+      std::index_sequence<R...>, Idxs... idxs) const {
+    if constexpr (Layout == Iterate::Left) {
+      return ((idxs < static_cast<index_type>(m_upper[R])) && ...);
+    } else {
+      return ((idxs < static_cast<index_type>(m_upper[Rank - 1 - R])) && ...);
+    }
+  }
+
   // ----------------------------------------------------------------------- //
   // Nested loops with recursive template instantiation
   //
@@ -503,7 +450,9 @@ struct DeviceIterate {
   //
   template <unsigned R, typename... Idxs>
   KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
-      std::integral_constant<unsigned, R>, Idxs... idxs) const {
+      std::integral_constant<unsigned, R>, Idxs... idxs) const
+    requires(grid_stride)
+  {
     constexpr unsigned rankIdx = R - 1;
     const index_type start     = my_begin<rankIdx>();
     const index_type end       = my_end<rankIdx>();
@@ -513,13 +462,15 @@ struct DeviceIterate {
       if constexpr (is_packed_index<rankIdx>()) {
         static_assert(R >= 2);
         // Unpack two consecutive indices
-        constexpr unsigned idx1 = (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
-        constexpr unsigned idx2 = (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
+        constexpr unsigned rankIdx1 =
+            (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
+        constexpr unsigned rankIdx2 =
+            (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
 
-        const index_type id_1 = idx % m_extent[idx1] + m_lower[idx1];
-        const index_type id_2 = idx / m_extent[idx1] + m_lower[idx2];
+        const index_type id_1 = idx % m_extent[rankIdx1] + m_lower[rankIdx1];
+        const index_type id_2 = idx / m_extent[rankIdx1] + m_lower[rankIdx2];
 
-        if (id_1 < m_upper[idx1] && id_2 < m_upper[idx2]) {
+        if (id_1 < m_upper[rankIdx1] && id_2 < m_upper[rankIdx2]) {
           if constexpr (Layout == Iterate::Left) {
             iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2,
                     idxs...);
@@ -538,10 +489,52 @@ struct DeviceIterate {
     }
   }
 
+  // Iteration pattern without grid stride. When the backend API is sufficient
+  // for iterating over the ND-range
+  template <unsigned R, typename... Idxs>
+  KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
+      std::integral_constant<unsigned, R>, Idxs... idxs) const
+    requires(!grid_stride)
+  {
+    constexpr unsigned rankIdx = R - 1;
+    const index_type thIdx     = my_thIdx<rankIdx>();
+
+    if constexpr (is_packed_index<rankIdx>()) {
+      static_assert(R >= 2);
+      // Unpack two consecutive indices
+      constexpr unsigned rankIdx1 =
+          (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
+      constexpr unsigned rankIdx2 =
+          (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
+
+      const index_type id_1 = thIdx % m_extent[rankIdx1] + m_lower[rankIdx1];
+      const index_type id_2 = thIdx / m_extent[rankIdx1] + m_lower[rankIdx2];
+
+      if constexpr (Layout == Iterate::Left) {
+        iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2, idxs...);
+      } else {
+        iterate(std::integral_constant<unsigned, R - 2>(), idxs..., id_2, id_1);
+      }
+    } else {
+      const index_type idx = thIdx + m_lower[rankIdx];
+      if constexpr (Layout == Iterate::Left) {
+        iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
+      } else {
+        iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);
+      }
+    }
+  }
+
   template <typename... Idxs>
   KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
       std::integral_constant<unsigned, 0u>, Idxs... idxs) const {
-    Impl::_tag_invoke<Tag>(m_functor, idxs...);
+    if constexpr (grid_stride) {
+      Impl::_tag_invoke<Tag>(m_functor, idxs...);
+    } else {  // !grid_stride
+      if (check_bounds(std::make_index_sequence<Rank>{}, idxs...)) {
+        Impl::_tag_invoke<Tag>(m_functor, idxs...);
+      }
+    }
   }
 };
 

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -7,11 +7,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <algorithm>
-
 #include <utility>
-
-#include <impl/Kokkos_Profiling_Interface.hpp>
-#include <typeinfo>
 
 namespace Kokkos {
 namespace Impl {
@@ -52,6 +48,151 @@ KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
   _tag_invoke_array_helper<Tag>(f, vals, std::make_index_sequence<N>{},
                                 (Args&&)args...);
 }
+
+// ------------------------------------------------------------------------- //
+// ParallelFor iteration pattern without stride
+// When the backend API is sufficient for iterating over the ND-range
+//
+template <int Rank, typename array_index_type, typename index_type,
+          typename Functor, Kokkos::Iterate Layout, typename Tag>
+struct DeviceIterateNoStride {
+  using array_type = Kokkos::Array<array_index_type, Rank>;
+
+ private:
+  const array_type m_lower;
+  const array_type m_upper;
+  const array_type m_extent;  // tile_size * num_tiles
+  const Functor& m_functor;
+
+#ifdef KOKKOS_ENABLE_SYCL
+  const EmulateCUDADim3<index_type> gridDim;
+  const EmulateCUDADim3<index_type> blockDim;
+  const EmulateCUDADim3<index_type> blockIdx;
+  const EmulateCUDADim3<index_type> threadIdx;
+#endif
+
+ public:
+#ifdef KOKKOS_ENABLE_SYCL
+  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateNoStride(
+      const array_type& lower, const array_type& upper,
+      const array_type& extent, const Functor& functor,
+      const EmulateCUDADim3<index_type> gridDim_,
+      const EmulateCUDADim3<index_type> blockDim_,
+      const EmulateCUDADim3<index_type> blockIdx_,
+      const EmulateCUDADim3<index_type> threadIdx_)
+      : m_lower(lower),
+        m_upper(upper),
+        m_extent(extent),
+        m_functor(functor),
+        gridDim(gridDim_),
+        blockDim(blockDim_),
+        blockIdx(blockIdx_),
+        threadIdx(threadIdx_) {}
+#else
+  KOKKOS_IMPL_DEVICE_FUNCTION DeviceIterateNoStride(const array_type& lower,
+                                                    const array_type& upper,
+                                                    const array_type& extent,
+                                                    const Functor& functor)
+      : m_lower(lower), m_upper(upper), m_extent(extent), m_functor(functor) {}
+#endif
+
+  KOKKOS_IMPL_DEVICE_FUNCTION
+  void exec_range() const { iterate(std::integral_constant<unsigned, Rank>()); }
+
+ private:
+  // Runtime expression to determine if Dim is part of a packed pair
+  // Packing occurs on consecutive dimension pairs for rank > 3
+  template <unsigned Dim>
+  KOKKOS_IMPL_DEVICE_FUNCTION static consteval bool is_packed_index() {
+    return ((Dim == 0 || Dim == 1) && Rank > 3) ||
+           ((Dim == 2 || Dim == 3) && Rank > 4) ||
+           ((Dim == 4 || Dim == 5) && Rank > 5);
+  }
+
+  // Packed: returns flat hardware thread index (unpacking happens in iterate())
+  // Unpacked: hardware thread index (blockIdx * blockDim + threadIdx)
+  template <unsigned R>
+  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
+  my_thIdx() const noexcept {
+    static_assert(R < 6);
+    if constexpr (is_packed_index<R>()) {
+      if constexpr (R == 0 || R == 1) {
+        return blockIdx.x * blockDim.x + threadIdx.x;
+      } else if constexpr (R == 2 || R == 3) {
+        return blockIdx.y * blockDim.y + threadIdx.y;
+      } else if constexpr (R == 4 || R == 5) {
+        return blockIdx.z * blockDim.z + threadIdx.z;
+      }
+    } else {
+      // No packed index
+      if constexpr (Rank < 4) {
+        if constexpr (R == 0) {
+          return blockIdx.x * blockDim.x + threadIdx.x;
+        } else if constexpr (R == 1) {
+          return blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 2) {
+          return blockIdx.z * blockDim.z + threadIdx.z;
+        }
+      } else {
+        // Mix of packed and unpacked for Rank 4 and 5
+        if constexpr (R == 2) {
+          return blockIdx.y * blockDim.y + threadIdx.y;
+        } else if constexpr (R == 3 || R == 4) {
+          return blockIdx.z * blockDim.z + threadIdx.z;
+        }
+      }
+    }
+    return index_type{0};
+  }
+
+  template <unsigned R, typename... Idxs>
+  KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
+      std::integral_constant<unsigned, R>, Idxs... idxs) const {
+    constexpr unsigned rankIdx = R - 1;
+    const index_type thIdx     = my_thIdx<rankIdx>();
+
+    if constexpr (is_packed_index<rankIdx>()) {
+      static_assert(R >= 2);
+      // Unpack two consecutive indices
+      constexpr unsigned rankId1 = (rankIdx % 2 == 0) ? rankIdx : (rankIdx - 1);
+      constexpr unsigned rankId2 = (rankIdx % 2 == 0) ? (rankIdx + 1) : rankIdx;
+
+      const index_type id_1 = thIdx % m_extent[rankId1] + m_lower[rankId1];
+      const index_type id_2 = thIdx / m_extent[rankId1] + m_lower[rankId2];
+
+      if constexpr (Layout == Iterate::Left) {
+        iterate(std::integral_constant<unsigned, R - 2>(), id_1, id_2, idxs...);
+      } else {
+        iterate(std::integral_constant<unsigned, R - 2>(), idxs..., id_2, id_1);
+      }
+    } else {
+      const index_type idx = thIdx + m_lower[rankIdx];
+      if constexpr (Layout == Iterate::Left) {
+        iterate(std::integral_constant<unsigned, R - 1>(), idx, idxs...);
+      } else {
+        iterate(std::integral_constant<unsigned, R - 1>(), idxs..., idx);
+      }
+    }
+  }
+
+  template <size_t... R, typename... Idxs>
+  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
+      std::index_sequence<R...>, Idxs... idxs) const {
+    if constexpr (Layout == Iterate::Left) {
+      return ((idxs < m_upper[R]) && ...);
+    } else {
+      return ((idxs < m_upper[Rank - 1 - R]) && ...);
+    }
+  }
+
+  template <typename... Idxs>
+  KOKKOS_IMPL_DEVICE_FUNCTION inline void iterate(
+      std::integral_constant<unsigned, 0u>, Idxs... idxs) const {
+    if (check_bounds(std::make_index_sequence<Rank>{}, idxs...)) {
+      Impl::_tag_invoke<Tag>(m_functor, idxs...);
+    }
+  }
+};
 
 // ------------------------------------------------------------------------- //
 // Compute GPU launch parameters (grid/block dimensions) for MDRangePolicy


### PR DESCRIPTION
When using the CUDA or HIP backend, if the API can provide enough threads to cover the entire iteration space, there is no need to rely on a grid-stride loop. This PR skips the grid-stride loop in that case.

This optimization is disabled for graph nodes.

Example, on the [PolyBench heat-3d](https://github.com/llnl/RAJAPerf/blob/develop/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp) bench on A100 with CUDA 12.8

| Version         |   Bandwidth (GB/s)   |  Registers (Occupancy)  |
|-----------------|----------------------|-------------------------|
|  Kokkos 5.1     |   815                |   48  (49%)             |
|  No stride loop |   1169               |   28  (85%)             |
|  Native CUDA    |   1189               |   28  (87%)             |

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

