### PR TITLE
RangePolicy (Cuda backend): revert treating static batch size = 1 specially 

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -8,7 +8,6 @@
 #if defined(KOKKOS_ENABLE_CUDA)
 
 #include <algorithm>
-#include <cstdint>
 #include <string>
 
 #include <Kokkos_Parallel.hpp>
@@ -68,32 +67,28 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
              iwork < static_cast<Member>(work_end - work_stride * batch_size)
                  ? iwork + work_stride * batch_size
                  : work_end) {
-      if constexpr (batch_size == 1) {
-        this->template exec_range<WorkTag>(iwork);
-      } else {
+// FIXME: batch_size == 1 can be treated without nested loops but faced issue
+// with cuda-12.6.2 on Hopper90 GPU (compiler hangs) when implementing that
 #if defined(KOKKOS_COMPILER_NVCC)
 #pragma unroll
 #endif
-        for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
-                           i < work_end - iwork;
-             i = (i < static_cast<Member>(work_end - work_stride - iwork))
-                     ? i + work_stride
-                     : work_end - iwork) {
-          this->template exec_range<WorkTag>(iwork + i);
-        }
+      for (Member i = 0; i < static_cast<Member>(work_stride * batch_size) &&
+                         i < work_end - iwork;
+           i = (i < static_cast<Member>(work_end - work_stride - iwork))
+                   ? i + work_stride
+                   : work_end - iwork) {
+        this->template exec_range<WorkTag>(iwork + i);
       }
     }
   }
 
   inline void execute() const {
-    const typename Policy::index_type range = m_policy.end() - m_policy.begin();
-    typename Policy::index_type nwork       = range;
+    constexpr typename Policy::index_type batch_size =
+        StaticBatchSize::batch_size;
+    const typename Policy::index_type nwork =
+        (m_policy.end() - m_policy.begin()) / batch_size +
+        ((m_policy.end() - m_policy.begin()) % batch_size == 0 ? 0 : 1);
 
-    if constexpr (StaticBatchSize::batch_size != 1) {
-      constexpr typename Policy::index_type batch_size =
-          StaticBatchSize::batch_size;
-      nwork = (uint64_t(range) + batch_size - 1) / batch_size;
-    }
     cudaFuncAttributes attr =
         CudaParallelLaunch<ParallelFor, LaunchBounds>::get_cuda_func_attributes(
             m_policy.space().impl_internal_space_instance());


### PR DESCRIPTION
This is to revert special treatment for static batch size of 1 in RangePolicy for CUDA backend.

Nested loops lead to two more registers being used. So, that case was handled without nested loops.

However, this is leading to compiler issue (it hangs) while compiling the unit tests for Panzer (Trilinos). For example, this has been observed with cuda-12.6.2 for Hopper90 GPU.