### PR TITLE
fix ValueType for accumulation in `parallel_scan`

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Team.hpp
@@ -818,7 +818,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     // perform team scan
     local_accum = member.team_scan(local_accum);
     // add this blocks accum to total accumulation
-    auto val = accum + local_accum;
+    ValueType val = accum + local_accum;
     // user updates their data with total accumulation
     if (ii < loop_bounds.end) lambda(ii, val, true);
     // the last value needs to be propogated to next chunk

--- a/core/src/HIP/Kokkos_HIP_Team.hpp
+++ b/core/src/HIP/Kokkos_HIP_Team.hpp
@@ -597,7 +597,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     // perform team scan
     local_accum = member.team_scan(local_accum);
     // add this blocks accum to total accumulation
-    auto val = accum + local_accum;
+    ValueType val = accum + local_accum;
     // user updates their data with total accumulation
     if (ii < loop_bounds.end) lambda(ii, val, true);
     // the last value needs to be propogated to next chunk

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -641,7 +641,7 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
     // perform team scan
     local_accum = member.team_scan(local_accum);
     // add this blocks accum to total accumulation
-    auto val = accum + local_accum;
+    ValueType val = accum + local_accum;
     // user updates their data with total accumulation
     if (ii < loop_bounds.end) lambda(ii, val, true);
     // the last value needs to be propogated to next chunk


### PR DESCRIPTION
This fixes compile errors in applications when using a `ValueType` for which `ValueType + ValueType`  does not result in a  `ValueType`. That is the case for some automatic differentiation frameworks, for example.

The error I'm getting with clang + CUDA when using the `codi::RealForwardCUDA` type of [CoDiPack](https://github.com/SciCompKL/CoDiPack) is

```
/home/pedelmann/local/spack/var/spack/environments/codipack-cuda/.spack-env/view/include/Cuda/Kokkos_Cuda_Team.hpp:823:31: error: 
      no matching function for call to object of type 'const (lambda at
      /home/pedelmann/code/kokkos-ad/main.cc:70:50)'
  823 |     if (ii < loop_bounds.end) lambda(ii, val, true);
      |                               ^~~~~~
/home/pedelmann/code/kokkos-ad/main.cc:68:36: note: in instantiation of function template
      specialization 'Kokkos::parallel_scan<unsigned long, (lambda at
      /home/pedelmann/code/kokkos-ad/main.cc:70:50),
      codi::ActiveTypeStatelessTape<codi::ForwardEvaluation<double, double>>>' requested here
   68 |                            Kokkos::parallel_scan(
      |                                    ^
/home/pedelmann/code/kokkos-ad/main.cc:70:50: note: candidate function not viable: no known
      conversion from 'ComputeExpression<double, OperationAdd,
      codi::ActiveTypeStatelessTape<codi::ForwardEvaluation<double, double>>,
      codi::ActiveTypeStatelessTape<codi::ForwardEvaluation<double, double>>>' to 'Real &' (aka
      'ActiveTypeStatelessTape<ForwardEvaluation<double, double>> &') for 2nd argument
   70 |   ...KOKKOS_LAMBDA(const int j, Real& update, const bool final) {
```


The fix just forces the output of the `+` operator to be converted to the correct type of the argument of the lambda. I don't think this will have an effect on any common use case, since the `auto` is usually deduced to `ValueType` anyway and if it's not it would also fail in the same way when passing `val` by reference into the lambda.

I'm happy to provide a full reproducer  with CoDiPack if you think it's valuable.

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
- Fix accumulator type in `parallel_scan` to support more exotic types (e.g., automatic differentiation frameworks).