### PR TITLE
Fix SYCL Dockerfile

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -8,6 +8,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 
 RUN apt-get update && apt-get install -y \
         bc \
+        ca-certificates \
         wget \
         ccache \
         ninja-build \


### PR DESCRIPTION
Should fix https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-6811/10/stages/.
```
Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 23.62.72.247 443]

Fetched 48.5 MB in 7s (6618 kB/s)

Reading package lists...

W: Failed to fetch <a href="https://apt.repos.intel.com/oneapi/dists/all/InRelease">https://apt.repos.intel.com/oneapi/dists/all/InRelease</a>  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 23.62.72.247 443]

W: Some index files failed to download. They have been ignored, or old ones used instead.
```