### PR TITLE
core(graph): unique_ptr instead of shared_ptr

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_GraphNodeKernel.hpp
@@ -86,9 +86,20 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
   // covers and we're not modifying it
   cudaGraph_t const* m_graph_ptr    = nullptr;
   cudaGraphNode_t* m_graph_node_ptr = nullptr;
+
+  struct DriverStorageDeleter {
+    std::string label;
+    CudaSpace mem;
+
+    void operator()(base_t* const ptr) const {
+      mem.deallocate(label.c_str(), ptr, sizeof(base_t));
+    }
+  };
+
   // Basically, we have to make this mutable for the same reasons that the
   // global kernel buffers in the Cuda instance are mutable...
-  mutable std::shared_ptr<base_t> m_driver_storage = nullptr;
+  mutable std::unique_ptr<base_t, DriverStorageDeleter> m_driver_storage =
+      nullptr;
   std::string label;
 
  public:
@@ -127,16 +138,12 @@ class GraphNodeKernelImpl<Kokkos::Cuda, PolicyType, Functor, PatternTag,
     KOKKOS_EXPECTS(m_driver_storage == nullptr)
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
-    m_driver_storage = std::shared_ptr<base_t>(
+    m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
         static_cast<base_t*>(mem.allocate(alloc_label.c_str(), sizeof(base_t))),
-        [alloc_label, mem](base_t* ptr) {
-          mem.deallocate(alloc_label.c_str(), ptr, sizeof(base_t));
-        });
+        DriverStorageDeleter{.label = alloc_label, .mem = mem});
     KOKKOS_ENSURES(m_driver_storage != nullptr)
     return m_driver_storage.get();
   }
-
-  auto get_driver_storage() const { return m_driver_storage; }
 };
 
 struct CudaGraphNodeAggregate {};

--- a/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
+++ b/core/src/HIP/Kokkos_HIP_GraphNodeKernel.hpp
@@ -71,7 +71,17 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
       typename PatternImplSpecializationFromTag<PatternTag, Functor, Policy,
                                                 Args..., Kokkos::HIP>::type;
 
-  // TODO use the name and executionspace
+ private:
+  struct DriverStorageDeleter {
+    std::string label;
+    HIPSpace mem;
+
+    void operator()(base_t* const ptr) const {
+      mem.deallocate(label.c_str(), ptr, sizeof(base_t));
+    }
+  };
+
+ public:
   template <typename PolicyDeduced, typename... ArgsDeduced>
   GraphNodeKernelImpl(std::string label_, HIP const&, Functor arg_functor,
                       PolicyDeduced&& arg_policy, ArgsDeduced&&... args)
@@ -97,27 +107,22 @@ class GraphNodeKernelImpl<Kokkos::HIP, PolicyType, Functor, PatternTag, Args...>
 
   hipGraph_t const* get_hip_graph_ptr() const { return m_graph_ptr; }
 
-  base_t* allocate_driver_memory_buffer(const HIP& exec) const {
+  base_t* allocate_driver_memory_buffer(const HIPSpace& mem) const {
     KOKKOS_EXPECTS(m_driver_storage == nullptr);
     std::string alloc_label =
         label + " - GraphNodeKernel global memory functor storage";
-    m_driver_storage = std::shared_ptr<base_t>(
-        static_cast<base_t*>(
-            HIPSpace().allocate(exec, alloc_label.c_str(), sizeof(base_t))),
-        // FIXME_HIP Custom deletor should use same 'exec' as for allocation.
-        [alloc_label](base_t* ptr) {
-          HIPSpace().deallocate(alloc_label.c_str(), ptr, sizeof(base_t));
-        });
+    m_driver_storage = std::unique_ptr<base_t, DriverStorageDeleter>(
+        static_cast<base_t*>(mem.allocate(alloc_label.c_str(), sizeof(base_t))),
+        DriverStorageDeleter{.label = alloc_label, .mem = mem});
     KOKKOS_ENSURES(m_driver_storage != nullptr);
     return m_driver_storage.get();
   }
 
-  auto get_driver_storage() const { return m_driver_storage; }
-
  private:
-  hipGraph_t const* m_graph_ptr                    = nullptr;
-  hipGraphNode_t* m_graph_node_ptr                 = nullptr;
-  mutable std::shared_ptr<base_t> m_driver_storage = nullptr;
+  hipGraph_t const* m_graph_ptr    = nullptr;
+  hipGraphNode_t* m_graph_node_ptr = nullptr;
+  mutable std::unique_ptr<base_t, DriverStorageDeleter> m_driver_storage =
+      nullptr;
   std::string label;
 };
 
@@ -140,14 +145,14 @@ struct get_graph_node_kernel_type<KernelType, Kokkos::ParallelReduceTag>
           Kokkos::ParallelReduceTag>> {};
 
 template <typename KernelType>
-auto* allocate_driver_storage_for_kernel(const HIP& exec,
+auto* allocate_driver_storage_for_kernel(const HIPSpace& mem,
                                          KernelType const& kernel) {
   using graph_node_kernel_t =
       typename get_graph_node_kernel_type<KernelType>::type;
   auto const& kernel_as_graph_kernel =
       static_cast<graph_node_kernel_t const&>(kernel);
 
-  return kernel_as_graph_kernel.allocate_driver_memory_buffer(exec);
+  return kernel_as_graph_kernel.allocate_driver_memory_buffer(mem);
 }
 
 template <typename KernelType>

--- a/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
+++ b/core/src/HIP/Kokkos_HIP_KernelLaunch.hpp
@@ -438,7 +438,8 @@ struct HIPParallelLaunchKernelInvoker<DriverType, LaunchBounds,
 
     if (!Impl::is_empty_launch(grid, block)) {
       auto *driver_ptr = Impl::allocate_driver_storage_for_kernel(
-          HIP(hip_instance->m_stream, ManageStream::no), driver);
+          HIPSpace::impl_create(hip_instance->m_hipDev, hip_instance->m_stream),
+          driver);
 
       // Unlike in the non-graph case, we can get away with doing an async copy
       // here because the `DriverType` instance is held in the GraphNodeImpl


### PR DESCRIPTION
This PR switches from `shared_ptr` to `unique_ptr` for the CUDA/HIP kernel node driver storage (used to store the node driver when using the global launch mechanism).

Extracted from:
- #9139 

As requested by @dalg24 in https://github.com/kokkos/kokkos/pull/9139#pullrequestreview-4210981892.

Note that to align with CUDA, HIP now passes a memory space instance to `allocate_driver_memory_buffer`, instead of an execution space instance.

### Changelog Entry

Not required.
