### PR TITLE
simd-sve: replace memory load by zip-lane-set in gen-based simd constructors

### DIFF
--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -441,33 +441,51 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>()))
-#if SVE_DOUBLES_IN_VECTOR > 2
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_DOUBLES_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
+#if SVE_DOUBLES_IN_VECTOR == 2
+    m_value =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())));
+#elif SVE_DOUBLES_IN_VECTOR == 4
+    implementation_type b02 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())));
+    implementation_type b13 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+    m_value = svzip1_f64(b02, b13);
+#elif SVE_DOUBLES_IN_VECTOR == 8
+    implementation_type b04 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())));
+    implementation_type b26 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b15 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())));
+    implementation_type b37 =
+        svdupq_f64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    implementation_type b0246 = svzip1_f64(b04, b26);
+    implementation_type b1357 = svzip1_f64(b15, b37);
+    m_value                   = svzip1_f64(b0246, b1357);
+#else
+#error "Not implemented: SVE_DOUBLES_IN_VECTOR > 8"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b64(), temp);
   }
 
   template <typename FlagType>
@@ -835,49 +853,79 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_WORDS_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
-#if SVE_WORDS_IN_VECTOR > 8
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 8>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 9>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 10>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 11>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 12>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 13>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 14>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 15>()))
+#if SVE_WORDS_IN_VECTOR == 4
+    m_value =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+#elif SVE_WORDS_IN_VECTOR == 8
+    implementation_type b0246 =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b1357 =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    m_value = svzip1_f32(b0246, b1357);
+#elif SVE_WORDS_IN_VECTOR == 16
+    implementation_type b048c =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 8>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 12>())));
+    implementation_type b26ae =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 10>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 14>())));
+    implementation_type b159d =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 9>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 13>())));
+    implementation_type b37bf =
+        svdupq_f32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 11>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 15>())));
+    implementation_type b02468ace = svzip1_f32(b048c, b26ae);
+    implementation_type b13579bdf = svzip1_f32(b159d, b37bf);
+    m_value                       = svzip1_f32(b02468ace, b13579bdf);
+#else
+#error "Not implemented: SVE_WORDS_IN_VECTOR > 16"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b32(), temp);
   }
 
   template <typename FlagType>
@@ -1238,49 +1286,79 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_WORDS_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
-#if SVE_WORDS_IN_VECTOR > 8
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 8>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 9>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 10>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 11>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 12>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 13>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 14>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 15>()))
+#if SVE_WORDS_IN_VECTOR == 4
+    m_value =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+#elif SVE_WORDS_IN_VECTOR == 8
+    implementation_type b0246 =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b1357 =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    m_value = svzip1_s32(b0246, b1357);
+#elif SVE_WORDS_IN_VECTOR == 16
+    implementation_type b048c =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 8>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 12>())));
+    implementation_type b26ae =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 10>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 14>())));
+    implementation_type b159d =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 9>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 13>())));
+    implementation_type b37bf =
+        svdupq_s32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 11>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 15>())));
+    implementation_type b02468ace = svzip1_s32(b048c, b26ae);
+    implementation_type b13579bdf = svzip1_s32(b159d, b37bf);
+    m_value                       = svzip1_s32(b02468ace, b13579bdf);
+#else
+#error "Not implemented: SVE_WORDS_IN_VECTOR > 16"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b32(), temp);
   }
 
   template <typename FlagType>
@@ -1705,49 +1783,79 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_WORDS_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
-#if SVE_WORDS_IN_VECTOR > 8
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 8>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 9>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 10>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 11>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 12>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 13>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 14>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 15>()))
+#if SVE_WORDS_IN_VECTOR == 4
+    m_value =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+#elif SVE_WORDS_IN_VECTOR == 8
+    implementation_type b0246 =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b1357 =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    m_value = svzip1_u32(b0246, b1357);
+#elif SVE_WORDS_IN_VECTOR == 16
+    implementation_type b048c =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 8>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 12>())));
+    implementation_type b26ae =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 10>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 14>())));
+    implementation_type b159d =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 9>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 13>())));
+    implementation_type b37bf =
+        svdupq_u32(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 11>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 15>())));
+    implementation_type b02468ace = svzip1_u32(b048c, b26ae);
+    implementation_type b13579bdf = svzip1_u32(b159d, b37bf);
+    m_value                       = svzip1_u32(b02468ace, b13579bdf);
+#else
+#error "Not implemented: SVE_WORDS_IN_VECTOR > 16"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b32(), temp);
   }
 
   template <typename FlagType>
@@ -2162,33 +2270,51 @@ class basic_simd<std::int64_t,
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>()))
-#if SVE_DOUBLES_IN_VECTOR > 2
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_DOUBLES_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
+#if SVE_DOUBLES_IN_VECTOR == 2
+    m_value =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())));
+#elif SVE_DOUBLES_IN_VECTOR == 4
+    implementation_type b02 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())));
+    implementation_type b13 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+    m_value = svzip1_s64(b02, b13);
+#elif SVE_DOUBLES_IN_VECTOR == 8
+    implementation_type b04 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())));
+    implementation_type b26 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b15 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())));
+    implementation_type b37 =
+        svdupq_s64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    implementation_type b0246 = svzip1_s64(b04, b26);
+    implementation_type b1357 = svzip1_s64(b15, b37);
+    m_value                   = svzip1_s64(b0246, b1357);
+#else
+#error "Not implemented: SVE_DOUBLES_IN_VECTOR > 8"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b64(), temp);
   }
 
   template <typename FlagType>
@@ -2626,33 +2752,51 @@ class basic_simd<std::uint64_t,
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       G&& gen) noexcept {
-    // TODO: use set-lane instead of load
-    value_type temp[] = {
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 0>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 1>()))
-#if SVE_DOUBLES_IN_VECTOR > 2
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 2>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 3>()))
-#if SVE_DOUBLES_IN_VECTOR > 4
-          ,
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 4>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 5>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 6>())),
-      static_cast<value_type>(
-          gen(std::integral_constant<Impl::simd_size_t, 7>()))
+#if SVE_DOUBLES_IN_VECTOR == 2
+    m_value =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())));
+#elif SVE_DOUBLES_IN_VECTOR == 4
+    implementation_type b02 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())));
+    implementation_type b13 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())));
+    m_value = svzip1_u64(b02, b13);
+#elif SVE_DOUBLES_IN_VECTOR == 8
+    implementation_type b04 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 0>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 4>())));
+    implementation_type b26 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 2>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 6>())));
+    implementation_type b15 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 1>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 5>())));
+    implementation_type b37 =
+        svdupq_u64(static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 3>())),
+                   static_cast<value_type>(
+                       gen(std::integral_constant<Impl::simd_size_t, 7>())));
+    implementation_type b0246 = svzip1_u64(b04, b26);
+    implementation_type b1357 = svzip1_u64(b15, b37);
+    m_value                   = svzip1_u64(b0246, b1357);
+#else
+#error "Not implemented: SVE_DOUBLES_IN_VECTOR > 8"
 #endif
-#endif
-    };
-
-    m_value = svld1(svptrue_b64(), temp);
   }
 
   template <typename FlagType>


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

- Performance improvement: replace initializing a temporary buffer and loading from it by direct in-register lane-set using dup and zip operations

<!-- Link any related issues or PRs. -->

### Changelog Entry
- simd-sve: replace memory load by zip-lane-set in gen-based simd constructors
