### PR TITLE
Revert "[test] Add smoke testing for fast test iterations"

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,10 +118,6 @@ ctest -j$(nproc)                       # Parallel execution
 **Test structure:** `core/unit_test/` (main), `algorithms/unit_tests/`, `containers/unit_tests/`, `simd/unit_tests/`, `example/` (integration)
 **Naming:** `Kokkos_<Component>UnitTest_<Backend>_<TestName>`
 **Note:** Tests are backend-specific. Some disabled for certain backends (see `# FIXME_<BACKEND>` comments in CMakeLists.txt).
-**Smoke test:** A small subset of core unit tests for quicker compilation and execution. Requires `Kokkos_ENABLE_TESTS=ON`. Run with
-```bash
-ctest --test-dir builddir -R SmokeTest --output-on-failure
-```
 
 ## Critical Rules
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -114,11 +114,6 @@ whether it was given with the wrong case, e.g. `-DKokkos_Enable_Tests`,
 and then defines a regular (non-cache) variable `KOKKOS_ENABLE_TESTS` to `ON` or `OFF`
 depending on the given default and whether the option was specified.
 
-When `Kokkos_ENABLE_TESTS` is `ON`, a smoke target `Kokkos_CoreUnitTest_<Backend>_SmokeTest`
-is generated for each enabled backend; each target contains a small subset of the core unit tests.
-As a guideline for adding more smoke tests, we suggest including one test case per major API
-category or feature block. Do not duplicate by adding variations. Measure compilation time to quantify impact.
-
 ### Defining Kokkos Config Macros
 
 Sometimes you may want to add `#define Kokkos_X` macros to the config header.

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -88,27 +88,6 @@ endif()
 
 kokkos_add_executable(CoreTestCompileOnly SOURCES TestCompileMain.cpp ${COMPILE_ONLY_SOURCES})
 
-# Smoke tests, one per major API category
-set(SMOKE_TEST_NAMES
-    Abort
-    Atomics
-    BlockSizeDeduction
-    CommonPolicyInterface
-    Complex
-    DeepCopy_Assignment
-    ExecutionSpace
-    Graph
-    MDRange_a
-    RangePolicy
-    Reductions
-    SharedAlloc
-    TeamBasic
-    TeamMDRange
-    TeamVectorRange
-    ViewAPI_a
-    WorkGraph
-)
-
 foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
   string(TOUPPER ${Tag} DEVICE)
   string(TOLOWER ${Tag} dir)
@@ -122,6 +101,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
     set(${Tag}_SOURCES1A)
     foreach(
       Name
+      Abort
       ArrayOps
       AtomicOperations_complexdouble
       AtomicOperations_complexfloat
@@ -135,18 +115,25 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
       AtomicOperations_shared
       AtomicOperations_unsignedint
       AtomicOperations_unsignedlongint
+      Atomics
       AtomicViews
       BitManipulationBuiltins
+      BlockSizeDeduction
       CheckedIntegerOps
       CommonPolicyConstructors
+      CommonPolicyInterface
+      Complex
       Concepts
       Crs
+      DeepCopy_Assignment
       DeepCopy_Narrowing
       DeepCopy_SameArgument
       DeepCopyAlignment
       ExecSpacePartitioning
       ExecSpaceThreadSafety
+      ExecutionSpace
       FunctorAnalysis
+      Graph
       GraphNodeCtorProps
       HostSharedPtr
       HostSharedPtrAccessOnDevice
@@ -168,6 +155,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
 
     set(${Tag}_SOURCES1B)
     set(${Tag}_TESTNAMES1B
+        MDRange_a
         MDRange_b
         MDRange_c
         MDRange_d
@@ -187,6 +175,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
         CustomScalarParallelScan
         Printf
         QuadPrecisionMath
+        RangePolicy
         RangePolicyConstructors
         RangePolicyRequire
         ReducerCTADs
@@ -195,7 +184,9 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
         Reducers_c
         Reducers_d
         Reducers_e
+        Reductions
         Reductions_DeviceView
+        SharedAlloc
         SpaceAwareAccessorAccessViolation
         SpaceAwareAccessor
         Swap
@@ -228,15 +219,19 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
 
     set(${Tag}_SOURCES2A)
     set(${Tag}_TESTNAMES2A
+        TeamBasic
         TeamCombinedReducers
+        TeamMDRange
         TeamPolicyConstructors
         TeamReductionScan
         TeamScan
         TeamScratch
         TeamTeamSize
+        TeamVectorRange
         Timer
         UniqueToken
         View_64bit
+        ViewAPI_a
         ViewAPI_b
         ViewAPI_c
         ViewAPI_d
@@ -259,6 +254,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
         ViewOfViews
         ViewOutOfBoundsAccess
         ViewResize
+        WorkGraph
         WithoutInitializing
     )
     # Workaround to internal compiler error with intel classic compilers
@@ -362,31 +358,6 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
       endforeach()
       kokkos_add_executable_and_test(CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT})
     endif()
-    # Smoke test: minimal subset for quick iteration (generate sources not built with main targets).
-    foreach(Name IN LISTS SMOKE_TEST_NAMES)
-      set(file ${dir}/Test${Tag}_${Name}.cpp)
-      file(WRITE ${dir}/dummy.cpp "#include <Test${Tag}_Category.hpp>\n" "#include <Test${Name}.hpp>\n")
-      configure_file(${dir}/dummy.cpp ${file})
-    endforeach()
-    set(${Tag}_SOURCES_SMOKE)
-    foreach(Name IN LISTS SMOKE_TEST_NAMES)
-      set(file ${dir}/Test${Tag}_${Name}.cpp)
-      list(APPEND ${Tag}_SOURCES_SMOKE ${file})
-    endforeach()
-    # Fails serial.atomics_tpetra_max_abs when we test with Clacc (same as CoreUnitTest_Serial1).
-    if(Tag STREQUAL "Serial" AND KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
-
-      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Atomics.cpp)
-    endif()
-    # WorkGraph is not supported for SYCL in unit tests (historically excluded from CoreUnitTest_SYCL2A).
-    if(Tag STREQUAL "SYCL")
-      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_WorkGraph.cpp)
-    endif()
-    # Same as OpenACC_SOURCES (WorkGraph removed from the main OpenACC unit-test bundle).
-    if(Tag STREQUAL "OpenACC")
-      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_WorkGraph.cpp)
-    endif()
-    kokkos_add_executable_and_test(CoreUnitTest_${Tag}_SmokeTest SOURCES UnitTestMainInit.cpp ${${Tag}_SOURCES_SMOKE})
   endif()
 endforeach()
 
@@ -440,6 +411,7 @@ if(Kokkos_ENABLE_OPENACC)
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamMDRange.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamReductionScan.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamScan.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_TeamVectorRange.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_e.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewMapping_subview.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewOfClass.cpp
@@ -560,6 +532,8 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
       ${CMAKE_CURRENT_BINARY_DIR}/openacc/TestOpenACC_ViewAPI_c.cpp
     )
   endif()
+  # Fails serial.atomics_tpetra_max_abs when we test with Clacc.
+  list(REMOVE_ITEM Serial_SOURCES1 ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Atomics.cpp)
 endif()
 
 if(Kokkos_ENABLE_SERIAL)
@@ -679,6 +653,8 @@ if(Kokkos_ENABLE_HIP)
 endif()
 
 if(Kokkos_ENABLE_SYCL)
+  list(REMOVE_ITEM SYCL_SOURCES2A ${CMAKE_CURRENT_BINARY_DIR}/sycl/TestSYCL_WorkGraph.cpp)
+
   kokkos_add_executable_and_test(CoreUnitTest_SYCL1A SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1A})
 
   kokkos_add_executable_and_test(CoreUnitTest_SYCL1B SOURCES UnitTestMainInit.cpp ${SYCL_SOURCES1B})

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -362,7 +362,7 @@ struct TestStaticBatchSize {
 
 TEST(TEST_CATEGORY, range_dynamic_policy) {
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
-    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENACC)
+    !defined(KOKKOS_ENABLE_SYCL)
   {
     TestRange<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>> f(0);
     f.test_dynamic_policy();

--- a/core/unit_test/TestRangePolicyRequire.hpp
+++ b/core/unit_test/TestRangePolicyRequire.hpp
@@ -353,7 +353,7 @@ TEST(TEST_CATEGORY, range_reduce_require) {
 
 TEST(TEST_CATEGORY, range_dynamic_policy_require) {
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
-    !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENACC)
+    !defined(KOKKOS_ENABLE_SYCL)
   using Property = Kokkos::Experimental::WorkItemProperty::HintLightWeight_t;
   {
     TestRangeRequire<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Dynamic>,

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -69,9 +69,6 @@ TEST(TEST_CATEGORY, team_reduce_large) {
   }
 }
 
-#if !defined(KOKKOS_ENABLE_OPENACC)
-// FIXME_OPENACC: Kokkos::single(..., value&) uses team_broadcast; scratch query
-// APIs and team_broadcast are not implemented for OpenACC.
 /*! \brief Test passing an aggregate to Kokkos::single in a parallel_for with
            team policy
 */
@@ -263,7 +260,6 @@ TEST(TEST_CATEGORY_DEATH, exceed_max_team_scratch_size_1) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_exceed_max_team_scratch_size_1();
 }
-#endif
 
 void test_exceed_max_team_size() {
   Kokkos::TeamPolicy<TEST_EXECSPACE> policy(1, 1);
@@ -297,7 +293,6 @@ TEST(TEST_CATEGORY_DEATH, exceed_max_team_size) {
   test_exceed_max_team_size();
 }
 
-#if !defined(KOKKOS_ENABLE_OPENACC)
 TEST(TEST_CATEGORY, team_broadcast_long) {
   TestTeamBroadcast<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static>,
                     long>::test_teambroadcast(0, 1);
@@ -463,9 +458,7 @@ TEST(TEST_CATEGORY, team_broadcast_double) {
       }
   }
 }
-#endif
 
-#if !defined(KOKKOS_ENABLE_OPENACC)
 struct TeamBroadcastIntPtrFunctor {
   using TeamMember = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
 
@@ -494,7 +487,6 @@ TEST(TEST_CATEGORY, team_broadcast_int_ptr) {
   TeamBroadcastIntPtrFunctor team_broadcast_functor;
   team_broadcast_functor.run();
 }
-#endif
 
 struct TeamSingleThreadIntPtrFunctor {
   using TeamMember = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
@@ -527,7 +519,6 @@ TEST(TEST_CATEGORY, team_single_thread_int_ptr) {
   team_single_thread_functor.run();
 }
 
-#if !defined(KOKKOS_ENABLE_OPENACC)
 struct TeamSingleTeamIntPtrFunctor {
   using TeamMember = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
 
@@ -558,7 +549,6 @@ TEST(TEST_CATEGORY, team_single_team_int_ptr) {
   TeamSingleTeamIntPtrFunctor team_single_team_functor;
   team_single_team_functor.run();
 }
-#endif
 
 TEST(TEST_CATEGORY, team_handle_by_value) {
   { TestTeamPolicyHandleByValue<TEST_EXECSPACE>(); }

--- a/core/unit_test/TestTeamVector.hpp
+++ b/core/unit_test/TestTeamVector.hpp
@@ -690,11 +690,9 @@ bool test_scalar(int nteams, int team_size, int test) {
         Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
         functor_vec_red_reducer<Scalar, ExecutionSpace>(d_flag));
   } else if (test == 2) {
-#if !defined(KOKKOS_ENABLE_OPENACC)
     Kokkos::parallel_for(
         Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),
         functor_vec_scan<Scalar, ExecutionSpace>(d_flag));
-#endif
   } else if (test == 3) {
     Kokkos::parallel_for(
         Kokkos::TeamPolicy<ExecutionSpace>(nteams, team_size, 8),


### PR DESCRIPTION
Reverts kokkos/kokkos#8976

Breaks the `OPENACC-NVHPC-CUDA-12.2` build on ORNL Jenkins CI
https://github.com/kokkos/kokkos/pull/8976#issuecomment-4354693894