### PR TITLE
Enable construction from array like types that convert to pointers

### DIFF
--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -949,17 +949,8 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
              std::is_convertible_v<P, pointer_type> &&
              std::is_constructible_v<typename base_t::data_handle_type,
                                      pointer_type> &&
-             sizeof...(Args) != rank() + 1)
+             ((sizeof...(Args)) != rank() + 1))
   KOKKOS_FUNCTION explicit View(P&& ptr_, Args... args)
-      : View(Kokkos::view_wrap(static_cast<pointer_type>(ptr_)), args...) {}
-
-  template <class P, class... Args>
-    requires(!std::is_null_pointer_v<P> &&
-             std::is_convertible_v<P, pointer_type> &&
-             std::is_constructible_v<typename base_t::data_handle_type,
-                                     pointer_type> &&
-             sizeof...(Args) != rank() + 1)
-  KOKKOS_FUNCTION explicit View(P& ptr_, Args... args)
       : View(Kokkos::view_wrap(static_cast<pointer_type>(ptr_)), args...) {}
 
   // Special function to be preferred over the above for string literals
@@ -1085,16 +1076,15 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 #endif
 
   template <class... Args>
-  View(std::enable_if_t<
+    requires(
 #ifndef KOKKOS_COMPILER_MSVC
-           ((sizeof...(Args)) != rank() + 1) &&
-               (std::is_constructible_v<size_t, Args> && ... && true),
+        ((sizeof...(Args)) != rank() + 1) &&
+        (std::is_constructible_v<size_t, Args> && ... && true)
 #else
-           msvc_workaround_ctor_condition_1<Args...>(),
+        msvc_workaround_ctor_condition_1<Args...>()
 #endif
-           const std::string&>
-           arg_label,
-       const Args... args)
+            )
+  View(const std::string& arg_label, const Args... args)
 #ifdef KOKKOS_COMPILER_INTEL_LLVM  // FIXME_INTEL
       // Eventually we want to get rid of the array_layout thing entirely.
       // For now this avoids a bug in the intel compiler 2024.2, and 2025 tested
@@ -1140,16 +1130,15 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
 
  public:
   template <class... Args>
-  View(std::enable_if_t<
+    requires(
 #ifndef KOKKOS_COMPILER_MSVC
-           ((sizeof...(Args)) == rank() + 1) &&
-               (std::is_constructible_v<size_t, Args> && ... && true),
+        ((sizeof...(Args)) == rank() + 1) &&
+        (std::is_constructible_v<size_t, Args> && ... && true)
 #else
-           msvc_workaround_ctor_condition_2<Args...>(),
+        msvc_workaround_ctor_condition_2<Args...>()
 #endif
-           const std::string&>
-           arg_label,
-       const Args... args)
+            )
+  View(const std::string arg_label, const Args... args)
       : View(
             view_alloc_from_label_and_integrals(
                 std::bool_constant<traits::impl_is_customized>(), arg_label,
@@ -1166,17 +1155,15 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
   }
 
   template <class... Args>
-  KOKKOS_FUNCTION View(
-      std::enable_if_t<
+    requires(
 #ifndef KOKKOS_COMPILER_MSVC
-          ((sizeof...(Args)) == rank() + 1) &&
-              (std::is_constructible_v<size_t, Args> && ... && true),
+        ((sizeof...(Args)) == rank() + 1) &&
+        (std::is_constructible_v<size_t, Args> && ... && true)
 #else
-           msvc_workaround_ctor_condition_2<Args...>(),
+           msvc_workaround_ctor_condition_2<Args...>()
 #endif
-          const pointer_type&>
-          arg_ptr,
-      const Args... args)
+            )
+  KOKKOS_FUNCTION View(const pointer_type& arg_ptr, const Args... args)
       : View(
             Kokkos::view_wrap(arg_ptr,
                               Kokkos::Impl::AccessorArg_t{

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -940,12 +940,26 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
             Impl::mapping_from_array_layout<typename mdspan_type::mapping_type>(
                 arg_layout)) {}
 
+  // Need both rvalue and lvalue versions of ctors which take
+  // things that are convertible to pointer_type.
+  // Can't take P by value since that would prevent value semantic
+  // types that allow implicit extraction of their ptr.
   template <class P, class... Args>
     requires(!std::is_null_pointer_v<P> &&
              std::is_convertible_v<P, pointer_type> &&
-             std::is_constructible_v<typename base_t::data_handle_type, P> &&
+             std::is_constructible_v<typename base_t::data_handle_type,
+                                     pointer_type> &&
              sizeof...(Args) != rank() + 1)
-  KOKKOS_FUNCTION explicit View(P ptr_, Args... args)
+  KOKKOS_FUNCTION explicit View(P&& ptr_, Args... args)
+      : View(Kokkos::view_wrap(static_cast<pointer_type>(ptr_)), args...) {}
+
+  template <class P, class... Args>
+    requires(!std::is_null_pointer_v<P> &&
+             std::is_convertible_v<P, pointer_type> &&
+             std::is_constructible_v<typename base_t::data_handle_type,
+                                     pointer_type> &&
+             sizeof...(Args) != rank() + 1)
+  KOKKOS_FUNCTION explicit View(P& ptr_, Args... args)
       : View(Kokkos::view_wrap(static_cast<pointer_type>(ptr_)), args...) {}
 
   // Special function to be preferred over the above for string literals

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1138,7 +1138,7 @@ class View : public Impl::BasicViewFromTraits<DataType, Properties...>::type {
         msvc_workaround_ctor_condition_2<Args...>()
 #endif
             )
-  View(const std::string arg_label, const Args... args)
+  View(const std::string& arg_label, const Args... args)
       : View(
             view_alloc_from_label_and_integrals(
                 std::bool_constant<traits::impl_is_customized>(), arg_label,

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -346,13 +346,14 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
     # detail tests for the mdspan based View
     if(Kokkos_ENABLE_IMPL_MDSPAN)
       set(BV_TestNames
+          AllocationAndSpanSize
           BasicView
+          CreateMirrorViewAndCopy
+          LegacyLayoutFunction
           ReferenceCountedAccessor
           ReferenceCountedDataHandle
-          AllocationAndSpanSize
           ViewEqualityOperator
-          LegacyLayoutFunction
-          CreateMirrorViewAndCopy
+          ViewCtorConvertibleToPtr
       )
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_OPENACC)
         list(APPEND BV_TestNames ViewCustomizationAccessorArg ViewCustomizationAllocationType

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -15,11 +15,14 @@ namespace {
 
 struct ArrayLike {
   double data[3];
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_FUNCTION
   operator double*() { return data; }
+  KOKKOS_FUNCTION
   operator const double*() const { return data; }
 };
 
+// clang-format off
+// clang-format gets confused, and thinks the lambda closure brace is the namespace
 void from_array_like() {
   Kokkos::View<ArrayLike*, TEST_EXECSPACE> a("A", 2);
   int errors = 0;
@@ -27,23 +30,23 @@ void from_array_like() {
     {
       Kokkos::View<double*> b(a(0), 3);
       if(b.data() != &a(0).data[0]) err++;
+    }
+    {
+      Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
+      if (b.data() != &a(0).data[0]) err++;
+    }
+    {
+      Kokkos::View<const double*> b(a(0), 3);
+      if (b.data() != &a(0).data[0]) err++;
+    }
+    {
+      Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
+      if (b.data() != &a(0).data[0]) err++;
+    }
+  }, errors);
+  ASSERT_EQ(errors, 0);
 }
-{
-  Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
-  if (b.data() != &a(0).data[0]) err++;
-}
-{
-  Kokkos::View<const double*> b(a(0), 3);
-  if (b.data() != &a(0).data[0]) err++;
-}
-{
-  Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
-  if (b.data() != &a(0).data[0]) err++;
-}
-}  // namespace
-, errors);
-ASSERT_EQ(errors, 0);
-}
+// clang-format on
 
 void from_carray() {
   int errors = 0;

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -174,21 +174,23 @@ void from_nullptr_and_0() {
           if (b.data() != nullptr) err++;
         }
         {
-          Kokkos::View<const double*, TEST_EXECSPACE> b(0, 0);
+          Kokkos::View<const double*, TEST_EXECSPACE> b(
+              0, 0);  // NOLINT(modernize-use-nullptr)
           if (b.data() != nullptr) err++;
         }
         {
           Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
-              b(0, 0);
+              b(0, 0);  // NOLINT(modernize-use-nullptr)
           if (b.data() != nullptr) err++;
         }
         {
-          Kokkos::View<const double*, TEST_EXECSPACE> b(NULL, 0);
+          Kokkos::View<const double*, TEST_EXECSPACE> b(
+              NULL, 0);  // NOLINT(modernize-use-nullptr)
           if (b.data() != nullptr) err++;
         }
         {
           Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
-              b(NULL, 0);
+              b(NULL, 0);  // NOLINT(modernize-use-nullptr)
           if (b.data() != nullptr) err++;
         }
       },

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -11,16 +11,14 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
-#define N 3
+constexpr int N = 3;
 
 namespace {
 
 struct ArrayLike {
   double data[N];
-  KOKKOS_FUNCTION
-  operator double*() { return data; }
-  KOKKOS_FUNCTION
-  operator const double*() const { return data; }
+  KOKKOS_FUNCTION operator double*() { return data; }
+  KOKKOS_FUNCTION operator const double*() const { return data; }
 };
 
 // clang-format off
@@ -81,8 +79,7 @@ void from_carray() {
 
 struct CustomPtr {
   double* ptr;
-  KOKKOS_INLINE_FUNCTION
-  operator double*() const { return ptr; }
+  KOKKOS_FUNCTION operator double*() const { return ptr; }
 };
 
 void from_custom_ptr() {

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+namespace {
+
+struct ArrayLike {
+  double data[3];
+  KOKKOS_INLINE_FUNCTION
+  operator double*() { return data; }
+  operator const double*() const { return data; }
+};
+
+void from_array_like() {
+  Kokkos::View<ArrayLike*, TEST_EXECSPACE> a("A", 2);
+  int errors = 0;
+  Kokkos::parallel_reduce(Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1), KOKKOS_LAMBDA(int, int& err) {
+    {
+      Kokkos::View<double*> b(a(0), 3);
+      if(b.data() != &a(0).data[0]) err++;
+}
+{
+  Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
+  if (b.data() != &a(0).data[0]) err++;
+}
+{
+  Kokkos::View<const double*> b(a(0), 3);
+  if (b.data() != &a(0).data[0]) err++;
+}
+{
+  Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
+  if (b.data() != &a(0).data[0]) err++;
+}
+}  // namespace
+, errors);
+ASSERT_EQ(errors, 0);
+}
+
+void from_carray() {
+  int errors = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
+      KOKKOS_LAMBDA(int, int& err) {
+        double a[3];
+        {
+          Kokkos::View<double*> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+      },
+      errors);
+  ASSERT_EQ(errors, 0);
+}
+
+struct CustomPtr {
+  double* ptr;
+  KOKKOS_INLINE_FUNCTION
+  operator double*() const { return ptr; }
+};
+
+void from_custom_ptr() {
+  int errors = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
+      KOKKOS_LAMBDA(int, int& err) {
+        double data[3];
+        CustomPtr a{&data[0]};
+        {
+          Kokkos::View<double*> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          if (b.data() != &a[0]) err++;
+        }
+      },
+      errors);
+  ASSERT_EQ(errors, 0);
+}
+
+void from_ptr() {
+  int errors = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
+      KOKKOS_LAMBDA(int, int& err) {
+        double a[3];
+        {
+          Kokkos::View<double*> b(&a[0], 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(&a[0], 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*> b(&a[0], 3);
+          if (b.data() != &a[0]) err++;
+        }
+        {
+          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(&a[0], 3);
+          if (b.data() != &a[0]) err++;
+        }
+      },
+      errors);
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(TEST_CATEGORY, view_ctor_ptr_convertible) {
+  from_array_like();
+  from_carray();
+  from_custom_ptr();
+  from_ptr();
+}
+
+}  // namespace

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -11,10 +11,12 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
+#define N 3
+
 namespace {
 
 struct ArrayLike {
-  double data[3];
+  double data[N];
   KOKKOS_FUNCTION
   operator double*() { return data; }
   KOKKOS_FUNCTION
@@ -24,24 +26,24 @@ struct ArrayLike {
 // clang-format off
 // clang-format gets confused, and thinks the lambda closure brace is the namespace
 void from_array_like() {
-  Kokkos::View<ArrayLike*, TEST_EXECSPACE> a("A", 2);
+  Kokkos::View<ArrayLike, TEST_EXECSPACE> a("A");
   int errors = 0;
   Kokkos::parallel_reduce(Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1), KOKKOS_LAMBDA(int, int& err) {
     {
-      Kokkos::View<double*> b(a(0), 3);
-      if(b.data() != &a(0).data[0]) err++;
+      Kokkos::View<double*, TEST_EXECSPACE> b(a(), N);
+      if(b.data() != &a().data[0]) err++;
     }
     {
-      Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
-      if (b.data() != &a(0).data[0]) err++;
+      Kokkos::View<double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(a(), N);
+      if (b.data() != &a().data[0]) err++;
     }
     {
-      Kokkos::View<const double*> b(a(0), 3);
-      if (b.data() != &a(0).data[0]) err++;
+      Kokkos::View<const double*, TEST_EXECSPACE> b(a(), N);
+      if (b.data() != &a().data[0]) err++;
     }
     {
-      Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a(0), 3);
-      if (b.data() != &a(0).data[0]) err++;
+      Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(a(), N);
+      if (b.data() != &a().data[0]) err++;
     }
   }, errors);
   ASSERT_EQ(errors, 0);
@@ -53,21 +55,23 @@ void from_carray() {
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
       KOKKOS_LAMBDA(int, int& err) {
-        double a[3];
+        double a[N];
         {
-          Kokkos::View<double*> b(a, 3);
+          Kokkos::View<double*, TEST_EXECSPACE> b(a, N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          Kokkos::View<double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(a,
+                                                                           N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*> b(a, 3);
+          Kokkos::View<const double*, TEST_EXECSPACE> b(a, N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(a, N);
           if (b.data() != &a[0]) err++;
         }
       },
@@ -86,22 +90,24 @@ void from_custom_ptr() {
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
       KOKKOS_LAMBDA(int, int& err) {
-        double data[3];
+        double data[N];
         CustomPtr a{&data[0]};
         {
-          Kokkos::View<double*> b(a, 3);
+          Kokkos::View<double*, TEST_EXECSPACE> b(a, N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          Kokkos::View<double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(a,
+                                                                           N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*> b(a, 3);
+          Kokkos::View<const double*, TEST_EXECSPACE> b(a, N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(a, 3);
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(a, N);
           if (b.data() != &a[0]) err++;
         }
       },
@@ -114,22 +120,76 @@ void from_ptr() {
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
       KOKKOS_LAMBDA(int, int& err) {
-        double a[3];
+        double a[N];
         {
-          Kokkos::View<double*> b(&a[0], 3);
+          Kokkos::View<double*, TEST_EXECSPACE> b(&a[0], N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<double*, Kokkos::MemoryUnmanaged> b(&a[0], 3);
+          Kokkos::View<double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(
+              &a[0], N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*> b(&a[0], 3);
+          Kokkos::View<const double*, TEST_EXECSPACE> b(&a[0], N);
           if (b.data() != &a[0]) err++;
         }
         {
-          Kokkos::View<const double*, Kokkos::MemoryUnmanaged> b(&a[0], 3);
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(&a[0], N);
           if (b.data() != &a[0]) err++;
+        }
+      },
+      errors);
+  ASSERT_EQ(errors, 0);
+}
+
+std::nullptr_t& nullptr_ref(std::nullptr_t& val) { return val; }
+
+void from_nullptr_and_0() {
+  int errors = 0;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy(TEST_EXECSPACE(), 0, 1),
+      KOKKOS_LAMBDA(int, int& err) {
+        {
+          Kokkos::View<double*, TEST_EXECSPACE> b(nullptr, 0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged> b(
+              nullptr, 0);
+          if (b.data() != nullptr) err++;
+        }
+        // need a temporary so we can test reference to nullptr_t
+        // you can't get a non-const ref to nullptr (the variable)
+        std::nullptr_t nullptrtmp;
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE> b(nullptr_ref(nullptrtmp),
+                                                        0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(nullptr_ref(nullptrtmp), 0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE> b(0, 0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(0, 0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE> b(NULL, 0);
+          if (b.data() != nullptr) err++;
+        }
+        {
+          Kokkos::View<const double*, TEST_EXECSPACE, Kokkos::MemoryUnmanaged>
+              b(NULL, 0);
+          if (b.data() != nullptr) err++;
         }
       },
       errors);
@@ -141,6 +201,7 @@ TEST(TEST_CATEGORY, view_ctor_ptr_convertible) {
   from_carray();
   from_custom_ptr();
   from_ptr();
+  from_nullptr_and_0();
 }
 
 }  // namespace

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -144,7 +144,7 @@ void from_ptr() {
   ASSERT_EQ(errors, 0);
 }
 
-std::nullptr_t& nullptr_ref(std::nullptr_t& val) { return val; }
+KOKKOS_FUNCTION std::nullptr_t& nullptr_ref(std::nullptr_t& val) { return val; }
 
 void from_nullptr_and_0() {
   int errors = 0;

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -162,7 +162,7 @@ void from_nullptr_and_0() {
         }
         // need a temporary so we can test reference to nullptr_t
         // you can't get a non-const ref to nullptr (the variable)
-        std::nullptr_t nullptrtmp;
+        std::nullptr_t nullptrtmp = {};
         {
           Kokkos::View<const double*, TEST_EXECSPACE> b(nullptr_ref(nullptrtmp),
                                                         0);


### PR DESCRIPTION
Imagine a type such as this: 
```c++
struct ArrayLike {
  double data[3];
  KOKKOS_INLINE_FUNCTION
  operator double*() { return data; }
  operator const double*() const { return data; }
};
```

it used to work (i.e. with legacy view) that you could construct an unmanaged `Kokkos::View` from that like this:
```c++
ArrayLike data;
View<double*> a(data, 3);
```
because we had a constructor in `View` which would take a `pointer_type`, i.e. `double*` by value and that would trigger the implicit conversion. 

With the new `View` (before this PR) we only have a ctor (simplified) like this:

```c++
template<class P, class ... Args>
requires(is_convertible_v<P, pointer_type>)
View(P ptr, Args ... args)
```

Thus if you try the above construction you get a ptr to a temporary copy of `data`, instead of the ptr in side of `data`. I.e. the unmanaged View immediately has a dangling ptr.

This PR enables that scenario to work again, which was encountered (a lot) in Empire.

Note that this works for `mdspan` so from an alignment perspective we probably should support this. 