### PR TITLE
nvcc_wrapper: Handle response files.

### DIFF
--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -490,6 +490,12 @@ do
     object_files="$object_files $1"
     object_files_xlinker="$object_files_xlinker -Xlinker $1"
     ;;
+  # Handle response files
+  @*.rsp)
+    rsp_file="${1#@}"
+    # Need $1 at the start so it gets shifted out instead of the first thing in the rsp file
+    set -- $1 $(cat "$rsp_file") "${@:2}"
+    ;;
   #Handle object files which always need to use "-Xlinker": -x cu applies to all input files, so give them to linker, except if only linking
   @*|*.dylib)
     object_files="$object_files -Xlinker $1"


### PR DESCRIPTION
In some large projects cmake with the ninja generator decides to put some object files and rpath arguments for the linker inside a *.rsp file that it passes to the compiler via @CMakeFiles/foo.rsp. Prior to this change nvcc would fail with an error about no input files. See https://gitlab.kitware.com/cmake/cmake/-/work_items/21793 for example.

This patch just has nvcc_wrapper extract the contents of the response file and push it onto the list of arguments to be processed which works fine for several of our large projects.