### PR TITLE
Adjustment to support SCALE compiler which pretends to be NVCC and CLANG at the same time

### DIFF
--- a/core/unit_test/TestTypeInfo.cpp
+++ b/core/unit_test/TestTypeInfo.cpp
@@ -25,7 +25,8 @@ using Lambda = decltype(func);
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__)
 // can't do much
 // it looks like that there is 1st an EDG pass and then a host pass and they cannot both agree on what the type info is
-#elif defined(__EDG__) || (defined(__NVCC__) && defined(__CUDA_ARCH__))
+// We check that the compiler is Nvidia's NVCC. SCALE's compiler (from Spectral Compute) is true for both defined(__clang__) and defined(__NVCC__). This is the only place where such precaution is needed.
+#elif defined(__EDG__) || (defined(__NVCC__) && !defined(__clang__) && defined(__CUDA_ARCH__))
 static_assert(TypeInfo<Foo>::name()      == "<unnamed>::Foo");
 static_assert(TypeInfo<FooAlias>::name() == "<unnamed>::Foo");
 static_assert(TypeInfo<Bar>::name()      == "<unnamed>::Bar");


### PR DESCRIPTION
I am trying to compile Kokkos with the [SCALE compiler](https://docs.scale-lang.com/stable/) to compare backends.

Scale's `nvcc` is a drop in replacement for `nvcc` but is a clang fork. Therefore, when using it, both `__NVCC__` and `__clang__` are true at the same time and leads to a failure of the compile time tests.

This commit fixes this corner case and should not hinder other compile paths

### Related issues / PRs

Kokkos integration in scale's validation test base: https://github.com/spectral-compute/scale-validation/pull/12
