### PR TITLE
Use dependabot also for pre-commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "https://github.com/pre-commit/mirrors-clang-format"


### PR DESCRIPTION
See https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks.