### PR TITLE
Add nextsilicon setup/teardown wrapper script

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -422,24 +422,4 @@ jobs:
         env:
           XDG_CACHE_HOME: $HOME/optimizer-cache
         run: |
-          nextsystemd --ui-collector-address none &
-          NEXTSYSTEMD_PID=$!
-
-          # need to make sure nextcli application wait starts before the binary we're waiting on
-          # expect that optimizer is idle since current test has no grid code
-          (nextcli application wait --timeout 30 2>&1 | grep IDLE) &
-          WAIT_PID=$!
-
-          # binary under test
-          ctest --output-on-failure --timeout 3600 -R Kokkos_IncrementalTest_NEXTSILICON
-
-          # wait for nextcli application wait to complete
-          # returns code from backgrounded command
-          wait "$WAIT_PID"
-
-          # FIXME_NEXTSILICON: `nextcli system terminate` will soon block but doesn't yet
-          nextcli system terminate || true
-          wait "$NEXTSYSTEMD_PID"
-
-          # make sure nextsystemd shut down properly
-          nextcli system status | grep "Service: DOWN"
+          ctest -V --timeout 3600 -R Kokkos_IncrementalTest_NEXTSILICON

--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -60,8 +60,10 @@ function(KOKKOS_ADD_TEST)
     add_test(NAME ${TEST_NAME} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${EXE}${CMAKE_EXECUTABLE_SUFFIX}
                                                                                 ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS}
     )
-  elseif (KOKKOS_ENABLE_NEXTSILICON)
-    add_test(NAME ${TEST_NAME} COMMAND ${KOKKOS_SOURCE_DIR}/scripts/nextsilicon-test-wrapper.sh ${EXE} ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS})
+  elseif(KOKKOS_ENABLE_NEXTSILICON)
+    add_test(NAME ${TEST_NAME} COMMAND ${KOKKOS_SOURCE_DIR}/scripts/nextsilicon-test-wrapper.sh ${EXE} ${TEST_ARGS}
+                                       ${${TEST_NAME}_EXTRA_ARGS}
+    )
   else()
     add_test(NAME ${TEST_NAME} COMMAND ${EXE} ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS})
   endif()

--- a/cmake/fake_tribits.cmake
+++ b/cmake/fake_tribits.cmake
@@ -60,6 +60,8 @@ function(KOKKOS_ADD_TEST)
     add_test(NAME ${TEST_NAME} WORKING_DIRECTORY ${LIBRARY_OUTPUT_PATH} COMMAND ${EXE}${CMAKE_EXECUTABLE_SUFFIX}
                                                                                 ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS}
     )
+  elseif (KOKKOS_ENABLE_NEXTSILICON)
+    add_test(NAME ${TEST_NAME} COMMAND ${KOKKOS_SOURCE_DIR}/scripts/nextsilicon-test-wrapper.sh ${EXE} ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS})
   else()
     add_test(NAME ${TEST_NAME} COMMAND ${EXE} ${TEST_ARGS} ${${TEST_NAME}_EXTRA_ARGS})
   endif()

--- a/scripts/nextsilicon-test-wrapper.sh
+++ b/scripts/nextsilicon-test-wrapper.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+# This script has two different modes of operation:
+# if KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS is anything, we run in a telemetry-less mode, where any projection error counts as a failure
+# else, we run the two-pass telemetry-based flow
+
+set -e
+set -x
+
+# make sure nextsystemd shuts down no matter what
+cleanup() {
+        # code from last thing that ran
+        local result=$?
+        echo "cleanup..."
+        nextcli system terminate || true
+        wait ${NEXTSYSTEMD_PID}
+        echo "exit with $result"
+        exit $result
+}
+trap cleanup EXIT
+
+patch_dir=$(mktemp -d)
+if [[ -n "${KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS:-}" ]]; then
+    echo "nextsilicon-test-wrapper.sh: KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS is set"
+
+    # configure nextsystemd for telemetry-less mode
+    echo -e "optimizer-pi:\n  enable-telemetry-less: true" > ${patch_dir}/kokkos.patch
+    
+    # start nextsystemd without profiling tools data collection
+    nextsystemd --ui-collector-address none --cfg-file ${patch_dir}/kokkos.patch &
+    NEXTSYSTEMD_PID=$!
+
+    # telemetry-less run
+    ./"$1" "${@:2}"
+else
+    echo "nextsilicon-test-wrapper.sh: KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS is not set"
+
+    # configure nextsystemd to try to offload every parallel region
+    echo -e "optimizer-pi:\n  mlc:\n    acceleration-threshold: 1" > ${patch_dir}/kokkos.patch
+
+    # start nextsystemd without profiling tools data collection
+    nextsystemd --ui-collector-address none --cfg-file ${patch_dir}/kokkos.patch &
+    NEXTSYSTEMD_PID=$!
+
+    # training run
+    ./"$1" "${@:2}"
+
+    # if there are mills, we will get to optimized
+    # if there are no mills, we'll get to idle really fast
+
+    # if there are no mills, we will get to idle really fast
+    status="$(nextcli application wait --timeout 10 2>&1 || true)"
+
+    if [[ $status != *IDLE* ]]; then
+        # If there are mills (status is not IDLE), then we will eventually get to OPTIMIZED (or error)
+        nextcli application wait --timeout 300
+        # handoff run
+        ./"$1" "${@:2}"
+    fi
+
+fi

--- a/scripts/nextsilicon-test-wrapper.sh
+++ b/scripts/nextsilicon-test-wrapper.sh
@@ -25,7 +25,7 @@ if [[ -n "${KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS:-}" ]]; then
 
     # configure nextsystemd for telemetry-less mode
     echo -e "optimizer-pi:\n  enable-telemetry-less: true" > ${patch_dir}/kokkos.patch
-    
+
     # start nextsystemd without profiling tools data collection
     nextsystemd --ui-collector-address none --cfg-file ${patch_dir}/kokkos.patch &
     NEXTSYSTEMD_PID=$!
@@ -45,17 +45,29 @@ else
     # training run
     ./"$1" "${@:2}"
 
-    # if there are mills, we will get to optimized
-    # if there are no mills, we'll get to idle really fast
+   # wait for optimization/projection to finish, up to 5 minutes
+   SECONDS=0
+   while [ $SECONDS -lt 300 ]; do
+       # check current state
+       ret=0
+       status="$(nextcli application status | grep 'Optimization state:')"
+       if [[ $status == *IDLE* ]]; then
+           # no mills found, return
+           exit 0
+       elif [[ $status == *IMPROVED* ]]; then
+           # optimization/projection finished, do device run
+           ./"$1" "${@:2}"
+           exit
+       elif [[ $status == *OPTIMIZING* ]]; then
+           # optimization/projection still running, wait 10 more seconds
+           sleep 10
+           continue
+       else
+           # in some other state, something went wrong
+           exit 2
+       fi
+   done
 
-    # if there are no mills, we will get to idle really fast
-    status="$(nextcli application wait --timeout 10 2>&1 || true)"
-
-    if [[ $status != *IDLE* ]]; then
-        # If there are mills (status is not IDLE), then we will eventually get to OPTIMIZED (or error)
-        nextcli application wait --timeout 300
-        # handoff run
-        ./"$1" "${@:2}"
-    fi
-
+   echo "error: timed out" >&2
+   exit 127
 fi


### PR DESCRIPTION
Realize the NextSilicon environment setup/teardown in a script. Configure CTest to invoke that script during tests.

This also adjusts the setup/teardown logic to be compatible with NextSilicon toolchain 1.2.0-288.

Script supports two modes:
1) standard telemetry mode: training run, followed by handoff run for supported parallel regions. We need to run the same binary twice in a row, we can't just invoke `ctest` twice to do training followed by handoff.
2) telemetry-less mode: (try to put all parallel regions on device ahead-of-time, error if any parallel region is unsupported for any reason) when environment variable `KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS` is set to anything (including empty).

Use `ctest -V` while the NextSilicon environment stabilizes so we can observe any unusual failure modes.

In #9100 we will use both of these modes to test actual parallel regions. 

(@kc9jud)