### PR TITLE
nextsilicon: ci: enable persistent optimizer cache

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -419,7 +419,8 @@ jobs:
       # when the container exits
       - name: test_kokkos
         working-directory: kokkos/build
-        env: XDG_CACHE_HOME=$HOME/optimizer-cache
+        env:
+          XDG_CACHE_HOME: $HOME/optimizer-cache
         run: |
           nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -418,9 +418,9 @@ jobs:
       # create this directory and use it as a cache, but the contents will be lost
       # when the container exits
       - name: test_kokkos
-        working-directory: kokkos/build
-        run: |
-          export XDG_CACHE_HOME=$HOME/optimizer-cache
+working-directory: kokkos/build
+env: XDG_CACHE_HOME=$HOME/optimizer-cache
+run: |
           nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!
 

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -418,9 +418,9 @@ jobs:
       # create this directory and use it as a cache, but the contents will be lost
       # when the container exits
       - name: test_kokkos
-working-directory: kokkos/build
-env: XDG_CACHE_HOME=$HOME/optimizer-cache
-run: |
+      working-directory: kokkos/build
+      env: XDG_CACHE_HOME=$HOME/optimizer-cache
+      run: |
           nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!
 

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -418,9 +418,9 @@ jobs:
       # create this directory and use it as a cache, but the contents will be lost
       # when the container exits
       - name: test_kokkos
-      working-directory: kokkos/build
-      env: XDG_CACHE_HOME=$HOME/optimizer-cache
-      run: |
+        working-directory: kokkos/build
+        env: XDG_CACHE_HOME=$HOME/optimizer-cache
+        run: |
           nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!
 

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -413,9 +413,14 @@ jobs:
           cmake --build build --parallel $(nproc) \
             --target Kokkos_IncrementalTest_NEXTSILICON
 
+      # the SNL runners map a named volume to $HOME/optimizer-cache for a persistent
+      # optimizer cache across runs. If this doesn't get mapped, nextsystemd will
+      # create this directory and use it as a cache, but the contents will be lost
+      # when the container exits
       - name: test_kokkos
         working-directory: kokkos/build
         run: |
+          export XDG_CACHE_HOME=$HOME/optimizer-cache
           nextsystemd --ui-collector-address none &
           NEXTSYSTEMD_PID=$!
 


### PR DESCRIPTION
This should reduce projection time as we enable more tests. `nextsystemd` will report every time there is a projection cache hit so we can observe how well this actually works.

We'll be looking for something like this eventually (specifics may vary according to runtime version)
```
[projection] [info] [slot_projector.py:1679] [slot_8] Slot projection finished. Runtime 0:00:01 (HH:MM:SS) aka 0.032 minutes
[projection] [info] [mill_projector.py:816] [slot_13] CG projector results cache hit, skipping projection
[projection] [info] [mill_projector.py:2035] [slot_13] Suggested thread capacity: 511
```