### PR TITLE
 Fix compiling modules with clang++-22 

### DIFF
--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -10,7 +10,9 @@
 #include <cstdio>
 #include <Kokkos_Timer.hpp>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+// FIXME_MODULES The Impl::ApplyToViewOfStaticRank specialization for
+// DynRankView isn't visible
+#if 0  // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.dyn_rank_view;
 import kokkos.random;

--- a/algorithms/unit_tests/TestSort.hpp
+++ b/algorithms/unit_tests/TestSort.hpp
@@ -6,7 +6,9 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+// FIXME_MODULES The CommonSubview specialization for DynamicView doesn't get
+// properly exported
+#if 0  // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.dynamic_view;
 import kokkos.random;

--- a/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAdjacentFind.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <TestStdAlgorithmsCommon.hpp>
+#ifndef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 #include "std_algorithms/Kokkos_AdjacentFind.hpp"
+#endif
 #include <utility>
 
 namespace Test {

--- a/algorithms/unit_tests/TestStdAlgorithmsAllAnyNoneOf.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsAllAnyNoneOf.cpp
@@ -2,9 +2,12 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <TestStdAlgorithmsCommon.hpp>
+#include <Kokkos_Macros.hpp>
+#ifndef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 #include <std_algorithms/Kokkos_AllOf.hpp>
 #include <std_algorithms/Kokkos_AnyOf.hpp>
 #include <std_algorithms/Kokkos_NoneOf.hpp>
+#endif
 #include <algorithm>
 
 namespace Test {

--- a/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsTeamInclusiveScan.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <TestStdAlgorithmsCommon.hpp>
+#ifndef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 #include "std_algorithms/Kokkos_InclusiveScan.hpp"
+#endif
 
 namespace Test {
 namespace stdalgos {

--- a/containers/src/Kokkos_DynRankView.cppm
+++ b/containers/src/Kokkos_DynRankView.cppm
@@ -28,6 +28,11 @@ export {
   using ::Kokkos::create_mirror_view;
   using ::Kokkos::create_mirror_view_and_copy;
 
+  namespace Experimental {
+  using ::Kokkos::Experimental::python_view_type;
+  using ::Kokkos::Experimental::python_view_type_t;
+  }  // namespace Experimental
+
   using ::Kokkos::operator!=;
   using ::Kokkos::operator==;
   }  // namespace Kokkos

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -8,6 +8,12 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_OFFSETVIEW
 #endif
 
+#include <type_traits>
+#include <initializer_list>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
@@ -15,8 +21,6 @@ import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
 #endif
-
-#include <Kokkos_View.hpp>
 
 namespace Kokkos {
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -17,16 +17,18 @@
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
+import kokkos.core_impl;
 import kokkos.bitset;
 import kokkos.functional;
+import kokkos.unordered_map_impl;
 #else
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Bitset.hpp>
 #include <Kokkos_Functional.hpp>
+#include <impl/Kokkos_UnorderedMap_impl.hpp>
 #endif
 #include <Kokkos_Assert.hpp>
 #include <impl/Kokkos_Traits.hpp>
-#include <impl/Kokkos_UnorderedMap_impl.hpp>
 #include <View/Kokkos_ViewCtor.hpp>
 
 #include <cstdint>

--- a/containers/src/Kokkos_UnorderedMap_Impl.cppm
+++ b/containers/src/Kokkos_UnorderedMap_Impl.cppm
@@ -3,12 +3,18 @@
 
 module;
 
-#include <Kokkos_UnorderedMap.hpp>
+#include <impl/Kokkos_UnorderedMap_impl.hpp>
 
 export module kokkos.unordered_map_impl;
 
 export {
   namespace Kokkos::Impl {
+  using ::Kokkos::Impl::append_to_label;
+  using ::Kokkos::Impl::find_hash_size;
+  using ::Kokkos::Impl::UnorderedMapCanAssign;
+  using ::Kokkos::Impl::UnorderedMapErase;
+  using ::Kokkos::Impl::UnorderedMapHistogram;
   using ::Kokkos::Impl::UnorderedMapPrint;
+  using ::Kokkos::Impl::UnorderedMapRehash;
   }  // namespace Kokkos::Impl
 }

--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -4,7 +4,9 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+// FIXME_MODULES The Impl::ApplyToViewOfStaticRank specialization for
+// DynRankView isn't visible
+#if 0  // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.dyn_rank_view;
 import kokkos.dyn_rank_view_impl;

--- a/containers/unit_tests/TestDynamicView.hpp
+++ b/containers/unit_tests/TestDynamicView.hpp
@@ -9,7 +9,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+// FIXME_MODULES The CommonSubview for DynamicView isn't properly exported
+#if 0  // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.dynamic_view;
 #else

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -846,8 +846,13 @@ operator/(const RealType1& x,
 
 template <class RealType>
 std::ostream& operator<<(std::ostream& os, const complex<RealType>& x) {
+// FIXME_MODULES For some reason the operator<< for std::complex can't be found
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+  os << '(' << x.real() << ',' << x.imag() << ')';
+#else
   const std::complex<RealType> x_std(Kokkos::real(x), Kokkos::imag(x));
   os << x_std;
+#endif
   return os;
 }
 

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -213,7 +213,8 @@ export {
   using ::Kokkos::Timer;
   namespace Experimental {
   using ::Kokkos::Experimental::python_view_type;
-  }
+  using ::Kokkos::Experimental::python_view_type_t;
+  }  // namespace Experimental
 
   // initialization/finalization
   using ::Kokkos::finalize;

--- a/core/unit_test/TestInterOp.cpp
+++ b/core/unit_test/TestInterOp.cpp
@@ -2,14 +2,18 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+// FIXME_MODULES The pyhton_view_type specialization for DynRankView doesn't get
+// properly exported
+#if 0  // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.dyn_rank_view;
 #else
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DynRankView.hpp>
 #endif
-#include <KokkosExp_InterOp.hpp>
+
+#include <cstdint>
+#include <type_traits>
 
 // View
 static_assert(


### PR DESCRIPTION
Apparently, `clang-22` regressed from earlier versions when it comes to usage of template specializations and (weirdly) printing `std::complex`.
For the former, we are reverting to header includes for affected tests via `#if 0 // KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES` since this worked previously (and adding a FIXME).