### PR TITLE
Fixing argument for hipMemcpy call

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -410,8 +410,7 @@ jobs:
       - name: build_kokkos
         working-directory: kokkos
         run: |
-          cmake --build build --parallel $(nproc) \
-            --target Kokkos_IncrementalTest_NEXTSILICON
+          cmake --build build --parallel $(nproc)
 
       # the SNL runners map a named volume to $HOME/optimizer-cache for a persistent
       # optimizer cache across runs. If this doesn't get mapped, nextsystemd will
@@ -424,4 +423,4 @@ jobs:
           GTEST_FILTER: -*DeathTest*
           XDG_CACHE_HOME: $HOME/optimizer-cache
         run: |
-          ctest -V --timeout 3600 -R Kokkos_IncrementalTest_NEXTSILICON
+          ctest -V --timeout 3600

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -420,6 +420,8 @@ jobs:
       - name: test_kokkos
         working-directory: kokkos/build
         env:
+          # FIXME_NEXTSILICON: death tests require fork, not supported by runtime
+          GTEST_FILTER: -*DeathTest*
           XDG_CACHE_HOME: $HOME/optimizer-cache
         run: |
           ctest -V --timeout 3600 -R Kokkos_IncrementalTest_NEXTSILICON

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -416,6 +416,16 @@ jobs:
       # optimizer cache across runs. If this doesn't get mapped, nextsystemd will
       # create this directory and use it as a cache, but the contents will be lost
       # when the container exits
+      - name: test_kokkos_telemetryless
+        working-directory: kokkos/build
+        env:
+          # FIXME_NEXTSILICON: death tests require fork, not supported by runtime
+          GTEST_FILTER: -*DeathTest*
+          KOKKOS_NEXTSILICON_TEST_TELEMETRYLESS: 1
+          XDG_CACHE_HOME: $HOME/optimizer-cache
+        run: |
+          ctest -V --timeout 3600
+
       - name: test_kokkos
         working-directory: kokkos/build
         env:

--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -417,6 +417,8 @@ jobs:
       # create this directory and use it as a cache, but the contents will be lost
       # when the container exits
       - name: test_kokkos_telemetryless
+        # FIXME_NEXTSILICON: re-enable when telemetry-less mode is working
+        if: false
         working-directory: kokkos/build
         env:
           # FIXME_NEXTSILICON: death tests require fork, not supported by runtime

--- a/algorithms/CMakeLists.txt
+++ b/algorithms/CMakeLists.txt
@@ -2,7 +2,8 @@ if(NOT Kokkos_INSTALL_TESTING)
   add_subdirectory(src)
 endif()
 # FIXME_OPENACC: temporarily disabled due to unimplemented features
-if(NOT KOKKOS_ENABLE_OPENACC)
+# FIXME_NEXTSILICON: unimplemented features
+if(NOT (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_NEXTSILICON))
   kokkos_add_test_directories(unit_tests)
 endif()
 

--- a/benchmarks/stream/stream-kokkos.cpp
+++ b/benchmarks/stream/stream-kokkos.cpp
@@ -6,8 +6,6 @@
 #include <cstdlib>
 #include <cmath>
 
-#include <sys/time.h>
-
 #define STREAM_ARRAY_SIZE 100000000
 #define STREAM_NTIMES 20
 

--- a/benchmarks/view_copy_constructor/view_copy_constructor.cpp
+++ b/benchmarks/view_copy_constructor/view_copy_constructor.cpp
@@ -10,7 +10,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <sys/time.h>
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;

--- a/containers/CMakeLists.txt
+++ b/containers/CMakeLists.txt
@@ -3,7 +3,8 @@ if(NOT Kokkos_INSTALL_TESTING)
 endif()
 
 # FIXME_OPENACC: temporarily disabled due to unimplemented features
-if(NOT KOKKOS_ENABLE_OPENACC)
+# FIXME_NEXTSILICON: unimplemented features
+if(NOT (KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_NEXTSILICON))
   kokkos_add_test_directories(unit_tests)
   kokkos_add_test_directories(performance_tests)
 endif()

--- a/core/src/Kokkos_Abort.hpp
+++ b/core/src/Kokkos_Abort.hpp
@@ -45,6 +45,9 @@ namespace Impl {
 #elif defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__)
 // FIXME_SYCL SYCL doesn't abort
 #define KOKKOS_IMPL_ABORT_NORETURN
+#elif defined(KOKKOS_ENABLE_NEXTSILICON)
+// NextSilicon aborts
+#define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]
 #elif !defined(KOKKOS_ENABLE_OPENACC)
 // Host aborts
 #define KOKKOS_IMPL_ABORT_NORETURN [[noreturn]]

--- a/core/src/Kokkos_BitManipulation.hpp
+++ b/core/src/Kokkos_BitManipulation.hpp
@@ -13,6 +13,11 @@
 
 namespace Kokkos::Impl {
 
+// This is not technically a valid use of KOKKOS_IF_ON_HOST/DEVICE macros:
+// NextSilicon compiler doesn't permit it to be used in a constexpr way, so work
+// around: KOKKOS_IF_ON_HOST here really just means "can we call the host
+// compiler intrinsic", which we are allowed to do on NextSilicon
+#if !defined(KOKKOS_ENABLE_NEXTSILICON)
 template <template <bool /*constant_evaluated*/, bool /*device*/> class Op,
           class T>
 KOKKOS_FUNCTION constexpr auto dispatch_helper(T x) noexcept {
@@ -35,6 +40,22 @@ KOKKOS_FUNCTION constexpr auto dispatch_helper(T x) noexcept {
 #endif
   KOKKOS_IMPL_UNREACHABLE();
 }
+#else
+template <template <bool /*constant_evaluated*/, bool /*device*/> class Op,
+          class T>
+KOKKOS_FUNCTION constexpr auto dispatch_helper(T x) noexcept {
+#if defined(__cpp_if_consteval)  // since C++23
+  if consteval {
+    return Op<true, false>::do_compute(x);
+
+  } else {
+    return Op<false, false>::do_compute(x);
+  }
+#else
+  return Op<true, false>::do_compute(x);
+#endif
+}
+#endif
 
 template <template <bool /*constant_evaluated*/, bool /*device*/> class Op,
           class T>

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -478,9 +478,35 @@
 #endif
 
 #ifdef KOKKOS_ENABLE_NEXTSILICON
-// FIXME_NEXTSILICON: Placeholder until proper ON_DEVICE/ON_HOST
-#define KOKKOS_IF_ON_DEVICE(CODE)
-#define KOKKOS_IF_ON_HOST(CODE) KOKKOS_IMPL_STRIP_PARENS(CODE)
+#include <nextapi/intrinsics.h>
+#include <NextSilicon/Kokkos_NextSilicon_InParallelRegion.hpp>
+
+// For grid execution, the optimizer knows __next_is_in_handed_of_code() is
+// always true, in_parallel_region() will short-circuit, and not actually be
+// called and the underlying flag will never be migrated to the device.
+//
+// During host execution the macro will check if we are in a parallel region by
+// checking the flag and execute CODE only if we are IN a parallel region
+// - hence we are on device!
+#define KOKKOS_IF_ON_DEVICE(CODE)                                \
+  if (__next_is_in_handed_off_code() ||                          \
+      Kokkos::Impl::NextSiliconParallelRegionScopeGuard::in()) { \
+    KOKKOS_IMPL_STRIP_PARENS(CODE)                               \
+  }
+
+// For grid execution, the optimizer knows __next_is_in_handed_of_code() is
+// always true. Hence all code in KOKKOS_IF_ON_HOST will be dead code and
+// optimized out. This is important to avoid unnecessary enlargening of
+// the projection.
+//
+// For hosts execution macro will check if we are in a parallel region by
+// checking the flag and execute CODE only if we are NOT IN a parallel
+// region - we are on host!
+#define KOKKOS_IF_ON_HOST(CODE)                                   \
+  if (!__next_is_in_handed_off_code() &&                          \
+      !Kokkos::Impl::NextSiliconParallelRegionScopeGuard::in()) { \
+    KOKKOS_IMPL_STRIP_PARENS(CODE)                                \
+  }
 #endif
 
 #if !defined(KOKKOS_IF_ON_HOST) && !defined(KOKKOS_IF_ON_DEVICE)

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -59,6 +59,7 @@
  *  KOKKOS_COMPILER_INTEL_LLVM
  *  KOKKOS_COMPILER_CRAYC
  *  KOKKOS_COMPILER_APPLECC
+ *  KOKKOS_COMPILER_NEXT_LLVM
  *  KOKKOS_COMPILER_CLANG
  *  KOKKOS_COMPILER_NVHPC
  *  KOKKOS_COMPILER_MSVC
@@ -133,6 +134,10 @@
 #define KOKKOS_COMPILER_NVHPC                                 \
   __NVCOMPILER_MAJOR__ * 10000 + __NVCOMPILER_MINOR__ * 100 + \
       __NVCOMPILER_PATCHLEVEL__
+
+#elif defined(__NEXTSILICON__)
+#define KOKKOS_COMPILER_NEXT_LLVM \
+  __clang_major__ * 100 + __clang_minor__ * 10 + __clang_patchlevel__
 
 #elif defined(__clang__)
 // Check this after the Clang-based proprietary compilers which will also define
@@ -259,6 +264,27 @@
      defined(__x86_64__) || defined(__PPC64__))
 #define KOKKOS_ENABLE_ASM 1
 #endif
+#endif
+
+//----------------------------------------------------------------------------
+// NextLLVM compiler macros
+
+#if defined(KOKKOS_COMPILER_NEXT_LLVM)
+// #define KOKKOS_ENABLE_PRAGMA_UNROLL 1
+// #define KOKKOS_ENABLE_PRAGMA_IVDEP 1
+// #define KOKKOS_ENABLE_PRAGMA_LOOPCOUNT 1
+// #define KOKKOS_ENABLE_PRAGMA_VECTOR 1
+
+#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
+#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
+  inline __attribute__((always_inline))
+#define KOKKOS_IMPL_HOST_FORCEINLINE __attribute__((always_inline))
+#endif
+
+#if !defined(KOKKOS_IMPL_ALIGN_PTR)
+#define KOKKOS_IMPL_ALIGN_PTR(size) __attribute__((aligned(size)))
+#endif
+
 #endif
 
 //----------------------------------------------------------------------------
@@ -625,8 +651,9 @@
 #endif
 // clang-format on
 
-#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||         \
-     defined(KOKKOS_COMPILER_INTEL_LLVM) || defined(KOKKOS_COMPILER_NVHPC)) && \
+#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||        \
+     defined(KOKKOS_COMPILER_INTEL_LLVM) ||                                   \
+     defined(KOKKOS_COMPILER_NEXT_LLVM) || defined(KOKKOS_COMPILER_NVHPC)) && \
     !defined(_WIN32) && !defined(__ANDROID__)
 #if __has_include(<execinfo.h>)
 #define KOKKOS_IMPL_ENABLE_STACKTRACE

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Abort.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Abort.hpp
@@ -4,8 +4,6 @@
 #ifndef KOKKOS_NEXTSILICON_ABORT_HPP
 #define KOKKOS_NEXTSILICON_ABORT_HPP
 
-#include <NextSilicon/Kokkos_NextSilicon_Abort.hpp>
-
 #include <nextapi/intrinsics.h>
 #include <cstdio>
 
@@ -16,6 +14,7 @@ namespace Impl {
   // FIXME_NEXTSILICON: We need to add printing from handed off code also.
   if (!__next_is_in_handed_off_code()) {
     std::fprintf(stderr, "%s", msg);
+    std::fflush(stderr);
   }
 
   __builtin_trap();

--- a/core/src/NextSilicon/Kokkos_NextSilicon_DeepCopy.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_DeepCopy.hpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_NEXTSILICON_DEEP_COPY_HPP
+#define KOKKOS_NEXTSILICON_DEEP_COPY_HPP
+
+#include <nextapi/memory.h>
+
+#include <NextSilicon/Kokkos_NextSilicon.hpp>
+#include <NextSilicon/Kokkos_NextSiliconSpace.hpp>
+
+#include <Kokkos_Concepts.hpp>
+
+namespace Kokkos {
+namespace Impl {
+
+template <>
+struct DeepCopy<Kokkos::Experimental::NextSiliconSharedSpace,
+                Kokkos::Experimental::NextSiliconSharedSpace,
+                Kokkos::Experimental::NextSilicon> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const Kokkos::Experimental::NextSilicon&, void* dst, const void* src,
+           size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+template <class ExecutionSpace>
+struct DeepCopy<Kokkos::Experimental::NextSiliconSharedSpace,
+                Kokkos::Experimental::NextSiliconSharedSpace, ExecutionSpace> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
+    exec.fence(
+        "Kokkos::Impl::DeepCopy<NextSiliconSharedSpace, "
+        "NextSiliconSharedSpace, "
+        "ExecutionSpace>::DeepCopy: fence before copy");
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+template <>
+struct DeepCopy<Kokkos::Experimental::NextSiliconSharedSpace, Kokkos::HostSpace,
+                Kokkos::Experimental::NextSilicon> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const Kokkos::Experimental::NextSilicon&, void* dst, const void* src,
+           size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+template <class ExecutionSpace>
+struct DeepCopy<Kokkos::Experimental::NextSiliconSharedSpace, Kokkos::HostSpace,
+                ExecutionSpace> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
+    exec.fence(
+        "Kokkos::Impl::DeepCopy<NextSiliconSharedSpace, HostSpace, "
+        "ExecutionSpace>::DeepCopy: fence before copy");
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+template <>
+struct DeepCopy<Kokkos::HostSpace, Kokkos::Experimental::NextSiliconSharedSpace,
+                Kokkos::Experimental::NextSilicon> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const Kokkos::Experimental::NextSilicon&, void* dst, const void* src,
+           size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+template <class ExecutionSpace>
+struct DeepCopy<Kokkos::HostSpace, Kokkos::Experimental::NextSiliconSharedSpace,
+                ExecutionSpace> {
+  DeepCopy(void* dst, const void* src, size_t n) {
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+  DeepCopy(const ExecutionSpace& exec, void* dst, const void* src, size_t n) {
+    exec.fence(
+        "Kokkos::Impl::DeepCopy<HostSpace, NextSiliconSharedSpace, "
+        "ExecutionSpace>::DeepCopy: fence before copy");
+    // Let NextSilicon runtime select the correct implementation.
+    nextapi_memory_copy(dst, src, n);
+  }
+};
+
+}  // namespace Impl
+}  // namespace Kokkos
+
+#endif

--- a/core/src/NextSilicon/Kokkos_NextSilicon_HeapBuffer.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_HeapBuffer.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_NEXTSILICON_HEAPBUFFER_HPP
+#define KOKKOS_NEXTSILICON_HEAPBUFFER_HPP
+
+#include <NextSilicon/Kokkos_NextSiliconSpace.hpp>
+
+namespace Kokkos::Experimental::Impl {
+
+class NextSiliconHeapBuffer {
+  size_t data_size_ = 0;
+  void *data_       = nullptr;
+
+  void allocate(const char *label, size_t requested) {
+    Kokkos::Experimental::NextSiliconSharedSpace space;
+    data_      = space.allocate(label, requested);
+    data_size_ = requested;
+  }
+
+  void deallocate() {
+    if (data_) {
+      Kokkos::Experimental::NextSiliconSharedSpace space;
+      space.deallocate(data_, data_size_);
+      data_      = nullptr;
+      data_size_ = 0;
+    }
+  }
+
+ public:
+  NextSiliconHeapBuffer()                                         = default;
+  NextSiliconHeapBuffer(const NextSiliconHeapBuffer &)            = delete;
+  NextSiliconHeapBuffer &operator=(const NextSiliconHeapBuffer &) = delete;
+  NextSiliconHeapBuffer(NextSiliconHeapBuffer &&other) noexcept {
+    deallocate();
+    data_      = std::exchange(other.data_, nullptr);
+    data_size_ = std::exchange(other.data_size_, 0);
+  }
+  NextSiliconHeapBuffer &operator=(NextSiliconHeapBuffer &&other) noexcept {
+    if (this != &other) {
+      deallocate();
+      data_      = std::exchange(other.data_, nullptr);
+      data_size_ = std::exchange(other.data_size_, 0);
+    }
+    return *this;
+  }
+  ~NextSiliconHeapBuffer() { deallocate(); }
+
+  std::byte *ensure(const char *label, size_t requested) {
+    if (requested > data_size_) {
+      deallocate();
+      allocate(label, requested);
+    }
+    return static_cast<std::byte *>(data_);
+  }
+};
+}  // namespace Kokkos::Experimental::Impl
+
+#endif
+
+// HeapBuffer -> NextSiliconSpace

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InParallelRegion.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InParallelRegion.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <NextSilicon/Kokkos_NextSilicon_InParallelRegion.hpp>
+#include <Kokkos_Abort.hpp>
+#include <Kokkos_Atomic.hpp>
+#include <nextapi/memory.h>
+
+namespace Kokkos::Impl {
+/*static*/ NextSiliconParallelRegionScopeGuard::HostPinnedBool
+    NextSiliconParallelRegionScopeGuard::s_is_in_parallel_region = false;
+
+NextSiliconParallelRegionScopeGuard::HostPinnedBool::HostPinnedBool(
+    const bool &b)
+    : b_(b) {
+  // Upon construction, pin this variable to host memory to prevent it from
+  // being migrated to device.
+  nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST, true);
+}
+
+NextSiliconParallelRegionScopeGuard::NextSiliconParallelRegionScopeGuard() {
+  // FIXME_NEXTSILICON: Currently parallel dispatch from multiple host threads
+  // is not supported. Remove this atomic and assert when when support is added.
+  bool old = Kokkos::atomic_exchange(
+      &static_cast<bool &>(s_is_in_parallel_region), true);
+  if (old != false) {
+    Kokkos::abort("Already in a parallel region");
+  }
+}
+NextSiliconParallelRegionScopeGuard::~NextSiliconParallelRegionScopeGuard() {
+  // FIXME_NEXTSILICON: Currently parallel dispatch from multiple host threads
+  // is not supported. Remove this atomic and assert when when support is added.
+  bool old = Kokkos::atomic_exchange(
+      &static_cast<bool &>(s_is_in_parallel_region), false);
+  if (old != true) {
+    Kokkos::abort("Not in a parallel region");
+  }
+}
+
+}  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InParallelRegion.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InParallelRegion.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_NEXTSILICON_IN_PARALLEL_REGION_HPP
+#define KOKKOS_NEXTSILICON_IN_PARALLEL_REGION_HPP
+
+#include <cstddef>
+
+// used to implement KOKKOS_IF_ON_HOST / KOKKOS_IF_ON_DEVICE
+namespace Kokkos::Impl {
+
+// NextSiliconParallelRegionScopeGuard maintains a flag that
+// tracks whether the current thread is executing under the NextSilicon
+// device execution space. This is needed to correctly implement
+// KOKKOS_IF_ON_DEVICE/KOKKOS_IF_ON_HOST semantics: unlike CUDA or SYCL,
+// NextSilicon kernels may run on the host during training/telemetry
+// collection while still being under the device execution space, so we
+// cannot simply equate "on device" with "offloaded to device".
+
+class NextSiliconParallelRegionScopeGuard {
+  // FIXME_NEXTSILICON: It quacks like a bool, but sizeof and alignas -> SIZE.
+  // It's pinned to the host to prevent migration to device memory, which would
+  // cause problems when we try to access it from the host. This should be a
+  // facility provided by the toolchain.
+  struct HostPinnedBool {
+    static constexpr int SIZE = 4096;  // Page-aligned for nextapi_mem_migrate.
+
+    union {
+      bool b_;
+      std::byte pad[SIZE];
+    };
+
+   public:
+    constexpr operator bool&() { return b_; }
+
+    HostPinnedBool(const bool& b);
+  };
+
+  static_assert(sizeof(HostPinnedBool) == 4096);
+  static HostPinnedBool s_is_in_parallel_region;
+
+ public:
+  static bool in() { return s_is_in_parallel_region; }
+
+  // This constructor is in RAII context to set the flag to true when the
+  // object is created and to false when the object is destroyed.
+  NextSiliconParallelRegionScopeGuard();
+  ~NextSiliconParallelRegionScopeGuard();
+  NextSiliconParallelRegionScopeGuard(
+      NextSiliconParallelRegionScopeGuard const&) = delete;
+  NextSiliconParallelRegionScopeGuard& operator=(
+      NextSiliconParallelRegionScopeGuard const&) = delete;
+  NextSiliconParallelRegionScopeGuard(NextSiliconParallelRegionScopeGuard&&) =
+      default;
+  NextSiliconParallelRegionScopeGuard& operator=(
+      NextSiliconParallelRegionScopeGuard&&) = default;
+};
+
+}  // namespace Kokkos::Impl
+
+#endif

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.cpp
@@ -10,6 +10,7 @@
 #include <impl/Kokkos_Profiling.hpp>
 #include <ostream>
 #include <cstdint>
+#include <cstddef>
 
 namespace Kokkos::Experimental::Impl {
 
@@ -41,6 +42,13 @@ void NextSiliconInternal::fence(std::string const &name) const {
 uint32_t NextSiliconInternal::instance_id() const noexcept {
   return Kokkos::Tools::Experimental::Impl::idForInstance<
       Kokkos::Experimental::NextSilicon>(reinterpret_cast<uintptr_t>(this));
+}
+
+std::byte *NextSiliconInternal::resize_functor_buffer(size_t requested) {
+  constexpr static size_t MIN_FUNCTOR_BUFFER_SIZE = 4 * 1024 * 1024;  // 4 MB
+  requested = std::max(requested, MIN_FUNCTOR_BUFFER_SIZE);
+
+  return functorBuffer_.ensure("functor heap buffer", requested);
 }
 
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
@@ -7,20 +7,41 @@
 #include <impl/Kokkos_HostSharedPtr.hpp>
 
 #include <cstdint>
+#include <cstddef>
 #include <iosfwd>
 #include <string>
+#include <memory>
+
+#include <NextSilicon/Kokkos_NextSilicon_HeapBuffer.hpp>
 
 namespace Kokkos::Experimental::Impl {
 
 class NextSiliconInternal {
+  Impl::NextSiliconHeapBuffer functorBuffer_;
+
   NextSiliconInternal(const NextSiliconInternal&)            = delete;
   NextSiliconInternal& operator=(const NextSiliconInternal&) = delete;
+
+  std::byte* resize_functor_buffer(size_t requested);
 
  public:
   static Kokkos::Impl::HostSharedPtr<NextSiliconInternal> default_instance;
 
   NextSiliconInternal();
   ~NextSiliconInternal();
+
+  template <class Driver>
+  auto clone_driver(const Driver& driver) {
+    // Helper to clone the driver before going into the handoff function. This
+    // prevents the stack from getting migrated into device.
+    size_t functor_size = sizeof(Driver);
+    std::byte* buffer   = resize_functor_buffer(functor_size);
+    auto deleter        = [](Driver* const p) {
+      if (p) p->~Driver();
+    };
+    return std::unique_ptr<Driver, decltype(deleter)>(
+        new (buffer) Driver(driver), deleter);
+  }
 
   void print_configuration(std::ostream& os) const;
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Intrinsics.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Intrinsics.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <NextSilicon/Kokkos_NextSilicon_Intrinsics.hpp>
+
+extern "C" void
+Kokkos::Experimental::Impl::__ns_immutable_thread_invariant_parameter_struct(
+    const void*) {
+  // FIXME_NEXTSILICON: this thing purposefully left empty to be filled in by NS
+  // toolchain
+}

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Intrinsics.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Intrinsics.hpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+// FIXME_NEXTSILICON: placeholder intrinsic declaration (tracked by NextSilicon
+// ticket CS-694)
+/// An internal-use-only intrinsic used to communicate from Kokkos C++ code to
+/// the MLIR compiler stack that a struct at the address `parameter_struct` can
+/// be considered immutable and thread invariant for the full duration of the
+/// microtask, and that consequently all its members are read only, and that the
+/// pointer to the struct and any derived pointer does not alias with anything
+/// else (pointers stored in the struct can still alias). This should _only_ be
+/// used to annotate the functor objects passed into Kokkos parallel constructs,
+/// and should not be used _anywhere_ outside of Kokkos.
+namespace Kokkos::Experimental::Impl {
+extern "C" void __ns_immutable_thread_invariant_parameter_struct(
+    const void* parameter_struct);
+}

--- a/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_NEXTSILICON_PARALLELFOR_RANGE_HPP
+#define KOKKOS_NEXTSILICON_PARALLELFOR_RANGE_HPP
+
+#include <NextSilicon/Kokkos_NextSilicon.hpp>
+#include <NextSilicon/Kokkos_NextSilicon_Intrinsics.hpp>
+
+#include <Kokkos_Parallel.hpp>
+
+#include <nextapi/parallelism.hpp>
+
+#include <cstddef>
+
+template <class Functor, class... Traits>
+class Kokkos::Impl::ParallelFor<Functor, Kokkos::RangePolicy<Traits...>,
+                                Kokkos::Experimental::NextSilicon> {
+  using Policy    = Kokkos::RangePolicy<Traits...>;
+  using WorkTag   = typename Policy::work_tag;
+  using WorkRange = typename Policy::WorkRange;
+  using Member    = typename Policy::member_type;
+  using IndexType = typename Policy::index_type;
+
+  Functor m_functor;
+  Policy m_policy;
+
+ public:
+  ParallelFor(Functor const& functor, Policy const& policy)
+      : m_functor(functor), m_policy(policy) {}
+
+  void execute() const {
+    // Clone the driver to prevent the stack from getting migrated to device.
+    auto internal_instance = m_policy.space().impl_internal_space_instance();
+    auto cloned_driver     = internal_instance->clone_driver(*this);
+    cloned_driver->execute_internal();
+  }
+
+ private:
+  __attribute__((noinline)) void execute_internal() const {
+    const IndexType begin = m_policy.begin();
+    const IndexType end   = m_policy.end();
+
+    if (end <= begin) return;
+
+    const IndexType chunk_size = m_policy.chunk_size();
+    nextapi::parallel_for(begin, end, {.chunk_size = chunk_size},
+                          parallel_function, &m_functor);
+  }
+
+ private:
+  /// Executes a single parallel iteration `index` for `functor`.
+  static void parallel_function(IndexType index,
+                                Functor const* __restrict functor) {
+    // Communicate to the compiler that the functor is a immutable and thread
+    // invariant for the duration of the microtask.
+    Kokkos::Experimental::Impl::
+        __ns_immutable_thread_invariant_parameter_struct(functor);
+    // Invokes the functor itself. Expected to inline (if compiler visible) the
+    // functor body while passing the extra this pointer.
+    (*functor)(index);
+  }
+};
+
+#endif  // KOKKOS_NEXTSILICON_PARALLELFOR_RANGE_HPP

--- a/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
@@ -6,6 +6,7 @@
 
 #include <NextSilicon/Kokkos_NextSilicon.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_Intrinsics.hpp>
+#include <NextSilicon/Kokkos_NextSilicon_InParallelRegion.hpp>
 
 #include <Kokkos_Parallel.hpp>
 
@@ -30,6 +31,11 @@ class Kokkos::Impl::ParallelFor<Functor, Kokkos::RangePolicy<Traits...>,
       : m_functor(functor), m_policy(policy) {}
 
   void execute() const {
+    // Set the flag to true to indicate that we are in a parallel region. This
+    // is in RAII context to set the flag to true when the object is created and
+    // to false when the object is destroyed.
+    Kokkos::Impl::NextSiliconParallelRegionScopeGuard parallel_region_flag{};
+
     // Clone the driver to prevent the stack from getting migrated to device.
     auto internal_instance = m_policy.space().impl_internal_space_instance();
     auto cloned_driver     = internal_instance->clone_driver(*this);

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Printf.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Printf.hpp
@@ -6,12 +6,20 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include <cstdio>
+
 namespace Kokkos {
 namespace Impl {
 
 template <typename... Args>
-void nextsilicon_printf(const char* /*format*/, Args... /*args*/) {
+void nextsilicon_printf(const char* format, Args... args) {
   // FIXME_NEXTSILICON: CS-515 tracks printing from device
+  if (!__next_is_in_handed_off_code()) {
+    if constexpr (sizeof...(Args) == 0)
+      ::printf("%s", format);
+    else
+      ::printf(format, args...);
+  }
 }
 
 }  // namespace Impl

--- a/core/src/decl/Kokkos_Declare_NEXTSILICON.hpp
+++ b/core/src/decl/Kokkos_Declare_NEXTSILICON.hpp
@@ -10,6 +10,7 @@
 #include <NextSilicon/Kokkos_NextSilicon_DeepCopy.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_ZeroMemset.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_SharedAllocationRecord.hpp>
+#include <NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp>
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_NEXTSILICON.hpp
+++ b/core/src/decl/Kokkos_Declare_NEXTSILICON.hpp
@@ -7,6 +7,7 @@
 #if defined(KOKKOS_ENABLE_NEXTSILICON)
 #include <NextSilicon/Kokkos_NextSilicon.hpp>
 #include <NextSilicon/Kokkos_NextSiliconSpace.hpp>
+#include <NextSilicon/Kokkos_NextSilicon_DeepCopy.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_ZeroMemset.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_SharedAllocationRecord.hpp>
 #endif

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -400,6 +400,38 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_TeamMDRange.cpp)
       list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_TeamVectorRange.cpp)
     endif()
+    if((Tag STREQUAL "Serial") AND KOKKOS_ENABLE_NEXTSILICON)
+      #FIXME_NEXTSILICON: requires parallel_for tagged dispatch
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Atomics.cpp)
+      #FIXME_NEXTSILICON: requires TeamPolicy parallel_for on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_DeepCopy_Assignment.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Graph.cpp)
+      #FIXME_NEXTSILICON: requires TeamPolicy parallel_reduce on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_CommonPolicyInterface.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Reductions.cpp)
+    endif()
+    if(Tag STREQUAL "NextSilicon")
+      #FIXME_NEXTSILICON: requires parallel_for tagged dispatch
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Atomics.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_BlockSizeDeduction.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Complex.cpp)
+      #FIXME_NEXTSILICON: requires MDRange parallel_for on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_ViewAPI_a.cpp)
+      #FIXME_NEXTSILICON: requires TeamPolicy parallel_for on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_DeepCopy_Assignment.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_TeamBasic.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_TeamMDRange.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_TeamVectorRange.cpp)
+      #FIXME_NEXTSILICON: requires WorkGraphPolicy parallel_for on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_WorkGraph.cpp)
+      #FIXME_NEXTSILICON: requires parallel_reduce on NextSilicon
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_CommonPolicyInterface.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_ExecutionSpace.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Graph.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_MDRange_a.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_RangePolicy.cpp)
+      list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Reductions.cpp)
+    endif()
     kokkos_add_executable_and_test(CoreUnitTest_${Tag}_SmokeTest SOURCES UnitTestMainInit.cpp ${${Tag}_SOURCES_SMOKE})
   endif()
 endforeach()

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
   set(KOKKOS_OPENACC_FEATURE_LEVEL 17)
 endif()
 
-set(KOKKOS_NEXTSILICON_FEATURE_LEVEL 3)
+set(KOKKOS_NEXTSILICON_FEATURE_LEVEL 4)
 set(KOKKOS_NEXTSILICON_NAME Experimental::NextSilicon)
 
 set(KOKKOS_OPENACC_NAME Experimental::OpenACC)
@@ -62,6 +62,11 @@ set(COMPILE_ONLY_SOURCES
     view/TestConversionFromPointer.cpp
     view/TestMemoryTraitTypes.cpp
 )
+
+# FIXME_NEXTSILICON: whitelisted tests
+if(Kokkos_ENABLE_NEXTSILICON)
+  set(COMPILE_ONLY_SOURCES TestCreateMirror.cpp)
+endif()
 
 if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR KOKKOS_CXX_COMPILER_ID STREQUAL "Intel")
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestBasicViewMDSpanConversion.cpp)
@@ -109,7 +114,7 @@ set(SMOKE_TEST_NAMES
     WorkGraph
 )
 
-foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
+foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
   string(TOUPPER ${Tag} DEVICE)
   string(TOLOWER ${Tag} dir)
 
@@ -360,7 +365,13 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL)
         configure_file(${dir}/dummy.cpp ${file})
         list(APPEND ${Tag}_VIEWSUPPORT ${file})
       endforeach()
-      kokkos_add_executable_and_test(CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT})
+
+      # FIXME_NEXTSILICON: requires parallel_for
+      if(NOT KOKKOS_ENABLE_NEXTSILICON)
+        kokkos_add_executable_and_test(
+          CoreUnitTest_${Tag}_ViewSupport SOURCES UnitTestMainInit.cpp ${${Tag}_VIEWSUPPORT}
+        )
+      endif()
     endif()
     # Smoke test: minimal subset for quick iteration (generate sources not built with main targets).
     foreach(Name IN LISTS SMOKE_TEST_NAMES)
@@ -563,6 +574,36 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   endif()
 endif()
 
+if(Kokkos_ENABLE_NEXTSILICON)
+  #FIXME_NEXTSILICON: some Serial tests require operations on the default device
+  list(
+    REMOVE_ITEM
+    Serial_SOURCES1
+    #FIXME_NEXTSILICON: requires TeamPolicy<NextSilicon>
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_CommonPolicyConstructors.cpp
+    #FIXME_NEXTSILICON: requires TeamPolicy parallel_for on NextSilicon
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_DeepCopy_Assignment.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_DeepCopy_Narrowing.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Graph.cpp
+    #FIXME_NEXTSILICON: requires long double support
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MathematicalConstants.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MathematicalFunctions1.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MathematicalFunctions2.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MathematicalFunctions3.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_NumericTraits.cpp
+    #FIXME_NEXTSILICON requires parallel_for
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_MinMaxClamp.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Other.cpp
+    #FIXME_NEXTSILICON requires parallel_reduce
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_RangePolicyExecutionTypes.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_CommonPolicyInterface.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Reducers_a.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Reducers_b.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Reducers_c.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/serial/TestSerial_Reductions.cpp
+  )
+endif()
+
 if(Kokkos_ENABLE_SERIAL)
   kokkos_add_executable_and_test(CoreUnitTest_Serial1 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES1})
   kokkos_add_executable_and_test(CoreUnitTest_Serial2 SOURCES UnitTestMainInit.cpp ${Serial_SOURCES2})
@@ -719,6 +760,16 @@ if(Kokkos_ENABLE_SYCL)
   endif()
 endif()
 
+# FIXME_NEXTSILICON: whitelist tests
+if(Kokkos_ENABLE_NEXTSILICON)
+  set(NEXTSILICON_SOURCES
+      ${CMAKE_CURRENT_BINARY_DIR}/nextsilicon/TestNextSilicon_Abort.cpp
+      ${CMAKE_CURRENT_BINARY_DIR}/nextsilicon/TestNextSilicon_MinMaxClamp.cpp
+      # ${CMAKE_CURRENT_BINARY_DIR}/nextsilicon/TestNextSilicon_DeepCopyAlignment.cpp # MDRange parallel for
+  )
+  kokkos_add_executable_and_test(CoreUnitTest_NextSilicon SOURCES UnitTestMainInit.cpp ${NEXTSILICON_SOURCES})
+endif()
+
 set(DEFAULT_DEVICE_SOURCES
     UnitTestMainInit.cpp
     TestCStyleMemoryManagement.cpp
@@ -740,11 +791,13 @@ set(DEFAULT_DEVICE_SOURCES
 )
 # FIXME_OPENACC do not provide a MemorySpace that can be accessed from all ExecSpaces
 # FIXME_SYCL clock_tic does not give the correct timings for cloc_tic
+# FIXME_NEXTSILICON requires parallel_reduce
 if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_SYCL)
   list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedSpace.cpp)
 endif()
 # FIXME_OPENACC do not provide a HostPinnedMemorySpace that can be accessed from all ExecSpaces
-if(KOKKOS_ENABLE_OPENACC)
+# FIXME_NEXTSILICON: does not provide a HostPinnedMemorySpace
+if(KOKKOS_ENABLE_OPENACC OR KOKKOS_ENABLE_NEXTSILICON)
   list(REMOVE_ITEM DEFAULT_DEVICE_SOURCES TestSharedHostPinnedSpace.cpp)
 endif()
 
@@ -786,21 +839,27 @@ if(KOKKOS_ENABLE_OPENACC AND KOKKOS_CXX_COMPILER_ID STREQUAL Clang)
   )
 endif()
 
-kokkos_add_executable_and_test(CoreUnitTest_Default SOURCES ${DEFAULT_DEVICE_SOURCES})
+#FIXME_NEXTSILICON: requires parallel_for
+if(NOT KOKKOS_ENABLE_NEXTSILICON)
+  kokkos_add_executable_and_test(CoreUnitTest_Default SOURCES ${DEFAULT_DEVICE_SOURCES})
+endif()
 
-kokkos_add_executable_and_test(
-  CoreUnitTest_InitializeFinalize
-  SOURCES
-  UnitTestMain.cpp
-  TestExecutionEnvironmentNonInitializedOrFinalized.cpp
-  TestInitializationSettings.cpp
-  TestInitializeFinalize.cpp
-  TestKokkosHelpCausesNormalProgramTermination.cpp
-  TestLegionInitialization.cpp
-  TestParseCmdLineArgsAndEnvVars.cpp
-  TestPushFinalizeHook.cpp
-  TestScopeGuard.cpp
-)
+# FIXME_NEXTSILICON: requires parallel_reduce
+if(NOT Kokkos_ENABLE_NEXTSILICON)
+  kokkos_add_executable_and_test(
+    CoreUnitTest_InitializeFinalize
+    SOURCES
+    UnitTestMain.cpp
+    TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+    TestInitializationSettings.cpp
+    TestInitializeFinalize.cpp
+    TestKokkosHelpCausesNormalProgramTermination.cpp
+    TestLegionInitialization.cpp
+    TestParseCmdLineArgsAndEnvVars.cpp
+    TestPushFinalizeHook.cpp
+    TestScopeGuard.cpp
+  )
+endif()
 
 # This test is intended for development and debugging by putting code
 # into TestDefaultDeviceDevelop.cpp. By default its empty.
@@ -816,7 +875,14 @@ set(KOKKOSP_SOURCES UnitTestMainInit.cpp tools/TestEventCorrectness.cpp tools/Te
                     tools/TestProfilingSection.cpp tools/TestScopedRegion.cpp tools/TestWithoutInitializing.cpp
 )
 
+# FIXME_NEXTSILICON: others require parallel_reduce and parallel_scan
+if(KOKKOS_ENABLE_NEXTSILICON)
+  set(KOKKOSP_SOURCES UnitTestMainInit.cpp tools/TestWithoutInitializing.cpp)
+endif()
+
+# if (NOT KOKKOS_ENABLE_NEXTSILICON)
 kokkos_add_executable_and_test(CoreUnitTest_KokkosP SOURCES ${KOKKOSP_SOURCES})
+# endif()
 if(KOKKOS_ENABLE_LIBDL)
   kokkos_add_executable_and_test(CoreUnitTest_ToolIndependence SOURCES tools/TestIndependence.cpp)
   target_compile_definitions(Kokkos_CoreUnitTest_ToolIndependence PUBLIC KOKKOS_TOOLS_INDEPENDENT_BUILD)
@@ -830,7 +896,10 @@ if(KOKKOS_ENABLE_LIBDL)
 
   kokkos_add_test_executable(ProfilingAllCalls tools/TestAllCalls.cpp)
 
-  kokkos_add_test_executable(ToolsInitialization UnitTestMain.cpp tools/TestToolsInitialization.cpp)
+  # FIXME_NEXTSILICON: requires parallel_reduce
+  if(NOT KOKKOS_ENABLE_NEXTSILICON)
+    kokkos_add_test_executable(ToolsInitialization UnitTestMain.cpp tools/TestToolsInitialization.cpp)
+  endif()
 
   kokkos_add_test_executable(EmptyProfilingLibraryDeathTest UnitTestMain.cpp tools/TestEmptyProfilingLibrary.cpp)
 

--- a/core/unit_test/category_files/TestNextSilicon_Category.hpp
+++ b/core/unit_test/category_files/TestNextSilicon_Category.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_TEST_NEXTSILICON_HPP
+#define KOKKOS_TEST_NEXTSILICON_HPP
+
+#include <gtest/gtest.h>
+
+#define TEST_CATEGORY nextsilicon
+#define TEST_CATEGORY_NUMBER 9
+#define TEST_CATEGORY_DEATH nextsilicon_DeathTest
+#define TEST_EXECSPACE Kokkos::Experimental::NextSilicon
+#define TEST_CATEGORY_FIXTURE(name) nextsilicon_##name
+
+#endif

--- a/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
+++ b/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
@@ -44,7 +44,7 @@ TEST(hip, async_launcher) {
   instance->fence();
   size_t h_flag;
   KOKKOS_IMPL_HIP_SAFE_CALL(
-      hipMemcpy(&h_flag, flag, sizeof(size_t), hipMemcpyHostToDevice));
+      hipMemcpy(&h_flag, flag, sizeof(size_t), hipMemcpyDeviceToHost));
   ASSERT_EQ(h_flag, (nkernels * (nkernels - 1)) / 2);
   KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(flag));
 }

--- a/simd/CMakeLists.txt
+++ b/simd/CMakeLists.txt
@@ -2,5 +2,8 @@ if(NOT Kokkos_INSTALL_TESTING)
   add_subdirectory(src)
 endif()
 
-kokkos_add_test_directories(unit_tests)
-kokkos_add_benchmark_directories(perf_tests)
+# FIXME_NEXTSILICON: unimplemented
+if(NOT KOKKOS_ENABLE_NEXTSILICON)
+  kokkos_add_test_directories(unit_tests)
+  kokkos_add_benchmark_directories(perf_tests)
+endif()


### PR DESCRIPTION
This small fix prevents a test failure with latest ROCm runtimes. The hipMemcpy is passing the destination pointer to host memory, but the flag was for host to device. This resulted in a runtime error.

Fixes #9188

### Changelog Entry

n/a