### PR TITLE
Fix : Adds checks for doing unaligned simd stores

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -656,8 +656,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
-                       static_cast<__m512d>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
+                         static_cast<__m512d>(simd));
+  } else {
+    _mm512_mask_storeu_pd(ptr, static_cast<__mmask8>(mask),
+                          static_cast<__m512d>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -1029,8 +1035,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
-                       static_cast<__m256>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
+                         static_cast<__m256>(simd));
+  } else {
+    _mm256_mask_storeu_ps(ptr, static_cast<__mmask8>(mask),
+                          static_cast<__m256>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -1404,8 +1416,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
-  _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
-                       static_cast<__m512>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
+                         static_cast<__m512>(simd));
+  } else {
+    _mm512_mask_storeu_ps(ptr, static_cast<__mmask16>(mask),
+                          static_cast<__m512>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -1772,8 +1790,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m256i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m256i>(simd));
+  } else {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m256i>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -2511,8 +2535,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m256i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m256i>(simd));
+  } else {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m256i>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -3246,8 +3276,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m512i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m512i>(simd));
+  } else {
+    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m512i>(simd));
+  }
 }
 
 template <typename FlagType>
@@ -3602,8 +3638,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m512i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m512i>(simd));
+  } else {
+    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m512i>(simd));
+  }
 }
 
 template <typename FlagType>

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -2859,8 +2859,6 @@ template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  // Flagging to see if this a correct usage. Should this be only using aligned
-  // stores?
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
@@ -2878,8 +2876,6 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
-  // Flagging to see if this a correct usage. Should this be only using aligned
-  // stores?
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -665,8 +665,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
-                       static_cast<__m512d>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
+                         static_cast<__m512d>(simd));
+  } else {
+    _mm512_mask_storeu_pd(ptr, static_cast<__mmask8>(mask),
+                          static_cast<__m512d>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1032,8 +1038,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
-                       static_cast<__m256>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
+                         static_cast<__m256>(simd));
+  } else {
+    _mm256_mask_storeu_ps(ptr, static_cast<__mmask8>(mask),
+                          static_cast<__m256>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1401,8 +1413,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
-  _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
-                       static_cast<__m512>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
+                         static_cast<__m512>(simd));
+  } else {
+    _mm512_mask_storeu_ps(ptr, static_cast<__mmask16>(mask),
+                          static_cast<__m512>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -1764,8 +1782,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m256i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m256i>(simd));
+  } else {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m256i>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2133,8 +2157,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
-  _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
-                          static_cast<__m512i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
+                            static_cast<__m512i>(simd));
+  } else {
+    _mm512_mask_storeu_epi32(ptr, static_cast<__mmask16>(mask),
+                             static_cast<__m512i>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2491,8 +2521,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m256i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m256i>(simd));
+  } else {
+    _mm256_mask_storeu_epi32(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m256i>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -2823,6 +2859,8 @@ template <typename FlagType>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+  // Flagging to see if this a correct usage. Should this be only using aligned
+  // stores?
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
@@ -2840,6 +2878,8 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
     FlagType) {
+  // Flagging to see if this a correct usage. Should this be only using aligned
+  // stores?
   if constexpr (std::is_same_v<FlagType,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
@@ -3220,8 +3260,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m512i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m512i>(simd));
+  } else {
+    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m512i>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
@@ -3570,8 +3616,14 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
     FlagType) {
-  _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
-                          static_cast<__m512i>(simd));
+  if constexpr (std::is_same_v<FlagType,
+                               simd_flags<simd_alignment_vector_aligned>>) {
+    _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
+                            static_cast<__m512i>(simd));
+  } else {
+    _mm512_mask_storeu_epi64(ptr, static_cast<__mmask8>(mask),
+                             static_cast<__m512i>(simd));
+  }
 }
 
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION

--- a/simd/unit_tests/include/TestSIMD_LoadStore.hpp
+++ b/simd/unit_tests/include/TestSIMD_LoadStore.hpp
@@ -48,6 +48,42 @@ inline void host_test_simd_load(SimdType const& init, SimdType const& expected,
 }
 
 template <typename SimdType, typename... Args>
+inline void host_test_simd_unaligned_load(SimdType const& init,
+                                          SimdType const& expected,
+                                          Args... args) {
+  using data_type = typename SimdType::value_type;
+  using abi_type  = typename SimdType::abi_type;
+
+  constexpr size_t alignment =
+      SimdType::size() * sizeof(typename SimdType::value_type);
+
+  alignas(alignment)
+      typename SimdType::value_type arr[SimdType::size() + 1] = {0};
+  simd_unchecked_store(init, arr + 1, Kokkos::Experimental::simd_flag_default);
+
+  SimdType result;
+
+  if constexpr (sizeof...(args) > 1) {
+    result = simd_partial_load(arr + 1, args...);
+  } else {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<data_type>,
+                                 abi_type>) {
+      result = Kokkos::Experimental::simd_unchecked_load(arr + 1, args...);
+    } else {
+      result =
+          Kokkos::Experimental::simd_unchecked_load<SimdType>(arr + 1, args...);
+    }
+  }
+
+  auto mask = (result == expected);
+  for (Kokkos::Experimental::Impl::simd_size_t i = 0; i < SimdType::size();
+       ++i) {
+    EXPECT_TRUE(mask[i]);
+  }
+}
+
+template <typename SimdType, typename... Args>
 inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
                                  Args... args) {
   constexpr size_t alignment =
@@ -67,6 +103,28 @@ inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
   }
 }
 
+template <typename SimdType, typename... Args>
+inline void host_test_simd_unaligned_store(SimdType const& init,
+                                           SimdType const& expected,
+                                           Args... args) {
+  constexpr size_t alignment =
+      SimdType::size() * sizeof(typename SimdType::value_type);
+
+  alignas(alignment)
+      typename SimdType::value_type arr[SimdType::size() + 1] = {0};
+
+  if constexpr (sizeof...(args) > 1) {
+    simd_partial_store(init, arr + 1, args...);
+  } else {
+    simd_unchecked_store(init, arr + 1, args...);
+  }
+
+  for (Kokkos::Experimental::Impl::simd_size_t i = 0; i < SimdType::size();
+       ++i) {
+    EXPECT_EQ(arr[i + 1], expected[i]);
+  }
+}
+
 template <typename Abi, typename DataType>
 inline void host_test_simd_loadstore() {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
@@ -80,19 +138,27 @@ inline void host_test_simd_loadstore() {
 
   host_test_simd_store(expected, expected,
                        Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_store(expected, expected,
+                                 Kokkos::Experimental::simd_flag_default);
   host_test_simd_store(expected, expected,
                        Kokkos::Experimental::simd_flag_aligned);
   host_test_simd_store(expected, expected_masked, mask,
                        Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_store(expected, expected_masked, mask,
+                                 Kokkos::Experimental::simd_flag_default);
   host_test_simd_store(expected, expected_masked, mask,
                        Kokkos::Experimental::simd_flag_aligned);
 
   host_test_simd_load(expected, expected,
                       Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_load(expected, expected,
+                                Kokkos::Experimental::simd_flag_default);
   host_test_simd_load(expected, expected,
                       Kokkos::Experimental::simd_flag_aligned);
   host_test_simd_load(expected, expected_masked, mask,
                       Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_load(expected, expected_masked, mask,
+                                Kokkos::Experimental::simd_flag_default);
   host_test_simd_load(expected, expected_masked, mask,
                       Kokkos::Experimental::simd_flag_aligned);
 }
@@ -149,6 +215,37 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_load(SimdType const& init,
 }
 
 template <typename SimdType, typename... Args>
+KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_load(
+    SimdType const& init, SimdType const& expected, Args... args) {
+  using data_type = typename SimdType::value_type;
+  using abi_type  = typename SimdType::abi_type;
+
+  constexpr size_t alignment =
+      SimdType::size() * sizeof(typename SimdType::value_type);
+
+  alignas(alignment)
+      typename SimdType::value_type arr[SimdType::size() + 1] = {0};
+  simd_unchecked_store(init, arr + 1, Kokkos::Experimental::simd_flag_default);
+
+  SimdType result;
+
+  if constexpr (sizeof...(args) > 1) {
+    result = simd_partial_load(arr + 1, args...);
+  } else {
+    if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
+                                     host_fixed_native<data_type>,
+                                 abi_type>) {
+      result = Kokkos::Experimental::simd_unchecked_load(arr + 1, args...);
+    } else {
+      result =
+          Kokkos::Experimental::simd_unchecked_load<SimdType>(arr + 1, args...);
+    }
+  }
+
+  device_check_equality(result, expected, SimdType::size());
+}
+
+template <typename SimdType, typename... Args>
 KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
                                                    SimdType const& expected,
                                                    Args... args) {
@@ -170,6 +267,28 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
   }
 }
 
+template <typename SimdType, typename... Args>
+KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_store(
+    SimdType const& init, SimdType const& expected, Args... args) {
+  constexpr size_t alignment =
+      SimdType::size() * sizeof(typename SimdType::value_type);
+
+  alignas(alignment)
+      typename SimdType::value_type arr[SimdType::size() + 1] = {0};
+
+  if constexpr (sizeof...(args) > 1) {
+    simd_partial_store(init, arr + 1, args...);
+  } else {
+    simd_unchecked_store(init, arr + 1, args...);
+  }
+
+  kokkos_checker checker;
+  for (Kokkos::Experimental::Impl::simd_size_t i = 0; i < SimdType::size();
+       ++i) {
+    checker.equality(arr[i + 1], expected[i]);
+  }
+}
+
 template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
@@ -182,19 +301,27 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
 
   device_test_simd_store(expected, expected,
                          Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_store(expected, expected,
+                                   Kokkos::Experimental::simd_flag_default);
   device_test_simd_store(expected, expected,
                          Kokkos::Experimental::simd_flag_aligned);
   device_test_simd_store(expected, expected_masked, mask,
                          Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_store(expected, expected_masked, mask,
+                                   Kokkos::Experimental::simd_flag_default);
   device_test_simd_store(expected, expected_masked, mask,
                          Kokkos::Experimental::simd_flag_aligned);
 
   device_test_simd_load(expected, expected,
                         Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_load(expected, expected,
+                                  Kokkos::Experimental::simd_flag_default);
   device_test_simd_load(expected, expected,
                         Kokkos::Experimental::simd_flag_aligned);
   device_test_simd_load(expected, expected_masked, mask,
                         Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_load(expected, expected_masked, mask,
+                                  Kokkos::Experimental::simd_flag_default);
   device_test_simd_load(expected, expected_masked, mask,
                         Kokkos::Experimental::simd_flag_aligned);
 }


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
I ran into segfaults when trying to upgrade to the new SIMD interface from Kokkos 4.7 -> 5.1.1

All simd_partial_store overloads for AVX512 were unconditionally using aligned store intrinsics (_mm512_mask_store_*, _mm256_mask_store_*). 

Use ``FlagType`` to check for unaligned stores. 

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
