### PR TITLE
core(graph): rename interoperability graph access with `<backend>_` prefix

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -112,9 +112,30 @@ struct [[nodiscard]] Graph {
     (*m_impl_ptr).submit(exec);
   }
 
-  decltype(auto) native_graph();
-
-  decltype(auto) native_graph_exec();
+#if defined(KOKKOS_ENABLE_CUDA)
+  cudaGraph_t cuda_graph() const
+  // FIXME_MSVC Did not work with Visual Studio 17 2022.
+#if !defined(KOKKOS_COMPILER_MSVC)
+    requires std::same_as<ExecutionSpace, Kokkos::Cuda>
+#endif
+  ;
+  cudaGraphExec_t cuda_graph_exec() const
+  // FIXME_MSVC Did not work with Visual Studio 17 2022.
+#if !defined(KOKKOS_COMPILER_MSVC)
+    requires std::same_as<ExecutionSpace, Kokkos::Cuda>
+#endif
+  ;
+#elif defined(KOKKOS_ENABLE_HIP)
+  hipGraph_t hip_graph() const
+    requires std::same_as<ExecutionSpace, Kokkos::HIP>;
+  hipGraphExec_t hip_graph_exec() const
+    requires std::same_as<ExecutionSpace, Kokkos::HIP>;
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
+  const auto& sycl_graph() const
+    requires std::same_as<ExecutionSpace, Kokkos::SYCL>;
+  const auto& sycl_graph_exec() const
+    requires std::same_as<ExecutionSpace, Kokkos::SYCL>;
+#endif
 };
 
 // </editor-fold> end Graph }}}1
@@ -181,41 +202,58 @@ create_graph(Closure&& arg_closure) {
 // </editor-fold> end create_graph }}}1
 //==============================================================================
 
-template <class ExecutionSpace>
-decltype(auto) Graph<ExecutionSpace>::native_graph() {
-  KOKKOS_EXPECTS(bool(m_impl_ptr));
 #if defined(KOKKOS_ENABLE_CUDA)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
-    return m_impl_ptr->cuda_graph();
-  }
-#elif defined(KOKKOS_ENABLE_HIP)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
-    return m_impl_ptr->hip_graph();
-  }
-#elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
-    return m_impl_ptr->sycl_graph();
-  }
-#endif
-}
-
 template <class ExecutionSpace>
-decltype(auto) Graph<ExecutionSpace>::native_graph_exec() {
-  KOKKOS_EXPECTS(bool(m_impl_ptr));
-#if defined(KOKKOS_ENABLE_CUDA)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::Cuda>) {
-    return m_impl_ptr->cuda_graph_exec();
-  }
-#elif defined(KOKKOS_ENABLE_HIP)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::HIP>) {
-    return m_impl_ptr->hip_graph_exec();
-  }
-#elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
-  if constexpr (std::is_same_v<ExecutionSpace, Kokkos::SYCL>) {
-    return m_impl_ptr->sycl_graph_exec();
-  }
+cudaGraph_t Graph<ExecutionSpace>::cuda_graph() const
+// FIXME_MSVC Did not work with Visual Studio 17 2022.
+#if !defined(KOKKOS_COMPILER_MSVC)
+  requires std::same_as<ExecutionSpace, Kokkos::Cuda>
 #endif
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->cuda_graph();
 }
+template <class ExecutionSpace>
+cudaGraphExec_t Graph<ExecutionSpace>::cuda_graph_exec() const
+// FIXME_MSVC Did not work with Visual Studio 17 2022.
+#if !defined(KOKKOS_COMPILER_MSVC)
+  requires std::same_as<ExecutionSpace, Kokkos::Cuda>
+#endif
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->cuda_graph_exec();
+}
+#elif defined(KOKKOS_ENABLE_HIP)
+template <class ExecutionSpace>
+hipGraph_t Graph<ExecutionSpace>::hip_graph() const
+  requires std::same_as<ExecutionSpace, Kokkos::HIP>
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->hip_graph();
+}
+template <class ExecutionSpace>
+hipGraphExec_t Graph<ExecutionSpace>::hip_graph_exec() const
+  requires std::same_as<ExecutionSpace, Kokkos::HIP>
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->hip_graph_exec();
+}
+#elif defined(KOKKOS_ENABLE_SYCL) && defined(KOKKOS_IMPL_SYCL_GRAPH_SUPPORT)
+template <class ExecutionSpace>
+const auto& Graph<ExecutionSpace>::sycl_graph() const
+  requires std::same_as<ExecutionSpace, Kokkos::SYCL>
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->sycl_graph();
+}
+template <class ExecutionSpace>
+const auto& Graph<ExecutionSpace>::sycl_graph_exec() const
+  requires std::same_as<ExecutionSpace, Kokkos::SYCL>
+{
+  KOKKOS_EXPECTS(bool(m_impl_ptr));
+  return m_impl_ptr->sycl_graph_exec();
+}
+#endif
 
 }  // end namespace Experimental
 }  // namespace Kokkos

--- a/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_GraphNodeKernel.hpp
@@ -19,7 +19,7 @@ namespace Impl {
 template <typename Functor>
 struct GraphNodeThenHostImpl<Kokkos::SYCL, Functor> {
  private:
-  using native_graph_t = sycl::ext::oneapi::experimental::command_graph<
+  using sycl_graph_t = sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::modifiable>;
 
   std::optional<Functor> m_functor = std::nullopt;
@@ -31,7 +31,7 @@ struct GraphNodeThenHostImpl<Kokkos::SYCL, Functor> {
   explicit GraphNodeThenHostImpl(Functor functor)
       : m_functor{std::move(functor)} {}
 
-  void add_to_graph(native_graph_t& graph) {
+  void add_to_graph(sycl_graph_t& graph) {
     KOKKOS_ENSURES(!m_node);
     KOKKOS_ENSURES(m_functor.has_value());
     m_node = graph.add([&](sycl::handler& cgh) {
@@ -45,17 +45,17 @@ struct GraphNodeThenHostImpl<Kokkos::SYCL, Functor> {
 
 template <typename Functor>
 struct GraphNodeCaptureImpl<Kokkos::SYCL, Functor> {
-  using native_graph_t = sycl::ext::oneapi::experimental::command_graph<
+  using sycl_graph_t = sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::modifiable>;
 
   Functor m_functor;
   std::optional<sycl::ext::oneapi::experimental::node> m_node = std::nullopt;
 
-  void capture(const Kokkos::SYCL& exec, native_graph_t& graph) {
+  void capture(const Kokkos::SYCL& exec, sycl_graph_t& graph) {
     auto& sycl_queue = exec.sycl_queue();
 
-    native_graph_t recorded_graph(sycl_queue.get_context(),
-                                  sycl_queue.get_device());
+    sycl_graph_t recorded_graph(sycl_queue.get_context(),
+                                sycl_queue.get_device());
 
     recorded_graph.begin_recording(sycl_queue);
     m_functor(exec);

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -32,8 +32,10 @@ class GraphImpl<Kokkos::SYCL> {
       GraphNodeImpl<Kokkos::SYCL, aggregate_impl_t,
                     Kokkos::Experimental::TypeErasedTag>;
 
-  using native_graph_t = sycl::ext::oneapi::experimental::command_graph<
+  using sycl_graph_t = sycl::ext::oneapi::experimental::command_graph<
       sycl::ext::oneapi::experimental::graph_state::modifiable>;
+  using sycl_graph_exec_t = sycl::ext::oneapi::experimental::command_graph<
+      sycl::ext::oneapi::experimental::graph_state::executable>;
 
   // Not movable or copyable; it spends its whole life as a shared_ptr in the
   // Graph object.
@@ -47,7 +49,7 @@ class GraphImpl<Kokkos::SYCL> {
 
   explicit GraphImpl(const device_handle_t& device_handle);
 
-  GraphImpl(const device_handle_t& device_handle, native_graph_t native_graph);
+  GraphImpl(const device_handle_t& device_handle, sycl_graph_t graph);
 
   void add_node(std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr);
 
@@ -88,10 +90,8 @@ class GraphImpl<Kokkos::SYCL> {
 
  private:
   device_handle_t m_device_handle;
-  native_graph_t m_graph;
-  std::optional<sycl::ext::oneapi::experimental::command_graph<
-      sycl::ext::oneapi::experimental::graph_state::executable>>
-      m_graph_exec;
+  sycl_graph_t m_graph;
+  std::optional<sycl_graph_exec_t> m_graph_exec;
 
   std::vector<std::shared_ptr<node_details_t>> m_nodes;
 };
@@ -107,8 +107,8 @@ inline GraphImpl<Kokkos::SYCL>::GraphImpl(const device_handle_t& device_handle)
               m_device_handle.m_exec.sycl_queue().get_device()) {}
 
 inline GraphImpl<Kokkos::SYCL>::GraphImpl(const device_handle_t& device_handle,
-                                          native_graph_t native_graph)
-    : m_device_handle(device_handle), m_graph(std::move(native_graph)) {}
+                                          sycl_graph_t graph)
+    : m_device_handle(device_handle), m_graph(std::move(graph)) {}
 
 inline void GraphImpl<Kokkos::SYCL>::add_node(
     std::shared_ptr<aggregate_node_impl_t> const& arg_node_ptr) {

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -51,8 +51,8 @@ class TEST_CATEGORY_FIXTURE(GraphInterOp) : public ::testing::Test {
 };
 
 // This test checks the promises of Kokkos::Graph against its
-// underlying Cuda native objects.
-TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), promises_on_native_objects) {
+// underlying CUDA graph objects.
+TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), promises_on_cuda_objects) {
   // Before instantiation, the Cuda graph is valid, but the Cuda executable
   // graph is still null.
   cudaGraph_t cuda_graph = graph->cuda_graph();
@@ -60,7 +60,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), promises_on_native_objects) {
   ASSERT_NE(cuda_graph, nullptr);
   ASSERT_EQ(graph->cuda_graph_exec(), nullptr);
 
-  // After instantiation, both native objects are valid.
+  // After instantiation, both CUDA objects are valid.
   graph->instantiate();
 
   cudaGraphExec_t cuda_graph_exec = graph->cuda_graph_exec();
@@ -88,7 +88,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), count_nodes) {
   ASSERT_EQ(num_nodes, 2u);
 }
 
-// Use native Cuda graph to generate a DOT representation.
+// Use CUDA graph to generate a DOT representation.
 TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), debug_dot_print) {
   graph->instantiate();
 
@@ -131,18 +131,19 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), instantiation_flags) {
 }
 
 // Build a Kokkos::Graph from an existing cudaGraph_t.
-TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_native) {
+TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_cuda_graph) {
   cudaGraph_t cuda_graph = nullptr;
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&cuda_graph, 0));
 
-  Kokkos::Experimental::Graph graph_from_native(
+  Kokkos::Experimental::Graph graph_from_cuda_graph(
       Kokkos::Experimental::get_device_handle(this->exec), cuda_graph);
 
-  ASSERT_EQ(cuda_graph, graph_from_native.cuda_graph());
+  ASSERT_EQ(cuda_graph, graph_from_cuda_graph.cuda_graph());
 
-  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
+  graph_from_cuda_graph.root_node().then_parallel_for(1,
+                                                      Increment<view_t>{data});
 
-  graph_from_native.submit(this->exec);
+  graph_from_cuda_graph.submit(this->exec);
 
   this->exec.fence();
 

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -55,24 +55,24 @@ class TEST_CATEGORY_FIXTURE(GraphInterOp) : public ::testing::Test {
 TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), promises_on_native_objects) {
   // Before instantiation, the Cuda graph is valid, but the Cuda executable
   // graph is still null.
-  cudaGraph_t cuda_graph = graph->native_graph();
+  cudaGraph_t cuda_graph = graph->cuda_graph();
 
   ASSERT_NE(cuda_graph, nullptr);
-  ASSERT_EQ(graph->native_graph_exec(), nullptr);
+  ASSERT_EQ(graph->cuda_graph_exec(), nullptr);
 
   // After instantiation, both native objects are valid.
   graph->instantiate();
 
-  cudaGraphExec_t cuda_graph_exec = graph->native_graph_exec();
+  cudaGraphExec_t cuda_graph_exec = graph->cuda_graph_exec();
 
-  ASSERT_EQ(graph->native_graph(), cuda_graph);
+  ASSERT_EQ(graph->cuda_graph(), cuda_graph);
   ASSERT_NE(cuda_graph_exec, nullptr);
 
   // Submission should not affect the underlying objects.
   graph->submit();
 
-  ASSERT_EQ(graph->native_graph(), cuda_graph);
-  ASSERT_EQ(graph->native_graph_exec(), cuda_graph_exec);
+  ASSERT_EQ(graph->cuda_graph(), cuda_graph);
+  ASSERT_EQ(graph->cuda_graph_exec(), cuda_graph_exec);
 }
 
 // Count the number of nodes. This is useful to ensure no spurious
@@ -83,7 +83,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), count_nodes) {
   size_t num_nodes;
 
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaGraphGetNodes(graph->native_graph(), nullptr, &num_nodes));
+      cudaGraphGetNodes(graph->cuda_graph(), nullptr, &num_nodes));
 
   ASSERT_EQ(num_nodes, 2u);
 }
@@ -96,7 +96,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), debug_dot_print) {
 
   // Convert path to string then to const char * to make it work on Windows.
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaGraphDebugDotPrint(graph->native_graph(), dot.string().c_str(),
+      cudaGraphDebugDotPrint(graph->cuda_graph(), dot.string().c_str(),
                              cudaGraphDebugDotFlagsVerbose));
 
   ASSERT_TRUE(std::filesystem::exists(dot));
@@ -124,7 +124,7 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), instantiation_flags) {
   graph->instantiate();
   unsigned long long flags = Kokkos::finite_max_v<unsigned long long>;
   KOKKOS_IMPL_CUDA_SAFE_CALL(
-      cudaGraphExecGetFlags(graph->native_graph_exec(), &flags));
+      cudaGraphExecGetFlags(graph->cuda_graph_exec(), &flags));
 
   ASSERT_EQ(flags, 0u);
 #endif
@@ -132,13 +132,13 @@ TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), instantiation_flags) {
 
 // Build a Kokkos::Graph from an existing cudaGraph_t.
 TEST_F(TEST_CATEGORY_FIXTURE(GraphInterOp), construct_from_native) {
-  cudaGraph_t native_graph = nullptr;
-  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&native_graph, 0));
+  cudaGraph_t cuda_graph = nullptr;
+  KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGraphCreate(&cuda_graph, 0));
 
   Kokkos::Experimental::Graph graph_from_native(
-      Kokkos::Experimental::get_device_handle(this->exec), native_graph);
+      Kokkos::Experimental::get_device_handle(this->exec), cuda_graph);
 
-  ASSERT_EQ(native_graph, graph_from_native.native_graph());
+  ASSERT_EQ(cuda_graph, graph_from_native.cuda_graph());
 
   graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -27,8 +27,8 @@ struct Increment {
 };
 
 // This test checks the promises of Kokkos::Graph against its
-// underlying HIP native objects.
-TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
+// underlying HIP graph objects.
+TEST(TEST_CATEGORY, graph_promises_on_hip_objects) {
   Kokkos::Experimental::Graph<Kokkos::HIP> graph{};
   // Before instantiation, the HIP graph is valid, but the HIP executable
   // graph is still null.
@@ -37,7 +37,7 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
   ASSERT_NE(hip_graph, nullptr);
   ASSERT_EQ(graph.hip_graph_exec(), nullptr);
 
-  // After instantiation, both native objects are valid.
+  // After instantiation, both HIP objects are valid.
   graph.instantiate();
 
   hipGraphExec_t hip_graph_exec = graph.hip_graph_exec();
@@ -52,7 +52,7 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
   ASSERT_EQ(graph.hip_graph_exec(), hip_graph_exec);
 }
 
-// Use native HIP graph to generate a DOT representation.
+// Use HIP graph to generate a DOT representation.
 TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   using view_t = Kokkos::View<int, Kokkos::HIP>;
 
@@ -97,7 +97,7 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 }
 
 // Build a Kokkos::Graph from an existing hipGraph_t.
-TEST(TEST_CATEGORY, graph_construct_from_native) {
+TEST(TEST_CATEGORY, graph_construct_from_hip_graph) {
   using view_t = Kokkos::View<int, Kokkos::HIPManagedSpace>;
 
   hipGraph_t hip_graph = nullptr;
@@ -105,16 +105,17 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
 
   const Kokkos::HIP exec{};
 
-  Kokkos::Experimental::Graph graph_from_native(
+  Kokkos::Experimental::Graph graph_from_hip_graph(
       Kokkos::Experimental::get_device_handle(exec), hip_graph);
 
-  ASSERT_EQ(hip_graph, graph_from_native.hip_graph());
+  ASSERT_EQ(hip_graph, graph_from_hip_graph.hip_graph());
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
+  graph_from_hip_graph.root_node().then_parallel_for(1,
+                                                     Increment<view_t>{data});
 
-  graph_from_native.submit(exec);
+  graph_from_hip_graph.submit(exec);
 
   exec.fence();
 

--- a/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
+++ b/core/unit_test/hip/TestHIP_InterOp_Graph.cpp
@@ -32,24 +32,24 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
   Kokkos::Experimental::Graph<Kokkos::HIP> graph{};
   // Before instantiation, the HIP graph is valid, but the HIP executable
   // graph is still null.
-  hipGraph_t hip_graph = graph.native_graph();
+  hipGraph_t hip_graph = graph.hip_graph();
 
   ASSERT_NE(hip_graph, nullptr);
-  ASSERT_EQ(graph.native_graph_exec(), nullptr);
+  ASSERT_EQ(graph.hip_graph_exec(), nullptr);
 
   // After instantiation, both native objects are valid.
   graph.instantiate();
 
-  hipGraphExec_t hip_graph_exec = graph.native_graph_exec();
+  hipGraphExec_t hip_graph_exec = graph.hip_graph_exec();
 
-  ASSERT_EQ(graph.native_graph(), hip_graph);
+  ASSERT_EQ(graph.hip_graph(), hip_graph);
   ASSERT_NE(hip_graph_exec, nullptr);
 
   // Submission should not affect the underlying objects.
   graph.submit();
 
-  ASSERT_EQ(graph.native_graph(), hip_graph);
-  ASSERT_EQ(graph.native_graph_exec(), hip_graph_exec);
+  ASSERT_EQ(graph.hip_graph(), hip_graph);
+  ASSERT_EQ(graph.hip_graph_exec(), hip_graph_exec);
 }
 
 // Use native HIP graph to generate a DOT representation.
@@ -70,14 +70,14 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   size_t num_nodes;
 
   KOKKOS_IMPL_HIP_SAFE_CALL(
-      hipGraphGetNodes(graph.native_graph(), nullptr, &num_nodes));
+      hipGraphGetNodes(graph.hip_graph(), nullptr, &num_nodes));
 
   ASSERT_EQ(num_nodes, 2u);
 
   const auto dot = std::filesystem::temp_directory_path() / "hip_graph.dot";
 
   KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphDebugDotPrint(
-      graph.native_graph(), dot.c_str(), hipGraphDebugDotFlagsVerbose));
+      graph.hip_graph(), dot.c_str(), hipGraphDebugDotFlagsVerbose));
 
   ASSERT_TRUE(std::filesystem::exists(dot));
   ASSERT_GT(std::filesystem::file_size(dot), 0u);
@@ -100,15 +100,15 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 TEST(TEST_CATEGORY, graph_construct_from_native) {
   using view_t = Kokkos::View<int, Kokkos::HIPManagedSpace>;
 
-  hipGraph_t native_graph = nullptr;
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphCreate(&native_graph, 0));
+  hipGraph_t hip_graph = nullptr;
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipGraphCreate(&hip_graph, 0));
 
   const Kokkos::HIP exec{};
 
   Kokkos::Experimental::Graph graph_from_native(
-      Kokkos::Experimental::get_device_handle(exec), native_graph);
+      Kokkos::Experimental::get_device_handle(exec), hip_graph);
 
-  ASSERT_EQ(native_graph, graph_from_native.native_graph());
+  ASSERT_EQ(hip_graph, graph_from_native.hip_graph());
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -26,7 +26,7 @@ struct Increment {
   void operator()(const int) const { ++data(); }
 };
 
-TEST(TEST_CATEGORY, graph_get_native_return_types_are_references) {
+TEST(TEST_CATEGORY, graph_get_sycl_objects_return_types_are_references) {
   using graph_t           = Kokkos::Experimental::Graph<Kokkos::SYCL>;
   using graph_impl_t      = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
   using sycl_graph_t      = typename graph_impl_t::sycl_graph_t;
@@ -39,8 +39,8 @@ TEST(TEST_CATEGORY, graph_get_native_return_types_are_references) {
 }
 
 // This test checks the promises of Kokkos::Graph against its
-// underlying SYCL native objects.
-TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
+// underlying SYCL command graph objects.
+TEST(TEST_CATEGORY, graph_promises_on_sycl_objects) {
   Kokkos::Experimental::Graph<Kokkos::SYCL> graph{};
 
   // Before instantiation, the SYCL graph is valid, but the SYCL executable
@@ -50,13 +50,13 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
   // so let's check it is empty for now.
   ASSERT_FALSE(graph.sycl_graph_exec().has_value());
 
-  // After instantiation, both native objects are valid.
+  // After instantiation, both SYCL objects are valid.
   graph.instantiate();
 
   ASSERT_TRUE(graph.sycl_graph_exec().has_value());
 }
 
-// Use native SYCL graph to generate a DOT representation.
+// Use SYCL command graph to generate a DOT representation.
 TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   using view_t = Kokkos::View<int, Kokkos::SYCL>;
 
@@ -100,7 +100,7 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 }
 
 // Build a Kokkos::Graph from an existing SYCL command graph.
-TEST(TEST_CATEGORY, graph_construct_from_native) {
+TEST(TEST_CATEGORY, graph_construct_from_sycl_command_graph) {
   using graph_impl_t = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
   using sycl_graph_t = typename graph_impl_t::sycl_graph_t;
 
@@ -111,14 +111,15 @@ TEST(TEST_CATEGORY, graph_construct_from_native) {
   sycl_graph_t sycl_graph(exec.sycl_queue().get_context(),
                           exec.sycl_queue().get_device());
 
-  Kokkos::Experimental::Graph graph_from_native(
+  Kokkos::Experimental::Graph graph_from_sycl_cmd_graph(
       Kokkos::Experimental::get_device_handle(exec), std::move(sycl_graph));
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 
-  graph_from_native.root_node().then_parallel_for(1, Increment<view_t>{data});
+  graph_from_sycl_cmd_graph.root_node().then_parallel_for(
+      1, Increment<view_t>{data});
 
-  graph_from_native.submit(exec);
+  graph_from_sycl_cmd_graph.submit(exec);
 
   exec.fence();
 

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -27,11 +27,15 @@ struct Increment {
 };
 
 TEST(TEST_CATEGORY, graph_get_native_return_types_are_references) {
-  using graph_t = Kokkos::Experimental::Graph<Kokkos::SYCL>;
+  using graph_t           = Kokkos::Experimental::Graph<Kokkos::SYCL>;
+  using graph_impl_t      = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
+  using sycl_graph_t      = typename graph_impl_t::sycl_graph_t;
+  using sycl_graph_exec_t = typename graph_impl_t::sycl_graph_exec_t;
+  static_assert(std::same_as<decltype(std::declval<graph_t>().sycl_graph()),
+                             const sycl_graph_t&>);
   static_assert(
-      std::is_reference_v<decltype(std::declval<graph_t>().native_graph())>);
-  static_assert(std::is_reference_v<
-                decltype(std::declval<graph_t>().native_graph_exec())>);
+      std::same_as<decltype(std::declval<graph_t>().sycl_graph_exec()),
+                   const std::optional<sycl_graph_exec_t>&>);
 }
 
 // This test checks the promises of Kokkos::Graph against its
@@ -44,12 +48,12 @@ TEST(TEST_CATEGORY, graph_promises_on_native_objects) {
   // no check is needed.
   // However, the executable SYCL command graph is stored as an optional,
   // so let's check it is empty for now.
-  ASSERT_FALSE(graph.native_graph_exec().has_value());
+  ASSERT_FALSE(graph.sycl_graph_exec().has_value());
 
   // After instantiation, both native objects are valid.
   graph.instantiate();
 
-  ASSERT_TRUE(graph.native_graph_exec().has_value());
+  ASSERT_TRUE(graph.sycl_graph_exec().has_value());
 }
 
 // Use native SYCL graph to generate a DOT representation.
@@ -67,11 +71,11 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
   graph.instantiate();
 
-  ASSERT_EQ(graph.native_graph().get_nodes().size(), 2u);
+  ASSERT_EQ(graph.sycl_graph().get_nodes().size(), 2u);
 
   const auto dot = std::filesystem::temp_directory_path() / "sycl_graph.dot";
 
-  graph.native_graph().print_graph(dot, true);
+  graph.sycl_graph().print_graph(dot, true);
 
   ASSERT_TRUE(std::filesystem::exists(dot));
   ASSERT_GT(std::filesystem::file_size(dot), 0u);
@@ -97,18 +101,18 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
 
 // Build a Kokkos::Graph from an existing SYCL command graph.
 TEST(TEST_CATEGORY, graph_construct_from_native) {
-  using graph_impl_t   = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
-  using native_graph_t = typename graph_impl_t::native_graph_t;
+  using graph_impl_t = Kokkos::Impl::GraphImpl<Kokkos::SYCL>;
+  using sycl_graph_t = typename graph_impl_t::sycl_graph_t;
 
   using view_t = Kokkos::View<int, Kokkos::SYCLSharedUSMSpace>;
 
   const Kokkos::SYCL exec{};
 
-  native_graph_t native_graph(exec.sycl_queue().get_context(),
-                              exec.sycl_queue().get_device());
+  sycl_graph_t sycl_graph(exec.sycl_queue().get_context(),
+                          exec.sycl_queue().get_device());
 
   Kokkos::Experimental::Graph graph_from_native(
-      Kokkos::Experimental::get_device_handle(exec), std::move(native_graph));
+      Kokkos::Experimental::get_device_handle(exec), std::move(sycl_graph));
 
   const view_t data(Kokkos::view_alloc(exec, "witness"));
 


### PR DESCRIPTION
@dalg24 rightly pointed out in 
* https://github.com/kokkos/kokkos/pull/6904#discussion_r1543196102

> I am tempted to suggest to call these `get_cuda_graph[_exec]` because I am not convinced there is much generic code one could write that get the native graph nor that the concept of "executable" graph will always make sense.

> That's my point, it is more about interoperability than portability here.

At the time of #6904, we followed @masterleinad suggestion https://github.com/kokkos/kokkos/pull/6904#discussion_r1763256123 and converged to `native_graph[_exec]`, *i.e.* same API name for all backends.

Together with @maartenarnst, we acknowledge that naming the "get underlying vendor graph[exec]" as `native_graph[_exec]` was a wrong choice. The getters are about interoperability, not portability.

This PR renames the accessors as `<backend>_graph[_exec]`, to follow `Kokkos` naming convention for interoperability features.

Beyond renaming:
1. The accessors are now `const`-qualified functions, much like `Kokkos::Cuda::cuda_stream` for instance.
2. The returned object type does not allow the user to change the handles stored in `Kokkos::Experimental::Graph`, to ensure they don't break any invariant.

### Related issues / PRs

* https://github.com/kokkos/kokkos/pull/6904

### Changelog Entry

Not sure anyone uses these already, but probably worth a changelog entry nevertheless.
