### PR TITLE
Don't use std::unreachable with HIP

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -368,8 +368,9 @@
 
 // ---------------------------------------------------------------------------
 // Define macro for unreachable code:
+// FIXME_HIP doesn't support std::unreachable in device code
 #if defined(__cpp_lib_unreachable) && !defined(KOKKOS_ENABLE_HIP)
-#include <utility>
+#include <utility>  // since C++23
 #define KOKKOS_IMPL_UNREACHABLE() std::unreachable()
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -368,7 +368,7 @@
 
 // ---------------------------------------------------------------------------
 // Define macro for unreachable code:
-#if defined(__cpp_lib_unreachable)  // since C++23
+#if defined(__cpp_lib_unreachable) && !defined(KOKKOS_ENABLE_HIP)
 #include <utility>
 #define KOKKOS_IMPL_UNREACHABLE() std::unreachable()
 #elif defined(__has_builtin)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -368,9 +368,10 @@
 
 // ---------------------------------------------------------------------------
 // Define macro for unreachable code:
+// Only available in C++23
 // FIXME_HIP doesn't support std::unreachable in device code
 #if defined(__cpp_lib_unreachable) && !defined(KOKKOS_ENABLE_HIP)
-#include <utility>  // since C++23
+#include <utility>
 #define KOKKOS_IMPL_UNREACHABLE() std::unreachable()
 #elif defined(__has_builtin)
 #if __has_builtin(__builtin_unreachable)


### PR DESCRIPTION
Fixes https://my.cdash.org/builds/3516014/build that shows that we can't use `std::unreachable` in device code with the HIP backend.