### PR TITLE
small typo in kokkos_function.cmake

### DIFF
--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -1061,7 +1061,7 @@ function(kokkos_compilation)
 
   if(NOT Kokkos_NVCC_WRAPPER)
     message(
-      FATAL_ERROR "Kokkos could not find 'nvcc_wrapper'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/nvcc_wrapper'"
+      FATAL_ERROR "Kokkos could not find 'nvcc_wrapper'. Please set '-DKokkos_NVCC_WRAPPER=/path/to/nvcc_wrapper'"
     )
   endif()
 

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -141,7 +141,7 @@ macro(kokkos_export_cmake_tpl NAME)
   #X_DIR or X_ROOT variables set prior to calling find_package
 
   #If Kokkos was configured to find the TPL through a _DIR variable
-  #make sure thar DIR variable is available to downstream packages
+  #make sure that DIR variable is available to downstream packages
   if(DEFINED ${NAME}_DIR)
     #The downstream project may override the TPL location that Kokkos used
     #Check if the downstream project chose its own TPL location
@@ -518,7 +518,7 @@ macro(kokkos_find_library VAR_NAME LIB TPL_NAME)
     set(TPL_SUFFIXES lib lib64)
   endif()
 
-  set(${VAR_NAME} "${VARNAME}-NOTFOUND")
+  set(${VAR_NAME} "${VAR_NAME}-NOTFOUND")
   set(HAVE_CUSTOM_PATHS FALSE)
 
   if(DEFINED ${TPL_NAME}_ROOT
@@ -1058,7 +1058,7 @@ function(kokkos_compilation)
     PATH_SUFFIXES bin
   )
 
-  if(NOT Kokkos_COMPILE_LAUNCHER)
+  if(NOT Kokkos_NVCC_WRAPPER)
     message(
       FATAL_ERROR "Kokkos could not find 'nvcc_wrapper'. Please set '-DKokkos_COMPILE_LAUNCHER=/path/to/nvcc_wrapper'"
     )

--- a/cmake/kokkos_functions.cmake
+++ b/cmake/kokkos_functions.cmake
@@ -518,6 +518,7 @@ macro(kokkos_find_library VAR_NAME LIB TPL_NAME)
     set(TPL_SUFFIXES lib lib64)
   endif()
 
+  # Follow standard CMake <VAR_NAME>-NOTFOUND convention to improve readability.
   set(${VAR_NAME} "${VAR_NAME}-NOTFOUND")
   set(HAVE_CUSTOM_PATHS FALSE)
 


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

**Fix 1 - Line 521 ( `kokkos_find_library`)**
The NOT_FOUND reset used `VARNAME` (undefined variable) instead of `VAR_NAME`,
causing the variable to be initialized to the literal string `-NOTFOUND`
rather than `<VAR_NAME>-NOTFOUND`. This means find results were never
correctly reset before a new search.

**Fix 2 - Line 1061 (`kokkos_compilation`)**
After `find_program(Kokkos_NVCC_WRAPPER ...)`, the failure guard tested
`Kokkos_COMPILE_LAUNCHER` instead of `Kokkos_NVCC_WRAPPER`. If
`nvcc_wrapper` was missing but `kokkos_launch_compiler` was found, the
error was silently swallowed and the build would fail later with a
confusing message.

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
