### PR TITLE
View: Add debug check for mdspan overflow

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -28,8 +28,7 @@ class ViewMapping;
 }
 #include <View/Kokkos_ViewMapping.hpp>
 #include <Kokkos_MinMax.hpp>
-
-#include <limits>
+#include <Kokkos_NumericTraits.hpp>
 
 namespace Kokkos {
 template <class DataType, class... Properties>
@@ -468,7 +467,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
                                  Kokkos::layout_stride>) {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
       using idx_type = std::common_type_t<IndexOffset>;
-      if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
+      if (Kokkos::finite_max_v<idx_type> < m_map.required_span_size())
         Kokkos::abort(
             "Kokkos::View ERROR: index type cannot represent the full index "
             "range of the view");
@@ -487,7 +486,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     using idx_type = std::common_type_t<IndexOffsets...>;
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
-    if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
+    if (Kokkos::finite_max_v<idx_type> < m_map.required_span_size())
       Kokkos::abort(
           "Kokkos::View ERROR: index type cannot represent the full index "
           "range of the view");

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -469,7 +469,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
       using idx_type = std::common_type_t<IndexOffset>;
       if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
-        Kokkos::abort("Kokkos::View ERROR: index type cannot represent the full index range of the view");
+        Kokkos::abort(
+            "Kokkos::View ERROR: index type cannot represent the full index "
+            "range of the view");
 #endif
       return index_offset * static_cast<IndexOffset>(m_map.stride(0));
     } else
@@ -486,7 +488,9 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
     if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
-      Kokkos::abort("Kokkos::View ERROR: index type cannot represent span");
+      Kokkos::abort(
+          "Kokkos::View ERROR: index type cannot represent the full index "
+          "range of the view");
 #endif
 
     if constexpr (Kokkos::Impl::IsLayoutLeftPadded<

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -29,6 +29,8 @@ class ViewMapping;
 #include <View/Kokkos_ViewMapping.hpp>
 #include <Kokkos_MinMax.hpp>
 
+#include <limits>
+
 namespace Kokkos {
 template <class DataType, class... Properties>
 struct ViewTraits;
@@ -463,9 +465,14 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_FUNCTION constexpr auto compute_offset(
       std::index_sequence<0>, IndexOffset index_offset) const {
     if constexpr (std::is_same_v<typename base_t::layout_type,
-                                 Kokkos::layout_stride>)
+                                 Kokkos::layout_stride>) {
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+      using idx_type = std::common_type_t<IndexOffset>;
+      if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
+        Kokkos::abort("Kokkos::View ERROR: index type cannot represent span");
+#endif
       return index_offset * static_cast<IndexOffset>(m_map.stride(0));
-    else
+    } else
       return index_offset;
   }
 
@@ -476,6 +483,11 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   KOKKOS_FUNCTION constexpr auto compute_offset(
       std::index_sequence<I...>, IndexOffsets... index_offsets) const {
     using idx_type = std::common_type_t<IndexOffsets...>;
+
+#ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
+    if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
+      Kokkos::abort("Kokkos::View ERROR: index type cannot represent span");
+#endif
 
     if constexpr (Kokkos::Impl::IsLayoutLeftPadded<
                       typename base_t::layout_type>::value) {

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -469,7 +469,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
       using idx_type = std::common_type_t<IndexOffset>;
       if (std::numeric_limits<idx_type>::max() < m_map.required_span_size())
-        Kokkos::abort("Kokkos::View ERROR: index type cannot represent span");
+        Kokkos::abort("Kokkos::View ERROR: index type cannot represent the full index range of the view");
 #endif
       return index_offset * static_cast<IndexOffset>(m_map.stride(0));
     } else

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -466,8 +466,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
     if constexpr (std::is_same_v<typename base_t::layout_type,
                                  Kokkos::layout_stride>) {
 #ifdef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
-      using idx_type = std::common_type_t<IndexOffset>;
-      if (Kokkos::finite_max_v<idx_type> < m_map.required_span_size())
+      if (Kokkos::finite_max_v<IndexOffset> < m_map.required_span_size())
         Kokkos::abort(
             "Kokkos::View ERROR: index type cannot represent the full index "
             "range of the view");

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -160,28 +160,64 @@ TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
   test_view_out_of_bounds_access<ExecutionSpace>();
 }
 
+template <class View>
+struct TestViewIndexTypeCannotRepresentFullRangeRank1 {
+  View view;
+
+  KOKKOS_FUNCTION void operator()(int) const {
+    std::int16_t i = 0;
+    ++view(i);
+  }
+};
+
+template <class View>
+struct TestViewIndexTypeCannotRepresentFullRangeRank2 {
+  View view;
+
+  KOKKOS_FUNCTION void operator()(int) const {
+    std::int16_t i = 0;
+    std::int16_t j = 0;
+    ++view(i, j);
+  }
+};
+
+template <class ExecutionSpace>
+void test_view_index_type_cannot_represent_full_range() {
+  ExecutionSpace const exec_space{};
+  using MemorySpace = typename ExecutionSpace::memory_space;
+  constexpr char const* message =
+      "Kokkos::View ERROR: index type cannot represent the full index range "
+      "of the view";
+
+  Kokkos::LayoutStride layout_rank_1(40000, 1);
+  Kokkos::View<int*, Kokkos::LayoutStride, MemorySpace> view_1("view_rank_1",
+                                                               layout_rank_1);
+  EXPECT_DEATH(
+      {
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, 1),
+            TestViewIndexTypeCannotRepresentFullRangeRank1<decltype(view_1)>{
+                view_1});
+        Kokkos::fence();
+      },
+      message);
+
+  Kokkos::View<int**, Kokkos::LayoutRight, MemorySpace> view_2("view_rank_2",
+                                                               200, 200);
+  EXPECT_DEATH(
+      {
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy<ExecutionSpace>(exec_space, 0, 1),
+            TestViewIndexTypeCannotRepresentFullRangeRank2<decltype(view_2)>{
+                view_2});
+        Kokkos::fence();
+      },
+      message);
+}
+
 TEST(TEST_CATEGORY_DEATH, view_index_type_cannot_represent_full_range) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-  // Test on rank 1
-  Kokkos::LayoutStride layout_rank_1(40000, 1);
-  Kokkos::View<int*, Kokkos::LayoutStride, Kokkos::HostSpace> v1("view_rank_1",
-                                                                 layout_rank_1);
-  std::int16_t i1 = 0;
-  EXPECT_DEATH(
-      { (void)v1(i1); },
-      "Kokkos::View ERROR: index type cannot represent the full index range "
-      "of the view");
-
-  // Test on rank 2
-  Kokkos::View<int**, Kokkos::LayoutRight, Kokkos::HostSpace> v2("view_rank_2",
-                                                                 200, 200);
-  std::int16_t i2 = 0;
-  std::int16_t j2 = 0;
-  EXPECT_DEATH(
-      { (void)v2(i2, j2); },
-      "Kokkos::View ERROR: index type cannot represent the full index range "
-      "of the view");
+  test_view_index_type_cannot_represent_full_range<TEST_EXECSPACE>();
 }
 
 #endif

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -8,6 +8,7 @@ import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
+#include <cstdint>
 #include <sstream>
 
 #include <gtest/gtest.h>
@@ -157,6 +158,30 @@ TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
 #endif
 
   test_view_out_of_bounds_access<ExecutionSpace>();
+}
+
+TEST(TEST_CATEGORY_DEATH, view_index_type_cannot_represent_full_range) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  // Test on rank 1
+  Kokkos::LayoutStride layout_rank_1(40000, 1);
+  Kokkos::View<int*, Kokkos::LayoutStride, Kokkos::HostSpace> v1("view_rank_1",
+                                                                 layout_rank_1);
+  std::int16_t i1 = 0;
+  EXPECT_DEATH(
+      { (void)v1(i1); },
+      "Kokkos::View ERROR: index type cannot represent the full index range "
+      "of the view");
+
+  // Test on rank 2
+  Kokkos::View<int**, Kokkos::LayoutRight, Kokkos::HostSpace> v2("view_rank_2",
+                                                                 200, 200);
+  std::int16_t i2 = 0;
+  std::int16_t j2 = 0;
+  EXPECT_DEATH(
+      { (void)v2(i2, j2); },
+      "Kokkos::View ERROR: index type cannot represent the full index range "
+      "of the view");
 }
 
 #endif


### PR DESCRIPTION
Adds a debug-only bounds check to the mdspan-based `View::operator()` offset computation.

Related to #9136
Follow-up to #9150

### Changelog Entry
Not required

