### PR TITLE
Add strict bounds checking and error formatting for SubviewExtents

### DIFF
--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -216,7 +216,7 @@ struct SubviewExtents {
 
     return set(domain_rank + 1, range_rank + 1, dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (e <= b + dim.extent(domain_rank))
+           && (b <= e) && (e <= b + dim.extent(domain_rank))
 #endif
         ;
   }
@@ -237,7 +237,7 @@ struct SubviewExtents {
 
     return set(domain_rank + 1, range_rank + 1, dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (e <= b + dim.extent(domain_rank))
+           && (b <= e) && (e <= b + dim.extent(domain_rank))
 #endif
         ;
   }
@@ -249,6 +249,9 @@ struct SubviewExtents {
                                        const ViewDimension<DimArgs...>& dim,
                                        const std::initializer_list<T>& val,
                                        Args... args) {
+    // Runtime check: must have exactly 2 elements before array access
+    if (val.size() != 2) return false;
+
     const size_t b = static_cast<size_t>(val.begin()[0]);
     const size_t e = static_cast<size_t>(val.begin()[1]);
 
@@ -258,7 +261,7 @@ struct SubviewExtents {
 
     return set(domain_rank + 1, range_rank + 1, dim, args...)
 #if defined(KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK)
-           && (val.size() == 2) && (e <= b + dim.extent(domain_rank))
+           && (b <= e) && (e <= b + dim.extent(domain_rank))
 #endif
         ;
   }
@@ -300,13 +303,22 @@ struct SubviewExtents {
   void error(char* buf, int buf_len, unsigned domain_rank, unsigned range_rank,
              const ViewDimension<DimArgs...>& dim, const std::pair<T, T>& val,
              Args... args) const {
-    // d <= e - b
-    const int n = std::min(
-        buf_len, snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
-                          static_cast<unsigned long>(dim.extent(domain_rank)),
-                          static_cast<unsigned long>(val.second),
-                          static_cast<unsigned long>(val.first),
-                          int(sizeof...(Args) ? ',' : ')')));
+    int n = 0;
+    // Check for invalid range: begin > end
+    if (val.first > val.second) {
+      n = std::min(buf_len, snprintf(buf, buf_len, " begin %lu > end %lu %c",
+                                     static_cast<unsigned long>(val.first),
+                                     static_cast<unsigned long>(val.second),
+                                     int(sizeof...(Args) ? ',' : ')')));
+    } else {
+      // d <= e - b
+      n = std::min(buf_len,
+                   snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
+                            static_cast<unsigned long>(dim.extent(domain_rank)),
+                            static_cast<unsigned long>(val.second),
+                            static_cast<unsigned long>(val.first),
+                            int(sizeof...(Args) ? ',' : ')')));
+    }
 
     error(buf + n, buf_len - n, domain_rank + 1, range_rank + 1, dim, args...);
   }
@@ -316,13 +328,22 @@ struct SubviewExtents {
   void error(char* buf, int buf_len, unsigned domain_rank, unsigned range_rank,
              const ViewDimension<DimArgs...>& dim,
              const Kokkos::pair<T, T>& val, Args... args) const {
-    // d <= e - b
-    const int n = std::min(
-        buf_len, snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
-                          static_cast<unsigned long>(dim.extent(domain_rank)),
-                          static_cast<unsigned long>(val.second),
-                          static_cast<unsigned long>(val.first),
-                          int(sizeof...(Args) ? ',' : ')')));
+    int n = 0;
+    // Check for invalid range: begin > end
+    if (val.first > val.second) {
+      n = std::min(buf_len, snprintf(buf, buf_len, " begin %lu > end %lu %c",
+                                     static_cast<unsigned long>(val.first),
+                                     static_cast<unsigned long>(val.second),
+                                     int(sizeof...(Args) ? ',' : ')')));
+    } else {
+      // d <= e - b
+      n = std::min(buf_len,
+                   snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
+                            static_cast<unsigned long>(dim.extent(domain_rank)),
+                            static_cast<unsigned long>(val.second),
+                            static_cast<unsigned long>(val.first),
+                            int(sizeof...(Args) ? ',' : ')')));
+    }
 
     error(buf + n, buf_len - n, domain_rank + 1, range_rank + 1, dim, args...);
   }
@@ -332,19 +353,25 @@ struct SubviewExtents {
   void error(char* buf, int buf_len, unsigned domain_rank, unsigned range_rank,
              const ViewDimension<DimArgs...>& dim,
              const std::initializer_list<T>& val, Args... args) const {
-    // d <= e - b
     int n = 0;
-    if (val.size() == 2) {
-      n = std::min(buf_len,
-                   snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
-                            static_cast<unsigned long>(dim.extent(domain_rank)),
-                            static_cast<unsigned long>(val.begin()[0]),
-                            static_cast<unsigned long>(val.begin()[1]),
-                            int(sizeof...(Args) ? ',' : ')')));
-    } else {
+    if (val.size() != 2) {
       n = std::min(buf_len, snprintf(buf, buf_len, " { ... }.size() == %u %c",
                                      unsigned(val.size()),
                                      int(sizeof...(Args) ? ',' : ')')));
+    } else if (val.begin()[0] > val.begin()[1]) {
+      // Check for invalid range: begin > end
+      n = std::min(buf_len, snprintf(buf, buf_len, " begin %lu > end %lu %c",
+                                     static_cast<unsigned long>(val.begin()[0]),
+                                     static_cast<unsigned long>(val.begin()[1]),
+                                     int(sizeof...(Args) ? ',' : ')')));
+    } else {
+      // d <= e - b
+      n = std::min(buf_len,
+                   snprintf(buf, buf_len, " %lu <= %lu - %lu %c",
+                            static_cast<unsigned long>(dim.extent(domain_rank)),
+                            static_cast<unsigned long>(val.begin()[1]),
+                            static_cast<unsigned long>(val.begin()[0]),
+                            int(sizeof...(Args) ? ',' : ')')));
     }
 
     error(buf + n, buf_len - n, domain_rank + 1, range_rank + 1, dim, args...);


### PR DESCRIPTION
Tested with :
```
using View_3_dim_ = Kokkos::Impl::ViewDimension<10,20,30>;
View_3_dim_ view_3_dim;
using subview_extents_3d = Kokkos::Impl::SubviewExtents<3,1>;
subview_extents_3d subview_extents_3d_inst(view_3_dim, 1, 5, std::initializer_list<int>{20,7,10});
ASSERT_EQ(subview_extents_3d_inst.domain_offset(1),5);
```
Result:
```
Kokkos::subview bounds error ( 1 < 10 , 5 < 20 , { ... }.size() == 3 )
```
If: 
```
using View_3_dim_ = Kokkos::Impl::ViewDimension<10,20,30>;
View_3_dim_ view_3_dim;
using subview_extents_3d = Kokkos::Impl::SubviewExtents<3,1>;
subview_extents_3d subview_extents_3d_inst(view_3_dim, 1, 5, std::pair<int,int>(20,10));
```

Result:
```
Kokkos::subview bounds error ( 1 < 10 , 5 < 20 , begin 20 > end 10 )
```

If:
```
using View_3_dim_ = Kokkos::Impl::ViewDimension<10,20,30>;
View_3_dim_ view_3_dim;
using subview_extents_3d = Kokkos::Impl::SubviewExtents<3,1>;
subview_extents_3d subview_extents_3d_inst(view_3_dim, 1, 5, std::pair<int,int>(50,100));
ASSERT_EQ(subview_extents_3d_inst.domain_offset(1),5);
```
Result:
```
Kokkos::subview bounds error ( 1 < 10 , 5 < 20 , 30 <= 100 - 50 )
```




### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
