### PR TITLE
Add problem_size as a tuning input context variable

### DIFF
--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -58,6 +58,10 @@ struct Device;
 // forward declare here so that backend initializer calls can use it.
 class InitializationSettings;
 
+// forward declare WorkGraphPolicy so we can refer to it for tuning policies
+template <class... Properties>
+class WorkGraphPolicy;
+
 }  // namespace Kokkos
 
 // Include backend forward statements as determined by build options

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -795,9 +795,8 @@ void initialize(const std::string& profileLibrary) {
       Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
 
   Experimental::VariableInfo problem_size;
-  problem_size.type = Experimental::ValueType::kokkos_value_int64;
-  problem_size.category =
-      Experimental::StatisticalCategory::kokkos_value_ratio;
+  problem_size.type     = Experimental::ValueType::kokkos_value_int64;
+  problem_size.category = Experimental::StatisticalCategory::kokkos_value_ratio;
   problem_size.valueQuantity =
       Experimental::CandidateValueType::kokkos_value_unbounded;
   Experimental::problem_size_context_variable_id =

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -294,7 +294,8 @@ static void updateProfileLibraryState() {
 }
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID, int64_t problemSize) {
+                      uint64_t* kernelID,
+                      [[maybe_unused]] int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_for, kernelPrefix.c_str(),
@@ -327,7 +328,8 @@ void endParallelFor(const uint64_t kernelID) {
 }
 
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID, int64_t problemSize) {
+                       uint64_t* kernelID,
+                       [[maybe_unused]] int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.c_str(),
@@ -360,7 +362,8 @@ void endParallelScan(const uint64_t kernelID) {
 }
 
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID, int64_t problemSize) {
+                         uint64_t* kernelID,
+                         [[maybe_unused]] int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_reduce,

--- a/core/src/impl/Kokkos_Profiling.cpp
+++ b/core/src/impl/Kokkos_Profiling.cpp
@@ -217,6 +217,7 @@ void tool_invoked_fence(const uint32_t /* devID */) {
 #ifdef KOKKOS_ENABLE_TUNING
 static size_t kernel_name_context_variable_id;
 static size_t kernel_type_context_variable_id;
+size_t problem_size_context_variable_id;
 static std::unordered_map<size_t, std::unordered_set<size_t>>
     features_per_context;
 static std::unordered_set<size_t> active_features;
@@ -293,7 +294,7 @@ static void updateProfileLibraryState() {
 }
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID) {
+                      uint64_t* kernelID, int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_for, kernelPrefix.c_str(),
@@ -306,8 +307,10 @@ void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
         Experimental::make_variable_value(
             Experimental::kernel_name_context_variable_id, kernelPrefix),
         Experimental::make_variable_value(
-            Experimental::kernel_type_context_variable_id, "parallel_for")};
-    Experimental::set_input_values(context_id, 2, contextValues);
+            Experimental::kernel_type_context_variable_id, "parallel_for"),
+        Experimental::make_variable_value(
+            Experimental::problem_size_context_variable_id, problemSize)};
+    Experimental::set_input_values(context_id, 3, contextValues);
   }
 #endif
 }
@@ -324,7 +327,7 @@ void endParallelFor(const uint64_t kernelID) {
 }
 
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID) {
+                       uint64_t* kernelID, int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_scan, kernelPrefix.c_str(),
@@ -337,8 +340,10 @@ void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
         Experimental::make_variable_value(
             Experimental::kernel_name_context_variable_id, kernelPrefix),
         Experimental::make_variable_value(
-            Experimental::kernel_type_context_variable_id, "parallel_scan")};
-    Experimental::set_input_values(context_id, 2, contextValues);
+            Experimental::kernel_type_context_variable_id, "parallel_scan"),
+        Experimental::make_variable_value(
+            Experimental::problem_size_context_variable_id, problemSize)};
+    Experimental::set_input_values(context_id, 3, contextValues);
   }
 #endif
 }
@@ -355,7 +360,7 @@ void endParallelScan(const uint64_t kernelID) {
 }
 
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID) {
+                         uint64_t* kernelID, int64_t problemSize) {
   Experimental::invoke_kokkosp_callback(
       Experimental::MayRequireGlobalFencing::Yes,
       Experimental::current_callbacks.begin_parallel_reduce,
@@ -368,8 +373,10 @@ void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
         Experimental::make_variable_value(
             Experimental::kernel_name_context_variable_id, kernelPrefix),
         Experimental::make_variable_value(
-            Experimental::kernel_type_context_variable_id, "parallel_reduce")};
-    Experimental::set_input_values(context_id, 2, contextValues);
+            Experimental::kernel_type_context_variable_id, "parallel_reduce"),
+        Experimental::make_variable_value(
+            Experimental::problem_size_context_variable_id, problemSize)};
+    Experimental::set_input_values(context_id, 3, contextValues);
   }
 #endif
 }
@@ -786,6 +793,15 @@ void initialize(const std::string& profileLibrary) {
   kernel_type.candidates = kernel_type_variable_candidates;
   Experimental::kernel_type_context_variable_id =
       Experimental::declare_input_type("kokkos.kernel_type", kernel_type);
+
+  Experimental::VariableInfo problem_size;
+  problem_size.type = Experimental::ValueType::kokkos_value_int64;
+  problem_size.category =
+      Experimental::StatisticalCategory::kokkos_value_ratio;
+  problem_size.valueQuantity =
+      Experimental::CandidateValueType::kokkos_value_unbounded;
+  Experimental::problem_size_context_variable_id =
+      Experimental::declare_input_type("kokkos.problem_size", problem_size);
 
 #endif
 

--- a/core/src/impl/Kokkos_Profiling.hpp
+++ b/core/src/impl/Kokkos_Profiling.hpp
@@ -70,13 +70,13 @@ struct ToolResponse {
 bool profileLibraryLoaded();
 
 void beginParallelFor(const std::string& kernelPrefix, const uint32_t devID,
-                      uint64_t* kernelID);
+                      uint64_t* kernelID, int64_t problemSize = 0);
 void endParallelFor(const uint64_t kernelID);
 void beginParallelScan(const std::string& kernelPrefix, const uint32_t devID,
-                       uint64_t* kernelID);
+                       uint64_t* kernelID, int64_t problemSize = 0);
 void endParallelScan(const uint64_t kernelID);
 void beginParallelReduce(const std::string& kernelPrefix, const uint32_t devID,
-                         uint64_t* kernelID);
+                         uint64_t* kernelID, int64_t problemSize = 0);
 void endParallelReduce(const uint64_t kernelID);
 
 void pushRegion(const std::string& kName);

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -479,6 +479,26 @@ void report_policy_results(const size_t /**tuning_context*/,
 
 namespace Impl {
 
+template <class... Properties>
+int64_t get_policy_work_size(const Kokkos::RangePolicy<Properties...>& policy) {
+  return static_cast<int64_t>(policy.end() - policy.begin());
+}
+
+template <class... Properties>
+int64_t get_policy_work_size(const Kokkos::TeamPolicy<Properties...>& policy) {
+  return static_cast<int64_t>(policy.league_size());
+}
+
+template <class... Properties>
+int64_t get_policy_work_size(
+    const Kokkos::MDRangePolicy<Properties...>& policy) {
+  int64_t total = 1;
+  for (int i = 0; i < (int)Kokkos::MDRangePolicy<Properties...>::rank; ++i) {
+    total *= static_cast<int64_t>(policy.m_upper[i] - policy.m_lower[i]);
+  }
+  return total;
+}
+
 template <class ExecPolicy, class FunctorType>
 auto begin_parallel_for(const ExecPolicy& policy, FunctorType& functor,
                         const std::string& label, uint64_t& kpID) {
@@ -491,7 +511,7 @@ auto begin_parallel_for(const ExecPolicy& policy, FunctorType& functor,
         name(label);
     Kokkos::Tools::beginParallelFor(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
+        &kpID, get_policy_work_size(policy));
   }
 #ifdef KOKKOS_ENABLE_TUNING
   size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
@@ -536,7 +556,7 @@ auto begin_parallel_scan(const ExecPolicy& policy, FunctorType& functor,
         name(label);
     Kokkos::Tools::beginParallelScan(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
+        &kpID, get_policy_work_size(policy));
   }
 #ifdef KOKKOS_ENABLE_TUNING
   size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();
@@ -580,7 +600,7 @@ auto begin_parallel_reduce(const ExecPolicy& policy, FunctorType& functor,
         name(label);
     Kokkos::Tools::beginParallelReduce(
         name.get(), Kokkos::Profiling::Experimental::device_id(policy.space()),
-        &kpID);
+        &kpID, get_policy_work_size(policy));
   }
 #ifdef KOKKOS_ENABLE_TUNING
   size_t context_id = Kokkos::Tools::Experimental::get_current_context_id();

--- a/core/src/impl/Kokkos_Tools_Generic.hpp
+++ b/core/src/impl/Kokkos_Tools_Generic.hpp
@@ -479,25 +479,46 @@ void report_policy_results(const size_t /**tuning_context*/,
 
 namespace Impl {
 
+#ifdef KOKKOS_ENABLE_TUNING
 template <class... Properties>
-int64_t get_policy_work_size(const Kokkos::RangePolicy<Properties...>& policy) {
+KOKKOS_INLINE_FUNCTION int64_t
+get_policy_work_size(const Kokkos::RangePolicy<Properties...>& policy) {
   return static_cast<int64_t>(policy.end() - policy.begin());
 }
 
 template <class... Properties>
-int64_t get_policy_work_size(const Kokkos::TeamPolicy<Properties...>& policy) {
+KOKKOS_INLINE_FUNCTION int64_t
+get_policy_work_size(const Kokkos::TeamPolicy<Properties...>& policy) {
   return static_cast<int64_t>(policy.league_size());
 }
 
 template <class... Properties>
-int64_t get_policy_work_size(
-    const Kokkos::MDRangePolicy<Properties...>& policy) {
+KOKKOS_INLINE_FUNCTION int64_t
+get_policy_work_size(const Kokkos::MDRangePolicy<Properties...>& policy) {
   int64_t total = 1;
   for (int i = 0; i < (int)Kokkos::MDRangePolicy<Properties...>::rank; ++i) {
     total *= static_cast<int64_t>(policy.m_upper[i] - policy.m_lower[i]);
   }
   return total;
 }
+
+template <class... Properties>
+KOKKOS_INLINE_FUNCTION int64_t
+get_policy_work_size(const Kokkos::WorkGraphPolicy<Properties...>& policy) {
+  return static_cast<int64_t>(0);
+}
+
+/* Generic implementation of helper function to support WorkGraphPolicy */
+template <typename T>
+KOKKOS_INLINE_FUNCTION int64_t get_policy_work_size(const T&) {
+  return static_cast<int64_t>(0);
+}
+#else
+template <typename T>
+KOKKOS_INLINE_FUNCTION int64_t get_policy_work_size(const T&) {
+  return static_cast<int64_t>(0);
+}
+#endif
 
 template <class ExecPolicy, class FunctorType>
 auto begin_parallel_for(const ExecPolicy& policy, FunctorType& functor,


### PR DESCRIPTION
Pass the execution policy work size (RangePolicy: end-begin, TeamPolicy: league_size, MDRangePolicy: product of dimension extents) as a new int64 input context variable "kokkos.problem_size" to the tuning infrastructure. This allows tuning plugins to differentiate optimal parameters by problem size.

Modified files:
- Kokkos_Profiling.cpp: declare and register the variable at init, include it in set_input_values for parallel_for/scan/reduce
- Kokkos_Profiling.hpp: add problemSize parameter to beginParallel*
- Kokkos_Tools_Generic.hpp: add get_policy_work_size() overloads for RangePolicy, TeamPolicy, and MDRangePolicy

Disclosure: Cursor assisted with these code modifications

<!-- Provide a short summary of the changes in this pull request. -->

Currently, the only identifying feature for internal Kokkos tuning contexts are the name of the parallel region and the type (for/scan/reduce). This PR will include the problem size, which is useful when Kokkos is used in solver libraries that have have different runtime tunable parameter "optimal" values depending on problem size. 

No issue or PR associated with this PR. 

### Changelog Entry

Kokkos Profiling Tuner interface now includes a context variable that represents the problem size. The problem size is useful in tuning runtime parameters for kernels that are reused with variable input data sizes (e.g. solver libraries).