### PR TITLE
Fix deduction for templated operator

### DIFF
--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -208,7 +208,18 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static A deduce(void (Functor::*)(M, M, M, M, M, M,
                                                              M, M, A&) const);
 
-    using type = decltype(deduce(&F::operator()));
+    template <typename FF, typename = void>
+    struct deduce_operator_type {
+      using type = void;
+    };
+
+    template <typename FF>
+    struct deduce_operator_type<
+        FF, std::void_t<decltype(deduce(&FF::operator()))>> {
+      using type = decltype(deduce(&FF::operator()));
+    };
+
+    using type = typename deduce_operator_type<F>::type;
   };
 
   template <typename F>
@@ -283,7 +294,18 @@ struct FunctorAnalysis {
                                                              M, M, M, M, M, M,
                                                              A&) const);
 
-    using type = decltype(deduce(&F::operator()));
+    template <typename FF, typename = void>
+    struct deduce_operator_type {
+      using type = void;
+    };
+
+    template <typename FF>
+    struct deduce_operator_type<
+        FF, std::void_t<decltype(deduce(&FF::operator()))>> {
+      using type = decltype(deduce(&FF::operator()));
+    };
+
+    using type = typename deduce_operator_type<F>::type;
   };
 
   template <typename F>
@@ -291,7 +313,18 @@ struct FunctorAnalysis {
     template <typename M, typename A, typename I>
     KOKKOS_INLINE_FUNCTION static A deduce(void (Functor::*)(M, A&, I) const);
 
-    using type = decltype(deduce(&F::operator()));
+    template <typename FF, typename = void>
+    struct deduce_operator_type {
+      using type = void;
+    };
+
+    template <typename FF>
+    struct deduce_operator_type<
+        FF, std::void_t<decltype(deduce(&FF::operator()))>> {
+      using type = decltype(deduce(&FF::operator()));
+    };
+
+    using type = typename deduce_operator_type<F>::type;
   };
 
   template <typename F>
@@ -304,7 +337,18 @@ struct FunctorAnalysis {
     KOKKOS_INLINE_FUNCTION static A deduce(void (Functor::*)(WTag const&, M, A&,
                                                              I) const);
 
-    using type = decltype(deduce(&F::operator()));
+    template <typename FF, typename = void>
+    struct deduce_operator_type {
+      using type = void;
+    };
+
+    template <typename FF>
+    struct deduce_operator_type<
+        FF, std::void_t<decltype(deduce(&FF::operator()))>> {
+      using type = decltype(deduce(&FF::operator()));
+    };
+
+    using type = typename deduce_operator_type<F>::type;
   };
 
   //----------------------------------------

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -60,11 +60,42 @@ struct TestTeamReduceLarge {
   }
 };
 
+template <typename ExecutionSpace>
+struct TestTeamReduceTemplatedOperator {
+  using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+
+  int m_range;
+
+  TestTeamReduceTemplatedOperator(const int range) : m_range(range) {}
+
+  template <typename MemberType>
+  KOKKOS_INLINE_FUNCTION void operator()(const MemberType& t,
+                                         int& update) const {
+    Kokkos::single(Kokkos::PerTeam(t), [&]() { update++; });
+  }
+
+  void run() {
+    int result = 0;
+    Kokkos::parallel_reduce(team_policy_t(m_range, Kokkos::AUTO), *this,
+                            result);
+    EXPECT_EQ(m_range, result);
+  }
+};
+
 TEST(TEST_CATEGORY, team_reduce_large) {
   std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
                           (2LU << 24) + 1, 1LU << 29};
   for (const auto range : ranges) {
     TestTeamReduceLarge<TEST_EXECSPACE> test(range);
+    test.run();
+  }
+}
+
+TEST(TEST_CATEGORY, team_reduce_templated_operator) {
+  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
+                          (2LU << 24) + 1, 1LU << 29};
+  for (const auto range : ranges) {
+    TestTeamReduceTemplatedOperator<TEST_EXECSPACE> test(range);
     test.run();
   }
 }


### PR DESCRIPTION
This PR aims at fixing the deduction for the template operator.
In Kokkos-kernels, we have a pattern like this.

```C++
template <typename DeviceType, typename XViewType, typename YViewType, typename CType, typename SType, bool Conj,
          typename ArgMode>
struct Functor_BatchedTeamRot {
  using execution_space = typename DeviceType::execution_space;
  XViewType m_x;
  YViewType m_y;
  CType m_c;
  SType m_s;

  Functor_BatchedTeamRot(const XViewType &x, const YViewType &y, const CType c, const SType s)
      : m_x(x), m_y(y), m_c(c), m_s(s) {}

  template <typename MemberType>
  KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member) const {
    const int k = member.league_rank();
    auto sub_x  = Kokkos::subview(m_x, k, Kokkos::ALL());
    auto sub_y  = Kokkos::subview(m_y, k, Kokkos::ALL());
    KokkosBatched::TeamRot<MemberType, Conj>::invoke(member, sub_x, sub_y, m_c, m_s);
  }

  //template <typename MemberType>
  //KOKKOS_INLINE_FUNCTION void operator()(const MemberType &member, int &info) const {
  //  const int k = member.league_rank();
  //  auto sub_x  = Kokkos::subview(m_x, k, Kokkos::ALL());
  //  auto sub_y  = Kokkos::subview(m_y, k, Kokkos::ALL());
  //  int info += KokkosBatched::TeamRot<MemberType, Conj>::invoke(member, sub_x, sub_y, m_c, m_s);
  //}


  inline void run() {
    using value_type        = typename XViewType::non_const_value_type;
    std::string name_region = std::is_same_v<ArgMode, KokkosBatched::Mode::Team> ? "KokkosBatched::Test::TeamRot"
                                                                                 : "KokkosBatched::Test::TeamVectorRot";
    const std::string name_value_type = Test::value_type_name<value_type>();
    std::string name                  = name_region + name_value_type;
    Kokkos::Profiling::pushRegion(name.c_str());
    const int league_size = m_x.extent_int(0);
    Kokkos::TeamPolicy<execution_space> policy(league_size, Kokkos::AUTO);
    Kokkos::parallel_for(name.c_str(), policy, *this);
    //int info_sum=0;
    //Kokkos::parallel_reduce(name.c_str(), policy, *this, info_sum);
    //return info_sum;
    Kokkos::Profiling::popRegion();
  }
};
```

Although the deduction works with `parallel_for`, it does not work with `parallel_reduce`. This happens with nvcc for CUDA backend, but not with gcc for Serial backend.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

  - Unsure
