### PR TITLE
Fixing argument for hipMemcpy call

### DIFF
--- a/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
+++ b/core/unit_test/hip/TestHIP_AsyncLauncher.cpp
@@ -44,7 +44,7 @@ TEST(hip, async_launcher) {
   instance->fence();
   size_t h_flag;
   KOKKOS_IMPL_HIP_SAFE_CALL(
-      hipMemcpy(&h_flag, flag, sizeof(size_t), hipMemcpyHostToDevice));
+      hipMemcpy(&h_flag, flag, sizeof(size_t), hipMemcpyDeviceToHost));
   ASSERT_EQ(h_flag, (nkernels * (nkernels - 1)) / 2);
   KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(flag));
 }


### PR DESCRIPTION
This small fix prevents a test failure with latest ROCm runtimes. The hipMemcpy is passing the destination pointer to host memory, but the flag was for host to device. This resulted in a runtime error.

Fixes https://github.com/kokkos/kokkos/issues/9188

Changelog Entry
n/a
