### PR TITLE
Test with external mdspan

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -252,6 +252,12 @@ NVIDIA-GRACE-GRACE:
   script:
     - apt-get update && apt-get install -y cmake git g++
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
+    - git clone https://github.com/kokkos/mdspan
+    - cd mdspan
+    - git reset --hard $(cat ../tpls/mdspan-hash.txt)
+    - cmake -B build -DCMAKE_INSTALL_PREFIX=/tmp/mdspan-install -S .
+    - cmake --build build --target install
+    - cd ..
     - export ENV_CMAKE_OPTIONS=""
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_BUILD_TYPE=${BUILD_TYPE}"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_COMPILER=g++"
@@ -262,6 +268,8 @@ NVIDIA-GRACE-GRACE:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_DEPRECATED_CODE_5=OFF"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_MDSPAN_EXTERNAL=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D mdspan_ROOT=/tmp/mdspan-install"
     - export CTEST_BUILD_NAME="NVIDIA-GRACE-GRACE"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -153,7 +153,7 @@ if(Kokkos_ENABLE_IMPL_MDSPAN)
   if(Kokkos_ENABLE_MDSPAN_EXTERNAL)
     global_set(KOKKOS_MDSPAN_VERSION "unknown")
     message(STATUS "Using external mdspan")
-    target_link_libraries(kokkoscore PUBLIC std::mdspan)
+    target_link_libraries(kokkoscore PUBLIC mdspan::mdspan)
   else()
     target_include_directories(kokkoscore SYSTEM PUBLIC $<BUILD_INTERFACE:${KOKKOS_SOURCE_DIR}/tpls/mdspan/include>)
 


### PR DESCRIPTION
As discussed in https://github.com/kokkos/development/blob/main/meeting_notes/kokkos-core/dev-meeting/2026/2026-04-29.md we want to test with external (kokkos/mdspan). We decided in the CI WG meeting to start with one HPSF CI build and extent to CEA nightlies later.

Since we expect `mdspan` in the `Kokkos::mdspan` namespace (for now), we need to link against `mdspan::mdspan` instead of `std::mdspan`.