### PR TITLE
core(graph): node kind enum

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Graph_Impl.hpp
@@ -53,9 +53,6 @@ struct GraphImpl<Kokkos::Cuda> {
     KOKKOS_ENSURES(m_graph_exec);
   }
 
-  using root_node_impl_t =
-      GraphNodeImpl<Kokkos::Cuda, Kokkos::Experimental::TypeErasedTag,
-                    Kokkos::Experimental::TypeErasedTag>;
   using aggregate_impl_t = CudaGraphNodeAggregate;
   using aggregate_node_impl_t =
       GraphNodeImpl<Kokkos::Cuda, aggregate_impl_t,
@@ -203,7 +200,7 @@ struct GraphImpl<Kokkos::Cuda> {
   auto create_root_node_ptr() {
     KOKKOS_EXPECTS(bool(m_graph))
     KOKKOS_EXPECTS(!bool(m_graph_exec))
-    auto rv = std::make_shared<root_node_impl_t>(
+    auto rv = std::make_shared<root_impl_t<Kokkos::Cuda>>(
         m_device_handle, _graph_node_is_root_ctor_tag{});
     KOKKOS_IMPL_CUDA_SAFE_CALL(
         (m_device_handle.m_exec.impl_internal_space_instance()

--- a/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
+++ b/core/src/HIP/Kokkos_HIP_Graph_Impl.hpp
@@ -19,10 +19,7 @@ namespace Impl {
 template <>
 class GraphImpl<Kokkos::HIP> {
  public:
-  using node_details_t = GraphNodeBackendSpecificDetails<Kokkos::HIP>;
-  using root_node_impl_t =
-      GraphNodeImpl<Kokkos::HIP, Kokkos::Experimental::TypeErasedTag,
-                    Kokkos::Experimental::TypeErasedTag>;
+  using node_details_t   = GraphNodeBackendSpecificDetails<Kokkos::HIP>;
   using aggregate_impl_t = HIPGraphNodeAggregate;
   using aggregate_node_impl_t =
       GraphNodeImpl<Kokkos::HIP, aggregate_impl_t,
@@ -221,8 +218,8 @@ inline auto GraphImpl<Kokkos::HIP>::get_device_handle() const noexcept
 inline auto GraphImpl<Kokkos::HIP>::create_root_node_ptr() {
   KOKKOS_EXPECTS(m_graph);
   KOKKOS_EXPECTS(!m_graph_exec);
-  auto rv = std::make_shared<root_node_impl_t>(m_device_handle,
-                                               _graph_node_is_root_ctor_tag{});
+  auto rv = std::make_shared<root_impl_t<Kokkos::HIP>>(
+      m_device_handle, _graph_node_is_root_ctor_tag{});
   KOKKOS_IMPL_HIP_SAFE_CALL(
       m_device_handle.m_exec.impl_internal_space_instance()
           ->hip_graph_add_empty_node_wrapper(&(rv->node_details_t::node),

--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -37,7 +37,7 @@ struct [[nodiscard]] Graph {
 
   using execution_space = ExecutionSpace;
   using graph           = Graph;
-  using root_t          = GraphNodeRef<ExecutionSpace>;
+  using root_t          = GraphNodeRef<ExecutionSpace, GraphNodeRootTag>;
 
   // </editor-fold> end public member types }}}2
   //----------------------------------------------------------------------------
@@ -56,11 +56,10 @@ struct [[nodiscard]] Graph {
   //----------------------------------------------------------------------------
   // <editor-fold desc="private data members"> {{{2
 
-  using impl_t      = Kokkos::Impl::GraphImpl<ExecutionSpace>;
-  using root_impl_t = typename impl_t::root_node_impl_t;
+  using impl_t = Kokkos::Impl::GraphImpl<ExecutionSpace>;
 
-  std::shared_ptr<impl_t> m_impl_ptr  = nullptr;
-  std::shared_ptr<root_impl_t> m_root = nullptr;
+  std::shared_ptr<impl_t> m_impl_ptr                                = nullptr;
+  std::shared_ptr<Kokkos::Impl::root_impl_t<ExecutionSpace>> m_root = nullptr;
 
   // </editor-fold> end private data members }}}2
   //----------------------------------------------------------------------------

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -638,6 +638,19 @@ class GraphNodeRef {
   //----------------------------------------------------------------------------
 
   // TODO @graph parallel scan, deep copy, etc.
+
+  static constexpr GraphNodeKind node_kind = []() {
+    if constexpr (requires { node_impl_t::node_kind; }) {
+      return node_impl_t::node_kind;
+    } else {
+      return GraphNodeKind::TypeErased;
+    }
+  }();
+
+  GraphNodeKind get_node_kind() const noexcept {
+    KOKKOS_EXPECTS(bool(m_node_impl));
+    return m_node_impl->get_node_kind();
+  }
 };
 
 }  // end namespace Experimental

--- a/core/src/Kokkos_Graph_fwd.hpp
+++ b/core/src/Kokkos_Graph_fwd.hpp
@@ -10,13 +10,25 @@
 
 #include <Kokkos_Concepts.hpp>
 
+#include <cstdint>
+
 namespace Kokkos {
 namespace Experimental {
 
 struct TypeErasedTag {};
+struct GraphNodeRootTag {};
 
 template <class ExecutionSpace>
 struct Graph;
+
+enum class GraphNodeKind : std::uint8_t {
+  TypeErased,
+  Root,
+  Kernel,
+  Aggregate,
+  Host,
+  Capture,
+};
 
 template <Kokkos::ExecutionSpace ExecutionSpace, class Kernel = TypeErasedTag,
           class Predecessor = TypeErasedTag>

--- a/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Graph_Impl.hpp
@@ -23,10 +23,7 @@ class GraphImpl<Kokkos::SYCL> {
   using device_handle_t = Kokkos::Impl::DeviceHandle<Kokkos::SYCL>;
 
  public:
-  using node_details_t = GraphNodeBackendSpecificDetails<Kokkos::SYCL>;
-  using root_node_impl_t =
-      GraphNodeImpl<Kokkos::SYCL, Kokkos::Experimental::TypeErasedTag,
-                    Kokkos::Experimental::TypeErasedTag>;
+  using node_details_t   = GraphNodeBackendSpecificDetails<Kokkos::SYCL>;
   using aggregate_impl_t = SYCLGraphNodeAggregate;
   using aggregate_node_impl_t =
       GraphNodeImpl<Kokkos::SYCL, aggregate_impl_t,
@@ -200,8 +197,8 @@ inline auto GraphImpl<Kokkos::SYCL>::get_device_handle() const noexcept
 
 inline auto GraphImpl<Kokkos::SYCL>::create_root_node_ptr() {
   KOKKOS_EXPECTS(!m_graph_exec);
-  auto rv                  = std::make_shared<root_node_impl_t>(m_device_handle,
-                                               _graph_node_is_root_ctor_tag{});
+  auto rv = std::make_shared<root_impl_t<Kokkos::SYCL>>(
+      m_device_handle, _graph_node_is_root_ctor_tag{});
   rv->node_details_t::node = m_graph.add();
   return rv;
 }

--- a/core/src/impl/Kokkos_Default_Graph_Impl.hpp
+++ b/core/src/impl/Kokkos_Default_Graph_Impl.hpp
@@ -28,10 +28,6 @@ template <class ExecutionSpace>
 struct GraphImpl
     : private InstanceStorage<Kokkos::Impl::DeviceHandle<ExecutionSpace>> {
  public:
-  using root_node_impl_t =
-      GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
-                    Kokkos::Experimental::TypeErasedTag>;
-
   using aggregate_impl_t = GraphNodeAggregateDefaultImpl<ExecutionSpace>;
 
  private:
@@ -118,8 +114,9 @@ struct GraphImpl
   }
 
   auto create_root_node_ptr() {
-    auto rv = Kokkos::Impl::GraphAccess::make_node_shared_ptr<root_node_impl_t>(
-        get_device_handle(), _graph_node_is_root_ctor_tag{});
+    auto rv = Kokkos::Impl::GraphAccess::make_node_shared_ptr<
+        root_impl_t<ExecutionSpace>>(get_device_handle(),
+                                     _graph_node_is_root_ctor_tag{});
     m_sinks.insert(rv);
     return rv;
   }

--- a/core/src/impl/Kokkos_GraphImpl.hpp
+++ b/core/src/impl/Kokkos_GraphImpl.hpp
@@ -12,10 +12,20 @@
 #include <Kokkos_Concepts.hpp>  // is_execution_policy
 #include <impl/Kokkos_GraphImpl_fwd.hpp>
 
+#include <concepts>
 #include <memory>  // std::make_shared
 
 namespace Kokkos {
 namespace Impl {
+
+template <Kokkos::ExecutionSpace Exec>
+using root_impl_t =
+    Kokkos::Impl::GraphNodeImpl<Exec, Kokkos::Experimental::GraphNodeRootTag,
+                                Kokkos::Experimental::TypeErasedTag>;
+
+template <typename T>
+constexpr bool is_graph_root_v =
+    std::same_as<T, Kokkos::Experimental::GraphNodeRootTag>;
 
 template <typename T>
 struct is_graph_capture<

--- a/core/src/impl/Kokkos_GraphNodeImpl.hpp
+++ b/core/src/impl/Kokkos_GraphNodeImpl.hpp
@@ -79,6 +79,9 @@ struct GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
   device_handle_t get_device_handle() const {
     return this->device_handle_storage_base_t::instance();
   }
+
+  virtual constexpr Experimental::GraphNodeKind get_node_kind()
+      const noexcept = 0;
 };
 
 // </editor-fold> end Fully type-erased GraphNodeImpl }}}1
@@ -167,6 +170,24 @@ struct GraphNodeImpl<ExecutionSpace, Kernel,
   Kernel const& get_kernel() const& { return m_kernel; }
   Kernel&& get_kernel() && = delete;
 
+  static constexpr Experimental::GraphNodeKind node_kind = []() {
+    if constexpr (is_graph_kernel_v<kernel_type>) {
+      return Experimental::GraphNodeKind::Kernel;
+    } else if constexpr (is_graph_root_v<kernel_type>) {
+      return Experimental::GraphNodeKind::Root;
+    } else if constexpr (is_graph_capture_v<kernel_type>) {
+      return Experimental::GraphNodeKind::Capture;
+    } else if constexpr (is_graph_then_host_v<kernel_type>) {
+      return Experimental::GraphNodeKind::Host;
+    } else {
+      return Experimental::GraphNodeKind::Aggregate;
+    }
+  }();
+
+  constexpr Experimental::GraphNodeKind get_node_kind() const noexcept final {
+    return node_kind;
+  }
+
   // </editor-fold> end member accessors }}}2
   //----------------------------------------------------------------------------
 };
@@ -190,11 +211,6 @@ struct GraphNodeImpl
   using backend_details_base_t =
       GraphNodeBackendDetailsBeforeTypeErasure<ExecutionSpace, Kernel,
                                                PredecessorRef>;
-  // The fully type-erased base type, for the destroy function
-  using type_erased_base_t =
-      GraphNodeImpl<ExecutionSpace, Kokkos::Experimental::TypeErasedTag,
-                    Kokkos::Experimental::TypeErasedTag>;
-
   using typename base_t::device_handle_t;
 
  public:

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -820,20 +820,12 @@ struct ThenFunctor {
   KOKKOS_FUNCTION void operator()(const TimesTwo) const { data() += 2 * value; }
 };
 
-// Supported graph node types.
-enum class GraphNodeType {
-  KERNEL    = 12,
-  AGGREGATE = 42,
-  THEN      = 66,
-  CAPTURE   = 666
-};
-
 template <typename Exec>
 struct GraphNodeTypes {
   // Type of a root node.
   using node_ref_root_t =
       Kokkos::Experimental::GraphNodeRef<Exec,
-                                         Kokkos::Experimental::TypeErasedTag,
+                                         Kokkos::Experimental::GraphNodeRootTag,
                                          Kokkos::Experimental::TypeErasedTag>;
 
 #if defined(KOKKOS_ENABLE_CUDA)
@@ -845,6 +837,12 @@ struct GraphNodeTypes {
 #else
   static constexpr bool support_capture = false;
 #endif
+
+  // Fully type-erased node.
+  using erased_t =
+      Kokkos::Experimental::GraphNodeRef<Exec,
+                                         Kokkos::Experimental::TypeErasedTag,
+                                         Kokkos::Experimental::TypeErasedTag>;
 
   // Type of a kernel node built using a Kokkos parallel construct.
   using kernel_t =
@@ -939,6 +937,33 @@ TEST(TEST_CATEGORY, when_all_type) {
   auto agg    = Kokkos::Experimental::when_all(node_A, node_B);
   auto tail   = agg.then_parallel_for(1, kernel_functor_t{});
 
+  static_assert(decltype(root)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Root);
+  static_assert(decltype(node_A)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Kernel);
+  static_assert(decltype(node_B)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Kernel);
+  static_assert(decltype(agg)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Aggregate);
+
+  static_assert(decltype(types::erased_t(root))::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::TypeErased);
+  static_assert(decltype(types::erased_t(node_A))::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::TypeErased);
+  static_assert(decltype(types::erased_t(node_B))::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::TypeErased);
+  static_assert(decltype(types::erased_t(agg))::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::TypeErased);
+
+  ASSERT_EQ(types::erased_t(root).get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Root);
+  ASSERT_EQ(types::erased_t(node_A).get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Kernel);
+  ASSERT_EQ(types::erased_t(node_B).get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Kernel);
+  ASSERT_EQ(types::erased_t(agg).get_node_kind(),
+            Kokkos::Experimental::GraphNodeKind::Aggregate);
+
   static_assert(std::is_same_v<decltype(graph), graph_t>);
   static_assert(
       std::is_same_v<decltype(root), typename types::node_ref_root_t>);
@@ -949,7 +974,8 @@ TEST(TEST_CATEGORY, when_all_type) {
 }
 
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-template <GraphNodeType value, typename DstType, typename... SrcTypes>
+template <Kokkos::Experimental::GraphNodeKind value, typename DstType,
+          typename... SrcTypes>
 __global__ void set_to(DstType* const dst, const SrcTypes* const... srcs) {
   dst[threadIdx.y] += (srcs[threadIdx.y] + ...) + static_cast<DstType>(value);
 }
@@ -982,7 +1008,7 @@ struct ExternalCapture {
   template <typename DstType, typename... SrcTypes>
   static void compute(const Kokkos::Cuda& exec, DstType* const dst,
                       const SrcTypes* const... srcs) {
-    set_to<GraphNodeType::CAPTURE>
+    set_to<Kokkos::Experimental::GraphNodeKind::Capture>
         <<<dim3(1, 1, 1), dim3(1, 1, 1), 0, exec.cuda_stream()>>>(dst, srcs...);
   }
 #endif
@@ -990,7 +1016,7 @@ struct ExternalCapture {
   template <typename DstType, typename... SrcTypes>
   static void compute(const Kokkos::HIP& exec, DstType* const dst,
                       const SrcTypes* const... srcs) {
-    set_to<GraphNodeType::CAPTURE>
+    set_to<Kokkos::Experimental::GraphNodeKind::Capture>
         <<<dim3(1, 1, 1), dim3(1, 1, 1), 0, exec.hip_stream()>>>(dst, srcs...);
   }
 #endif
@@ -1001,7 +1027,8 @@ struct ExternalCapture {
     exec.sycl_queue().submit([&](sycl::handler& cgh) {
       cgh.parallel_for(sycl::range<1>(1), [=](int) {
         dst[0] +=
-            (srcs[0] + ...) + static_cast<DstType>(GraphNodeType::CAPTURE);
+            (srcs[0] + ...) +
+            static_cast<DstType>(Kokkos::Experimental::GraphNodeKind::Capture);
       });
     });
   }
@@ -1052,6 +1079,11 @@ void test_graph_capture() {
   auto captured_right =
       ExternalCapture<Exec>::add(memset_right, exec_left, data_3, data_4);
 
+  static_assert(decltype(captured_left)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Capture);
+  static_assert(decltype(captured_right)::node_kind ==
+                Kokkos::Experimental::GraphNodeKind::Capture);
+
   // We don't keep a reference to the created external nodes, to mimic that
   // someone used capture in some deep-down library call (e.g. in
   // Kokkos Kernels).
@@ -1088,14 +1120,22 @@ void test_graph_capture() {
 
   graph.submit(exec_graph);
 
-  ASSERT_TRUE(contains(exec_graph, data_1,
-                       offset_left + static_cast<int>(GraphNodeType::CAPTURE)));
-  ASSERT_TRUE(
-      contains(exec_graph, data_3,
-               offset_right + static_cast<int>(GraphNodeType::CAPTURE)));
-  ASSERT_TRUE(contains(exec_graph, data_2,
-                       offset_left + offset_right +
-                           3 * static_cast<int>(GraphNodeType::CAPTURE)));
+  // Ensure the value added by the capture nodes was non-zero.
+  static_assert(
+      static_cast<int>(Kokkos::Experimental::GraphNodeKind::Capture) != 0);
+
+  ASSERT_TRUE(contains(
+      exec_graph, data_1,
+      offset_left +
+          static_cast<int>(Kokkos::Experimental::GraphNodeKind::Capture)));
+  ASSERT_TRUE(contains(
+      exec_graph, data_3,
+      offset_right +
+          static_cast<int>(Kokkos::Experimental::GraphNodeKind::Capture)));
+  ASSERT_TRUE(contains(
+      exec_graph, data_2,
+      offset_left + offset_right +
+          3 * static_cast<int>(Kokkos::Experimental::GraphNodeKind::Capture)));
 }
 
 TEST(TEST_CATEGORY, graph_capture) {
@@ -1207,7 +1247,8 @@ TEST(TEST_CATEGORY, then_host) {
   {
     // clang-format off
     auto graph = Kokkos::Experimental::create_graph(Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {
-      root.then_host("lonely", functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - lonely - host"))}});
+      auto host_node = root.then_host("lonely", functor_h_t{{counter, view_h_t(Kokkos::view_alloc("internal buffer - lonely - host"))}});
+      static_assert(decltype(host_node)::node_kind == Kokkos::Experimental::GraphNodeKind::Host);
     });
     // clang-format on
 

--- a/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
+++ b/core/unit_test/cuda/TestCuda_InterOp_Graph.cpp
@@ -41,7 +41,7 @@ class TEST_CATEGORY_FIXTURE(GraphInterOp) : public ::testing::Test {
   using graph_t         = Kokkos::Experimental::Graph<execution_space>;
 
   void SetUp() override {
-    data = view_t(Kokkos::view_alloc(exec, "witness"));
+    data = view_t(Kokkos::view_alloc("witness"));
 
     graph = Kokkos::Experimental::create_graph(
         Kokkos::Experimental::get_device_handle(exec), [&](const auto& root) {


### PR DESCRIPTION
This PR introduces:
1. A node kind `enum`:
    ```c++
    enum class GraphNodeKind : std::uint8_t;
    ```
2. A strongly type root node, so that we can distinguish the root node type from a fully type erased node.

Users may retrieve the node kind at runtime with `GraphNodeRef::get_node_kind()`, even if the node type is the most type-erased.

Users may also retrieve the node kind at compile-time through the `GraphNodeRef::node_kind`.

### Detailed description

There is a hierarchy of graph node types.

It starts with the fully typed `GraphNodeRef<ExecutionSpace, KernelType, PredecessorType>`. This type knows the type of its predecessor, and of its kernel. 

Then, the `PredecessorType` can be erased with `Kokkos::Exeperimental::TypeErasedTag`: `GraphNodeRef<ExecutionSpace, KernelType, TypeErasedTag>`.

Further, the `KernelType` can also be erased: `GraphNodeRef<ExecutionSpace, TypeErased, TypeErased>`.

This PR relies on the `KernelType` to determine at compile-time the kind of the node. Therefore, as long as the node type is not type-erasing the `KernelType`, it is possible to retrieve at compile-time the node kind. And the kind of the fully type-erased node must tell "sorry, I'm type-erased".

At runtime, the type-erasure scaffold should not prevent us from retrieving the node kind, even for a fully type-erased node. It could serve for logging the node kind for instance.

### Changelog Entry

Worth a changelog entry for sure.
