### PR TITLE
Implement create_mirror_view_and_copy one argument convenience overload

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1762,6 +1762,13 @@ auto create_mirror_view_and_copy(const Space&,
       Kokkos::view_alloc(typename Space::memory_space{}, name), src);
 }
 
+template <class T, class... P>
+auto create_mirror_view_and_copy(const Kokkos::DynRankView<T, P...>& src) {
+  return create_mirror_view_and_copy(
+      typename Kokkos::DynRankView<T, P...>::host_mirror_type::memory_space{},
+      src);
+}
+
 }  // namespace Kokkos
 
 //----------------------------------------------------------------------------

--- a/containers/src/Kokkos_DynamicView.hpp
+++ b/containers/src/Kokkos_DynamicView.hpp
@@ -978,6 +978,15 @@ auto create_mirror_view_and_copy(
       Kokkos::view_alloc(typename Space::memory_space{}, name), src);
 }
 
+template <class T, class... P>
+auto create_mirror_view_and_copy(
+    const Kokkos::Experimental::DynamicView<T, P...>& src) {
+  return create_mirror_view_and_copy(
+      typename Kokkos::Experimental::DynamicView<
+          T, P...>::host_mirror_type::memory_space{},
+      src);
+}
+
 }  // namespace Kokkos
 
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_DYNAMICVIEW

--- a/containers/src/Kokkos_OffsetView.hpp
+++ b/containers/src/Kokkos_OffsetView.hpp
@@ -1462,6 +1462,16 @@ create_mirror_view_and_copy(
     std::string const& name = "") {
   return {create_mirror_view_and_copy(space, src.view(), name), src.begins()};
 }
+
+template <class T, class... P>
+auto create_mirror_view_and_copy(
+    const Kokkos::Experimental::OffsetView<T, P...>& src) {
+  return create_mirror_view_and_copy(
+      typename Kokkos::Experimental::OffsetView<
+          T, P...>::host_mirror_type::memory_space{},
+      src);
+}
+
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/containers/unit_tests/TestCreateMirror.cpp
+++ b/containers/unit_tests/TestCreateMirror.cpp
@@ -91,6 +91,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror_view(view_alloc(DefaultExecutionSpace{},                            DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror_view_and_copy
+  check_memory_space(create_mirror_view_and_copy(                     view), host_mirror_test_space(view));
   check_memory_space(create_mirror_view_and_copy(HostSpace{},         view), HostSpace{});
   check_memory_space(create_mirror_view_and_copy(DeviceMemorySpace{}, view), DeviceMemorySpace{});
 

--- a/containers/unit_tests/TestCreateMirror.cpp
+++ b/containers/unit_tests/TestCreateMirror.cpp
@@ -91,7 +91,9 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror_view(view_alloc(DefaultExecutionSpace{},                            DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror_view_and_copy
-  check_memory_space(create_mirror_view_and_copy(                     view), host_mirror_test_space(view));
+  // FIXME DynamicView: host_mirror_type is the same type
+  if constexpr (!is_dynamic_view<View>::value)
+    check_memory_space(create_mirror_view_and_copy(                   view), host_mirror_test_space(view));
   check_memory_space(create_mirror_view_and_copy(HostSpace{},         view), HostSpace{});
   check_memory_space(create_mirror_view_and_copy(DeviceMemorySpace{}, view), DeviceMemorySpace{});
 

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3396,6 +3396,12 @@ create_mirror_view_and_copy(
       Kokkos::view_alloc(typename Space::memory_space{}, name), src);
 }
 
+template <class T, class... P>
+auto create_mirror_view_and_copy(const Kokkos::View<T, P...>& src) {
+  return create_mirror_view_and_copy(
+      typename Kokkos::View<T, P...>::host_mirror_type::memory_space{}, src);
+}
+
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -345,8 +345,14 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
     # ViewSupport should eventually contain the new implementation
     # detail tests for the mdspan based View
     if(Kokkos_ENABLE_IMPL_MDSPAN)
-      set(BV_TestNames BasicView ReferenceCountedAccessor ReferenceCountedDataHandle AllocationAndSpanSize
-                       ViewEqualityOperator LegacyLayoutFunction
+      set(BV_TestNames
+          BasicView
+          ReferenceCountedAccessor
+          ReferenceCountedDataHandle
+          AllocationAndSpanSize
+          ViewEqualityOperator
+          LegacyLayoutFunction
+          CreateMirrorViewAndCopy
       )
       if(NOT Kokkos_ENABLE_IMPL_VIEW_LEGACY AND NOT Kokkos_ENABLE_OPENACC)
         list(APPEND BV_TestNames ViewCustomizationAccessorArg ViewCustomizationAllocationType

--- a/core/unit_test/TestCreateMirror.cpp
+++ b/core/unit_test/TestCreateMirror.cpp
@@ -66,6 +66,7 @@ void test_create_mirror_properties(const View& view) {
   check_memory_space(create_mirror_view(view_alloc(DefaultExecutionSpace{},                          DeviceMemorySpace{}), view), DeviceMemorySpace{});
 
   // create_mirror_view_and_copy
+  check_memory_space(create_mirror_view_and_copy(                     view), host_mirror_test_space(view));
   check_memory_space(create_mirror_view_and_copy(HostSpace{},         view), HostSpace{});
   check_memory_space(create_mirror_view_and_copy(DeviceMemorySpace{}, view), DeviceMemorySpace{});
 

--- a/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
+++ b/core/unit_test/incremental/Test10_HierarchicalBasics.hpp
@@ -48,7 +48,7 @@ struct HierarchicalBasics {
           }
         });
     Kokkos::fence();
-    auto h_v = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto h_v = Kokkos::create_mirror_view_and_copy(v);
 
     int check = 0;
     int ref   = nP * nT;

--- a/core/unit_test/incremental/Test11a_ParallelFor_TeamThreadRange.hpp
+++ b/core/unit_test/incremental/Test11a_ParallelFor_TeamThreadRange.hpp
@@ -43,7 +43,7 @@ struct Hierarchical_ForLoop_A {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     long long int check   = 0;
     const long long int s = static_cast<long long int>(sY) * sX;

--- a/core/unit_test/incremental/Test11b_ParallelFor_TeamVectorRange.hpp
+++ b/core/unit_test/incremental/Test11b_ParallelFor_TeamVectorRange.hpp
@@ -43,7 +43,7 @@ struct Hierarchical_ForLoop_B {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     long long int check   = 0;
     const long long int s = static_cast<long long int>(sY) * sX;

--- a/core/unit_test/incremental/Test11c_ParallelFor_ThreadVectorRange.hpp
+++ b/core/unit_test/incremental/Test11c_ParallelFor_ThreadVectorRange.hpp
@@ -48,7 +48,7 @@ struct Hierarchical_ForLoop_C {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     size_t check   = 0;
     const size_t s = static_cast<size_t>(sX) * sY * sZ;

--- a/core/unit_test/incremental/Test12a_ThreadScratch.hpp
+++ b/core/unit_test/incremental/Test12a_ThreadScratch.hpp
@@ -77,7 +77,7 @@ struct ThreadScratch {
         *this);
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     size_t check   = 0;
     const size_t s = static_cast<size_t>(pN) * sX * sY;

--- a/core/unit_test/incremental/Test12b_TeamScratch.hpp
+++ b/core/unit_test/incremental/Test12b_TeamScratch.hpp
@@ -68,7 +68,7 @@ struct TeamScratch {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     size_t check   = 0;
     const size_t s = static_cast<size_t>(pN) * sX * sY;

--- a/core/unit_test/incremental/Test13a_ParallelRed_TeamThreadRange.hpp
+++ b/core/unit_test/incremental/Test13a_ParallelRed_TeamThreadRange.hpp
@@ -46,7 +46,7 @@ struct Hierarchical_Red_A {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     SCALAR_TYPE check = 0;
     SCALAR_TYPE ref   = 0;

--- a/core/unit_test/incremental/Test13b_ParallelRed_TeamVectorRange.hpp
+++ b/core/unit_test/incremental/Test13b_ParallelRed_TeamVectorRange.hpp
@@ -44,7 +44,7 @@ struct Hierarchical_Red_B {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     SCALAR_TYPE check = 0;
     SCALAR_TYPE ref   = 0;

--- a/core/unit_test/incremental/Test13c_ParallelRed_ThreadVectorRange.hpp
+++ b/core/unit_test/incremental/Test13c_ParallelRed_ThreadVectorRange.hpp
@@ -53,7 +53,7 @@ struct Hierarchical_Red_C {
         });
 
     Kokkos::fence();
-    auto v_H = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), v);
+    auto v_H = Kokkos::create_mirror_view_and_copy(v);
 
     SCALAR_TYPE check = 0;
     SCALAR_TYPE ref   = 0;

--- a/core/unit_test/incremental/Test16_ParallelScan.hpp
+++ b/core/unit_test/incremental/Test16_ParallelScan.hpp
@@ -85,8 +85,7 @@ struct TestScan {
                           FunctorType{d_data});
 
     // Copy back the data.
-    auto h_data =
-        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d_data);
+    auto h_data = Kokkos::create_mirror_view_and_copy(d_data);
 
     // Check Correctness
     ASSERT_EQ(h_data(0), 0.0);
@@ -120,8 +119,7 @@ struct TestScanWithTotal {
                           FunctorType{d_data}, total);
 
     // Copy back the data.
-    auto h_data =
-        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d_data);
+    auto h_data = Kokkos::create_mirror_view_and_copy(d_data);
 
     // Check Correctness
     ASSERT_EQ(h_data(0), 0.0);

--- a/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
+++ b/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <gtest/gtest.h>
+
+namespace {
+
+template <class MemorySpace>
+void test_create_mirror_view_and_copy() {
+  const int N = 10;
+  Kokkos::View<int*, MemorySpace> device_view("device_view", N);
+  Kokkos::deep_copy(device_view, 1);
+  auto device_view_copy   = Kokkos::create_mirror_view_and_copy(device_view);
+  using copy_memory_space = decltype(device_view_copy)::memory_space;
+  static_assert(
+      std::is_same_v<
+          copy_memory_space,
+          typename decltype(device_view)::host_mirror_type::memory_space>);
+  if (std::is_same_v<copy_memory_space, MemorySpace>)
+    ASSERT_EQ(device_view_copy, device_view);
+  else
+    ASSERT_NE(device_view_copy, device_view);
+  for (int i = 0; i < N; ++i) ASSERT_EQ(device_view_copy(i), 1);
+}
+
+TEST(TEST_CATEGORY, view_create_mirror_view_and_copy) {
+  test_create_mirror_view_and_copy<TEST_EXECSPACE::memory_space>();
+  if (std::is_same_v<TEST_EXECSPACE, Kokkos::DefaultExecutionSpace>) {
+#if defined(KOKKOS_HAS_SHARED_SPACE)
+    test_create_mirror_view_and_copy<Kokkos::SharedSpace>();
+#endif
+#if defined(KOKKOS_HAS_SHARED_HOST_PINNED_SPACE)
+    test_create_mirror_view_and_copy<Kokkos::SharedHostPinnedSpace>();
+#endif
+  }
+}
+}  // namespace

--- a/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
+++ b/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
@@ -14,20 +14,22 @@ namespace {
 
 template <class MemorySpace>
 void test_create_mirror_view_and_copy() {
-  const int N = 10;
-  Kokkos::View<int*, MemorySpace> device_view("device_view", N);
-  Kokkos::deep_copy(device_view, 1);
-  auto device_view_copy   = Kokkos::create_mirror_view_and_copy(device_view);
-  using copy_memory_space = decltype(device_view_copy)::memory_space;
-  static_assert(
-      std::is_same_v<
-          copy_memory_space,
-          typename decltype(device_view)::host_mirror_type::memory_space>);
+  const int N              = 10;
+  using original_view_type = Kokkos::View<int*, MemorySpace>;
+  original_view_type original_view("original_view", N);
+  Kokkos::deep_copy(original_view, 1);
+  auto original_view_copy = Kokkos::create_mirror_view_and_copy(original_view);
+  using copy_memory_space = decltype(original_view_copy)::memory_space;
+  static_assert(std::is_same_v<
+                decltype(original_view_copy),
+                typename Kokkos::Impl::MirrorViewType<
+                    typename original_view_type::host_mirror_type::memory_space,
+                    int*, MemorySpace>::view_type>);
   if (std::is_same_v<copy_memory_space, MemorySpace>)
-    ASSERT_EQ(device_view_copy, device_view);
+    ASSERT_EQ(original_view_copy, original_view);
   else
-    ASSERT_NE(device_view_copy, device_view);
-  for (int i = 0; i < N; ++i) ASSERT_EQ(device_view_copy(i), 1);
+    ASSERT_NE(original_view_copy, original_view);
+  for (int i = 0; i < N; ++i) ASSERT_EQ(original_view_copy(i), 1);
 }
 
 TEST(TEST_CATEGORY, view_create_mirror_view_and_copy) {


### PR DESCRIPTION
In response to https://github.com/kokkos/kokkos/issues/9160, it makes sense to provide an overload without `Space` argument to be consistent with `create_mirror` and `create_mirror_view`.