### PR TITLE
SYCL: Use std::size_t for MaxGridSize

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -24,7 +24,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   using array_index_type = typename Policy::array_index_type;
   using index_type       = typename Policy::index_type;
   using WorkTag          = typename Policy::work_tag;
-  using MaxGridSize      = Kokkos::Array<index_type, 3>;
+  using MaxGridSize      = Kokkos::Array<std::size_t, 3>;
   using array_type       = typename Policy::point_type;
 
   const FunctorType m_functor;
@@ -126,9 +126,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
     // as the one varying the fastest, so the order must be reversed for Kokkos
     // see:
     // https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:multi-dim-linearization
-    return {static_cast<index_type>(max_grid_size[2]),
-            static_cast<index_type>(max_grid_size[1]),
-            static_cast<index_type>(max_grid_size[0])};
+    return {max_grid_size[2], max_grid_size[1], max_grid_size[0]};
 #else
     // otherwise, we consider that the max is infinite
     return {std::numeric_limits<index_type>::max(),

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -159,9 +159,9 @@ auto compute_device_launch_params(
   // SYCL uses nd_range with global = grid * local sizes
   sycl::range<3> local_sizes(block.x, block.y, block.z);
   sycl::range<3> global_sizes(
-      std::min<array_index_type>(grid_0, max_grid_size[0]) * local_sizes[0],
-      std::min<array_index_type>(grid_1, max_grid_size[1]) * local_sizes[1],
-      std::min<array_index_type>(grid_2, max_grid_size[2]) * local_sizes[2]);
+      std::min<std::size_t>(grid_0, max_grid_size[0]) * local_sizes[0],
+      std::min<std::size_t>(grid_1, max_grid_size[1]) * local_sizes[1],
+      std::min<std::size_t>(grid_2, max_grid_size[2]) * local_sizes[2]);
   return sycl::nd_range<3>(global_sizes, local_sizes);
 #else
   dim3 grid(std::min<array_index_type>(grid_0, max_grid_size[0]),


### PR DESCRIPTION
https://github.com/intel/llvm/pull/21840 changed the value returned from `get_info<sycl::ext::oneapi::experimental::info::device::max_work_groups>` from `INT_MAX` to `SIZE_MAX` causing a conversion to `index_type=int` to overflow.
This pull request makes sure to use `std::size_t` for all operations including `MaxGridSize`.