### PR TITLE
Add new constructors and index template to team-level mdranges

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -999,25 +999,35 @@ template <typename Rank, typename TeamMDPolicy, typename Lambda,
 KOKKOS_INLINE_FUNCTION void md_parallel_impl(TeamMDPolicy const& policy,
                                              Lambda const& lambda,
                                              ReductionValueType&& val);
+
+// Concept for determining if type is std::integral_constant
+template <typename T>
+inline constexpr bool is_integral_constant_v =
+    std::is_same_v<T, std::integral_constant<typename T::value_type, T::value>>;
+
 }  // namespace Impl
 
-template <typename Rank, typename TeamHandle, typename iType = int>
+template <typename Rank, typename TeamHandle, typename UpperIndex = int,
+          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
 struct TeamThreadMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename iType>
-struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
+          typename UpperIndex, typename LowerIndex>
+struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
+                         LowerIndex> {
   static_assert(N >= 2u, "Kokkos Error: TeamThreadMDRange requires rank >= 2");
 
   using NestLevelType  = int;
-  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
+  using LowerIndexType = LowerIndex;
+  using UpperIndexType = UpperIndex;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
+  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
@@ -1031,44 +1041,84 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, IndexType> && ...))
-  KOKKOS_FUNCTION TeamThreadMDRange(TeamHandleType const& team_, Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {}
-
-  // Constructor range between lower and upper bounds
+             (std::convertible_to<Args, UpperIndexType> && ...))
   KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
-                                           const BoundaryType& lower_,
-                                           const BoundaryType& upper_)
+                                           Args&&... args)
+      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
+    // LowerIndexType is not required to be an integral_constant, in which case
+    // we must initialize to 0
+    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
+      for (std::size_t i = 0; i < total_nest_level; ++i) {
+        lower[i] = 0;
+      }
+    }
+  }
+
+  // Constructor for brace-initialized lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+  KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
+                                           LT const (&lower_)[total_nest_level],
+                                           UT const (&upper_)[total_nest_level])
+      : team(team_) {
+    for (std::size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<LowerIndexType>(lower_[i]);
+      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    }
+  }
+
+  // Constructor for Kokkos::Array lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+  KOKKOS_INLINE_FUNCTION TeamThreadMDRange(
+      TeamHandleType const& team_,
+      Kokkos::Array<LT, total_nest_level> const& lower_,
+      Kokkos::Array<UT, total_nest_level> const& upper_)
       : team(team_), lower(lower_), upper(upper_) {}
 
   TeamHandleType const& team;
-  BoundaryType lower = {};
-  BoundaryType upper = {};
+  LowerBoundaryType lower = {};
+  UpperBoundaryType upper = {};
 };
 
-template <typename TeamHandle, typename... Args>
-KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
-    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
-                         int>;
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&,
+                                         Kokkos::Array<LT, N> const&,
+                                         Kokkos::Array<UT, N> const&)
+    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
 
-template <typename Rank, typename TeamHandle, typename iType = int>
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, LT const (&)[N],
+                                         UT const (&)[N])
+    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+
+template <typename TeamHandle, typename... Args>
+  requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
+KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
+    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+
+template <typename Rank, typename TeamHandle, typename UpperIndex = int,
+          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
 struct ThreadVectorMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename iType>
-struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
+          typename UpperIndex, typename LowerIndex>
+struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
+                           LowerIndex> {
   static_assert(N >= 2u,
                 "Kokkos Error: ThreadVectorMDRange requires rank >= 2");
 
   using NestLevelType  = int;
-  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
+  using LowerIndexType = LowerIndex;
+  using UpperIndexType = UpperIndex;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
+  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::NotParThread;
@@ -1082,44 +1132,83 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, IndexType> && ...))
+             (std::convertible_to<Args, UpperIndexType> && ...))
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
                                              Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {}
+      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
+    // LowerIndexType is not required to be an integral_constant, in which case
+    // we must initialize to 0
+    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
+      for (std::size_t i = 0; i < total_nest_level; ++i) {
+        lower[i] = 0;
+      }
+    }
+  }
 
-  // Constructor range between lower and upper bounds
-  KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
-                                             const BoundaryType& lower_,
-                                             const BoundaryType& upper_)
+  // Constructor for brace-initialized lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+  KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(
+      TeamHandleType const& team_, LT const (&lower_)[total_nest_level],
+      UT const (&upper_)[total_nest_level])
+      : team(team_) {
+    for (std::size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<LowerIndexType>(lower_[i]);
+      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    }
+  }
+
+  // Constructor for Kokkos::Array lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+  KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(
+      TeamHandleType const& team_,
+      Kokkos::Array<LT, total_nest_level> const& lower_,
+      Kokkos::Array<UT, total_nest_level> const& upper_)
       : team(team_), lower(lower_), upper(upper_) {}
 
   TeamHandleType const& team;
-  BoundaryType lower = {};
-  BoundaryType upper = {};
+  LowerBoundaryType lower = {};
+  UpperBoundaryType upper = {};
 };
 
-template <typename TeamHandle, typename... Args>
-KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
-    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
-                           int>;
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&,
+                                           Kokkos::Array<LT, N> const&,
+                                           Kokkos::Array<UT, N> const&)
+    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
 
-template <typename Rank, typename TeamHandle, typename iType = int>
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, LT const (&)[N],
+                                           UT const (&)[N])
+    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+
+template <typename TeamHandle, typename... Args>
+  requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
+KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
+    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+
+template <typename Rank, typename TeamHandle, typename UpperIndex = int,
+          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
 struct TeamVectorMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename iType>
-struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
+          typename UpperIndex, typename LowerIndex>
+struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
+                         LowerIndex> {
   static_assert(N >= 2u, "Kokkos Error: TeamVectorMDRange requires rank >= 2");
 
   using NestLevelType  = int;
-  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
+  using LowerIndexType = LowerIndex;
+  using UpperIndexType = UpperIndex;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
+  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
@@ -1133,31 +1222,67 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, IndexType> && ...))
+             (std::convertible_to<Args, UpperIndexType> && ...))
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {}
+      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
+    // LowerIndexType is not required to be an integral_constant, in which case
+    // we must initialize to 0
+    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
+      for (std::size_t i = 0; i < total_nest_level; ++i) {
+        lower[i] = 0;
+      }
+    }
+  }
 
-  // Constructor range between lower and upper bounds
+  // Constructor for brace-initialized lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
-                                           const BoundaryType& lower_,
-                                           const BoundaryType& upper_)
+                                           LT const (&lower_)[total_nest_level],
+                                           UT const (&upper_)[total_nest_level])
+      : team(team_) {
+    for (std::size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<LowerIndexType>(lower_[i]);
+      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    }
+  }
+
+  // Constructor for Kokkos::Array lower and upper bounds
+  template <typename LT, typename UT>
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+  KOKKOS_INLINE_FUNCTION TeamVectorMDRange(
+      TeamHandleType const& team_,
+      Kokkos::Array<LT, total_nest_level> const& lower_,
+      Kokkos::Array<UT, total_nest_level> const& upper_)
       : team(team_), lower(lower_), upper(upper_) {}
 
   TeamHandleType const& team;
-  BoundaryType lower = {};
-  BoundaryType upper = {};
+  LowerBoundaryType lower = {};
+  UpperBoundaryType upper = {};
 };
 
-template <typename TeamHandle, typename... Args>
-KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
-    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
-                         int>;
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&,
+                                         Kokkos::Array<LT, N> const&,
+                                         Kokkos::Array<UT, N> const&)
+    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
-          typename ReducerValueType>
+template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, LT const (&)[N],
+                                         UT const (&)[N])
+    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+
+template <typename TeamHandle, typename... Args>
+  requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
+KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
+    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+
+template <typename Rank, typename TeamHandle, typename LowerIndexType,
+          typename UpperIndexType, typename Lambda, typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamThreadMDRange<Rank, TeamHandle, iType> const& policy,
+    TeamThreadMDRange<Rank, TeamHandle, LowerIndexType, UpperIndexType> const&
+        policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1171,17 +1296,18 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
+template <typename Rank, typename TeamHandle, typename UpperIndex,
+          typename LowerIndex, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamThreadMDRange<Rank, TeamHandle, iType> const& policy,
+    TeamThreadMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
-          typename ReducerValueType>
+template <typename Rank, typename TeamHandle, typename UpperIndex,
+          typename LowerIndex, typename Lambda, typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    ThreadVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    ThreadVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1208,17 +1334,18 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
             val});
 }
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
+template <typename Rank, typename TeamHandle, typename UpperIndex,
+          typename LowerIndex, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    ThreadVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    ThreadVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
-          typename ReducerValueType>
+template <typename Rank, typename TeamHandle, typename UpperIndex,
+          typename LowerIndex, typename Lambda, typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    TeamVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1247,9 +1374,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
+template <typename Rank, typename TeamHandle, typename UpperIndex,
+          typename LowerIndex, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    TeamVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1030,10 +1030,10 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
 
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
+    requires(sizeof...(Args) == total_nest_level &&
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_FUNCTION TeamThreadMDRange(TeamHandleType const& team_, Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {
-    static_assert(sizeof...(Args) == total_nest_level);
-  }
+      : team(team_), upper{static_cast<IndexType>(args)...} {}
 
   // Constructor range between lower and upper bounds
   KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
@@ -1081,11 +1081,11 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
 
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
+    requires(sizeof...(Args) == total_nest_level &&
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
                                              Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {
-    static_assert(sizeof...(Args) == total_nest_level);
-  }
+      : team(team_), upper{static_cast<IndexType>(args)...} {}
 
   // Constructor range between lower and upper bounds
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
@@ -1132,11 +1132,11 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
 
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
+    requires(sizeof...(Args) == total_nest_level &&
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            Args&&... args)
-      : team(team_), upper{static_cast<IndexType>(args)...} {
-    static_assert(sizeof...(Args) == total_nest_level);
-  }
+      : team(team_), upper{static_cast<IndexType>(args)...} {}
 
   // Constructor range between lower and upper bounds
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -999,35 +999,25 @@ template <typename Rank, typename TeamMDPolicy, typename Lambda,
 KOKKOS_INLINE_FUNCTION void md_parallel_impl(TeamMDPolicy const& policy,
                                              Lambda const& lambda,
                                              ReductionValueType&& val);
-
-// Concept for determining if type is std::integral_constant
-template <typename T>
-inline constexpr bool is_integral_constant_v =
-    std::is_same_v<T, std::integral_constant<typename T::value_type, T::value>>;
-
 }  // namespace Impl
 
-template <typename Rank, typename TeamHandle, typename UpperIndex = int,
-          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
+template <typename Rank, typename TeamHandle, typename Index = int>
 struct TeamThreadMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename UpperIndex, typename LowerIndex>
-struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
-                         LowerIndex> {
+          typename Index>
+struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, Index> {
   static_assert(N >= 2u, "Kokkos Error: TeamThreadMDRange requires rank >= 2");
 
   using NestLevelType  = int;
   using TeamHandleType = TeamHandle;
-  using LowerIndexType = LowerIndex;
-  using UpperIndexType = UpperIndex;
+  using IndexType      = Index;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
-  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
@@ -1041,84 +1031,89 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, UpperIndexType> && ...))
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
                                            Args&&... args)
-      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
-    // LowerIndexType is not required to be an integral_constant, in which case
-    // we must initialize to 0
-    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
-      for (std::size_t i = 0; i < total_nest_level; ++i) {
-        lower[i] = 0;
-      }
+      : team(team_), upper{static_cast<IndexType>(args)...} {
+    // Initialize lower bound to 0
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = 0;
     }
   }
 
   // Constructor for brace-initialized lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
                                            LT const (&lower_)[total_nest_level],
                                            UT const (&upper_)[total_nest_level])
       : team(team_) {
-    for (std::size_t i = 0; i < total_nest_level; ++i) {
-      lower[i] = static_cast<LowerIndexType>(lower_[i]);
-      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
     }
   }
 
   // Constructor for Kokkos::Array lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION TeamThreadMDRange(
       TeamHandleType const& team_,
       Kokkos::Array<LT, total_nest_level> const& lower_,
       Kokkos::Array<UT, total_nest_level> const& upper_)
-      : team(team_), lower(lower_), upper(upper_) {}
+      : team(team_) {
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
+    }
+  }
 
   TeamHandleType const& team;
-  LowerBoundaryType lower = {};
-  UpperBoundaryType upper = {};
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&,
                                          Kokkos::Array<LT, N> const&,
                                          Kokkos::Array<UT, N> const&)
-    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                         std::common_type_t<LT, UT>>;
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, LT const (&)[N],
                                          UT const (&)[N])
-    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> TeamThreadMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                         std::common_type_t<LT, UT>>;
 
 template <typename TeamHandle, typename... Args>
   requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
-    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                         std::common_type_t<std::remove_cvref_t<Args>...>>;
 
-template <typename Rank, typename TeamHandle, typename UpperIndex = int,
-          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
+template <typename Rank, typename TeamHandle, typename Index = int>
 struct ThreadVectorMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename UpperIndex, typename LowerIndex>
-struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
-                           LowerIndex> {
+          typename Index>
+struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, Index> {
   static_assert(N >= 2u,
                 "Kokkos Error: ThreadVectorMDRange requires rank >= 2");
 
   using NestLevelType  = int;
   using TeamHandleType = TeamHandle;
-  using LowerIndexType = LowerIndex;
-  using UpperIndexType = UpperIndex;
+  using IndexType      = Index;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
-  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::NotParThread;
@@ -1132,83 +1127,88 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, UpperIndexType> && ...))
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
                                              Args&&... args)
-      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
-    // LowerIndexType is not required to be an integral_constant, in which case
-    // we must initialize to 0
-    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
-      for (std::size_t i = 0; i < total_nest_level; ++i) {
-        lower[i] = 0;
-      }
+      : team(team_), upper{static_cast<IndexType>(args)...} {
+    // Initialize lower bound to 0
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = 0;
     }
   }
 
   // Constructor for brace-initialized lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(
       TeamHandleType const& team_, LT const (&lower_)[total_nest_level],
       UT const (&upper_)[total_nest_level])
       : team(team_) {
-    for (std::size_t i = 0; i < total_nest_level; ++i) {
-      lower[i] = static_cast<LowerIndexType>(lower_[i]);
-      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
     }
   }
 
   // Constructor for Kokkos::Array lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(
       TeamHandleType const& team_,
       Kokkos::Array<LT, total_nest_level> const& lower_,
       Kokkos::Array<UT, total_nest_level> const& upper_)
-      : team(team_), lower(lower_), upper(upper_) {}
+      : team(team_) {
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
+    }
+  }
 
   TeamHandleType const& team;
-  LowerBoundaryType lower = {};
-  UpperBoundaryType upper = {};
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&,
                                            Kokkos::Array<LT, N> const&,
                                            Kokkos::Array<UT, N> const&)
-    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                           std::common_type_t<LT, UT>>;
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, LT const (&)[N],
                                            UT const (&)[N])
-    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> ThreadVectorMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                           std::common_type_t<LT, UT>>;
 
 template <typename TeamHandle, typename... Args>
   requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
-    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                           std::common_type_t<std::remove_cvref_t<Args>...>>;
 
-template <typename Rank, typename TeamHandle, typename UpperIndex = int,
-          typename LowerIndex = std::integral_constant<UpperIndex, 0>>
+template <typename Rank, typename TeamHandle, typename Index = int>
 struct TeamVectorMDRange;
 
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
-          typename UpperIndex, typename LowerIndex>
-struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
-                         LowerIndex> {
+          typename Index>
+struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, Index> {
   static_assert(N >= 2u, "Kokkos Error: TeamVectorMDRange requires rank >= 2");
 
   using NestLevelType  = int;
   using TeamHandleType = TeamHandle;
-  using LowerIndexType = LowerIndex;
-  using UpperIndexType = UpperIndex;
+  using IndexType      = Index;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
-  using LowerBoundaryType = Kokkos::Array<LowerIndexType, total_nest_level>;
-  using UpperBoundaryType = Kokkos::Array<UpperIndexType, total_nest_level>;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
 
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
@@ -1222,67 +1222,75 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, UpperIndex,
   // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
     requires(sizeof...(Args) == total_nest_level &&
-             (std::convertible_to<Args, UpperIndexType> && ...))
+             (std::convertible_to<Args, IndexType> && ...))
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            Args&&... args)
-      : team(team_), upper{static_cast<UpperIndexType>(args)...} {
-    // LowerIndexType is not required to be an integral_constant, in which case
-    // we must initialize to 0
-    if constexpr (!Impl::is_integral_constant_v<LowerIndexType>) {
-      for (std::size_t i = 0; i < total_nest_level; ++i) {
-        lower[i] = 0;
-      }
+      : team(team_), upper{static_cast<IndexType>(args)...} {
+    // Initialize lower bound to 0
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = 0;
     }
   }
 
   // Constructor for brace-initialized lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            LT const (&lower_)[total_nest_level],
                                            UT const (&upper_)[total_nest_level])
       : team(team_) {
-    for (std::size_t i = 0; i < total_nest_level; ++i) {
-      lower[i] = static_cast<LowerIndexType>(lower_[i]);
-      upper[i] = static_cast<UpperIndexType>(upper_[i]);
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
     }
   }
 
   // Constructor for Kokkos::Array lower and upper bounds
   template <typename LT, typename UT>
-    requires(std::is_integral_v<LT> && std::is_integral_v<UT>)
+    requires(std::is_integral_v<LT> && std::is_integral_v<UT> &&
+             std::convertible_to<LT, IndexType> &&
+             std::convertible_to<UT, IndexType>)
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(
       TeamHandleType const& team_,
       Kokkos::Array<LT, total_nest_level> const& lower_,
       Kokkos::Array<UT, total_nest_level> const& upper_)
-      : team(team_), lower(lower_), upper(upper_) {}
+      : team(team_) {
+    for (size_t i = 0; i < total_nest_level; ++i) {
+      lower[i] = static_cast<IndexType>(lower_[i]);
+      upper[i] = static_cast<IndexType>(upper_[i]);
+    }
+  }
 
   TeamHandleType const& team;
-  LowerBoundaryType lower = {};
-  UpperBoundaryType upper = {};
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&,
                                          Kokkos::Array<LT, N> const&,
                                          Kokkos::Array<UT, N> const&)
-    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                         std::common_type_t<LT, UT>>;
 
-template <typename TeamHandle, std::size_t N, typename LT, typename UT>
+template <typename TeamHandle, size_t N, typename LT, typename UT>
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, LT const (&)[N],
                                          UT const (&)[N])
-    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle, UT, LT>;
+    -> TeamVectorMDRange<Rank<N, Iterate::Default>, TeamHandle,
+                         std::common_type_t<LT, UT>>;
 
 template <typename TeamHandle, typename... Args>
   requires((std::is_integral_v<std::remove_cvref_t<Args>> && ...))
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
-    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                         std::common_type_t<std::remove_cvref_t<Args>...>>;
 
-template <typename Rank, typename TeamHandle, typename LowerIndexType,
-          typename UpperIndexType, typename Lambda, typename ReducerValueType>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda,
+          typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamThreadMDRange<Rank, TeamHandle, LowerIndexType, UpperIndexType> const&
-        policy,
+    TeamThreadMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1296,18 +1304,17 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename UpperIndex,
-          typename LowerIndex, typename Lambda>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamThreadMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
+    TeamThreadMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename UpperIndex,
-          typename LowerIndex, typename Lambda, typename ReducerValueType>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda,
+          typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    ThreadVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
+    ThreadVectorMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1334,18 +1341,17 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
             val});
 }
 
-template <typename Rank, typename TeamHandle, typename UpperIndex,
-          typename LowerIndex, typename Lambda>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    ThreadVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
+    ThreadVectorMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename UpperIndex,
-          typename LowerIndex, typename Lambda, typename ReducerValueType>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda,
+          typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
+    TeamVectorMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
@@ -1374,10 +1380,9 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename UpperIndex,
-          typename LowerIndex, typename Lambda>
+template <typename Rank, typename TeamHandle, typename Index, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamVectorMDRange<Rank, TeamHandle, UpperIndex, LowerIndex> const& policy,
+    TeamVectorMDRange<Rank, TeamHandle, Index> const& policy,
     Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -16,6 +16,7 @@ static_assert(false,
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Concepts.hpp>
 #include <Kokkos_TypeInfo.hpp>
+#include <Kokkos_Array.hpp>
 #ifndef KOKKOS_ENABLE_IMPL_TYPEINFO
 #include <typeinfo>
 #endif
@@ -1000,21 +1001,29 @@ KOKKOS_INLINE_FUNCTION void md_parallel_impl(TeamMDPolicy const& policy,
                                              ReductionValueType&& val);
 }  // namespace Impl
 
-template <typename Rank, typename TeamHandle>
+template <typename Rank, typename TeamHandle, typename iType = int>
 struct TeamThreadMDRange;
 
+<<<<<<< HEAD
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle>
 struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
   static_assert(N >= 2u, "Kokkos Error: TeamThreadMDRange requires rank >= 2");
 
+=======
+template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
+          typename iType>
+struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
+>>>>>>> 098ee96c0 (Add constructors and index template to team-level mdranges)
   using NestLevelType  = int;
-  using BoundaryType   = int;
+  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::NotParVector;
@@ -1024,36 +1033,53 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
                                          ArrayLayout>::outer_iteration_pattern
                                    : iter;
 
+  // Constructor for range {[0, arg1), [1, arg2), ...}
   template <class... Args>
   KOKKOS_FUNCTION TeamThreadMDRange(TeamHandleType const& team_, Args&&... args)
-      : team(team_), boundaries{static_cast<BoundaryType>(args)...} {
+      : team(team_), upper{static_cast<IndexType>(args)...} {
     static_assert(sizeof...(Args) == total_nest_level);
   }
 
+  // Constructor range between lower and upper bounds
+  KOKKOS_INLINE_FUNCTION TeamThreadMDRange(TeamHandleType const& team_,
+                                           const BoundaryType& lower_,
+                                           const BoundaryType& upper_)
+      : team(team_), lower(lower_), upper(upper_) {}
+
   TeamHandleType const& team;
-  BoundaryType boundaries[total_nest_level];
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
-    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamThreadMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                         int>;
 
-template <typename Rank, typename TeamHandle>
+template <typename Rank, typename TeamHandle, typename iType = int>
 struct ThreadVectorMDRange;
 
+<<<<<<< HEAD
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle>
 struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
   static_assert(N >= 2u,
                 "Kokkos Error: ThreadVectorMDRange requires rank >= 2");
 
+=======
+template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
+          typename iType>
+struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
+>>>>>>> 098ee96c0 (Add constructors and index template to team-level mdranges)
   using NestLevelType  = int;
-  using BoundaryType   = int;
+  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::NotParThread;
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::ParVector;
@@ -1063,36 +1089,48 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
                                          ArrayLayout>::outer_iteration_pattern
                                    : iter;
 
+  // Constructor for range {[0, arg1), [1, arg2), ...}
   template <class... Args>
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
                                              Args&&... args)
-      : team(team_), boundaries{static_cast<BoundaryType>(args)...} {
+      : team(team_), upper{static_cast<IndexType>(args)...} {
     static_assert(sizeof...(Args) == total_nest_level);
   }
 
+  // Constructor range between lower and upper bounds
+  KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
+                                             const BoundaryType& lower_,
+                                             const BoundaryType& upper_)
+      : team(team_), lower(lower_), upper(upper_) {}
+
   TeamHandleType const& team;
-  BoundaryType boundaries[total_nest_level];
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE ThreadVectorMDRange(TeamHandle const&, Args&&...)
-    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> ThreadVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                           int>;
 
-template <typename Rank, typename TeamHandle>
+template <typename Rank, typename TeamHandle, typename iType = int>
 struct TeamVectorMDRange;
 
-template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle>
-struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
+template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
+          typename iType>
+struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
   static_assert(N >= 2u, "Kokkos Error: TeamVectorMDRange requires rank >= 2");
 
   using NestLevelType  = int;
-  using BoundaryType   = int;
+  using IndexType      = iType;
   using TeamHandleType = TeamHandle;
   using ExecutionSpace = typename TeamHandleType::execution_space;
   using ArrayLayout    = typename ExecutionSpace::array_layout;
 
   static constexpr NestLevelType total_nest_level =
       Rank<N, OuterDir, InnerDir>::rank;
+  using BoundaryType = Kokkos::Array<IndexType, total_nest_level>;
+
   static constexpr Iterate iter    = OuterDir;
   static constexpr auto par_thread = Impl::TeamMDRangeParThread::ParThread;
   static constexpr auto par_vector = Impl::TeamMDRangeParVector::ParVector;
@@ -1102,26 +1140,35 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
                                      ArrayLayout>::outer_iteration_pattern
                                : iter;
 
+  // Constructor for range {[0, arg1), [1, arg2), ...}
   template <class... Args>
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            Args&&... args)
-      : team(team_), boundaries{static_cast<BoundaryType>(args)...} {
+      : team(team_), upper{static_cast<IndexType>(args)...} {
     static_assert(sizeof...(Args) == total_nest_level);
   }
 
+  // Constructor range between lower and upper bounds
+  KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
+                                           const BoundaryType& lower_,
+                                           const BoundaryType& upper_)
+      : team(team_), lower(lower_), upper(upper_) {}
+
   TeamHandleType const& team;
-  BoundaryType boundaries[total_nest_level];
+  BoundaryType lower = {};
+  BoundaryType upper = {};
 };
 
 template <typename TeamHandle, typename... Args>
 KOKKOS_DEDUCTION_GUIDE TeamVectorMDRange(TeamHandle const&, Args&&...)
-    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle>;
+    -> TeamVectorMDRange<Rank<sizeof...(Args), Iterate::Default>, TeamHandle,
+                         int>;
 
-template <typename Rank, typename TeamHandle, typename Lambda,
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
           typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamThreadMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda,
-    ReducerValueType& val) {
+    TeamThreadMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
                     !std::is_pointer_v<ReducerValueType> &&
@@ -1134,17 +1181,18 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename Lambda>
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamThreadMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda) {
+    TeamThreadMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename Lambda,
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
           typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    ThreadVectorMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda,
-    ReducerValueType& val) {
+    ThreadVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
                     !std::is_pointer_v<ReducerValueType> &&
@@ -1170,17 +1218,18 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
             val});
 }
 
-template <typename Rank, typename TeamHandle, typename Lambda>
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    ThreadVectorMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda) {
+    ThreadVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 
-template <typename Rank, typename TeamHandle, typename Lambda,
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda,
           typename ReducerValueType>
 KOKKOS_INLINE_FUNCTION void parallel_reduce(
-    TeamVectorMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda,
-    ReducerValueType& val) {
+    TeamVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda, ReducerValueType& val) {
   static_assert(/*!Kokkos::is_view_v<ReducerValueType> &&*/
                 !std::is_array_v<ReducerValueType> &&
                     !std::is_pointer_v<ReducerValueType> &&
@@ -1208,9 +1257,10 @@ KOKKOS_INLINE_FUNCTION void parallel_reduce(
       Kokkos::Sum<ReducerValueType, typename TeamHandle::execution_space>{val});
 }
 
-template <typename Rank, typename TeamHandle, typename Lambda>
+template <typename Rank, typename TeamHandle, typename iType, typename Lambda>
 KOKKOS_INLINE_FUNCTION void parallel_for(
-    TeamVectorMDRange<Rank, TeamHandle> const& policy, Lambda const& lambda) {
+    TeamVectorMDRange<Rank, TeamHandle, iType> const& policy,
+    Lambda const& lambda) {
   Impl::md_parallel_impl<Rank>(policy, lambda, Impl::NoReductionTag());
 }
 

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1028,7 +1028,7 @@ struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
                                          ArrayLayout>::outer_iteration_pattern
                                    : iter;
 
-  // Constructor for range {[0, arg1), [1, arg2), ...}
+  // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
   KOKKOS_FUNCTION TeamThreadMDRange(TeamHandleType const& team_, Args&&... args)
       : team(team_), upper{static_cast<IndexType>(args)...} {
@@ -1079,7 +1079,7 @@ struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
                                          ArrayLayout>::outer_iteration_pattern
                                    : iter;
 
-  // Constructor for range {[0, arg1), [1, arg2), ...}
+  // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
   KOKKOS_INLINE_FUNCTION ThreadVectorMDRange(TeamHandleType const& team_,
                                              Args&&... args)
@@ -1130,7 +1130,7 @@ struct TeamVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
                                      ArrayLayout>::outer_iteration_pattern
                                : iter;
 
-  // Constructor for range {[0, arg1), [1, arg2), ...}
+  // Constructor for range {[0, arg1), [0, arg2), ...}
   template <class... Args>
   KOKKOS_INLINE_FUNCTION TeamVectorMDRange(TeamHandleType const& team_,
                                            Args&&... args)

--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -1004,16 +1004,11 @@ KOKKOS_INLINE_FUNCTION void md_parallel_impl(TeamMDPolicy const& policy,
 template <typename Rank, typename TeamHandle, typename iType = int>
 struct TeamThreadMDRange;
 
-<<<<<<< HEAD
-template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle>
-struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
-  static_assert(N >= 2u, "Kokkos Error: TeamThreadMDRange requires rank >= 2");
-
-=======
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
           typename iType>
 struct TeamThreadMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
->>>>>>> 098ee96c0 (Add constructors and index template to team-level mdranges)
+  static_assert(N >= 2u, "Kokkos Error: TeamThreadMDRange requires rank >= 2");
+
   using NestLevelType  = int;
   using IndexType      = iType;
   using TeamHandleType = TeamHandle;
@@ -1059,17 +1054,12 @@ KOKKOS_DEDUCTION_GUIDE TeamThreadMDRange(TeamHandle const&, Args&&...)
 template <typename Rank, typename TeamHandle, typename iType = int>
 struct ThreadVectorMDRange;
 
-<<<<<<< HEAD
-template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle>
-struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle> {
-  static_assert(N >= 2u,
-                "Kokkos Error: ThreadVectorMDRange requires rank >= 2");
-
-=======
 template <unsigned N, Iterate OuterDir, Iterate InnerDir, typename TeamHandle,
           typename iType>
 struct ThreadVectorMDRange<Rank<N, OuterDir, InnerDir>, TeamHandle, iType> {
->>>>>>> 098ee96c0 (Add constructors and index template to team-level mdranges)
+  static_assert(N >= 2u,
+                "Kokkos Error: ThreadVectorMDRange requires rank >= 2");
+
   using NestLevelType  = int;
   using IndexType      = iType;
   using TeamHandleType = TeamHandle;

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -171,7 +171,7 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
                                 next_nest_level>;
   using TeamMDNextMode = typename NextNestingTracker::RangeMode;
 
-  for (int i = policy.lower[CurrentNestLevel];
+  for (auto i = policy.lower[CurrentNestLevel];
        i < policy.upper[CurrentNestLevel]; ++i) {
     // FIXME
     // NOLINTBEGIN(bugprone-use-after-move)
@@ -209,7 +209,7 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
   parallel_for(
       nested_policy(mode, policy.team, policy.lower[CurrentNestLevel],
                     policy.upper[CurrentNestLevel]),
-      [&](int const& i) {
+      [&](auto const& i) {
         if constexpr (Rank::outer_direction == Iterate::Right) {
           nested_loop(TeamMDNextMode(), NextNestingTracker(), policy, lambda,
                       std::forward<ReducerValueType>(val), args..., i);

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -103,8 +103,8 @@ KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::NotParVector>,
-    TeamHandle const& team, int count) {
-  return TeamThreadRange(team, count);
+    TeamHandle const& team, int begin, int end) {
+  return TeamThreadRange(team, begin, end);
 }
 
 template <typename TeamHandle>
@@ -112,8 +112,8 @@ KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::NotParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, int count) {
-  return ThreadVectorRange(team, count);
+    TeamHandle const& team, int begin, int end) {
+  return ThreadVectorRange(team, begin, end);
 }
 
 template <typename TeamHandle>
@@ -121,8 +121,8 @@ KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, int count) {
-  return TeamVectorRange(team, count);
+    TeamHandle const& team, int begin, int end) {
+  return TeamVectorRange(team, begin, end);
 }
 
 // TeamMDRangeNestingTracker is only needed to deduce template parameters
@@ -171,7 +171,8 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
                                 next_nest_level>;
   using TeamMDNextMode = typename NextNestingTracker::RangeMode;
 
-  for (int i = 0; i != policy.boundaries[CurrentNestLevel]; ++i) {
+  for (int i = policy.lower[CurrentNestLevel];
+       i < policy.upper[CurrentNestLevel]; ++i) {
     // FIXME
     // NOLINTBEGIN(bugprone-use-after-move)
     if constexpr (Rank::outer_direction == Iterate::Right) {
@@ -206,7 +207,8 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
   // This recursively processes ranks from [0..TotalNestLevel-1]
   // args... is passed by value because it should always be ints
   parallel_for(
-      nested_policy(mode, policy.team, policy.boundaries[CurrentNestLevel]),
+      nested_policy(mode, policy.team, policy.lower[CurrentNestLevel],
+                    policy.upper[CurrentNestLevel]),
       [&](int const& i) {
         if constexpr (Rank::outer_direction == Iterate::Right) {
           nested_loop(TeamMDNextMode(), NextNestingTracker(), policy, lambda,

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -98,30 +98,30 @@ struct AcceleratorBasedNestLevel {
   static constexpr int invalid = -2;
 };
 
-template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
+template <typename TeamHandle, typename IndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::NotParVector>,
-    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
+    TeamHandle const& team, IndexType begin, IndexType end) {
   return TeamThreadRange(team, begin, end);
 }
 
-template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
+template <typename TeamHandle, typename IndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::NotParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
+    TeamHandle const& team, IndexType begin, IndexType end) {
   return ThreadVectorRange(team, begin, end);
 }
 
-template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
+template <typename TeamHandle, typename IndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
+    TeamHandle const& team, IndexType begin, IndexType end) {
   return TeamVectorRange(team, begin, end);
 }
 
@@ -170,10 +170,8 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
       TeamMDRangeNestingTracker<Rank, ParThreadNestLevel, ParVectorNestLevel,
                                 next_nest_level>;
   using TeamMDNextMode = typename NextNestingTracker::RangeMode;
-  using LoopType       = std::common_type_t<typename Policy::LowerIndexType,
-                                      typename Policy::UpperIndexType>;
 
-  for (LoopType i = policy.lower[CurrentNestLevel];
+  for (auto i = policy.lower[CurrentNestLevel];
        i < policy.upper[CurrentNestLevel]; ++i) {
     // FIXME
     // NOLINTBEGIN(bugprone-use-after-move)

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -98,30 +98,30 @@ struct AcceleratorBasedNestLevel {
   static constexpr int invalid = -2;
 };
 
-template <typename TeamHandle>
+template <typename TeamHandle, typename iType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::NotParVector>,
-    TeamHandle const& team, int begin, int end) {
+    TeamHandle const& team, iType begin, iType end) {
   return TeamThreadRange(team, begin, end);
 }
 
-template <typename TeamHandle>
+template <typename TeamHandle, typename iType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::NotParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, int begin, int end) {
+    TeamHandle const& team, iType begin, iType end) {
   return ThreadVectorRange(team, begin, end);
 }
 
-template <typename TeamHandle>
+template <typename TeamHandle, typename iType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, int begin, int end) {
+    TeamHandle const& team, iType begin, iType end) {
   return TeamVectorRange(team, begin, end);
 }
 

--- a/core/src/impl/Kokkos_TeamMDPolicy.hpp
+++ b/core/src/impl/Kokkos_TeamMDPolicy.hpp
@@ -98,30 +98,30 @@ struct AcceleratorBasedNestLevel {
   static constexpr int invalid = -2;
 };
 
-template <typename TeamHandle, typename iType>
+template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::NotParVector>,
-    TeamHandle const& team, iType begin, iType end) {
+    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
   return TeamThreadRange(team, begin, end);
 }
 
-template <typename TeamHandle, typename iType>
+template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::NotParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, iType begin, iType end) {
+    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
   return ThreadVectorRange(team, begin, end);
 }
 
-template <typename TeamHandle, typename iType>
+template <typename TeamHandle, typename LowerIndexType, typename UpperIndexType>
 KOKKOS_INLINE_FUNCTION auto nested_policy(
     TeamMDRangeMode<TeamMDRangeLastNestLevel::NotLastNestLevel,
                     TeamMDRangeParThread::ParThread,
                     TeamMDRangeParVector::ParVector>,
-    TeamHandle const& team, iType begin, iType end) {
+    TeamHandle const& team, LowerIndexType begin, UpperIndexType end) {
   return TeamVectorRange(team, begin, end);
 }
 
@@ -170,8 +170,10 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
       TeamMDRangeNestingTracker<Rank, ParThreadNestLevel, ParVectorNestLevel,
                                 next_nest_level>;
   using TeamMDNextMode = typename NextNestingTracker::RangeMode;
+  using LoopType       = std::common_type_t<typename Policy::LowerIndexType,
+                                      typename Policy::UpperIndexType>;
 
-  for (auto i = policy.lower[CurrentNestLevel];
+  for (LoopType i = policy.lower[CurrentNestLevel];
        i < policy.upper[CurrentNestLevel]; ++i) {
     // FIXME
     // NOLINTBEGIN(bugprone-use-after-move)
@@ -205,7 +207,8 @@ KOKKOS_INLINE_FUNCTION void nested_loop(
   using TeamMDNextMode = typename NextNestingTracker::RangeMode;
 
   // This recursively processes ranks from [0..TotalNestLevel-1]
-  // args... is passed by value because it should always be ints
+  // args... is passed by value because it should always be inexpensive index
+  // values
   parallel_for(
       nested_policy(mode, policy.team, policy.lower[CurrentNestLevel],
                     policy.upper[CurrentNestLevel]),

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -55,19 +55,19 @@ struct TestTeamMDParallelFor {
   static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor,
                               // For 4D, tests may not start at index 0
                               std::array<int, 4> const& lower = {0, 0, 0, 0}) {
-    for (size_t i = lower[0]; i < h_view.extent(0); ++i) {
-      for (size_t j = lower[1]; j < h_view.extent(1); ++j) {
-        for (size_t k = lower[2]; k < h_view.extent(2); ++k) {
-          for (size_t l = lower[3]; l < h_view.extent(3); ++l) {
+    for (auto i = lower[0]; i < h_view.extent_int(0); ++i) {
+      for (auto j = lower[1]; j < h_view.extent_int(1); ++j) {
+        for (auto k = lower[2]; k < h_view.extent_int(2); ++k) {
+          for (auto l = lower[3]; l < h_view.extent_int(3); ++l) {
             EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
           }
         }
       }
     }
-    for (size_t i = 0; i < lower[0]; ++i) {
-      for (size_t j = 0; j < lower[1]; ++j) {
-        for (size_t k = 0; k < lower[2]; ++k) {
-          for (size_t l = 0; l < lower[3]; ++l) {
+    for (auto i = 0; i < lower[0]; ++i) {
+      for (auto j = 0; j < lower[1]; ++j) {
+        for (auto k = 0; k < lower[2]; ++k) {
+          for (auto l = 0; l < lower[3]; ++l) {
             EXPECT_EQ(h_view(i, j, k, l),
                       typename decltype(h_view)::value_type());
           }

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -229,10 +229,9 @@ struct TestTeamThreadMDRangeParallelFor
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType,
-                                        IndexType, IndexType>(team, lowerBounds,
-                                                              upperBounds);
+          auto teamRange = Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>,
+                                                     TeamType, IndexType>(
+              team, lowerBounds, upperBounds);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -311,10 +310,9 @@ struct TestTeamThreadMDRangeParallelFor
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
+          auto teamRange = Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>,
+                                                     TeamType, IndexType>(
+              team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m) {
@@ -481,8 +479,8 @@ struct TestThreadVectorMDRangeParallelFor
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType,
-                                          IndexType, IndexType>(
-                  team, lowerBounds, upperBounds);
+                                          IndexType>(team, lowerBounds,
+                                                     upperBounds);
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k) {
@@ -568,8 +566,8 @@ struct TestThreadVectorMDRangeParallelFor
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<4, Direction>, TeamType,
-                                          IndexType, IndexType>(
-                  team, {s1, s2, s3, s4}, {n1, n2, n3, n4});
+                                          IndexType>(team, {s1, s2, s3, s4},
+                                                     {n1, n2, n3, n4});
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k, int l, int m) {
@@ -745,10 +743,9 @@ struct TestTeamVectorMDRangeParallelFor
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
-                                        IndexType, IndexType>(team, lowerBounds,
-                                                              upperBounds);
+          auto teamRange = Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>,
+                                                     TeamType, IndexType>(
+              team, lowerBounds, upperBounds);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -827,10 +824,9 @@ struct TestTeamVectorMDRangeParallelFor
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
+          auto teamRange = Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>,
+                                                     TeamType, IndexType>(
+              team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m) {
@@ -1091,8 +1087,8 @@ struct TestTeamThreadMDRangeParallelReduce
 
           Kokkos::parallel_reduce(
               Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2}, {n0, n1, n2}),
+                                        IndexType>(team, {s0, s1, s2},
+                                                   {n0, n1, n2}),
               [=](const int& i, const int& j, const int& k,
                   DataType& threadSum) { threadSum += v(leagueRank, i, j, k); },
               teamSum);
@@ -1200,8 +1196,8 @@ struct TestTeamThreadMDRangeParallelReduce
 
           Kokkos::parallel_reduce(
               Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4}),
+                                        IndexType>(team, {s0, s1, s2, s3, s4},
+                                                   {n0, n1, n2, n3, n4}),
               [=](const int& i, const int& j, const int& k, const int& l,
                   const int& m, DataType& threadSum) {
                 threadSum += v(leagueRank, i, j, k, l, m);
@@ -1390,8 +1386,7 @@ struct TestThreadVectorMDRangeParallelReduce
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType,
-                                          IndexType, IndexType>(team, {s1, s2},
-                                                                {n1, n2});
+                                          IndexType>(team, {s1, s2}, {n1, n2});
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1717,8 +1712,8 @@ struct TestTeamVectorMDRangeParallelReduce
 
           auto teamVectorRange =
               Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2}, {n0, n1, n2});
+                                        IndexType>(team, {s0, s1, s2},
+                                                   {n0, n1, n2});
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1832,8 +1827,8 @@ struct TestTeamVectorMDRangeParallelReduce
 
           auto teamVectorRange =
               Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
-                                        IndexType, IndexType>(
-                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
+                                        IndexType>(team, {s0, s1, s2, s3, s4},
+                                                   {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_reduce(
               teamVectorRange,

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -52,12 +52,24 @@ struct TestTeamMDParallelFor {
   }
 
   template <typename HostViewType, typename FillFunctor>
-  static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor) {
-    for (size_t i = 0; i < h_view.extent(0); ++i) {
-      for (size_t j = 0; j < h_view.extent(1); ++j) {
-        for (size_t k = 0; k < h_view.extent(2); ++k) {
-          for (size_t l = 0; l < h_view.extent(3); ++l) {
+  static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor,
+                              // For 4D, tests may not start at index 0
+                              std::array<int, 4> const& lower = {0, 0, 0, 0}) {
+    for (size_t i = lower[0]; i < h_view.extent(0); ++i) {
+      for (size_t j = lower[1]; j < h_view.extent(1); ++j) {
+        for (size_t k = lower[2]; k < h_view.extent(2); ++k) {
+          for (size_t l = lower[3]; l < h_view.extent(3); ++l) {
             EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
+          }
+        }
+      }
+    }
+    for (size_t i = 0; i < lower[0]; ++i) {
+      for (size_t j = 0; j < lower[1]; ++j) {
+        for (size_t k = 0; k < lower[2]; ++k) {
+          for (size_t l = 0; l < lower[3]; ++l) {
+            EXPECT_EQ(h_view(i, j, k, l),
+                      typename decltype(h_view)::value_type());
           }
         }
       }
@@ -188,6 +200,11 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
@@ -200,7 +217,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamRange =
               Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n0, n1, n2);
+                  team, {s0, s1, s2}, {n0, n1, n2});
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -210,7 +227,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex);
+    check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -416,6 +433,10 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
@@ -429,7 +450,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, n1, n2);
+                  team, {s1, s2}, {n1, n2});
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k) {
@@ -441,7 +462,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex);
+    check_result_4D(h_view, fillFlattenedIndex, {0, 0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -661,6 +682,11 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
@@ -673,7 +699,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamRange =
               Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n0, n1, n2);
+                  team, {s0, s1, s2}, {n0, n1, n2});
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -683,7 +709,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex);
+    check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -884,7 +910,8 @@ struct TestTeamMDParallelReduce {
   constexpr static DataType get_expected_partial_sum(DimsType const& dims,
                                                      size_t maxRank, F const& f,
                                                      DimsType& indices,
-                                                     size_t rank) {
+                                                     size_t rank,
+                                                     DimsType const& lower) {
     if (rank == maxRank) {
       return f(indices[0], indices[1], indices[2], indices[3], indices[4],
                indices[5], indices[6], indices[7]);
@@ -892,18 +919,21 @@ struct TestTeamMDParallelReduce {
 
     auto& index       = indices[rank];
     DataType accValue = 0;
-    for (index = 0; index < dims[rank]; ++index) {
-      accValue += get_expected_partial_sum(dims, maxRank, f, indices, rank + 1);
+    for (index = lower[rank]; index < dims[rank]; ++index) {
+      accValue +=
+          get_expected_partial_sum(dims, maxRank, f, indices, rank + 1, lower);
     }
 
     return accValue;
   }
 
   template <typename F>
-  static DataType get_expected_sum(DimsType const& dims, size_t maxRank,
-                                   F const& f) {
+  static DataType get_expected_sum(
+      DimsType const& dims, size_t maxRank, F const& f,
+      // Allows for different starting points in each dimension
+      DimsType const& lower = {0, 0, 0, 0, 0, 0, 0, 0}) {
     DimsType indices = {};
-    return get_expected_partial_sum(dims, maxRank, f, indices, 0);
+    return get_expected_partial_sum(dims, maxRank, f, indices, 0, lower);
   }
 };
 
@@ -967,12 +997,17 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+            {0, s0, s1, s2}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -989,7 +1024,7 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           Kokkos::parallel_reduce(
               Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n0, n1, n2),
+                  team, {s0, s1, s2}, {n0, n1, n2}),
               [=](const int& i, const int& j, const int& k,
                   DataType& threadSum) { threadSum += v(leagueRank, i, j, k); },
               teamSum);
@@ -998,7 +1033,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
+    DataType expectedSum =
+        get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1237,12 +1273,16 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+            {0, 0, s1, s2}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1259,7 +1299,7 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
               Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, n1, n2);
+                  team, {s1, s2}, {n1, n2});
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1275,7 +1315,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
+    DataType expectedSum =
+        get_expected_sum(dims, 4, fillFlattenedIndex, {0, 0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1539,12 +1580,17 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
     int n1         = dims[2];
     int n2         = dims[3];
 
+    // For 4D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
         Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, 0, 0, 0}, {leagueSize, n0, n1, n2}),
+            {0, s0, s1, s2}, {leagueSize, n0, n1, n2}),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1561,7 +1607,7 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           auto teamVectorRange =
               Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n0, n1, n2);
+                  team, {s0, s1, s2}, {n0, n1, n2});
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1573,7 +1619,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 4, fillFlattenedIndex);
+    DataType expectedSum =
+        get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -35,9 +35,10 @@ struct FillFlattenedIndex {
   int initValue[8];
 };
 
+template <typename IndexType>
 struct TestTeamMDParallelFor {
   using DataType = int64_t;
-  using DimsType = int[8];
+  using DimsType = IndexType[8];
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_3D(HostViewType h_view,
@@ -53,13 +54,15 @@ struct TestTeamMDParallelFor {
 
   template <typename HostViewType, typename FillFunctor>
   static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor,
-                              // For 4D, tests may not start at index 0
-                              std::array<int, 4> const& lower = {0, 0, 0, 0}) {
-    for (auto i = 0; i < h_view.extent_int(0); ++i) {
-      for (auto j = 0; j < h_view.extent_int(1); ++j) {
-        for (auto k = 0; k < h_view.extent_int(2); ++k) {
-          for (auto l = 0; l < h_view.extent_int(3); ++l) {
-            if (i < lower[0] || j < lower[1] || k < lower[2] || l < lower[3]) {
+                              // For 4D, tests do not start at index 0
+                              std::array<IndexType, 4> const& lower = {0, 0, 0,
+                                                                       0}) {
+    for (size_t i = 0; i < h_view.extent(0); ++i) {
+      for (size_t j = 0; j < h_view.extent(1); ++j) {
+        for (size_t k = 0; k < h_view.extent(2); ++k) {
+          for (size_t l = 0; l < h_view.extent(3); ++l) {
+            if (i < (size_t)lower[0] || j < (size_t)lower[1] ||
+                k < (size_t)lower[2] || l < (size_t)lower[3]) {
               EXPECT_EQ(h_view(i, j, k, l),
                         typename decltype(h_view)::value_type());
             } else {
@@ -87,15 +90,24 @@ struct TestTeamMDParallelFor {
   }
 
   template <typename HostViewType, typename FillFunctor>
-  static void check_result_6D(HostViewType h_view, FillFunctor& fillFunctor) {
+  static void check_result_6D(HostViewType h_view, FillFunctor& fillFunctor,
+                              std::array<IndexType, 6> const& lower = {
+                                  0, 0, 0, 0, 0, 0}) {
     for (size_t i = 0; i < h_view.extent(0); ++i) {
       for (size_t j = 0; j < h_view.extent(1); ++j) {
         for (size_t k = 0; k < h_view.extent(2); ++k) {
           for (size_t l = 0; l < h_view.extent(3); ++l) {
             for (size_t m = 0; m < h_view.extent(4); ++m) {
               for (size_t n = 0; n < h_view.extent(5); ++n) {
-                EXPECT_EQ(h_view(i, j, k, l, m, n),
-                          fillFunctor(i, j, k, l, m, n));
+                if (i < (size_t)lower[0] || j < (size_t)lower[1] ||
+                    k < (size_t)lower[2] || l < (size_t)lower[3] ||
+                    m < (size_t)lower[4] || n < (size_t)lower[5]) {
+                  EXPECT_EQ(h_view(i, j, k, l, m, n),
+                            typename decltype(h_view)::value_type());
+                } else {
+                  EXPECT_EQ(h_view(i, j, k, l, m, n),
+                            fillFunctor(i, j, k, l, m, n));
+                }
               }
             }
           }
@@ -147,18 +159,23 @@ struct TestTeamMDParallelFor {
   }
 };
 
-template <typename ExecSpace>
-struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
+template <typename ExecSpace, typename IndexType = int>
+struct TestTeamThreadMDRangeParallelFor
+    : public TestTeamMDParallelFor<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelFor<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_3D_TeamThreadMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
@@ -171,8 +188,8 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, n0, n1);
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<2, Direction>, TeamType,
+                                        IndexType>(team, n0, n1);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j) {
             v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
@@ -182,7 +199,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_3D(h_view, fillFlattenedIndex);
+    base_t::check_result_3D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -190,15 +207,17 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 3> upperBounds = {n0, n1, n2};
 
     // For 4D, use lower bound constructors
-    int s0 = 1;
-    int s1 = 1;
-    int s2 = 1;
+    int s0                                  = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 3> lowerBounds = {s0, s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
@@ -211,8 +230,9 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, {s0, s1, s2}, {n0, n1, n2});
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                        IndexType, IndexType>(team, lowerBounds,
+                                                              upperBounds);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -222,7 +242,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
+    base_t::check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -230,11 +250,11 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -247,8 +267,8 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n0, n1, n2, n3);
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
             v(leagueRank, i, j, k, l) +=
@@ -259,7 +279,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_5D(h_view, fillFlattenedIndex);
+    base_t::check_result_5D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -267,12 +287,19 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -285,8 +312,9 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4);
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                        IndexType, IndexType>(
+                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m) {
@@ -298,7 +326,8 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_6D(h_view, fillFlattenedIndex);
+    base_t::check_result_6D(h_view, fillFlattenedIndex,
+                            {0, s0, s1, s2, s3, s4});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -306,13 +335,13 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -324,9 +353,9 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5);
+          auto teamRange = Kokkos::TeamThreadMDRange<Kokkos::Rank<6, Direction>,
+                                                     TeamType, IndexType>(
+              team, n0, n1, n2, n3, n4, n5);
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m, int n) {
@@ -338,7 +367,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_7D(h_view, fillFlattenedIndex);
+    base_t::check_result_7D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -346,14 +375,14 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -366,9 +395,9 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<7, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5, n6);
+          auto teamRange = Kokkos::TeamThreadMDRange<Kokkos::Rank<7, Direction>,
+                                                     TeamType, IndexType>(
+              team, n0, n1, n2, n3, n4, n5, n6);
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
@@ -380,7 +409,7 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_8D(h_view, fillFlattenedIndex);
+    base_t::check_result_8D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -388,9 +417,9 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int n0 = dims[0];
-    int n1 = dims[1];
-    int n2 = dims[2];
+    auto n0 = dims[0];
+    auto n1 = dims[1];
+    auto n2 = dims[2];
 
     ViewType v("v", n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(n0, n1, n2);
@@ -399,8 +428,8 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
         Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),
         KOKKOS_LAMBDA(const TeamType& team) {
           auto teamRange =
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n0, n1, n2);
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(i, j, k) += fillFlattenedIndex(i, j, k);
@@ -410,27 +439,34 @@ struct TestTeamThreadMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_3D(h_view, fillFlattenedIndex);
+    base_t::check_result_3D(h_view, fillFlattenedIndex);
   }
 };
 
-template <typename ExecSpace>
-struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
+template <typename ExecSpace, typename IndexType = int>
+struct TestThreadVectorMDRangeParallelFor
+    : public TestTeamMDParallelFor<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelFor<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_4D_ThreadVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 2> upperBounds = {n1, n2};
 
     // For 4D, use lower bound constructors
-    int s1 = 1;
-    int s2 = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 2> lowerBounds = {s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
@@ -444,8 +480,9 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, {s1, s2}, {n1, n2});
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType,
+                                          IndexType, IndexType>(
+                  team, lowerBounds, upperBounds);
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k) {
@@ -457,7 +494,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex, {0, 0, s1, s2});
+    base_t::check_result_4D(h_view, fillFlattenedIndex, {0, 0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -465,11 +502,11 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -483,8 +520,8 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n1, n2, n3);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3);
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k, int l) {
@@ -497,7 +534,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_5D(h_view, fillFlattenedIndex);
+    base_t::check_result_5D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -505,12 +542,18 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -524,8 +567,9 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n1, n2, n3, n4);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                          IndexType, IndexType>(
+                  team, {s1, s2, s3, s4}, {n1, n2, n3, n4});
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(teamRange, [=](int j, int k, int l, int m) {
@@ -538,7 +582,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_6D(h_view, fillFlattenedIndex);
+    base_t::check_result_6D(h_view, fillFlattenedIndex, {0, 0, s1, s2, s3, s4});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -546,13 +590,13 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -566,8 +610,8 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n1, n2, n3, n4, n5);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3, n4, n5);
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(
@@ -581,7 +625,7 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_7D(h_view, fillFlattenedIndex);
+    base_t::check_result_7D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -589,14 +633,14 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -611,8 +655,9 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto teamRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n1, n2, n3, n4, n5, n6);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<6, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3, n4, n5,
+                                                     n6);
 
           Kokkos::parallel_for(teamThreadRange, [=](int i) {
             Kokkos::parallel_for(
@@ -626,21 +671,27 @@ struct TestThreadVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_8D(h_view, fillFlattenedIndex);
+    base_t::check_result_8D(h_view, fillFlattenedIndex);
   }
 };
 
-template <typename ExecSpace>
-struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
+template <typename ExecSpace, typename IndexType = int>
+struct TestTeamVectorMDRangeParallelFor
+    : public TestTeamMDParallelFor<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelFor<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
+
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_for_3D_TeamVectorMDRange(DimsType const& dims) {
     using ViewType     = typename Kokkos::View<DataType***, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
@@ -653,8 +704,8 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, n0, n1);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<2, Direction>, TeamType,
+                                        IndexType>(team, n0, n1);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j) {
             v(leagueRank, i, j) += fillFlattenedIndex(leagueRank, i, j);
@@ -664,7 +715,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_3D(h_view, fillFlattenedIndex);
+    base_t::check_result_3D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -672,15 +723,17 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 3> upperBounds = {n0, n1, n2};
 
     // For 4D, use lower bound constructors
-    int s0 = 1;
-    int s1 = 1;
-    int s2 = 1;
+    int s0                                  = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 3> lowerBounds = {s0, s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
@@ -693,8 +746,9 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, {s0, s1, s2}, {n0, n1, n2});
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                        IndexType, IndexType>(team, lowerBounds,
+                                                              upperBounds);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k) {
             v(leagueRank, i, j, k) += fillFlattenedIndex(leagueRank, i, j, k);
@@ -704,7 +758,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
+    base_t::check_result_4D(h_view, fillFlattenedIndex, {0, s0, s1, s2});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -712,11 +766,11 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -729,8 +783,8 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n0, n1, n2, n3);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
             v(leagueRank, i, j, k, l) +=
@@ -741,7 +795,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_5D(h_view, fillFlattenedIndex);
+    base_t::check_result_5D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -749,12 +803,19 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -767,8 +828,9 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
           int leagueRank = team.league_rank();
 
           auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                        IndexType, IndexType>(
+                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m) {
@@ -780,7 +842,8 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_6D(h_view, fillFlattenedIndex);
+    base_t::check_result_6D(h_view, fillFlattenedIndex,
+                            {0, s0, s1, s2, s3, s4});
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -788,13 +851,13 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType*******, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -806,9 +869,9 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5);
+          auto teamRange = Kokkos::TeamVectorMDRange<Kokkos::Rank<6, Direction>,
+                                                     TeamType, IndexType>(
+              team, n0, n1, n2, n3, n4, n5);
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m, int n) {
@@ -820,7 +883,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_7D(h_view, fillFlattenedIndex);
+    base_t::check_result_7D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -828,14 +891,14 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType********, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -848,9 +911,9 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
         KOKKOS_LAMBDA(const TeamType& team) {
           int leagueRank = team.league_rank();
 
-          auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<7, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5, n6);
+          auto teamRange = Kokkos::TeamVectorMDRange<Kokkos::Rank<7, Direction>,
+                                                     TeamType, IndexType>(
+              team, n0, n1, n2, n3, n4, n5, n6);
 
           Kokkos::parallel_for(
               teamRange, [=](int i, int j, int k, int l, int m, int n, int o) {
@@ -862,7 +925,7 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_8D(h_view, fillFlattenedIndex);
+    base_t::check_result_8D(h_view, fillFlattenedIndex);
   }
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
@@ -870,10 +933,10 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     using ViewType     = typename Kokkos::View<DataType****, ExecSpace>;
     using HostViewType = typename ViewType::host_mirror_type;
 
-    int n0 = dims[0];
-    int n1 = dims[1];
-    int n2 = dims[2];
-    int n3 = dims[3];
+    auto n0 = dims[0];
+    auto n1 = dims[1];
+    auto n2 = dims[2];
+    auto n3 = dims[3];
 
     ViewType v("v", n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(n0, n1, n2, n3);
@@ -882,8 +945,8 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
         Kokkos::TeamPolicy<ExecSpace>(1, Kokkos::AUTO),
         KOKKOS_LAMBDA(const TeamType& team) {
           auto teamRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n0, n1, n2, n3);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3);
 
           Kokkos::parallel_for(teamRange, [=](int i, int j, int k, int l) {
             v(i, j, k, l) += fillFlattenedIndex(i, j, k, l);
@@ -893,13 +956,14 @@ struct TestTeamVectorMDRangeParallelFor : public TestTeamMDParallelFor {
     HostViewType h_view = Kokkos::create_mirror_view_and_copy(
         typename HostViewType::traits::memory_space(), v);
 
-    check_result_4D(h_view, fillFlattenedIndex);
+    base_t::check_result_4D(h_view, fillFlattenedIndex);
   }
 };
 
+template <typename IndexType = int>
 struct TestTeamMDParallelReduce {
   using DataType = int64_t;
-  using DimsType = int[8];
+  using DimsType = IndexType[8];
 
   template <typename F>
   constexpr static DataType get_expected_partial_sum(DimsType const& dims,
@@ -932,18 +996,23 @@ struct TestTeamMDParallelReduce {
   }
 };
 
-template <typename ExecSpace>
-struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
+template <typename ExecSpace, typename IndexType = int>
+struct TestTeamThreadMDRangeParallelReduce
+    : public TestTeamMDParallelReduce<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelReduce<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
 
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_3D_TeamThreadMDRange(
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType***, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
 
     ViewType v("v", leagueSize, n0, n1);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1);
@@ -966,8 +1035,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, n0, n1),
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<2, Direction>, TeamType,
+                                        IndexType>(team, n0, n1),
               [=](const int& i, const int& j, DataType& threadSum) {
                 threadSum += v(leagueRank, i, j);
               },
@@ -977,7 +1046,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 3, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 3, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -987,22 +1057,24 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 4> upperBounds = {leagueSize, n0, n1, n2};
 
     // For 4D, use lower bound constructors
-    int s0 = 1;
-    int s1 = 1;
-    int s2 = 1;
+    int s0                                  = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 4> lowerBounds = {0, s0, s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, s0, s1, s2}, {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(lowerBounds,
+                                                          upperBounds),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1018,7 +1090,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType>(
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                        IndexType, IndexType>(
                   team, {s0, s1, s2}, {n0, n1, n2}),
               [=](const int& i, const int& j, const int& k,
                   DataType& threadSum) { threadSum += v(leagueRank, i, j, k); },
@@ -1029,7 +1102,7 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         finalSum);
 
     DataType expectedSum =
-        get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
+        base_t::get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1039,11 +1112,11 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -1067,8 +1140,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n0, n1, n2, n3),
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3),
               [=](const int& i, const int& j, const int& k, const int& l,
                   DataType& threadSum) {
                 threadSum += v(leagueRank, i, j, k, l);
@@ -1079,7 +1152,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1089,12 +1163,19 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -1118,8 +1199,9 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4),
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                        IndexType, IndexType>(
+                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4}),
               [=](const int& i, const int& j, const int& k, const int& l,
                   const int& m, DataType& threadSum) {
                 threadSum += v(leagueRank, i, j, k, l, m);
@@ -1130,7 +1212,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
+    DataType expectedSum = base_t::get_expected_sum(
+        dims, 6, fillFlattenedIndex, {0, s0, s1, s2, s3, s4, 0, 0});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1143,13 +1226,13 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -1177,8 +1260,9 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5),
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<6, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3, n4,
+                                                   n5),
               [=](const int& i, const int& j, const int& k, const int& l,
                   const int& m, const int& n, DataType& threadSum) {
                 threadSum += v(leagueRank, i, j, k, l, m, n);
@@ -1189,7 +1273,8 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 7, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 7, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1199,14 +1284,14 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType********, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -1237,8 +1322,9 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           Kokkos::parallel_reduce(
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<7, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5, n6),
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<7, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3, n4, n5,
+                                                   n6),
               [=](const int& i, const int& j, const int& k, const int& l,
                   const int& m, const int& n, const int& o,
                   DataType& threadSum) {
@@ -1250,35 +1336,44 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 8, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 8, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 };
 
-template <typename ExecSpace>
-struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
+template <typename ExecSpace, typename IndexType = int>
+struct TestThreadVectorMDRangeParallelReduce
+    : public TestTeamMDParallelReduce<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelReduce<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
+
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_ThreadVectorMDRange(
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 4> upperBounds = {leagueSize, n0, n1, n2};
 
     // For 4D, use lower bound constructors
-    int s1 = 1;
-    int s2 = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 4> lowerBounds = {0, 0, s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, 0, s1, s2}, {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(lowerBounds,
+                                                          upperBounds),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1294,8 +1389,9 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType>(
-                  team, {s1, s2}, {n1, n2});
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<2, Direction>, TeamType,
+                                          IndexType, IndexType>(team, {s1, s2},
+                                                                {n1, n2});
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1312,7 +1408,7 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         finalSum);
 
     DataType expectedSum =
-        get_expected_sum(dims, 4, fillFlattenedIndex, {0, 0, s1, s2});
+        base_t::get_expected_sum(dims, 4, fillFlattenedIndex, {0, 0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1322,11 +1418,11 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -1350,8 +1446,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
-                  team, n1, n2, n3);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3);
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1369,7 +1465,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1379,12 +1476,18 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -1406,10 +1509,9 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         KOKKOS_LAMBDA(TeamType const& team, DataType& leagueSum) {
           auto leagueRank = team.league_rank();
 
-          auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
-          auto threadVectorRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n1, n2, n3, n4);
+          auto teamThreadRange   = Kokkos::TeamThreadRange(team, n0);
+          auto threadVectorRange = Kokkos::ThreadVectorMDRange(
+              team, {s1, s2, s3, s4}, {n1, n2, n3, n4});
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1427,7 +1529,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
+    DataType expectedSum = base_t::get_expected_sum(
+        dims, 6, fillFlattenedIndex, {0, 0, s1, s2, s3, s4, 0, 0});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1437,13 +1540,13 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -1471,8 +1574,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n1, n2, n3, n4, n5);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3, n4, n5);
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1490,7 +1593,8 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 7, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 7, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1500,14 +1604,14 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType********, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -1538,8 +1642,9 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
 
           auto teamThreadRange = Kokkos::TeamThreadRange(team, n0);
           auto threadVectorRange =
-              Kokkos::ThreadVectorMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n1, n2, n3, n4, n5, n6);
+              Kokkos::ThreadVectorMDRange<Kokkos::Rank<6, Direction>, TeamType,
+                                          IndexType>(team, n1, n2, n3, n4, n5,
+                                                     n6);
 
           Kokkos::parallel_for(teamThreadRange, [=, &leagueSum](const int& i) {
             DataType threadSum = 0;
@@ -1557,36 +1662,45 @@ struct TestThreadVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 8, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 8, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
 };
 
-template <typename ExecSpace>
-struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
+template <typename ExecSpace, typename IndexType = int>
+struct TestTeamVectorMDRangeParallelReduce
+    : public TestTeamMDParallelReduce<IndexType> {
   using TeamType = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+
+  using base_t = TestTeamMDParallelReduce<IndexType>;
+  using typename base_t::DataType;
+  using typename base_t::DimsType;
+
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_4D_TeamVectorMDRange(
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
+    auto leagueSize                         = dims[0];
+    auto n0                                 = dims[1];
+    auto n1                                 = dims[2];
+    auto n2                                 = dims[3];
+    Kokkos::Array<IndexType, 4> upperBounds = {leagueSize, n0, n1, n2};
 
     // For 4D, use lower bound constructors
-    int s0 = 1;
-    int s1 = 1;
-    int s2 = 1;
+    int s0                                  = 1;
+    int s1                                  = 1;
+    int s2                                  = 1;
+    Kokkos::Array<IndexType, 4> lowerBounds = {0, s0, s1, s2};
 
     ViewType v("v", leagueSize, n0, n1, n2);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2);
 
     Kokkos::parallel_for(
-        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(
-            {0, s0, s1, s2}, {leagueSize, n0, n1, n2}),
+        Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>(lowerBounds,
+                                                          upperBounds),
         KOKKOS_LAMBDA(const int i, const int j, const int k, const int l) {
           v(i, j, k, l) = fillFlattenedIndex(i, j, k, l);
         });
@@ -1602,7 +1716,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           auto teamVectorRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType>(
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<3, Direction>, TeamType,
+                                        IndexType, IndexType>(
                   team, {s0, s1, s2}, {n0, n1, n2});
 
           Kokkos::parallel_reduce(
@@ -1616,7 +1731,7 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         finalSum);
 
     DataType expectedSum =
-        get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
+        base_t::get_expected_sum(dims, 4, fillFlattenedIndex, {0, s0, s1, s2});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1626,11 +1741,11 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*****, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3);
@@ -1654,8 +1769,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           auto teamVectorRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType>(
-                  team, n0, n1, n2, n3);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<4, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3);
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1669,7 +1784,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 5, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 5, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1679,12 +1795,19 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+
+    // For 6D, use lower bound constructors
+    int s0 = 1;
+    int s1 = 1;
+    int s2 = 1;
+    int s3 = 1;
+    int s4 = 1;
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4);
@@ -1708,8 +1831,9 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           auto teamVectorRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<5, Direction>, TeamType,
+                                        IndexType, IndexType>(
+                  team, {s0, s1, s2, s3, s4}, {n0, n1, n2, n3, n4});
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1723,7 +1847,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 6, fillFlattenedIndex);
+    DataType expectedSum = base_t::get_expected_sum(
+        dims, 6, fillFlattenedIndex, {0, s0, s1, s2, s3, s4, 0, 0});
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1733,13 +1858,13 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType*******, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5);
@@ -1767,8 +1892,9 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           auto teamVectorRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<6, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<6, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3, n4,
+                                                   n5);
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1782,7 +1908,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 7, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 7, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1792,14 +1919,14 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
       DimsType const& dims) {
     using ViewType = typename Kokkos::View<DataType********, ExecSpace>;
 
-    int leagueSize = dims[0];
-    int n0         = dims[1];
-    int n1         = dims[2];
-    int n2         = dims[3];
-    int n3         = dims[4];
-    int n4         = dims[5];
-    int n5         = dims[6];
-    int n6         = dims[7];
+    auto leagueSize = dims[0];
+    auto n0         = dims[1];
+    auto n1         = dims[2];
+    auto n2         = dims[3];
+    auto n3         = dims[4];
+    auto n4         = dims[5];
+    auto n5         = dims[6];
+    auto n6         = dims[7];
 
     ViewType v("v", leagueSize, n0, n1, n2, n3, n4, n5, n6);
     FillFlattenedIndex fillFlattenedIndex(leagueSize, n0, n1, n2, n3, n4, n5,
@@ -1830,8 +1957,9 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
           DataType teamSum;
 
           auto teamVectorRange =
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<7, Direction>, TeamType>(
-                  team, n0, n1, n2, n3, n4, n5, n6);
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<7, Direction>, TeamType,
+                                        IndexType>(team, n0, n1, n2, n3, n4, n5,
+                                                   n6);
 
           Kokkos::parallel_reduce(
               teamVectorRange,
@@ -1846,7 +1974,8 @@ struct TestTeamVectorMDRangeParallelReduce : public TestTeamMDParallelReduce {
         },
         finalSum);
 
-    DataType expectedSum = get_expected_sum(dims, 8, fillFlattenedIndex);
+    DataType expectedSum =
+        base_t::get_expected_sum(dims, 8, fillFlattenedIndex);
 
     EXPECT_EQ(finalSum, expectedSum);
   }
@@ -1859,8 +1988,9 @@ constexpr auto Right = Kokkos::Iterate::Right;
 // Using prime numbers makes debugging easier
 // small dimensions were needed for larger dimensions to reduce test run
 // time
-int dims[]      = {3, 5, 7, 11, 13, 17, 19, 23};
-int smallDims[] = {2, 3, 2, 3, 5, 2, 3, 5};
+int dims[]       = {3, 5, 7, 11, 13, 17, 19, 23};
+int64_t dims64[] = {3, 5, 7, 11, 13, 17, 19, 23};
+int smallDims[]  = {2, 3, 2, 3, 5, 2, 3, 5};
 
 TEST(TEST_CATEGORY, TeamThreadMDRangeParallelFor) {
   TestTeamThreadMDRangeParallelFor<
@@ -1868,15 +1998,15 @@ TEST(TEST_CATEGORY, TeamThreadMDRangeParallelFor) {
   TestTeamThreadMDRangeParallelFor<
       TEST_EXECSPACE>::test_parallel_for_3D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_TeamThreadMDRange<Right>(dims);
+  TestTeamThreadMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_TeamThreadMDRange<Left>(dims64);
+  TestTeamThreadMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_TeamThreadMDRange<Right>(dims64);
 
-  TestTeamThreadMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_TeamThreadMDRange<Right>(dims);
+  TestTeamThreadMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_TeamThreadMDRange<Left>(dims64);
+  TestTeamThreadMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_TeamThreadMDRange<Right>(dims64);
 
   TestTeamThreadMDRangeParallelFor<
       TEST_EXECSPACE>::test_parallel_for_6D_TeamThreadMDRange<Left>(dims);
@@ -1900,15 +2030,15 @@ TEST(TEST_CATEGORY, TeamThreadMDRangeParallelFor) {
 }
 
 TEST(TEST_CATEGORY, ThreadVectorMDRangeParallelFor) {
-  TestThreadVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_ThreadVectorMDRange<Left>(dims);
-  TestThreadVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_ThreadVectorMDRange<Right>(dims);
+  TestThreadVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_ThreadVectorMDRange<Left>(dims64);
+  TestThreadVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_ThreadVectorMDRange<Right>(dims64);
 
-  TestThreadVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_ThreadVectorMDRange<Left>(dims);
-  TestThreadVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_ThreadVectorMDRange<Right>(dims);
+  TestThreadVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_ThreadVectorMDRange<Left>(dims64);
+  TestThreadVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_ThreadVectorMDRange<Right>(dims64);
 
   TestThreadVectorMDRangeParallelFor<
       TEST_EXECSPACE>::test_parallel_for_6D_ThreadVectorMDRange<Left>(dims);
@@ -1932,15 +2062,15 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelFor) {
   TestTeamVectorMDRangeParallelFor<
       TEST_EXECSPACE>::test_parallel_for_3D_TeamVectorMDRange<Right>(dims);
 
-  TestTeamVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_4D_TeamVectorMDRange<Right>(dims);
+  TestTeamVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_TeamVectorMDRange<Left>(dims64);
+  TestTeamVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_4D_TeamVectorMDRange<Right>(dims64);
 
-  TestTeamVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelFor<
-      TEST_EXECSPACE>::test_parallel_for_5D_TeamVectorMDRange<Right>(dims);
+  TestTeamVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_TeamVectorMDRange<Left>(dims64);
+  TestTeamVectorMDRangeParallelFor<TEST_EXECSPACE, int64_t>::
+      test_parallel_for_5D_TeamVectorMDRange<Right>(dims64);
 
   TestTeamVectorMDRangeParallelFor<
       TEST_EXECSPACE>::test_parallel_for_6D_TeamVectorMDRange<Left>(dims);
@@ -1969,15 +2099,15 @@ TEST(TEST_CATEGORY, TeamThreadMDRangeParallelReduce) {
   TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
       test_parallel_reduce_for_3D_TeamThreadMDRange<Right>(dims);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamThreadMDRange<Right>(dims);
+  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_TeamThreadMDRange<Left>(dims64);
+  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_TeamThreadMDRange<Right>(dims64);
 
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamThreadMDRange<Left>(dims);
-  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamThreadMDRange<Right>(dims);
+  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_TeamThreadMDRange<Left>(dims64);
+  TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_TeamThreadMDRange<Right>(dims64);
 
   TestTeamThreadMDRangeParallelReduce<TEST_EXECSPACE>::
       test_parallel_reduce_for_6D_TeamThreadMDRange<Left>(dims);
@@ -2002,15 +2132,15 @@ TEST(TEST_CATEGORY, ThreadVectorMDRangeParallelReduce) {
     GTEST_SKIP() << "skipping because of bug in group_barrier implementation";
 #endif
 
-  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_ThreadVectorMDRange<Left>(dims);
-  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_ThreadVectorMDRange<Right>(dims);
+  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_ThreadVectorMDRange<Left>(dims64);
+  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_ThreadVectorMDRange<Right>(dims64);
 
-  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_ThreadVectorMDRange<Left>(dims);
-  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_ThreadVectorMDRange<Right>(dims);
+  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_ThreadVectorMDRange<Left>(dims64);
+  TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_ThreadVectorMDRange<Right>(dims64);
 
   TestThreadVectorMDRangeParallelReduce<TEST_EXECSPACE>::
       test_parallel_reduce_for_6D_ThreadVectorMDRange<Left>(dims);
@@ -2035,15 +2165,15 @@ TEST(TEST_CATEGORY, TeamVectorMDRangeParallelReduce) {
     GTEST_SKIP() << "skipping because of bug in group_barrier implementation";
 #endif
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_4D_TeamVectorMDRange<Right>(dims);
+  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_TeamVectorMDRange<Left>(dims64);
+  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_4D_TeamVectorMDRange<Right>(dims64);
 
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamVectorMDRange<Left>(dims);
-  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
-      test_parallel_reduce_for_5D_TeamVectorMDRange<Right>(dims);
+  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_TeamVectorMDRange<Left>(dims64);
+  TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE, int64_t>::
+      test_parallel_reduce_for_5D_TeamVectorMDRange<Right>(dims64);
 
   TestTeamVectorMDRangeParallelReduce<TEST_EXECSPACE>::
       test_parallel_reduce_for_6D_TeamVectorMDRange<Left>(dims);

--- a/core/unit_test/TestTeamMDRange.hpp
+++ b/core/unit_test/TestTeamMDRange.hpp
@@ -55,21 +55,16 @@ struct TestTeamMDParallelFor {
   static void check_result_4D(HostViewType h_view, FillFunctor& fillFunctor,
                               // For 4D, tests may not start at index 0
                               std::array<int, 4> const& lower = {0, 0, 0, 0}) {
-    for (auto i = lower[0]; i < h_view.extent_int(0); ++i) {
-      for (auto j = lower[1]; j < h_view.extent_int(1); ++j) {
-        for (auto k = lower[2]; k < h_view.extent_int(2); ++k) {
-          for (auto l = lower[3]; l < h_view.extent_int(3); ++l) {
-            EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
-          }
-        }
-      }
-    }
-    for (auto i = 0; i < lower[0]; ++i) {
-      for (auto j = 0; j < lower[1]; ++j) {
-        for (auto k = 0; k < lower[2]; ++k) {
-          for (auto l = 0; l < lower[3]; ++l) {
-            EXPECT_EQ(h_view(i, j, k, l),
-                      typename decltype(h_view)::value_type());
+    for (auto i = 0; i < h_view.extent_int(0); ++i) {
+      for (auto j = 0; j < h_view.extent_int(1); ++j) {
+        for (auto k = 0; k < h_view.extent_int(2); ++k) {
+          for (auto l = 0; l < h_view.extent_int(3); ++l) {
+            if (i < lower[0] || j < lower[1] || k < lower[2] || l < lower[3]) {
+              EXPECT_EQ(h_view(i, j, k, l),
+                        typename decltype(h_view)::value_type());
+            } else {
+              EXPECT_EQ(h_view(i, j, k, l), fillFunctor(i, j, k, l));
+            }
           }
         }
       }
@@ -1140,8 +1135,9 @@ struct TestTeamThreadMDRangeParallelReduce : public TestTeamMDParallelReduce {
     EXPECT_EQ(finalSum, expectedSum);
   }
 
-  // MDRangePolicy only allows up to rank of 6. Because of this, expectedSum
-  // array had to be constructed from a nested parallel_for loop.
+  // MDRangePolicy only allows up to rank of 6. Because of this,
+  // expectedSum array had to be constructed from a nested parallel_for
+  // loop.
   template <Kokkos::Iterate Direction = Kokkos::Iterate::Default>
   static void test_parallel_reduce_for_7D_TeamThreadMDRange(
       DimsType const& dims) {
@@ -1861,7 +1857,8 @@ constexpr auto Left  = Kokkos::Iterate::Left;
 constexpr auto Right = Kokkos::Iterate::Right;
 
 // Using prime numbers makes debugging easier
-// small dimensions were needed for larger dimensions to reduce test run time
+// small dimensions were needed for larger dimensions to reduce test run
+// time
 int dims[]      = {3, 5, 7, 11, 13, 17, 19, 23};
 int smallDims[] = {2, 3, 2, 3, 5, 2, 3, 5};
 

--- a/core/unit_test/TestTeamMDRangePolicyCTAD.cpp
+++ b/core/unit_test/TestTeamMDRangePolicyCTAD.cpp
@@ -34,12 +34,13 @@ struct TestTeamThreadMDRangeCTAD {
 
     // Rank 4 TeamThreadMDRange
     {
-      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0};
+      Kokkos::Array<int, 4> upper{0, 0, 0, 0};
       Kokkos::TeamThreadMDRange md_range(team_handle, lower, upper);
       static_assert(
-          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<4>, TeamHandle,
-                                                   int64_t, int64_t>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<4>, TeamHandle, int64_t>,
+              decltype(md_range)>);
     }
 
     // Rank 5 TeamThreadMDRange
@@ -48,8 +49,7 @@ struct TestTeamThreadMDRangeCTAD {
           team_handle, 0, 0, 0, 0, 0);
       static_assert(
           std::is_same_v<
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
-                                        std::integral_constant<int64_t, 0>>,
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<5>, TeamHandle, int64_t>,
               decltype(md_range)>);
     }
 
@@ -58,9 +58,8 @@ struct TestTeamThreadMDRangeCTAD {
       Kokkos::TeamThreadMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
                                          {0, 0, 0, 0, 0, 0});
       static_assert(
-          std::is_same_v<
-              Kokkos::TeamThreadMDRange<Kokkos::Rank<6>, TeamHandle, int, int>,
-              decltype(md_range)>);
+          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<6>, TeamHandle>,
+                         decltype(md_range)>);
     }
 
     // Rank 7 TeamThreadMDRange
@@ -108,12 +107,13 @@ struct TestTeamVectorMDRangeCTAD {
 
     // Rank 4 TeamVectorMDRange
     {
-      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0};
+      Kokkos::Array<int, 4> upper{0, 0, 0, 0};
       Kokkos::TeamVectorMDRange md_range(team_handle, lower, upper);
       static_assert(
-          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<4>, TeamHandle,
-                                                   int64_t, int64_t>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<4>, TeamHandle, int64_t>,
+              decltype(md_range)>);
     }
 
     // Rank 5 TeamVectorMDRange
@@ -122,8 +122,7 @@ struct TestTeamVectorMDRangeCTAD {
           team_handle, 0, 0, 0, 0, 0);
       static_assert(
           std::is_same_v<
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
-                                        std::integral_constant<int64_t, 0>>,
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t>,
               decltype(md_range)>);
     }
 
@@ -132,9 +131,8 @@ struct TestTeamVectorMDRangeCTAD {
       Kokkos::TeamVectorMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
                                          {0, 0, 0, 0, 0, 0});
       static_assert(
-          std::is_same_v<
-              Kokkos::TeamVectorMDRange<Kokkos::Rank<6>, TeamHandle, int, int>,
-              decltype(md_range)>);
+          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<6>, TeamHandle>,
+                         decltype(md_range)>);
     }
 
     // Rank 7 TeamVectorMDRange
@@ -186,10 +184,12 @@ struct TestThreadVectorMDRangeCTAD {
 
     // Rank 4 ThreadVectorMDRange
     {
-      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0};
+      Kokkos::Array<int, 4> upper{0, 0, 0, 0};
       Kokkos::ThreadVectorMDRange md_range(team_handle, lower, upper);
-      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<4>, TeamHandle,
-                                              int64_t, int64_t>>(md_range);
+      check_types<
+          Kokkos::ThreadVectorMDRange<Kokkos::Rank<4>, TeamHandle, int64_t>>(
+          md_range);
     }
 
     // Rank 5 ThreadVectorMDRange
@@ -197,8 +197,7 @@ struct TestThreadVectorMDRangeCTAD {
       Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t>
           md_range(team_handle, 0, 0, 0, 0, 0);
       check_types<
-          Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
-                                      std::integral_constant<int64_t, 0>>>(
+          Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t>>(
           md_range);
     }
 
@@ -206,8 +205,7 @@ struct TestThreadVectorMDRangeCTAD {
     {
       Kokkos::ThreadVectorMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
                                            {0, 0, 0, 0, 0, 0});
-      check_types<
-          Kokkos::ThreadVectorMDRange<Kokkos::Rank<6>, TeamHandle, int, int>>(
+      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<6>, TeamHandle>>(
           md_range);
     }
 

--- a/core/unit_test/TestTeamMDRangePolicyCTAD.cpp
+++ b/core/unit_test/TestTeamMDRangePolicyCTAD.cpp
@@ -16,6 +16,7 @@ struct TestTeamThreadMDRangeCTAD {
   using TeamHandle = TeamPolicy::member_type;
 
   KOKKOS_FUNCTION void operator()(TeamHandle const& team_handle) const {
+    // Rank 2 TeamThreadMDRange
     {
       Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0);
       static_assert(
@@ -23,6 +24,7 @@ struct TestTeamThreadMDRangeCTAD {
                          decltype(md_range)>);
     }
 
+    // Rank 3 TeamThreadMDRange
     {
       Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0);
       static_assert(
@@ -30,27 +32,38 @@ struct TestTeamThreadMDRangeCTAD {
                          decltype(md_range)>);
     }
 
+    // Rank 4 TeamThreadMDRange
     {
-      Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0, 0);
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::TeamThreadMDRange md_range(team_handle, lower, upper);
       static_assert(
-          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<4>, TeamHandle>,
+          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<4>, TeamHandle,
+                                                   int64_t, int64_t>,
                          decltype(md_range)>);
     }
 
+    // Rank 5 TeamThreadMDRange
     {
-      Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0, 0, 0);
+      Kokkos::TeamThreadMDRange<Kokkos::Rank<5>, TeamHandle, int64_t> md_range(
+          team_handle, 0, 0, 0, 0, 0);
       static_assert(
-          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<5>, TeamHandle>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
+                                        std::integral_constant<int64_t, 0>>,
+              decltype(md_range)>);
     }
 
+    // Rank 6 TeamThreadMDRange
     {
-      Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0);
+      Kokkos::TeamThreadMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0, 0});
       static_assert(
-          std::is_same_v<Kokkos::TeamThreadMDRange<Kokkos::Rank<6>, TeamHandle>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamThreadMDRange<Kokkos::Rank<6>, TeamHandle, int, int>,
+              decltype(md_range)>);
     }
 
+    // Rank 7 TeamThreadMDRange
     {
       Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0);
       static_assert(
@@ -58,6 +71,7 @@ struct TestTeamThreadMDRangeCTAD {
                          decltype(md_range)>);
     }
 
+    // Rank 8 TeamThreadMDRange
     {
       Kokkos::TeamThreadMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0, 0);
       static_assert(
@@ -76,12 +90,15 @@ struct TestTeamVectorMDRangeCTAD {
   using TeamHandle = TeamPolicy::member_type;
 
   KOKKOS_FUNCTION void operator()(TeamHandle const& team_handle) const {
+    // Rank 2 TeamVectorMDRange
     {
       Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0);
       static_assert(
           std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<2>, TeamHandle>,
                          decltype(md_range)>);
     }
+
+    // Rank 3 TeamVectorMDRange
     {
       Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0);
       static_assert(
@@ -89,27 +106,38 @@ struct TestTeamVectorMDRangeCTAD {
                          decltype(md_range)>);
     }
 
+    // Rank 4 TeamVectorMDRange
     {
-      Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0, 0);
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::TeamVectorMDRange md_range(team_handle, lower, upper);
       static_assert(
-          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<4>, TeamHandle>,
+          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<4>, TeamHandle,
+                                                   int64_t, int64_t>,
                          decltype(md_range)>);
     }
 
+    // Rank 5 TeamVectorMDRange
     {
-      Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0);
+      Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t> md_range(
+          team_handle, 0, 0, 0, 0, 0);
       static_assert(
-          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamHandle>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
+                                        std::integral_constant<int64_t, 0>>,
+              decltype(md_range)>);
     }
 
+    // Rank 6 TeamVectorMDRange
     {
-      Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0);
+      Kokkos::TeamVectorMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
+                                         {0, 0, 0, 0, 0, 0});
       static_assert(
-          std::is_same_v<Kokkos::TeamVectorMDRange<Kokkos::Rank<6>, TeamHandle>,
-                         decltype(md_range)>);
+          std::is_same_v<
+              Kokkos::TeamVectorMDRange<Kokkos::Rank<6>, TeamHandle, int, int>,
+              decltype(md_range)>);
     }
 
+    // Rank 7 TeamVectorMDRange
     {
       Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0);
       static_assert(
@@ -117,6 +145,7 @@ struct TestTeamVectorMDRangeCTAD {
                          decltype(md_range)>);
     }
 
+    // Rank 8 TeamVectorMDRange
     {
       Kokkos::TeamVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0, 0);
       static_assert(
@@ -141,42 +170,55 @@ struct TestThreadVectorMDRangeCTAD {
   }
 
   KOKKOS_FUNCTION void operator()(TeamHandle const& team_handle) const {
+    // Rank 2 ThreadVectorMDRange
     {
       Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0);
       check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<2>, TeamHandle>>(
           md_range);
     }
 
+    // Rank 3 ThreadVectorMDRange
     {
       Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0);
       check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<3>, TeamHandle>>(
           md_range);
     }
 
+    // Rank 4 ThreadVectorMDRange
     {
-      Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0, 0);
-      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<4>, TeamHandle>>(
+      Kokkos::Array<int64_t, 4> lower{0, 0, 0, 0}, upper{0, 0, 0, 0};
+      Kokkos::ThreadVectorMDRange md_range(team_handle, lower, upper);
+      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<4>, TeamHandle,
+                                              int64_t, int64_t>>(md_range);
+    }
+
+    // Rank 5 ThreadVectorMDRange
+    {
+      Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t>
+          md_range(team_handle, 0, 0, 0, 0, 0);
+      check_types<
+          Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle, int64_t,
+                                      std::integral_constant<int64_t, 0>>>(
           md_range);
     }
 
+    // Rank 6 ThreadVectorMDRange
     {
-      Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0);
-      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<5>, TeamHandle>>(
+      Kokkos::ThreadVectorMDRange md_range(team_handle, {0, 0, 0, 0, 0, 0},
+                                           {0, 0, 0, 0, 0, 0});
+      check_types<
+          Kokkos::ThreadVectorMDRange<Kokkos::Rank<6>, TeamHandle, int, int>>(
           md_range);
     }
 
-    {
-      Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0);
-      check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<6>, TeamHandle>>(
-          md_range);
-    }
-
+    // Rank 7 ThreadVectorMDRange
     {
       Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0);
       check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<7>, TeamHandle>>(
           md_range);
     }
 
+    // Rank 8 ThreadVectorMDRange
     {
       Kokkos::ThreadVectorMDRange md_range(team_handle, 0, 0, 0, 0, 0, 0, 0, 0);
       check_types<Kokkos::ThreadVectorMDRange<Kokkos::Rank<8>, TeamHandle>>(


### PR DESCRIPTION
Currently, `{TeamVector|TeamThread|ThreadVector}MDRange` only has a constructor for the upper iteration bound, and assumes 0 as the lower bound, and hard codes an index type `int`. Looking forward to self-similar interface, we need constructor which takes lower bound and policy traits can take in an index.

For testing, I changed team-level 4D mdranges tests to use the lower bound constructor.

### Changelog Entry
Expand team-level MDRanges to have non-trivial lower bound iterations and arbitrary index type.
