### PR TITLE
Windows: Fix 1st level warning C4530 and error C1128

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: configure
       shell: bash
       run: |
-        cmake -B build -DCMAKE_CUDA_FLAGS="-Xcompiler=-bigobj" -DBUILD_SHARED_LIBS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON
+        cmake -B build -DBUILD_SHARED_LIBS=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON
     - name: build library
       shell: bash
       run: |

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -899,6 +899,19 @@ else()
   compiler_specific_options(COMPILER_ID KOKKOS_CXX_HOST_COMPILER_ID MSVC /Zc:preprocessor)
 endif()
 
+# MSVC requires /EHsc for C++ exception handling (unwind semantics); without it
+# STL headers like <chrono> trigger C4530.  For CUDA nvcc already forwards /EHsc
+# to the host compiler automatically, so only inject it for non-NVIDIA builds.
+if(NOT KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
+  compiler_specific_options(COMPILER_ID KOKKOS_CXX_HOST_COMPILER_ID MSVC /EHsc)
+endif()
+
+# nvcc-generated .cudafe1.cpp files can exceed the default COFF section count
+# limit (C1128) on MSVC; pass /bigobj to the host compiler via -Xcompiler.
+if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
+  compiler_specific_options(COMPILER_ID KOKKOS_CXX_HOST_COMPILER_ID MSVC -Xcompiler=/bigobj)
+endif()
+
 #Right now we cannot get the compiler ID when cross-compiling, so just check
 #that HIP is enabled
 if(KOKKOS_ENABLE_HIP)

--- a/cmake/kokkos_arch.cmake
+++ b/cmake/kokkos_arch.cmake
@@ -907,8 +907,9 @@ if(NOT KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
 endif()
 
 # nvcc-generated .cudafe1.cpp files can exceed the default COFF section count
-# limit (C1128) on MSVC; pass /bigobj to the host compiler via -Xcompiler.
-if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA)
+# limit (C1128) on MSVC; in fact /bigobj is only needed for test targets,
+# not for the whole library.
+if(KOKKOS_CXX_COMPILER_ID STREQUAL NVIDIA AND Kokkos_ENABLE_TESTS)
   compiler_specific_options(COMPILER_ID KOKKOS_CXX_HOST_COMPILER_ID MSVC -Xcompiler=/bigobj)
 endif()
 


### PR DESCRIPTION
## Motivation

When building Kokkos with Ninja + MSVC without setting `CMAKE_CXX_FLAGS` explicitly, two issues arise that should be handled by CMake itself rather than by external build scripts:

**1. C4530 warnings (`/EHsc`)** - STL headers such as `<chrono>` use C++ exception handling internally. Without `/EHsc`, MSVC emits warning C4530 (*"C++ exception handler used, but unwind semantics are not enabled"*) for every translation unit that includes them.

> Note: for CUDA builds CMake already forwards `/EHsc` to the host compiler via `-Xcompiler` automatically, so this patch only injects the flag for non-NVIDIA compilers.

**2. C1128 errors (`/bigobj`)** - nvcc generates large intermediate `.cudafe1.cpp` files (e.g. `TestCuda_MathematicalFunctions*.cudafe1.cpp`) that exceed the default COFF section limit. The MSVC host compiler fails with *"number of sections exceeded object file format limit: compile with /bigobj"*. This flag needs to be passed via `-Xcompiler=/bigobj` and is only relevant for NVIDIA builds with an MSVC host.

Both flags are added in `cmake/kokkos_arch.cmake` following the existing `compiler_specific_options` pattern already used for `/Zc:preprocessor`.

## Related Issues

- [Trilinos Issue-14816](https://github.com/trilinos/Trilinos/issues/14816) (checklist table inside, also see **Additional Information** section below for details)

## Related Links

- [Exception Handling Model](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170)
- [Bigger number of sections in .obj file](https://learn.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-170)
- [COFF Object File Format](https://en.wikipedia.org/wiki/COFF)

## Environment

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 3.31.2                                           |
| MSVC       | 19.44.35211 (VS 2022 Community)                  |
| clang-cl   | 21.1.5;x86_64-pc-windows-msvc;thread-model:posix |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20               |

> NOTE: Clang-cl used only for the OpenMP backend, because MSVC's cl.exe does not support OpenMP 4.5+, only OpenMP 2.0, for other backends MSVC's cl.exe + Ninja used.

## Testing

### MSVC 2022 + Ninja Logs {Serial backend}

Configuration log: [configure-output-msvc2022-ninja-serial.log](https://github.com/user-attachments/files/27960697/configure-output-msvc2022-ninja-serial.log)
KokkosCore_config.h: [KokkosCore_config.h.txt](https://github.com/user-attachments/files/27960707/KokkosCore_config.h.txt)
Compilation log: [compilation-output-msvc2022-ninja-serial.log](https://github.com/user-attachments/files/27960711/compilation-output-msvc2022-ninja-serial.log)
Ctest log: [ctest-output-msvc2022-ninja-serial.log](https://github.com/user-attachments/files/27960712/ctest-output-msvc2022-ninja-serial.log)

Test command:

```powershell
$savedPath     = $env:PATH
$env:BUILD_DIR = "D:\Develop\kokkos\bserial"
$env:PATH      = "$env:BUILD_DIR\lib;$env:PATH"

try {
    Push-Location "$env:BUILD_DIR"
    & ctest -VV --output-on-failure > ctest-output-msvc2022-ninja-serial.log
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

> This command will be the same for all the next tests, but with different log files and build directories.

End part of test log:

```log
100% tests passed, 0 tests failed out of 40

Label Time Summary:
Kokkos    = 134.97 sec*proc (37 tests)

Total Test time (real) = 136.19 sec
```

### Clang-cl 21.1.5 + Ninja Logs {OpenMP backend}

Configuration log: [configure-output-clangcl-ninja-openmp.log](https://github.com/user-attachments/files/27960754/configure-output-clangcl-ninja-openmp.log)
KokkosCore_config.h: [KokkosCore_config.h.txt](https://github.com/user-attachments/files/27960762/KokkosCore_config.h.txt)
Compilation log: [compilation-output-clangcl-ninja-openmp.log](https://github.com/user-attachments/files/27960758/compilation-output-clangcl-ninja-openmp.log)
Ctest log: [ctest-output-clangcl-ninja-openmp.log](https://github.com/user-attachments/files/27960765/ctest-output-clangcl-ninja-openmp.log)

Test command:

```powershell
$savedPath     = $env:PATH
$env:BUILD_DIR = "D:\Develop\kokkos\bomp"
$env:PATH      = "$env:BUILD_DIR\lib;$env:PATH"

try {
    Push-Location "$env:BUILD_DIR"
    & ctest -VV --output-on-failure > ctest-output-clangcl-ninja-openmp.log
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

End part of test log:

```log
91% tests passed, 4 tests failed out of 47

Label Time Summary:
Kokkos    = 514.39 sec*proc (44 tests)

Total Test time (real) = 516.24 sec

The following tests FAILED:
	2 - Kokkos_CoreUnitTest_Serial_SmokeTest (Failed)     Kokkos
	4 - Kokkos_CoreUnitTest_OpenMP_SmokeTest (Failed)     Kokkos
	6 - Kokkos_CoreUnitTest_Serial2 (Failed)              Kokkos
	7 - Kokkos_CoreUnitTest_OpenMP (Failed)               Kokkos
```

### Ninja + MSVC 2022 Logs {MPI backend}

Configuration log: [configure-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27960803/configure-output-msvc2022-ninja-mpi.log)
KokkosCore_config.h: [KokkosCore_config.h.txt](https://github.com/user-attachments/files/27960831/KokkosCore_config.h.txt)
Compilation log: [compilation-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27960839/compilation-output-msvc2022-ninja-mpi.log)
Ctest log: [ctest-output-msvc2022-ninja-mpi.log](https://github.com/user-attachments/files/27960850/ctest-output-msvc2022-ninja-mpi.log)

Test command:

```powershell
$savedPath     = $env:PATH
$env:BUILD_DIR = "D:\Develop\kokkos\bmpi"
$env:PATH      = "$env:BUILD_DIR\lib;$env:PATH"

try {
    Push-Location "$env:BUILD_DIR"
    & ctest -VV --output-on-failure > ctest-output-msvc2022-ninja-mpi.log
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

End part of test log:

```log
100% tests passed, 0 tests failed out of 40

Label Time Summary:
Kokkos    = 141.43 sec*proc (37 tests)

Total Test time (real) = 142.58 sec
```

### Ninja + nvcc 13.0 (sm_89, MSVC host) Logs {CUDA backend}

Configuration log: [configuration-output-msvc2022-ninja-cuda.log](https://github.com/user-attachments/files/27964313/configuration-output-msvc2022-ninja-cuda.log)
KokkosCore_config.h: [KokkosCore_config.h.txt](https://github.com/user-attachments/files/27964321/KokkosCore_config.h.txt)
Compilation log: [compilation-output-msvc2022-ninja-cuda.log](https://github.com/user-attachments/files/27964333/compilation-output-msvc2022-ninja-cuda.log)
Ctest log: [ctest-output-msvc2022-ninja-cuda.log](https://github.com/user-attachments/files/27964341/ctest-output-msvc2022-ninja-cuda.log)

```powershell
$savedPath     = $env:PATH
$env:BUILD_DIR = "D:\Develop\kokkos\bcuda"
$env:PATH      = "$env:BUILD_DIR\lib;$env:PATH"

try {
    Push-Location "$env:BUILD_DIR"
    & ctest -VV --output-on-failure > ctest-output-msvc2022-ninja-cuda.log
}
finally {
    Pop-Location
    $env:PATH = $savedPath
}
```

End part of test log:

```log
10% tests passed, 47 tests failed out of 52

Label Time Summary:
Kokkos    =  21.52 sec*proc (51 tests)

Total Test time (real) =  22.69 sec

The following tests FAILED:
	  1 - Kokkos_CoreUnitTest_Serial_ViewSupport (SEGFAULT) Kokkos
	  2 - Kokkos_CoreUnitTest_Serial_SmokeTest (SEGFAULT)   Kokkos
	  3 - Kokkos_CoreUnitTest_Cuda_ViewSupport (SEGFAULT)   Kokkos
	  4 - Kokkos_CoreUnitTest_Cuda_SmokeTest (SEGFAULT)     Kokkos
	  5 - Kokkos_CoreUnitTest_Serial1 (SEGFAULT)            Kokkos
	  6 - Kokkos_CoreUnitTest_Serial2 (SEGFAULT)            Kokkos
	  7 - Kokkos_CoreUnitTest_Cuda1 (SEGFAULT)              Kokkos
	  8 - Kokkos_CoreUnitTest_Cuda2 (SEGFAULT)              Kokkos
	  9 - Kokkos_CoreUnitTest_Cuda3 (SEGFAULT)              Kokkos
	 10 - Kokkos_CoreUnitTest_CudaGraphAtomicLocks (SEGFAULT) Kokkos
	 11 - Kokkos_CoreUnitTest_CudaTimingBased (SEGFAULT)    Kokkos
	 12 - Kokkos_CoreUnitTest_CudaInterOpInit (Failed)      Kokkos
	 13 - Kokkos_CoreUnitTest_CudaInterOpStreams (Failed)   Kokkos
	 14 - Kokkos_CoreUnitTest_CudaInterOpStreamsMultiGPU (SEGFAULT) Kokkos
	 15 - Kokkos_CoreUnitTest_CudaInterOpGraph (SEGFAULT)   Kokkos
	 16 - Kokkos_CoreUnitTest_CudaInterOpGraphMultiGPU (SEGFAULT) Kokkos
	 17 - Kokkos_CoreUnitTest_Default (SEGFAULT)            Kokkos
	 18 - Kokkos_CoreUnitTest_InitializeFinalize (Failed)   Kokkos
	 19 - Kokkos_CoreUnitTest_Develop (SEGFAULT)            Kokkos
	 20 - Kokkos_CoreUnitTest_KokkosP (SEGFAULT)            Kokkos
	 21 - Kokkos_CoreUnitTest_StackTraceTest (SEGFAULT)     Kokkos
	 22 - Kokkos_IncrementalTest_SERIAL (SEGFAULT)          Kokkos
	 23 - Kokkos_IncrementalTest_CUDA (SEGFAULT)            Kokkos
	 29 - Kokkos_CoreUnitTest_DeviceAndThreads (Failed)
	 30 - Kokkos_ContainersUnitTest_Serial (SEGFAULT)       Kokkos
	 31 - Kokkos_ContainersUnitTest_Cuda (SEGFAULT)         Kokkos
	 32 - Kokkos_ContainersPerformanceTest_Cuda (SEGFAULT)  Kokkos
	 33 - Kokkos_UnitTest_Sort (SEGFAULT)                   Kokkos
	 34 - Kokkos_UnitTest_Random (SEGFAULT)                 Kokkos
	 35 - Kokkos_AlgorithmsUnitTest_StdSet_A (SEGFAULT)     Kokkos
	 36 - Kokkos_AlgorithmsUnitTest_StdSet_B (SEGFAULT)     Kokkos
	 37 - Kokkos_AlgorithmsUnitTest_StdSet_C (SEGFAULT)     Kokkos
	 38 - Kokkos_AlgorithmsUnitTest_StdSet_D (SEGFAULT)     Kokkos
	 39 - Kokkos_AlgorithmsUnitTest_StdSet_E (SEGFAULT)     Kokkos
	 40 - Kokkos_AlgorithmsUnitTest_StdSet_Team_A (SEGFAULT) Kokkos
	 41 - Kokkos_AlgorithmsUnitTest_StdSet_Team_B (SEGFAULT) Kokkos
	 42 - Kokkos_AlgorithmsUnitTest_StdSet_Team_C (SEGFAULT) Kokkos
	 43 - Kokkos_AlgorithmsUnitTest_StdSet_Team_D (SEGFAULT) Kokkos
	 44 - Kokkos_AlgorithmsUnitTest_StdSet_Team_E (SEGFAULT) Kokkos
	 45 - Kokkos_AlgorithmsUnitTest_StdSet_Team_F (SEGFAULT) Kokkos
	 46 - Kokkos_AlgorithmsUnitTest_StdSet_Team_G (SEGFAULT) Kokkos
	 47 - Kokkos_AlgorithmsUnitTest_StdSet_Team_H (SEGFAULT) Kokkos
	 48 - Kokkos_AlgorithmsUnitTest_StdSet_Team_I (SEGFAULT) Kokkos
	 49 - Kokkos_AlgorithmsUnitTest_StdSet_Team_L (SEGFAULT) Kokkos
	 50 - Kokkos_AlgorithmsUnitTest_StdSet_Team_M (SEGFAULT) Kokkos
	 51 - Kokkos_AlgorithmsUnitTest_StdSet_Team_P (SEGFAULT) Kokkos
	 52 - Kokkos_AlgorithmsUnitTest_StdSet_Team_Q (SEGFAULT) Kokkos
```

CUDA driver version is **576.28**:

```powershell
nvidia-smi
Mon May 18 17:03:24 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 576.28                 Driver Version: 576.28         CUDA Version: 12.9     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                  Driver-Model | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4060 ...  WDDM  |   00000000:01:00.0 Off |                  N/A |
| N/A   59C    P8              2W /   80W |      39MiB /   8188MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A           15500    C+G   ...Lab\Kaspersky 21.24\avpui.exe      N/A      |
+-----------------------------------------------------------------------------------------+
```

<img width="948" height="1010" alt="image" src="https://github.com/user-attachments/assets/7202a067-2a80-4666-8e8d-520e09f55e6a" />

Sorry, for the screenshot, but if I copy from this cmd.exe output will be broken, example:

```log
D:\Develop\kokkos>dir .\bcuda\lib                                                                                        Volume in drive D is Common Files                                                                                       Volume Serial Number is 8EB5-A74A                                                                                                                                                                                                               Directory of D:\Develop\kokkos\bcuda\lib                                                                                                                                                                                                       18.05.2026  17:48    <DIR>          .                                                                                   18.05.2026  17:52    <DIR>          ..                                                                                  03.10.2025  04:47        51 561 584 cublas64_13.dll                                                                     03.10.2025  04:47       480 401 520 cublasLt64_13.dll                                                                   27.09.2025  03:36           470 640 cudart64_13.dll                                                                     18.05.2026  16:44         7 233 140 gtest.lib                                                                           18.05.2026  17:45            59 904 impl_git_version.dll                                                                18.05.2026  17:45            32 072 impl_git_version.lib                                                                18.05.2026  17:24            80 744 kokkosalgorithms.lib                                                                18.05.2026  17:22           248 832 kokkoscontainers.dll                                                                18.05.2026  17:22           265 722 kokkoscontainers.lib                                                                18.05.2026  16:45         1 852 416 kokkoscore.dll                                                                      18.05.2026  16:45         3 086 220 kokkoscore.lib                                                                      18.05.2026  17:43            80 642 kokkossimd.lib                                                                      18.05.2026  17:46           498 108 Kokkos_StackTraceTestExec.lib                                                                     13 File(s)    545 871 544 bytes                                                                                          2 Dir(s)  299 037 282 304 bytes free                                                                                                                                                                                             D:\Develop\kokkos>dumpbin /dependents D:\Develop\kokkos\bcuda\algorithms\unit_tests\Kokkos_AlgorithmsUnitTest_StdSet_Team_Q.exe                                                                                                                 Microsoft (R) COFF/PE Dumper Version 14.44.35211.0                                                                      Copyright (C) Microsoft Corporation.  All rights reserved.                                                                                                                                                                                                                                                                                                              Dump of file D:\Develop\kokkos\bcuda\algorithms\unit_tests\Kokkos_AlgorithmsUnitTest_StdSet_Team_Q.exe                                                                                                                                          File Type: EXECUTABLE IMAGE                                                                                                                                                                                                                       Image has the following dependencies:                                                                                                                                                                                                             kokkoscore.dll                                                                                                          KERNEL32.dll                                                                                                            MSVCP140.dll                                                                                                            VCRUNTIME140.dll                                                                                                        VCRUNTIME140_1.dll                                                                                                      api-ms-win-crt-runtime-l1-1-0.dll                                                                                       api-ms-win-crt-heap-l1-1-0.dll                                                                                          api-ms-win-crt-math-l1-1-0.dll                                                                                          api-ms-win-crt-string-l1-1-0.dll                                                                                        api-ms-win-crt-environment-l1-1-0.dll                                                                                   api-ms-win-crt-stdio-l1-1-0.dll                                                                                         api-ms-win-crt-filesystem-l1-1-0.dll                                                                                    api-ms-win-crt-convert-l1-1-0.dll                                                                                       api-ms-win-crt-time-l1-1-0.dll                                                                                          api-ms-win-crt-locale-l1-1-0.dll                                                                                                                                                                                                              Summary                                                                                                                                                                                                                                               1000 .00cfg                                                                                                            17000 .data                                                                                                              6000 .idata                                                                                                             1000 .nvFatBi                                                                                                         179000 .nv_fatb                                                                                                          16000 .pdata                                                                                                            54000 .rdata                                                                                                             3000 .reloc                                                                                                             1000 .rsrc                                                                                                            1FB000 .text                                                                                                              1000 .tls                                                                                                                                                                                                                               D:\Develop\kokkos>   
```

### Summary

Verified by building all four backends on Windows (MSVC 19.44 / Ninja / RelWithDebInfo + Shared libs):

| Backend | Generator                            | Result            |
| ------- | ------------------------------------ | ----------------- |
| Serial  | Ninja + MSVC 2022                    | no C4530 warnings |
| OpenMP  | Ninja + clang-cl                     | no C4530 warnings; 4 tests failing |
| MPI     | Ninja + MSVC 2022                    | no C4530 warnings |
| CUDA    | Ninja + nvcc 13.0 (sm_89, MSVC host) | no C1128 errors; 47/52 failing, most of them `SEGFAULT`ing |

## Additional Information

This fix was discovered as part of an ongoing effort to make Kokkos buildable on Windows without requiring a custom build script that manually injects compiler flags. The idea is that `cmake/kokkos_arch.cmake` should be self-sufficient: a user should only need to specify *what* to build (generator, backend, packages), not *how* the compiler works on a given platform.

The issue was exposed intentionally by stripping all Windows-specific flags (`/EHsc`, `/bigobj`, `/DWIN32`, etc.) from the build script and observing what the compiler reported missing. Related Windows build work is tracked in the accompanying issue and PR series.

Here is my previous version of the build script: [build.ps1.bak.txt](https://github.com/user-attachments/files/27960885/build.ps1.bak.txt)
And here is the new one with stripped flags: [build.ps1.txt](https://github.com/user-attachments/files/27960893/build.ps1.txt)

Also I encountered with CE (compilation error) about header `<sys/time.h>` with benchmarks build turned on, that on Windows it is not present in the standard library. This is the reason, why all the next builds didn't use the benchmarks and serial was re-compiled without them.

Here is the proof log: [compilation-output-msvc2022-ninja-serial.log.err.log](https://github.com/user-attachments/files/27961048/compilation-output-msvc2022-ninja-serial.log.err.log)

## Questions

- Can I make a PR for fixing the CE about header `<sys/time.h>`?
- What am I doing wrong for the CUDA build?