### PR TITLE
Add a minimal MSVC modules build

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -29,6 +29,7 @@ jobs:
       shell: bash
       run: |
         cmake --build build --parallel 4 --config Debug
+
   windows-serial:
     # Serial build on Windows
     name: Serial VS-2022
@@ -49,6 +50,31 @@ jobs:
       run: |
         export PATH="$(pwd)/build/core/src/Release:$(pwd)/build/containers/src/Release:$PATH"
         ctest --test-dir build -C Release -j 4 --output-on-failure
+
+  windows-modules:
+    # Modules build on Windows
+    name: Modules VS-2022
+    runs-on: windows-2025
+
+    steps:
+    - name: Setup MSVC
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: configure
+      shell: bash
+      run: |
+        cmake -G Ninja -B build -DKokkos_ENABLE_EXPERIMENTAL_CXX20_MODULES=ON
+    - name: build library
+      shell: bash
+      run: |
+        cmake --build build --parallel 4 --target kokkoscore
+    - name: build and execute example
+      shell: bash
+      run: |
+        cd example/build_cmake_installed_modules
+        cmake -G Ninja -B build -DKokkos_ROOT=../../build .
+        cmake --build build --parallel 4
+        ctest --test-dir build --verbose
 
   windows-clang:
    # Threads build on Windows using ClangCL

--- a/core/src/Cuda/Kokkos_CudaSpace.cpp
+++ b/core/src/Cuda/Kokkos_CudaSpace.cpp
@@ -9,11 +9,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <Cuda/Kokkos_Cuda.hpp>
 #include <Cuda/Kokkos_CudaSpace.hpp>
 

--- a/core/src/Cuda/Kokkos_Cuda_Instance.cpp
+++ b/core/src/Cuda/Kokkos_Cuda_Instance.cpp
@@ -12,11 +12,7 @@
 #ifdef KOKKOS_ENABLE_CUDA
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 // #include <Cuda/Kokkos_Cuda_Error.hpp>
 // #include <Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp>

--- a/core/src/HIP/Kokkos_HIP.cpp
+++ b/core/src/HIP/Kokkos_HIP.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_IsXnack.hpp>

--- a/core/src/HIP/Kokkos_HIP_Instance.cpp
+++ b/core/src/HIP/Kokkos_HIP_Instance.cpp
@@ -9,11 +9,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP.hpp>

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -8,11 +8,7 @@
 #include <Kokkos_Macros.hpp>
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_IsXnack.hpp>
 

--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #ifdef KOKKOS_ENABLE_HPX
 #include <HPX/Kokkos_HPX.hpp>

--- a/core/src/Kokkos_Assert.hpp
+++ b/core/src/Kokkos_Assert.hpp
@@ -5,7 +5,9 @@
 #define KOKKOS_ASSERT_HPP
 
 #include <Kokkos_Macros.hpp>
+#ifndef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 #include <Kokkos_Abort.hpp>
+#endif
 
 #if !defined(NDEBUG) || defined(KOKKOS_ENFORCE_CONTRACTS) || \
     defined(KOKKOS_ENABLE_DEBUG)

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <OpenMP/Kokkos_OpenMP_Instance.hpp>
 #include <impl/Kokkos_Error.hpp>

--- a/core/src/SYCL/Kokkos_SYCL.cpp
+++ b/core/src/SYCL/Kokkos_SYCL.cpp
@@ -10,11 +10,7 @@
 #include <SYCL/Kokkos_SYCL.hpp>
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -6,8 +6,8 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Core.hpp>  // kokkos_malloc
-
+#include <impl/Kokkos_CStyleMemoryManagement.hpp>
+#include <Kokkos_CopyViews.hpp>  // ZeroMemset
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_Error.hpp>
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core; // kokkos_malloc
-#else
 #include <Kokkos_Core.hpp>  // kokkos_malloc
-#endif
 
 #include <impl/Kokkos_CheckedIntegerOps.hpp>
 #include <impl/Kokkos_Error.hpp>

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <Serial/Kokkos_Serial.hpp>
 #include <impl/Kokkos_CheckUsage.hpp>

--- a/core/src/Threads/Kokkos_Threads_Instance.cpp
+++ b/core/src/Threads/Kokkos_Threads_Instance.cpp
@@ -13,12 +13,7 @@
 #include <sstream>
 #include <thread>
 
-#include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_CPUDiscovery.hpp>

--- a/core/src/impl/Kokkos_CheckUsage.hpp
+++ b/core/src/impl/Kokkos_CheckUsage.hpp
@@ -9,7 +9,7 @@
 #include <impl/Kokkos_InitializeFinalize.hpp>
 #include <impl/Kokkos_Utilities.hpp>
 
-#include <sstream>
+#include <string>
 #include <type_traits>
 
 // FIXME: Obtain file and line number information via std::source_location
@@ -58,12 +58,12 @@ struct CheckUsage<UsageRequires::isInitialized> {
   static void check(const char* func_name, const T& exec_policy,
                     const char* meta_data = "no-label") {
     if (!Kokkos::is_initialized()) {
-      std::stringstream ss;
-      ss << "Kokkos ERROR: attempting to call " << func_name << "() "
-         << "**before** Kokkos::initialize() was called."
-         << " Concerns " << meta_data << " with exec policy "
-         << fetch_policy_name(exec_policy) << ".";
-      Kokkos::abort(ss.str().c_str());
+      std::string str("Kokkos ERROR: attempting to call ");
+      str += std::string(func_name) + "() " +
+             "**before** Kokkos::initialize() was called." + " Concerns " +
+             meta_data + " with exec policy " + fetch_policy_name(exec_policy) +
+             ".";
+      Kokkos::abort(str.c_str());
     }
   }
 };
@@ -74,12 +74,12 @@ struct CheckUsage<UsageRequires::isNotFinalized> {
   static void check(const char* func_name, const T& exec_policy,
                     const char* meta_data = "no-label") {
     if (Kokkos::is_finalized()) {
-      std::stringstream ss;
-      ss << "Kokkos ERROR: attempting to call " << func_name << "() "
-         << "**after** Kokkos::finalize() was called."
-         << " Concerns " << meta_data << " with exec policy "
-         << fetch_policy_name(exec_policy) << ".";
-      Kokkos::abort(ss.str().c_str());
+      std::string str("Kokkos ERROR: attempting to call ");
+      str += std::string(func_name) + "() " +
+             "**after** Kokkos::finalize() was called." + " Concerns " +
+             meta_data + " with exec policy " + fetch_policy_name(exec_policy) +
+             ".";
+      Kokkos::abort(str.c_str());
     }
   }
 };
@@ -102,29 +102,29 @@ struct CheckUsage<UsageRequires::insideExecEnv> {
 inline void check_execution_space_constructor_precondition(
     char const* name) noexcept {
   if (Kokkos::is_finalized()) {
-    std::stringstream err;
-    err << "Kokkos ERROR: " << name
-        << " execution space is being constructed"
+    std::string err("Kokkos ERROR: ");
+    err += std::string(name) +
+           " execution space is being constructed"
            " after finalize() has been called";
-    Kokkos::abort(err.str().c_str());
+    Kokkos::abort(err.c_str());
   }
   if (!Kokkos::is_initialized()) {
-    std::stringstream err;
-    err << "Kokkos ERROR: " << name
-        << " execution space is being constructed"
+    std::string err("Kokkos ERROR: ");
+    err += std::string(name) +
+           " execution space is being constructed"
            " before initialize() has been called";
-    Kokkos::abort(err.str().c_str());
+    Kokkos::abort(err.c_str());
   }
 }
 
 inline void check_execution_space_destructor_precondition(
     char const* name) noexcept {
   if (Kokkos::is_finalized()) {
-    std::stringstream err;
-    err << "Kokkos ERROR: " << name
-        << " execution space is being destructed"
+    std::string err("Kokkos ERROR: ");
+    err += std::string(name) +
+           " execution space is being destructed"
            " after finalize() has been called";
-    Kokkos::abort(err.str().c_str());
+    Kokkos::abort(err.c_str());
   }
 }
 // NOLINTEND(bugprone-exception-escape)

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <impl/Kokkos_Error.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
 #include <impl/Kokkos_ParseCommandLineArgumentsAndEnvironmentVariables.hpp>

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -10,11 +10,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core; // show_warnings
-#else
 #include <Kokkos_Core.hpp>  // show_warnings
-#endif
 #include <impl/Kokkos_Error.hpp>
 
 void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {

--- a/core/src/impl/Kokkos_ExecPolicy.cpp
+++ b/core/src/impl/Kokkos_ExecPolicy.cpp
@@ -6,11 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <sstream>
 #include <Kokkos_ExecPolicy.hpp>
 

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -6,12 +6,7 @@
 #endif
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-import kokkos.core_impl;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <impl/Kokkos_SharedAlloc.hpp>
 #include <impl/Kokkos_StringManipulation.hpp>
 

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -13,11 +13,7 @@
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 #include <Kokkos_hwloc.hpp>
 #include <impl/Kokkos_Error.hpp>
 

--- a/example/build_cmake_installed_modules/cmake_example.cpp
+++ b/example/build_cmake_installed_modules/cmake_example.cpp
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-// Replaces the usual #include <Kokkos_Core.hpp>
-import kokkos.core;
+#include <iostream>
+
 // We don't get any transitive includes or macro definitions when importing
 // C++20 modules. Since pretty much every Kokkos-based code needs configuration
 // macros, it's recommended to always include Kokkos_Macros.hpp. In this
 // example, we need it for KOKKOS_LAMBDA in particular.
 #include <Kokkos_Macros.hpp>
 
-#include <iostream>
+// Replaces the usual #include <Kokkos_Core.hpp>. For some compilers, it's
+// important not to include any headers after importing the module.
+import kokkos.core;
 
 int main(int argc, char* argv[]) {
   Kokkos::initialize(argc, argv);


### PR DESCRIPTION
I'm still running into a lot of problems but with the changes here I can build the `kokkoscore` target (including the `kokkos.core*` modules) and run the `modules` example.
- The most important change was to avoid using the `kokkos.core*` modules in `core/src`. 
- For some reason `MSVC` didn't like `stringstream` in `CheckUsage.hpp`. Replacing it with `std::string` fixed that problem.
- `Kokkos_Assert.hpp` defines macros so it needs to be included in downstream code. Therefore, we can't include `Kokkos_Core.hpp` in modules builds. At the same time, we can't import `kokkos.core*` (when building the module). The easiest fix is to just not add `include` or `import` anything (apart from maybe `Kokkos_Macros.hpp`) and assume that some other mechanism provides `Kokkos::abort`.