### PR TITLE
View<HostSpace>: Add NUMA membind capability to HostSpace with hwloc support 

### DIFF
--- a/benchmarks/stream/CMakeLists.txt
+++ b/benchmarks/stream/CMakeLists.txt
@@ -1,1 +1,12 @@
 kokkos_add_executable(stream SOURCES stream-kokkos.cpp)
+
+if(KOKKOS_ENABLE_HWLOC)
+  kokkos_add_executable(stream_cpu SOURCES stream-kokkos-cpu.cpp)
+
+  set(Kokkos_Benchmark_StreamCPU_NoNUMA_ENVIRONMENT          "NUMA_AWARE=0")
+  set(Kokkos_Benchmark_StreamCPU_Numa_Firsttouch_ENVIRONMENT "NUMA_AWARE=1 NUMA_POLICY=FIRSTTOUCH")
+  set(Kokkos_Benchmark_StreamCPU_Numa_Interleave_ENVIRONMENT "NUMA_AWARE=1 NUMA_POLICY=INTERLEAVE")
+  kokkos_add_test(NAME Benchmark_StreamCPU_NoNUMA_           EXE stream_cpu)
+  kokkos_add_test(NAME Benchmark_StreamCPU_Numa_Firsttouch   EXE stream_cpu)
+  kokkos_add_test(NAME Benchmark_StreamCPU_Numa_Interleave   EXE stream_cpu)
+endif()

--- a/benchmarks/stream/stream-kokkos-cpu.cpp
+++ b/benchmarks/stream/stream-kokkos-cpu.cpp
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include "Kokkos_Core.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+
+#include <sys/time.h>
+
+static size_t STREAM_ARRAY_SIZE = 100000000;
+#define STREAM_NTIMES 20
+
+#define HLINE "-------------------------------------------------------------\n"
+
+using StreamHostArray = Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Restrict>>;
+using StreamIndex = int;
+using Policy      = Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace, Kokkos::IndexType<StreamIndex>>;
+
+void perform_set(StreamHostArray& a, const double scalar) {
+  Kokkos::parallel_for(
+      "set", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { a[i] = scalar; });
+
+  Kokkos::fence();
+}
+
+void perform_copy(StreamHostArray& a, StreamHostArray& b) {
+  Kokkos::parallel_for(
+      "copy", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { b[i] = a[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_scale(StreamHostArray& b, StreamHostArray& c,
+                   const double scalar) {
+  Kokkos::parallel_for(
+      "scale", Policy(0, b.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { b[i] = scalar * c[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_add(StreamHostArray& a, StreamHostArray& b,
+                 StreamHostArray& c) {
+  Kokkos::parallel_for(
+      "add", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { c[i] = a[i] + b[i]; });
+
+  Kokkos::fence();
+}
+
+void perform_triad(StreamHostArray& a, StreamHostArray& b,
+                   StreamHostArray& c, const double scalar) {
+  Kokkos::parallel_for(
+      "triad", Policy(0, a.extent(0)),
+      KOKKOS_LAMBDA(const StreamIndex i) { a[i] = b[i] + scalar * c[i]; });
+
+  Kokkos::fence();
+}
+
+int perform_validation(StreamHostArray& a, StreamHostArray& b,
+                       StreamHostArray& c, const StreamIndex arraySize,
+                       const double scalar) {
+  double ai = 1.0;
+  double bi = 2.0;
+  double ci = 0.0;
+
+  for (StreamIndex i = 0; i < STREAM_NTIMES; ++i) {
+    ci = ai;
+    bi = scalar * ci;
+    ci = ai + bi;
+    ai = bi + scalar * ci;
+  };
+
+  double aError = 0.0;
+  double bError = 0.0;
+  double cError = 0.0;
+
+  for (StreamIndex i = 0; i < arraySize; ++i) {
+    aError = std::abs(a[i] - ai);
+    bError = std::abs(b[i] - bi);
+    cError = std::abs(c[i] - ci);
+  }
+
+  double aAvgError = aError / (double)arraySize;
+  double bAvgError = bError / (double)arraySize;
+  double cAvgError = cError / (double)arraySize;
+
+  const double epsilon = 1.0e-13;
+  int errorCount       = 0;
+
+  if (std::abs(aAvgError / ai) > epsilon) {
+    fprintf(stderr, "Error: validation check on View a failed.\n");
+    errorCount++;
+  }
+
+  if (std::abs(bAvgError / bi) > epsilon) {
+    fprintf(stderr, "Error: validation check on View b failed.\n");
+    errorCount++;
+  }
+
+  if (std::abs(cAvgError / ci) > epsilon) {
+    fprintf(stderr, "Error: validation check on View c failed.\n");
+    errorCount++;
+  }
+
+  if (errorCount == 0) {
+    printf("All solutions checked and verified.\n");
+  }
+
+  return errorCount;
+}
+
+template <typename T,
+          std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, int> = 0>
+static T get_env(const char* name, T defaultValue = -1) {
+  T value = defaultValue;
+  const char *str = std::getenv(name);
+  if (nullptr != str) {
+    value = static_cast<T>(std::stoi(str));
+  }
+  return value;
+}
+
+int run_benchmark() {
+  const char* array_size = std::getenv("STREAM_ARRAY_SIZE");
+  if (array_size != nullptr) {
+    STREAM_ARRAY_SIZE = std::stoull(array_size);
+  }
+
+  printf("Reports fastest timing per kernel\n");
+  printf("Creating Views...\n");
+
+  printf("Memory Sizes:\n");
+  printf("- Array Size:    %" PRIu64 "\n",
+         static_cast<uint64_t>(STREAM_ARRAY_SIZE));
+  printf("- Per Array:     %12.2f MB\n",
+         1.0e-6 * (double)STREAM_ARRAY_SIZE * (double)sizeof(double));
+  printf("- Total:         %12.2f MB\n",
+         3.0e-6 * (double)STREAM_ARRAY_SIZE * (double)sizeof(double));
+  printf("Benchmark kernels will be performed for %d iterations.\n",
+         STREAM_NTIMES);
+
+  printf(HLINE);
+
+#ifndef KOKKOS_ENABLE_HWLOC
+  StreamHostArray a(Kokkos::view_alloc(Kokkos::WithoutInitializing, "a"), STREAM_ARRAY_SIZE);
+  StreamHostArray b(Kokkos::view_alloc(Kokkos::WithoutInitializing, "b"), STREAM_ARRAY_SIZE);
+  StreamHostArray c(Kokkos::view_alloc(Kokkos::WithoutInitializing, "c"), STREAM_ARRAY_SIZE);
+#else
+  StreamHostArray a;
+  StreamHostArray b;
+  StreamHostArray c;
+
+  printf("- Possible NUMA settings by env vars: \n");
+  printf("   - <A|B|C>_NUMA_START=<int> <A|B|C>_NUMA_STEP=<int> : based on indexed list of node IDs\n");
+  // hwloc_memattr_id_e was introduced in version 2.3.0 (0x00020300)
+#if HWLOC_API_VERSION >= 0x00020300
+  printf("   - <A|B|C>_NUMA_MEMATTR=<bandwidth|latency> : based on hwloc memory attribute\n");
+#endif // HWLOC_API_VERSION
+  printf("   - NUMA_POLICY=<default|firsttouch|bind|interleave|nexttouch> : membind policy\n");
+  printf("   - NUMA_AWARE=<int> (default = 1) : if zero then disable all NUMA-aware binding (i.e. normal behavior)\n");
+
+  const int numa_aware = get_env<int>("NUMA_AWARE", 1);
+  printf("   - env(NUMA_AWARE) = %d (%s)\n", numa_aware, (numa_aware ? "true" : "false"));
+
+  if (!numa_aware) {
+    a = StreamHostArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "a"), STREAM_ARRAY_SIZE);
+    b = StreamHostArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "b"), STREAM_ARRAY_SIZE);
+    c = StreamHostArray(Kokkos::view_alloc(Kokkos::WithoutInitializing, "c"), STREAM_ARRAY_SIZE);
+  } else {
+    // example usage of customized hostspace with NUMA capability
+    auto my_views = std::array{
+      StreamHostArray(),
+      StreamHostArray(),
+      StreamHostArray()
+    };
+
+    #define NUMA_NODES_MAX 8
+    static Kokkos::NUMANodes<NUMA_NODES_MAX> numa_ids;
+
+    // if memattr is supported then use memattr by default if NUMA_START not set
+    constexpr int numa_start_default =
+      (HWLOC_API_VERSION >= 0x00020300) ? -1 : 0;
+
+    const int numa_starts[3] = {
+      get_env<int>("A_NUMA_START", numa_start_default),
+      get_env<int>("B_NUMA_START", numa_start_default),
+      get_env<int>("C_NUMA_START", numa_start_default)
+    };
+    const int numa_steps[3]  = {
+      get_env<int>("A_NUMA_STEP", 1),
+      get_env<int>("B_NUMA_STEP", 1),
+      get_env<int>("C_NUMA_STEP", 1),
+    };
+    const char* numa_memattrs[3]  = {
+      std::getenv("A_NUMA_MEMATTR"),
+      std::getenv("B_NUMA_MEMATTR"),
+      std::getenv("C_NUMA_MEMATTR"),
+    };
+    const char* numa_policy_str = std::getenv("NUMA_POLICY");
+    hwloc_membind_policy_t numa_policy = HWLOC_MEMBIND_DEFAULT;
+    if (numa_policy_str != nullptr) {
+      if (std::strstr(numa_policy_str, "default") || std::strstr(numa_policy_str, "DEFAULT")) {
+        numa_policy = HWLOC_MEMBIND_DEFAULT;
+      }
+      if (std::strstr(numa_policy_str, "firsttouch") || std::strstr(numa_policy_str, "FIRSTTOUCH")) {
+        numa_policy = HWLOC_MEMBIND_FIRSTTOUCH;
+      }
+      if (std::strstr(numa_policy_str, "bind") || std::strstr(numa_policy_str, "BIND")) {
+        numa_policy = HWLOC_MEMBIND_BIND;
+      }
+      if (std::strstr(numa_policy_str, "interleave") || std::strstr(numa_policy_str, "INTERLEAVE")) {
+        numa_policy = HWLOC_MEMBIND_INTERLEAVE;
+      }
+      if (std::strstr(numa_policy_str, "nexttouch") || std::strstr(numa_policy_str, "NEXTTOUCH")) {
+        numa_policy = HWLOC_MEMBIND_NEXTTOUCH;
+      }
+    }
+
+    for (int i = 0; i < 3; ++i) {
+      const char* numa_memattr  = numa_memattrs[i];
+      int numa_start = numa_starts[i];
+      int numa_step  = numa_steps[i];
+      char label[8];
+      snprintf(label, sizeof(label), "array%d", i);
+
+      if (numa_start >= 0) {
+        printf("- Bound NUMA nodes for %s: ", label);
+        for (int j = 0; j < NUMA_NODES_MAX; ++j) {
+          numa_ids[j] = numa_start + j*numa_step;
+          printf("  %2u%s", numa_ids[j], (j == (NUMA_NODES_MAX-1) ? "\n" : ""));
+        }
+        auto hspace  = Kokkos::HostSpace(numa_ids, numa_policy);
+        auto prop = Kokkos::view_alloc(label, hspace, Kokkos::WithoutInitializing);
+        my_views[i] = StreamHostArray(prop, STREAM_ARRAY_SIZE);
+      }
+
+#if HWLOC_API_VERSION >= 0x00020300
+      else {
+        hwloc_memattr_id_e memattr = HWLOC_MEMATTR_ID_BANDWIDTH;
+
+        if (numa_memattr != nullptr) {
+          if (std::strstr(numa_memattr, "bandwidth") || std::strstr(numa_memattr, "BANDWIDTH")) {
+            memattr = HWLOC_MEMATTR_ID_BANDWIDTH;
+          }
+          if (std::strstr(numa_memattr, "latency") || std::strstr(numa_memattr, "LATENCY")) {
+            memattr = HWLOC_MEMATTR_ID_LATENCY;
+          }
+        }
+        const char *memattr_str = memattr == HWLOC_MEMATTR_ID_BANDWIDTH ? "BANDWIDTH" :
+                                 (memattr == HWLOC_MEMATTR_ID_LATENCY ?  "LATENCY" :
+                                                  "UNKNOWN");
+
+        printf("- Bound NUMA nodes for %s: based on memattr = %s\n", label, memattr_str);
+        auto hspace = Kokkos::HostSpace(memattr, numa_policy);
+        auto prop = Kokkos::view_alloc(label, hspace, Kokkos::WithoutInitializing);
+        my_views[i] = StreamHostArray(prop, STREAM_ARRAY_SIZE);
+      }
+#endif // HWLOC_API_VERSION
+
+    } // for
+
+    a = my_views[0];
+    b = my_views[1];
+    c = my_views[2];
+  } // if (!numa_aware)
+
+  printf(HLINE);
+#endif // KOKKOS_ENABLE_HWLOC
+
+  const double scalar = 3.0;
+
+  double setTime   = std::numeric_limits<double>::max();
+  double copyTime  = std::numeric_limits<double>::max();
+  double scaleTime = std::numeric_limits<double>::max();
+  double addTime   = std::numeric_limits<double>::max();
+  double triadTime = std::numeric_limits<double>::max();
+
+  printf("Initializing Views...\n");
+
+  Kokkos::parallel_for(
+      "init",
+      Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,
+                                                             STREAM_ARRAY_SIZE),
+      KOKKOS_LAMBDA(const int i) {
+        a[i] = 1.0;
+        b[i] = 2.0;
+        c[i] = 0.0;
+      });
+
+  printf("Starting benchmarking...\n");
+
+  Kokkos::Timer timer;
+
+  for (StreamIndex k = 0; k < STREAM_NTIMES; ++k) {
+    timer.reset();
+    perform_set(c, 1.5);
+    setTime = std::min(setTime, timer.seconds());
+
+    timer.reset();
+    perform_copy(a, c);
+    copyTime = std::min(copyTime, timer.seconds());
+
+    timer.reset();
+    perform_scale(b, c, scalar);
+    scaleTime = std::min(scaleTime, timer.seconds());
+
+    timer.reset();
+    perform_add(a, b, c);
+    addTime = std::min(addTime, timer.seconds());
+
+    timer.reset();
+    perform_triad(a, b, c, scalar);
+    triadTime = std::min(triadTime, timer.seconds());
+  }
+
+  printf("Performing validation...\n");
+  int rc = perform_validation(a, b, c, STREAM_ARRAY_SIZE, scalar);
+
+  printf(HLINE);
+
+  printf("Set             %11.2f MB/s\n",
+         (1.0e-06 * 1.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             setTime);
+  printf("Copy            %11.2f MB/s\n",
+         (1.0e-06 * 2.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             copyTime);
+  printf("Scale           %11.2f MB/s\n",
+         (1.0e-06 * 2.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             scaleTime);
+  printf("Add             %11.2f MB/s\n",
+         (1.0e-06 * 3.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             addTime);
+  printf("Triad           %11.2f MB/s\n",
+         (1.0e-06 * 3.0 * (double)sizeof(double) * (double)STREAM_ARRAY_SIZE) /
+             triadTime);
+
+  printf(HLINE);
+
+  return rc;
+}
+
+int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
+  printf(HLINE);
+  printf("Kokkos STREAM CPU Benchmark\n");
+  printf(HLINE);
+
+  Kokkos::initialize(argc, argv);
+  const int rc = run_benchmark();
+  Kokkos::finalize();
+
+  return rc;
+}

--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -71,6 +71,7 @@
 #cmakedefine KOKKOS_ENABLE_LIBQUADMATH
 #cmakedefine KOKKOS_ENABLE_ONEDPL
 #cmakedefine KOKKOS_ENABLE_ROCTHRUST
+#cmakedefine KOKKOS_ENABLE_DEBUG_HWLOC
 
 /* Embedded dependencies */
 #define KOKKOS_IMPL_DESUL_VERSION "@KOKKOS_DESUL_VERSION@"

--- a/cmake/kokkos_enable_options.cmake
+++ b/cmake/kokkos_enable_options.cmake
@@ -63,6 +63,7 @@ kokkos_enable_option(DEBUG ${DEBUG_DEFAULT} "Whether to activate extra debug fea
 unset(_UPPERCASE_CMAKE_BUILD_TYPE)
 kokkos_enable_option(LARGE_MEM_TESTS OFF "Whether to perform extra large memory tests")
 kokkos_enable_option(DEBUG_BOUNDS_CHECK OFF "Whether to use bounds checking - will increase runtime")
+kokkos_enable_option(DEBUG_HWLOC OFF "Whether to enable extra hwloc debug messages - will increase runtime")
 kokkos_enable_option(COMPILER_WARNINGS OFF "Whether to print all compiler warnings")
 kokkos_enable_option(TUNING OFF "Whether to create bindings for tuning tools")
 kokkos_enable_option(AGGRESSIVE_VECTORIZATION OFF "Whether to aggressively vectorize loops")

--- a/core/src/Kokkos_HostSpace.hpp
+++ b/core/src/Kokkos_HostSpace.hpp
@@ -12,11 +12,17 @@ static_assert(false,
 #include <cstring>
 #include <string>
 #include <iosfwd>
+#include <iostream>
 #include <typeinfo>
 
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+
+#ifdef KOKKOS_ENABLE_HWLOC
+#include <Kokkos_hwloc.hpp>
+#include <Kokkos_NUMANodes.hpp>
+#endif // KOKKOS_ENABLE_HWLOC
 
 #include <impl/Kokkos_Traits.hpp>
 #include <impl/Kokkos_Error.hpp>
@@ -53,6 +59,157 @@ class HostSpace {
 
   HostSpace() = default;
 
+#ifdef KOKKOS_ENABLE_HWLOC
+  HostSpace(const HostSpace& rhs) {
+    if (nullptr != rhs.membind_set) {
+      this->membind_set = hwloc_bitmap_dup(rhs.membind_set);
+      this->membind_policy = rhs.membind_policy;
+      this->membind_flags = rhs.membind_flags;
+#ifdef KOKKOS_ENABLE_DEBUG_HWLOC
+      char *set_str;
+      hwloc_bitmap_list_asprintf(&set_str, this->membind_set);
+      std::cout << "INFO: " << __PRETTY_FUNCTION__
+                << " membind_set: " << set_str
+                << " membind_policy: " << this->membind_policy
+                << " membind_flags: " << this->membind_flags
+                << std::endl;
+      free(set_str);
+#endif // KOKKOS_ENABLE_DEBUG_HWLOC
+    }
+  }
+
+  template<typename T,
+    std::enable_if_t<std::is_same_v<std::decay_t<T>, hwloc_bitmap_t>
+    // hwloc_memattr_id_e was introduced in version 2.3.0 (0x00020300)
+#if HWLOC_API_VERSION >= 0x00020300
+                  || std::is_same_v<std::decay_t<T>, hwloc_memattr_id_e>
+#endif // HWLOC_API_VERSION
+                  || Kokkos::is_kokkos_numanodes_v<T>
+                  , int> = 0>
+  HostSpace(T&& arg,
+    const hwloc_membind_policy_t policy = KOKKOS_HWLOC_DEFAULT_MEMBIND_POLICY,
+    const int flags = KOKKOS_HWLOC_DEFAULT_MEMBIND_FLAGS)
+  : membind_policy(policy), membind_flags(flags) {
+    hwloc_bitmap_t const membind_set_cur = static_cast<hwloc_bitmap_t>(
+        Kokkos::hwloc::get_membind_set());
+    const hwloc_topology_t topology = Kokkos::hwloc::get_topology();
+
+    hwloc_bitmap_t membind_set_asked = hwloc_bitmap_alloc();
+
+    if (nullptr == this->membind_set) {
+      this->membind_set = hwloc_bitmap_alloc();
+    }
+
+    // build the user-requested set
+    using rawT = std::decay_t<T>;
+
+    if constexpr (std::is_same_v<rawT, hwloc_bitmap_t>) {
+
+      hwloc_bitmap_copy(membind_set_asked, arg);
+
+    // hwloc_memattr_id_e was introduced in version 2.3.0 (0x00020300)
+#if HWLOC_API_VERSION >= 0x00020300
+    } else if constexpr (std::is_same_v<rawT, hwloc_memattr_id_e>) {
+
+      hwloc_bitmap_t process_binding = Kokkos::hwloc::get_process_binding();
+      hwloc_obj_t best_node;
+      struct hwloc_location initiator;
+      initiator.type = HWLOC_LOCATION_TYPE_CPUSET;
+      initiator.location.cpuset = process_binding;
+
+      int err = hwloc_memattr_get_best_target(topology, arg,
+            &initiator, 0, &best_node, nullptr);
+      if (0 == err) {
+        hwloc_bitmap_copy(membind_set_asked, best_node->nodeset);
+      }
+
+      // If the cpuset is spread across multiple Sockets or Packages, hwloc
+      // might fail to decide THE best target, since the best for a core
+      // may not be the best for another core. In this case, we need to do
+      // more dichotomy and gather the best target of each core in cpuset.
+      if (hwloc_bitmap_iszero(membind_set_asked)) {
+        unsigned id;
+        hwloc_bitmap_foreach_begin(id, process_binding) {
+          // get cpuset of this core
+          hwloc_obj_t obj_core = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, id);
+
+          // get best numa node of this core, then OR with membind_set_asked
+          if (nullptr != obj_core) {
+            initiator.location.cpuset = obj_core->cpuset;
+            err = hwloc_memattr_get_best_target(topology, arg, &initiator, 0, &best_node, nullptr);
+            if (0 == err) {
+              hwloc_bitmap_or(membind_set_asked, membind_set_asked, best_node->nodeset);
+            }
+          }
+
+        } hwloc_bitmap_foreach_end();
+      }
+      // Foolproof: mark bitmap as processed as nodeset
+      membind_flags |= HWLOC_MEMBIND_BYNODESET;
+#endif // HWLOC_API_VERSION
+
+    } else if constexpr (Kokkos::is_kokkos_numanodes_v<T>) {
+
+      const bool is_physical = arg.is_physical();
+      const int nb_nodes = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_NUMANODE);
+      for (size_t i = 0; i < arg.size(); ++i) {
+        const unsigned id = arg[i];
+        // sanity check that asked node id exists
+        if (((int)id) >= nb_nodes) {
+#ifdef KOKKOS_ENABLE_DEBUG_HWLOC
+          std::cout << "WARNING: " << __PRETTY_FUNCTION__
+                    << " asked node id " << id << " does not exist"
+                    << " and will be ignored"
+                    << " (available nb_nodes = " << nb_nodes << ")"
+                    << std::endl;
+#endif // KOKKOS_ENABLE_DEBUG_HWLOC
+          continue;
+        }
+        hwloc_obj_t obj = is_physical
+                   ? hwloc_get_numanode_obj_by_os_index(topology, id)
+                   : hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, id);
+        if (nullptr != obj->nodeset) {
+          hwloc_bitmap_or(membind_set_asked, membind_set_asked, obj->nodeset);
+        }
+      }
+      // Foolproof: mark bitmap as processed as nodeset
+      membind_flags |= HWLOC_MEMBIND_BYNODESET;
+
+    } else {
+      __builtin_unreachable();
+    }
+
+    // fit in available nodes in membind_set_cur
+    // membind_set = membind_set_asked & membind_set_cur
+    hwloc_bitmap_and(this->membind_set, membind_set_asked, membind_set_cur);
+
+    // little check
+    if (hwloc_bitmap_iszero(this->membind_set)) {
+      char *set_cur, *set_asked;
+      hwloc_bitmap_list_asprintf(&set_cur, membind_set_cur);
+      hwloc_bitmap_list_asprintf(&set_asked, membind_set_asked);
+
+      std::cout << "ERROR: " << __PRETTY_FUNCTION__
+                << " membind_set is empty. Further allocation might fail."
+                << " Please review nodelist argument and/or numactl runtime."
+                << " Current membind nodeset: " << set_cur
+                << " Asked membind nodeset: " << set_asked
+                << std::endl;
+      free(set_cur);
+      free(set_asked);
+    }
+
+    hwloc_bitmap_free(membind_set_asked);
+  }
+
+  ~HostSpace() {
+    if (nullptr != membind_set) {
+      hwloc_bitmap_free(membind_set);
+      membind_set = nullptr;
+    }
+  }
+#endif  // KOKKOS_ENABLE_HWLOC
+
   /**\brief  Allocate untracked memory in the space */
   template <typename ExecutionSpace>
   void* allocate(const ExecutionSpace&, const size_t arg_alloc_size) const {
@@ -87,8 +244,27 @@ class HostSpace {
   /**\brief Return Name of the MemorySpace */
   static constexpr const char* name() { return m_name; }
 
+#ifdef KOKKOS_ENABLE_HWLOC
+  hwloc_bitmap_t get_membind_set(void) const {
+    return membind_set;
+  }
+  hwloc_membind_policy_t get_membind_policy(void) const {
+    return membind_policy;
+  }
+  int get_membind_flags(void) const {
+    return membind_flags;
+  }
+#endif  // KOKKOS_ENABLE_HWLOC
+
  private:
   static constexpr const char* m_name = "Host";
+
+#ifdef KOKKOS_ENABLE_HWLOC
+  hwloc_bitmap_t membind_set{nullptr};
+  hwloc_membind_policy_t membind_policy;
+  int membind_flags;
+#endif  // KOKKOS_ENABLE_HWLOC
+
 };
 
 }  // namespace Kokkos

--- a/core/src/Kokkos_NUMANodes.hpp
+++ b/core/src/Kokkos_NUMANodes.hpp
@@ -1,0 +1,50 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#ifndef KOKKOS_NUMANODE_HPP
+#define KOKKOS_NUMANODE_HPP
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Array.hpp>
+
+namespace Kokkos {
+
+// Nodes ID mapping on either logical nodes or physical ones
+// - If Physical: they will be used (mostly) as-is for memory binding
+// - If Logical : they will be converted to a physical bitmap for memory binding
+enum class ID_type : int { Physical, Logical };
+
+template <unsigned N, Kokkos::ID_type id_type = Kokkos::ID_type::Physical>
+struct NUMANodes: public Kokkos::Array<unsigned, N> {
+  public:
+    KOKKOS_INLINE_FUNCTION static constexpr bool is_physical() { return id_type == Kokkos::ID_type::Physical; }
+};
+
+template <typename T>
+struct is_kokkos_numanodes : public std::false_type{};
+
+template <unsigned N, Kokkos::ID_type id_type>
+struct is_kokkos_numanodes<Kokkos::NUMANodes<N, id_type>> : public std::true_type{};
+
+template <unsigned N>
+struct is_kokkos_numanodes<Kokkos::NUMANodes<N>> : public std::true_type{};
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION constexpr bool is_kokkos_numanodes_v = is_kokkos_numanodes<std::decay_t<T>>::value;
+
+}  // namespace Kokkos
+
+#endif /* #ifndef KOKKOS_NUMANODE_HPP */

--- a/core/src/Kokkos_hwloc.hpp
+++ b/core/src/Kokkos_hwloc.hpp
@@ -11,6 +11,23 @@ static_assert(false,
 
 #include <Kokkos_Macros.hpp>
 
+#ifdef KOKKOS_ENABLE_HWLOC
+#include <hwloc.h>
+
+#ifndef KOKKOS_HWLOC_DEFAULT_MEMBIND_FLAGS
+// set NOCPUBIND to prevent OS from binding/moving threads to memory nodes
+#define KOKKOS_HWLOC_DEFAULT_MEMBIND_FLAGS  (HWLOC_MEMBIND_NOCPUBIND)
+#endif
+
+#ifndef KOKKOS_HWLOC_DEFAULT_MEMBIND_POLICY
+#define KOKKOS_HWLOC_DEFAULT_MEMBIND_POLICY (HWLOC_MEMBIND_DEFAULT)
+#endif
+
+#else
+typedef void* hwloc_bitmap_t;
+typedef void* hwloc_topology_t;
+#endif  // KOKKOS_ENABLE_HWLOC
+
 #include <utility>
 
 namespace Kokkos {
@@ -47,6 +64,15 @@ unsigned get_available_cores_per_numa();
 /** \brief  Query number of available "hard" threads per core; i.e.,
  * hyperthreads */
 unsigned get_available_threads_per_core();
+
+/** \brief  Query the current membind in nodeset (not cpuset) */
+hwloc_bitmap_t get_membind_set();
+
+/** \brief  Query the current process binding (cpuset) */
+hwloc_bitmap_t get_process_binding();
+
+/** \brief  Query the current hwloc topology */
+hwloc_topology_t get_topology();
 
 } /* namespace hwloc */
 } /* namespace Kokkos */

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -578,6 +578,11 @@ void pre_initialize_internal(const Kokkos::InitializationSettings& settings) {
 #else
   declare_configuration_metadata("options", "KOKKOS_ENABLE_HWLOC", "no");
 #endif
+#ifdef KOKKOS_ENABLE_DEBUG_HWLOC
+  declare_configuration_metadata("options", "KOKKOS_ENABLE_DEBUG_HWLOC", "yes");
+#else
+  declare_configuration_metadata("options", "KOKKOS_ENABLE_DEBUG_HWLOC", "no");
+#endif
 #ifdef KOKKOS_ENABLE_LIBDL
   declare_configuration_metadata("options", "KOKKOS_ENABLE_LIBDL", "yes");
 #else

--- a/core/src/impl/Kokkos_HostSpace.cpp
+++ b/core/src/impl/Kokkos_HostSpace.cpp
@@ -39,23 +39,93 @@ void *HostSpace::impl_allocate(
     const char *arg_label, const size_t arg_alloc_size,
     const size_t arg_logical_size,
     const Kokkos::Tools::SpaceHandle arg_handle) const {
+  void *ptr = nullptr;
   const size_t reported_size =
       (arg_logical_size > 0) ? arg_logical_size : arg_alloc_size;
   static_assert(sizeof(void *) == sizeof(uintptr_t),
                 "Error sizeof(void*) != sizeof(uintptr_t)");
 
-  static_assert(Kokkos::has_single_bit(Kokkos::Impl::MEMORY_ALIGNMENT),
-                "Memory alignment must be power of two");
-
   constexpr uintptr_t alignment      = Kokkos::Impl::MEMORY_ALIGNMENT;
   constexpr uintptr_t alignment_mask = alignment - 1;
 
-  void *ptr = nullptr;
+#ifdef KOKKOS_ENABLE_HWLOC
+  // only use hwloc_alloc() when membind_set is initialized (i.e. HostSpace
+  // was constructed with hwloc nodes in mind), otherwise will fallback to
+  // default 'operator new'
+  if ((nullptr != membind_set) && arg_alloc_size) {
+    const hwloc_topology_t topology = Kokkos::hwloc::get_topology();
+
+    // We want to apply hwloc_membind_policy_t behavior uniquely to the
+    // current Kokkos memory space, and not the whole process. Moreover,
+    // the process memory binding can be larger than the current nodeset
+    // of this space, and should not be reduced (with hwloc_set_membind())
+    // for any reason.
+    // - Among all membind policies, Firsttouch and Nexttouch
+    //   are a bit tricky to treat: pages will be allocated (or moved) to
+    //   the **local** NUMA node of the toucher-thread. This local node
+    //   might not belong to the nodeset of this space and data will be
+    //   spread over unwanted nodes. After multiple tests, it turns out
+    //   that using:
+    //   - hwloc_alloc() followed by
+    //   - hwloc_set_area_membind() with
+    //       policy = HWLOC_MEMBIND_BIND and
+    //       flags |= (HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT)
+    //   responds to our expected behavior.
+    // - In the current implementation, HWLOC_MEMBIND_DEFAULT will be treated
+    //   as HWLOC_MEMBIND_FIRSTTOUCH
+    // - Other policies work straightforwardly.
+    if (membind_policy == HWLOC_MEMBIND_DEFAULT ||
+        membind_policy == HWLOC_MEMBIND_FIRSTTOUCH ||
+        membind_policy == HWLOC_MEMBIND_NEXTTOUCH)
+    {
+      // allocate
+      ptr = hwloc_alloc(topology, arg_alloc_size);
+
+      // set_area_membind
+      if (ptr) {
+        int err_set_area =
+          hwloc_set_area_membind(topology, ptr, arg_alloc_size,
+            membind_set, HWLOC_MEMBIND_BIND,
+            membind_flags | HWLOC_MEMBIND_MIGRATE | HWLOC_MEMBIND_STRICT);
+        if (err_set_area) {
+          std::cout << "ERROR: " << __PRETTY_FUNCTION__
+                  << " failed to hwloc_set_area_membind() a"
+                  << " [default|firsttouch|nexttouch] policy"
+                  << std::endl;
+          hwloc_free(topology, ptr, arg_alloc_size);
+          ptr = nullptr;
+        }
+      }
+    } else {
+      // allocate with membind
+      ptr = hwloc_alloc_membind(topology, arg_alloc_size,
+            membind_set, membind_policy, membind_flags);
+    }
+
+#ifdef KOKKOS_ENABLE_DEBUG_HWLOC
+    char *set_str;
+    hwloc_bitmap_list_asprintf(&set_str, membind_set);
+    std::cout << "INFO: " << __PRETTY_FUNCTION__
+                << " hwloc_alloc_membind() = " << ptr
+                << " arg_alloc_size: " << arg_alloc_size
+                << " membind_set: " << set_str
+                << " membind_policy: " << membind_policy
+                << " membind_flags: " << membind_flags
+                << std::endl;
+    free(set_str);
+#endif // KOKKOS_ENABLE_DEBUG_HWLOC
+    goto check;
+  }
+#endif  // KOKKOS_ENABLE_HWLOC
+
+  static_assert(Kokkos::has_single_bit(Kokkos::Impl::MEMORY_ALIGNMENT),
+                "Memory alignment must be power of two");
 
   if (arg_alloc_size)
     ptr = operator new(arg_alloc_size, std::align_val_t(alignment),
                        std::nothrow_t{});
 
+check:
   if (!ptr || (reinterpret_cast<uintptr_t>(ptr) == ~uintptr_t(0)) ||
       (reinterpret_cast<uintptr_t>(ptr) & alignment_mask)) {
     Impl::throw_bad_alloc(name(), arg_alloc_size, arg_label);
@@ -63,6 +133,7 @@ void *HostSpace::impl_allocate(
   if (Kokkos::Profiling::profileLibraryLoaded()) {
     Kokkos::Profiling::allocateData(arg_handle, arg_label, ptr, reported_size);
   }
+
   return ptr;
 }
 
@@ -88,6 +159,20 @@ void HostSpace::impl_deallocate(
       Kokkos::Profiling::deallocateData(arg_handle, arg_label, arg_alloc_ptr,
                                         reported_size);
     }
+
+#ifdef KOKKOS_ENABLE_HWLOC
+    if ((nullptr != membind_set) && arg_alloc_size) {
+#ifdef KOKKOS_ENABLE_DEBUG_HWLOC
+      std::cout << "INFO: " << __PRETTY_FUNCTION__
+                << " hwloc_free(" << arg_alloc_ptr << ")"
+                << " alloc_size: " << arg_alloc_size
+                << std::endl;
+#endif // KOKKOS_ENABLE_DEBUG_HWLOC
+      hwloc_free(Kokkos::hwloc::get_topology(), arg_alloc_ptr, arg_alloc_size);
+      return;
+    }
+#endif  // KOKKOS_ENABLE_HWLOC
+
     constexpr uintptr_t alignment = Kokkos::Impl::MEMORY_ALIGNMENT;
     operator delete(arg_alloc_ptr, std::align_val_t(alignment),
                     std::nothrow_t{});

--- a/core/src/impl/Kokkos_hwloc.cpp
+++ b/core/src/impl/Kokkos_hwloc.cpp
@@ -236,6 +236,7 @@ enum { MAX_CORE = 1024 };
 std::pair<unsigned, unsigned> s_core_topology(0, 0);
 unsigned s_core_capacity(0);
 hwloc_topology_t s_hwloc_topology(nullptr);
+hwloc_bitmap_t s_hwloc_membind_nodeset(nullptr);
 hwloc_bitmap_t s_hwloc_location(nullptr);
 hwloc_bitmap_t s_process_binding(nullptr);
 hwloc_bitmap_t s_core[MAX_CORE];
@@ -263,6 +264,7 @@ bool sentinel() {
 Sentinel::~Sentinel() {
   hwloc_topology_destroy(s_hwloc_topology);
   hwloc_bitmap_free(s_process_binding);
+  hwloc_bitmap_free(s_hwloc_membind_nodeset);
   hwloc_bitmap_free(s_hwloc_location);
 
   s_core_topology.first  = 0;
@@ -271,6 +273,7 @@ Sentinel::~Sentinel() {
   s_hwloc_topology       = nullptr;
   s_hwloc_location       = nullptr;
   s_process_binding      = nullptr;
+  s_hwloc_membind_nodeset = nullptr;
 }
 
 Sentinel::Sentinel() {
@@ -279,6 +282,8 @@ Sentinel::Sentinel() {
 #else
   static const bool remove_core_0 = false;
 #endif
+
+  hwloc_membind_policy_t membind_policy;
 
   s_core_topology   = std::pair<unsigned, unsigned>(0, 0);
   s_core_capacity   = 0;
@@ -293,7 +298,10 @@ Sentinel::Sentinel() {
 
   s_hwloc_location  = hwloc_bitmap_alloc();
   s_process_binding = hwloc_bitmap_alloc();
+  s_hwloc_membind_nodeset = hwloc_bitmap_alloc();
 
+  hwloc_get_membind(s_hwloc_topology, s_hwloc_membind_nodeset,
+    &membind_policy, HWLOC_MEMBIND_BYNODESET);
   hwloc_get_cpubind(s_hwloc_topology, s_process_binding, HWLOC_CPUBIND_PROCESS);
 
   if (hwloc_bitmap_iszero(s_process_binding)) {
@@ -521,6 +529,21 @@ unsigned get_available_threads_per_core() {
   return s_core_capacity;
 }
 
+hwloc_bitmap_t get_membind_set() {
+  sentinel();
+  return s_hwloc_membind_nodeset;
+}
+
+hwloc_bitmap_t get_process_binding() {
+  sentinel();
+  return s_process_binding;
+}
+
+hwloc_topology_t get_topology() {
+  sentinel();
+  return s_hwloc_topology;
+}
+
 bool can_bind_threads() {
   sentinel();
   return s_can_bind_threads;
@@ -690,6 +713,9 @@ bool can_bind_threads() { return false; }
 unsigned get_available_numa_count() { return 1; }
 unsigned get_available_cores_per_numa() { return 1; }
 unsigned get_available_threads_per_core() { return 1; }
+hwloc_bitmap_t get_membind_set() { return nullptr; }
+hwloc_bitmap_t get_process_binding() { return nullptr; }
+hwloc_topology_t get_topology() { return nullptr; }
 
 unsigned bind_this_thread(const unsigned, std::pair<unsigned, unsigned>[]) {
   return ~0;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -816,6 +816,90 @@ struct TestViewMirror {
     ASSERT_TRUE(u3.is_allocated());
   }
 
+#ifdef KOKKOS_ENABLE_HWLOC
+  // get hwloc area membind map of a view
+  template <typename T_View>
+  KOKKOS_INLINE_FUNCTION
+  static hwloc_bitmap_t get_area_membind(T_View& v, hwloc_bitmap_t nodeset) {
+    using value_type = typename T_View::value_type;
+    hwloc_topology_t topology = Kokkos::hwloc::get_topology();
+    hwloc_membind_policy_t policy;
+    int flags = (HWLOC_MEMBIND_BYNODESET | HWLOC_MEMBIND_STRICT);
+    hwloc_bitmap_zero(nodeset);
+
+    hwloc_get_area_membind(topology, v.data(), v.span() * sizeof(value_type),
+                           nodeset, &policy, flags);
+    return nodeset;
+  }
+
+  static void test_allocated_hwloc() {
+    using ExecutionSpace = Kokkos::DefaultHostExecutionSpace;
+    using dynamic_view   = Kokkos::View<int *, ExecutionSpace>;
+    using static_view    = Kokkos::View<int[5], ExecutionSpace>;
+    using unmanaged_view =
+        Kokkos::View<int *, ExecutionSpace,
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+    int const N = 100;
+
+    // user-given hwloc bitmap as nodeset, use current membind as example
+    hwloc_bitmap_t direct_nodeset = Kokkos::hwloc::get_membind_set();
+
+    // user-given array of node IDs (non-existent nodes will be ignored)
+    // default = Kokkos::ID_type::Physical
+    Kokkos::NUMANodes<4> numa_ids = {0, 1, 2, 3};
+    Kokkos::NUMANodes<4, Kokkos::ID_type::Physical> numa_ids_p = {0, 1, 2, 3};
+    Kokkos::NUMANodes<4, Kokkos::ID_type::Logical>  numa_ids_l = {0, 1, 2, 3};
+
+    dynamic_view d1;
+    static_view s1;
+    unmanaged_view u1;
+    ASSERT_FALSE(d1.is_allocated());
+    ASSERT_FALSE(s1.is_allocated());
+    ASSERT_FALSE(u1.is_allocated());
+
+    // test all possible HostSpace with hwloc support
+    std::vector<Kokkos::HostSpace> space_list = {
+    // hwloc_memattr_id_e was introduced in version 2.3.0 (0x00020300)
+#if HWLOC_API_VERSION >= 0x00020300
+      Kokkos::HostSpace(HWLOC_MEMATTR_ID_BANDWIDTH),
+      Kokkos::HostSpace(HWLOC_MEMATTR_ID_LATENCY),
+      Kokkos::HostSpace(HWLOC_MEMATTR_ID_LOCALITY),
+      Kokkos::HostSpace(HWLOC_MEMATTR_ID_CAPACITY),
+#endif // HWLOC_API_VERSION
+      Kokkos::HostSpace(direct_nodeset),
+      Kokkos::HostSpace(numa_ids_p),
+      Kokkos::HostSpace(numa_ids_l),
+      Kokkos::HostSpace(numa_ids)
+    };
+
+    hwloc_bitmap_t set_d1 = hwloc_bitmap_alloc();
+    hwloc_bitmap_t set_s1 = hwloc_bitmap_alloc();
+    hwloc_bitmap_t set_u1 = hwloc_bitmap_alloc();
+
+    for (const auto& hspace : space_list) {
+      d1 = dynamic_view(Kokkos::view_alloc("d1", hspace), N);
+      s1 = static_view(Kokkos::view_alloc("s1", hspace));
+      u1 = unmanaged_view(d1.data(), N);
+      ASSERT_TRUE(d1.is_allocated());
+      ASSERT_TRUE(s1.is_allocated());
+      ASSERT_TRUE(u1.is_allocated());
+
+      get_area_membind(d1, set_d1);
+      get_area_membind(s1, set_s1);
+      get_area_membind(u1, set_u1);
+
+      // check that view's membind matches the hspace's one
+      ASSERT_TRUE(1 == hwloc_bitmap_isincluded(set_d1, hspace.get_membind_set()));
+      ASSERT_TRUE(1 == hwloc_bitmap_isincluded(set_s1, hspace.get_membind_set()));
+      ASSERT_TRUE(1 == hwloc_bitmap_isincluded(set_u1, hspace.get_membind_set()));
+    }
+
+    hwloc_bitmap_free(set_d1);
+    hwloc_bitmap_free(set_s1);
+    hwloc_bitmap_free(set_u1);
+  }
+#endif // KOKKOS_ENABLE_HWLOC
+
   static void test_mirror_copy_const_data_type() {
     using ExecutionSpace = typename DeviceType::execution_space;
     int const N          = 100;
@@ -880,6 +964,9 @@ struct TestViewMirror {
     test_mirror_copy<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
     test_mirror_copy_const_data_type();
     test_allocated();
+#ifdef KOKKOS_ENABLE_HWLOC
+    test_allocated_hwloc();
+#endif // KOKKOS_ENABLE_HWLOC
     test_mirror_no_initialize<Kokkos::MemoryTraits<> >();
     test_mirror_no_initialize<Kokkos::MemoryTraits<Kokkos::Unmanaged> >();
   }


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

This PR adds the possibility to the HostSpace views to be allocated-and-bound to a subset of NUMA nodes on the machine, without relying on a binding program (e.g. `numactl`) to set the memory-binding of the process.

### Rationale

- On high-performance processors equiped with both default memories (DDR) and high-bandwidth memories (HBM), application developers may want to tune the placement of their data/buffers. It could be preferable to keep some highly-used and bandwidth-sensitive buffers as much as possible in a high-bandwidth memory, and let other less-used or small buffers in the default (DDR) memories. Using `numactl` for that purpose will force the whole-process membind to either DDR or HBM, disabling the flexibility of the memory system.
- It will be useful to extend `Kokkos::View` allocation ability to bind to a subset of process's nodeset, based on either an explicit index array of NUMA nodes, or some memory-related attributes (e.g. "I want all high-bandwidth memory nodes")

### Related issues / PRs
    - New HostSpace constructor with argument Kokkos::NUMANodes<N> as
      an array of node ID
    - New HostSpace constructor with argument hwloc_bitmap_t as a
      user-given nodeset
    - New HostSpace constructor with argument hwloc_memattr_id_e as
      a user-given memory attribute for best targets selection.
      If cpuset is spread across multiple sockets/packages, the best
      numanode of each core will be selected.
    - Per-view allocation can be customized by adding view_alloc()
      properties, created with a NUMA-specialized HostSpace()
      (see stream-kokkos-cpu.cpp for usage example)
    - Mimic hwloc Firsttouch policy to Kokkos::View without altering
      the process-wide mem-binding with hwloc_alloc() followed by
      hwloc_set_area_membind(). Tested on kernel 5.14
    
    * core/src/Kokkos_HostSpace.hpp: new constructors to setup a
                                     numa nodeset
    * core/src/Kokkos_NUMANodes.hpp: new helper class to express a
                                     list of numa nodes ID
    * core/src/Kokkos_hwloc.hpp: some new helper functions to query
                                 topology, membind and cpubind of
                                 the running process
    * core/src/impl/Kokkos_HostSpace.cpp: handle allocate()/deallocate()
                                          with specialized membind
    * cmake/KokkosCore_config.h.in: new cmake option
                                    KOKKOS_ENABLE_DEBUG_HWLOC
    * cmake/kokkos_enable_options.cmake: new cmake option
                                         KOKKOS_ENABLE_DEBUG_HWLOC
    * core/src/impl/Kokkos_Core.cpp: declaration of option
                                     KOKKOS_ENABLE_DEBUG_HWLOC
    * core/src/impl/Kokkos_hwloc.cpp: some new helper functions to query
                                      topology, membind and cpubind of
                                      the running process
    * core/unit_test/TestViewAPI.hpp: add new tests
    * benchmarks/stream/CMakeLists.txt: add new stream-kokkos-cpu benchmark
    * benchmarks/stream/stream-kokkos-cpu.cpp: new CPU-only stream benchmark

### Changelog Entry
- View<HostSpace>: Add NUMA membind capability to HostSpace with hwloc support 
