### PR TITLE
Remove unused <sys/time.h> includes

### DIFF
--- a/benchmarks/stream/stream-kokkos.cpp
+++ b/benchmarks/stream/stream-kokkos.cpp
@@ -6,8 +6,6 @@
 #include <cstdlib>
 #include <cmath>
 
-#include <sys/time.h>
-
 #define STREAM_ARRAY_SIZE 100000000
 #define STREAM_NTIMES 20
 

--- a/benchmarks/view_copy_constructor/view_copy_constructor.cpp
+++ b/benchmarks/view_copy_constructor/view_copy_constructor.cpp
@@ -10,7 +10,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <sys/time.h>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;


### PR DESCRIPTION
This PR removes two unused `#include <sys/time.h>` in the benchmarks, which also prevented the benchmarks from being built on windows.

### Related issues / PRs

Was reported in #9181 

### Changelog Entry

