### PR TITLE
Allow `half_t` and `bhalf_t` to be used in `complex`

### DIFF
--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -32,8 +32,14 @@ class
     alignas(2 * sizeof(RealType))
 #endif
         complex {
-  static_assert(std::is_floating_point_v<RealType> &&
-                    std::is_same_v<RealType, std::remove_cv_t<RealType>>,
+  static_assert((std::is_floating_point_v<RealType>
+#if defined KOKKOS_IMPL_HALF_TYPE_DEFINED
+                 || std::is_same_v<RealType, Kokkos::Experimental::half_t>
+#endif
+#if defined KOKKOS_IMPL_BHALF_TYPE_DEFINED
+                 || std::is_same_v<RealType, Kokkos::Experimental::bhalf_t>
+#endif
+                 )&&std::is_same_v<RealType, std::remove_cv_t<RealType>>,
                 "Kokkos::complex can only be instantiated for a cv-unqualified "
                 "floating point type");
 

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOSTEST_UTILS_HPP
+#define KOKKOSTEST_UTILS_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <type_traits>
+
+namespace KokkosTest {
+
+struct FloatingPointComparison {
+ private:
+  template <class T>
+  KOKKOS_FUNCTION static double eps(T) {
+    return DBL_EPSILON;
+  }
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+  KOKKOS_FUNCTION static Kokkos::Experimental::half_t eps(
+      Kokkos::Experimental::half_t) {
+// FIXME_NVHPC compile-time error
+#ifdef KOKKOS_COMPILER_NVHPC
+    return 0.0009765625F;
+#else
+    return Kokkos::Experimental::epsilon<Kokkos::Experimental::half_t>::value;
+#endif
+  }
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+  KOKKOS_FUNCTION
+  Kokkos::Experimental::bhalf_t static eps(Kokkos::Experimental::bhalf_t) {
+// FIXME_NVHPC compile-time error
+#ifdef KOKKOS_COMPILER_NVHPC
+    return 0.0078125;
+#else
+    return Kokkos::Experimental::epsilon<Kokkos::Experimental::bhalf_t>::value;
+#endif
+  }
+#endif
+
+  KOKKOS_FUNCTION static double eps(float) { return FLT_EPSILON; }
+
+// POWER9 gives unexpected values with LDBL_EPSILON issues
+// https://stackoverflow.com/questions/68960416/ppc64-long-doubles-machine-epsilon-calculation
+#if defined(KOKKOS_ARCH_POWER9) || defined(KOKKOS_ARCH_POWER8)
+  KOKKOS_FUNCTION static double eps(long double) { return DBL_EPSILON; }
+#else
+  KOKKOS_FUNCTION static double eps(long double) { return LDBL_EPSILON; }
+#endif
+
+  // Using absolute here instead of abs, since we actually test abs ...
+  template <class T>
+  KOKKOS_FUNCTION static T absolute(T val) {
+    if constexpr (std::is_signed_v<T>) {
+      return val < T(0) ? -val : val;
+    }
+    return val;
+  }
+
+ public:
+  template <class FPT>
+  KOKKOS_FUNCTION static bool compare_near_zero(FPT const& fpv, int ulp) {
+    auto abs_tol = eps(fpv) * ulp;
+
+    bool ar = absolute(fpv) <= abs_tol;
+    if (!ar) {
+      Kokkos::printf("absolute value exceeds tolerance [|%e| > %e]\n",
+                     (double)fpv, (double)abs_tol);
+    }
+
+    return ar;
+  }
+
+  template <class Lhs, class Rhs>
+  KOKKOS_FUNCTION static bool compare(Lhs const& lhs, Rhs const& rhs, int ulp) {
+    if (lhs == 0) {
+      return compare_near_zero(rhs, ulp);
+    } else if (rhs == 0) {
+      return compare_near_zero(lhs, ulp);
+    } else {
+      auto rel_tol     = (eps(lhs) < eps(rhs) ? eps(lhs) : eps(rhs)) * ulp;
+      double abs_diff  = static_cast<double>(rhs > lhs ? rhs - lhs : lhs - rhs);
+      double min_denom = static_cast<double>(
+          absolute(rhs) < absolute(lhs) ? absolute(rhs) : absolute(lhs));
+      double rel_diff = abs_diff / min_denom;
+      bool ar         = rel_diff <= rel_tol;
+      if (!ar) {
+        Kokkos::printf("relative difference exceeds tolerance [%e > %e]\n",
+                       (double)rel_diff, (double)rel_tol);
+      }
+
+      return ar;
+    }
+  }
+};
+
+struct IntegerComparison {
+  template <class Lhs, class Rhs>
+  KOKKOS_FUNCTION bool compare(Lhs const& lhs, Rhs const& rhs) const {
+    static_assert(std::is_integral_v<Lhs>);
+    static_assert(std::is_integral_v<Rhs>);
+    return lhs == rhs;
+  }
+};
+
+}  // namespace KokkosTest
+#endif

--- a/core/unit_test/TestComplex.hpp
+++ b/core/unit_test/TestComplex.hpp
@@ -27,6 +27,8 @@ import kokkos.core;
 #include <complex>
 #include <sstream>
 
+#include "KokkosTest_Utils.hpp"
+
 namespace {
 template <typename... Ts>
 KOKKOS_FUNCTION constexpr void maybe_unused(Ts &&...) noexcept {}
@@ -36,14 +38,14 @@ namespace Test {
 
 // Test construction and assignment
 
-template <class ExecSpace>
-struct TestComplexConstruction {
-  Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
-      h_results;
+template <class ExecSpace, class RealType>
+struct TestComplexConstruction : KokkosTest::FloatingPointComparison {
+  Kokkos::View<Kokkos::complex<RealType> *, ExecSpace> d_results;
+  typename Kokkos::View<Kokkos::complex<RealType> *,
+                        ExecSpace>::host_mirror_type h_results;
 
   void testit() {
-    d_results = Kokkos::View<Kokkos::complex<double> *, ExecSpace>(
+    d_results = Kokkos::View<Kokkos::complex<RealType> *, ExecSpace>(
         "TestComplexConstruction", 10);
     h_results = Kokkos::create_mirror_view(d_results);
 
@@ -51,80 +53,97 @@ struct TestComplexConstruction {
     Kokkos::fence();
     Kokkos::deep_copy(h_results, d_results);
 
-    ASSERT_FLOAT_EQ(h_results(0).real(), 1.5);
-    ASSERT_FLOAT_EQ(h_results(0).imag(), 2.5);
-    ASSERT_FLOAT_EQ(h_results(1).real(), 1.5);
-    ASSERT_FLOAT_EQ(h_results(1).imag(), 2.5);
-    ASSERT_FLOAT_EQ(h_results(2).real(), 0.0);
-    ASSERT_FLOAT_EQ(h_results(2).imag(), 0.0);
-    ASSERT_FLOAT_EQ(h_results(3).real(), 3.5);
-    ASSERT_FLOAT_EQ(h_results(3).imag(), 0.0);
-    ASSERT_FLOAT_EQ(h_results(4).real(), 4.5);
-    ASSERT_FLOAT_EQ(h_results(4).imag(), 5.5);
-    ASSERT_FLOAT_EQ(h_results(5).real(), 1.5);
-    ASSERT_FLOAT_EQ(h_results(5).imag(), 2.5);
-    ASSERT_FLOAT_EQ(h_results(6).real(), 4.5);
-    ASSERT_FLOAT_EQ(h_results(6).imag(), 5.5);
-    ASSERT_FLOAT_EQ(h_results(7).real(), 7.5);
-    ASSERT_FLOAT_EQ(h_results(7).imag(), 0.0);
-    ASSERT_FLOAT_EQ(h_results(8).real(), double(8));
-    ASSERT_FLOAT_EQ(h_results(8).imag(), 0.0);
-
-    // Copy construction conversion between
-    // Kokkos::complex and std::complex doesn't compile
-    Kokkos::complex<double> a(1.5, 2.5), b(3.25, 5.25), r_kk;
-    std::complex<double> sa(a), sb(3.25, 5.25), r;
-    r    = a;
-    r_kk = a;
-    ASSERT_FLOAT_EQ(r.real(), r_kk.real());
-    ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
-    r    = sb * a;
-    r_kk = b * a;
-    ASSERT_FLOAT_EQ(r.real(), r_kk.real());
-    ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
-    r    = sa;
-    r_kk = a;
-    ASSERT_FLOAT_EQ(r.real(), r_kk.real());
-    ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
+    ASSERT_TRUE(compare(h_results(0).real(), 1.5, 4));
+    ASSERT_TRUE(compare(h_results(0).imag(), 2.5, 4));
+    ASSERT_TRUE(compare(h_results(1).real(), 1.5, 4));
+    ASSERT_TRUE(compare(h_results(1).imag(), 2.5, 4));
+    ASSERT_TRUE(compare(h_results(2).real(), 0.0, 4));
+    ASSERT_TRUE(compare(h_results(2).imag(), 0.0, 4));
+    ASSERT_TRUE(compare(h_results(3).real(), 3.5, 4));
+    ASSERT_TRUE(compare(h_results(3).imag(), 0.0, 4));
+    ASSERT_TRUE(compare(h_results(4).real(), 4.5, 4));
+    ASSERT_TRUE(compare(h_results(4).imag(), 5.5, 4));
+    ASSERT_TRUE(compare(h_results(5).real(), 1.5, 4));
+    ASSERT_TRUE(compare(h_results(5).imag(), 2.5, 4));
+    ASSERT_TRUE(compare(h_results(6).real(), 4.5, 4));
+    ASSERT_TRUE(compare(h_results(6).imag(), 5.5, 4));
+    ASSERT_TRUE(compare(h_results(7).real(), 7.5, 4));
+    ASSERT_TRUE(compare(h_results(7).imag(), 0.0, 4));
+    ASSERT_TRUE(compare(h_results(8).real(), RealType(8), 4));
+    ASSERT_TRUE(compare(h_results(8).imag(), 0.0, 4));
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int & /*i*/) const {
-    Kokkos::complex<double> a(1.5, 2.5);
+    Kokkos::complex<RealType> a(1.5, 2.5);
     d_results(0) = a;
-    Kokkos::complex<double> b(a);
-    d_results(1)              = b;
-    Kokkos::complex<double> c = Kokkos::complex<double>();
-    d_results(2)              = c;
-    Kokkos::complex<double> d(3.5);
+    Kokkos::complex<RealType> b(a);
+    d_results(1)                = b;
+    Kokkos::complex<RealType> c = Kokkos::complex<RealType>();
+    d_results(2)                = c;
+    Kokkos::complex<RealType> d(3.5);
     d_results(3) = d;
-    Kokkos::complex<double> a_v(4.5, 5.5);
+    Kokkos::complex<RealType> a_v(4.5, 5.5);
     d_results(4) = a_v;
-    Kokkos::complex<double> b_v(a);
+    Kokkos::complex<RealType> b_v(a);
     d_results(5) = b_v;
-    Kokkos::complex<double> e(a_v);
+    Kokkos::complex<RealType> e(a_v);
     d_results(6) = e;
 
-    d_results(7) = double(7.5);
+    d_results(7) = RealType(7.5);
     d_results(8) = int(8);
   }
 };
 
+template <typename RealType>
+void test_construction_from_std() {
+  // Copy construction conversion between
+  // Kokkos::complex and std::complex doesn't compile
+  Kokkos::complex<RealType> a(1.5, 2.5), b(3.25, 5.25), r_kk;
+  std::complex<RealType> sa(a), sb(3.25, 5.25), r;
+  r    = a;
+  r_kk = a;
+  ASSERT_FLOAT_EQ(r.real(), r_kk.real());
+  ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
+  r    = sb * a;
+  r_kk = b * a;
+  ASSERT_FLOAT_EQ(r.real(), r_kk.real());
+  ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
+  r    = sa;
+  r_kk = a;
+  ASSERT_FLOAT_EQ(r.real(), r_kk.real());
+  ASSERT_FLOAT_EQ(r.imag(), r_kk.imag());
+}
+
 TEST(TEST_CATEGORY, complex_construction) {
-  TestComplexConstruction<TEST_EXECSPACE> test;
-  test.testit();
+  TestComplexConstruction<TEST_EXECSPACE, float> f;
+  f.testit();
+  TestComplexConstruction<TEST_EXECSPACE, double> d;
+  d.testit();
+
+  test_construction_from_std<float>();
+  test_construction_from_std<double>();
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  TestComplexConstruction<TEST_EXECSPACE, Kokkos::Experimental::half_t> h;
+  h.testit();
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  TestComplexConstruction<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t> bh;
+  bh.testit();
+#endif
 }
 
 // Test Math FUnction
 
-template <class ExecSpace>
-struct TestComplexBasicMath {
-  Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
-      h_results;
+template <class ExecSpace, class RealType>
+struct TestComplexBasicMath : KokkosTest::FloatingPointComparison {
+  Kokkos::View<Kokkos::complex<RealType> *, ExecSpace> d_results;
+  typename Kokkos::View<Kokkos::complex<RealType> *,
+                        ExecSpace>::host_mirror_type h_results;
 
   void testit() {
-    d_results = Kokkos::View<Kokkos::complex<double> *, ExecSpace>(
+    d_results = Kokkos::View<Kokkos::complex<RealType> *, ExecSpace>(
         "TestComplexBasicMath", 24);
     h_results = Kokkos::create_mirror_view(d_results);
 
@@ -132,88 +151,88 @@ struct TestComplexBasicMath {
     Kokkos::fence();
     Kokkos::deep_copy(h_results, d_results);
 
-    std::complex<double> a(1.5, 2.5);
-    std::complex<double> b(3.25, 5.75);
-    std::complex<double> d(1.0, 2.0);
-    double c = 9.3;
-    int e    = 2;
+    std::complex<RealType> a(1.5, 2.5);
+    std::complex<RealType> b(3.25, 5.75);
+    std::complex<RealType> d(1.0, 2.0);
+    RealType c = 9.3;
+    int e      = 2;
 
-    std::complex<double> r;
+    std::complex<RealType> r;
     r = a + b;
-    ASSERT_FLOAT_EQ(h_results(0).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(0).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(0).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(0).imag(), r.imag(), 4));
     r = a - b;
-    ASSERT_FLOAT_EQ(h_results(1).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(1).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(1).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(1).imag(), r.imag(), 4));
     r = a * b;
-    ASSERT_FLOAT_EQ(h_results(2).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(2).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(2).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(2).imag(), r.imag(), 4));
     r = a / b;
-    ASSERT_FLOAT_EQ(h_results(3).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(3).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(3).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(3).imag(), r.imag(), 12));
     r = d + a;
-    ASSERT_FLOAT_EQ(h_results(4).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(4).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(4).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(4).imag(), r.imag(), 4));
     r = d - a;
-    ASSERT_FLOAT_EQ(h_results(5).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(5).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(5).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(5).imag(), r.imag(), 4));
     r = d * a;
-    ASSERT_FLOAT_EQ(h_results(6).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(6).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(6).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(6).imag(), r.imag(), 4));
     r = d / a;
-    ASSERT_FLOAT_EQ(h_results(7).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(7).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(7).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(7).imag(), r.imag(), 4));
     r = a + c;
-    ASSERT_FLOAT_EQ(h_results(8).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(8).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(8).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(8).imag(), r.imag(), 4));
     r = a - c;
-    ASSERT_FLOAT_EQ(h_results(9).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(9).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(9).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(9).imag(), r.imag(), 4));
     r = a * c;
-    ASSERT_FLOAT_EQ(h_results(10).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(10).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(10).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(10).imag(), r.imag(), 4));
     r = a / c;
-    ASSERT_FLOAT_EQ(h_results(11).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(11).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(11).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(11).imag(), r.imag(), 4));
     r = d + c;
-    ASSERT_FLOAT_EQ(h_results(12).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(12).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(12).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(12).imag(), r.imag(), 4));
     r = d - c;
-    ASSERT_FLOAT_EQ(h_results(13).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(13).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(13).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(13).imag(), r.imag(), 4));
     r = d * c;
-    ASSERT_FLOAT_EQ(h_results(14).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(14).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(14).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(14).imag(), r.imag(), 4));
     r = d / c;
-    ASSERT_FLOAT_EQ(h_results(15).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(15).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(15).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(15).imag(), r.imag(), 4));
     r = c + a;
-    ASSERT_FLOAT_EQ(h_results(16).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(16).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(16).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(16).imag(), r.imag(), 4));
     r = c - a;
-    ASSERT_FLOAT_EQ(h_results(17).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(17).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(17).imag(), r.imag(), 4));
     r = c * a;
-    ASSERT_FLOAT_EQ(h_results(18).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(18).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(18).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(18).imag(), r.imag(), 4));
     r = c / a;
-    ASSERT_FLOAT_EQ(h_results(19).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(19).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(19).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(19).imag(), r.imag(), 4));
     r = a;
-    /* r = a+e; */ ASSERT_FLOAT_EQ(h_results(20).real(), r.real() + e);
-    ASSERT_FLOAT_EQ(h_results(20).imag(), r.imag());
-    /* r = a-e; */ ASSERT_FLOAT_EQ(h_results(21).real(), r.real() - e);
-    ASSERT_FLOAT_EQ(h_results(21).imag(), r.imag());
-    /* r = a*e; */ ASSERT_FLOAT_EQ(h_results(22).real(), r.real() * e);
-    ASSERT_FLOAT_EQ(h_results(22).imag(), r.imag() * e);
-    /* r = a/e; */ ASSERT_FLOAT_EQ(h_results(23).real(), r.real() / 2);
-    ASSERT_FLOAT_EQ(h_results(23).imag(), r.imag() / e);
+    /* r = a+e; */ ASSERT_TRUE(compare(h_results(20).real(), r.real() + e, 4));
+    ASSERT_TRUE(compare(h_results(20).imag(), r.imag(), 4));
+    /* r = a-e; */ ASSERT_TRUE(compare(h_results(21).real(), r.real() - e, 4));
+    ASSERT_TRUE(compare(h_results(21).imag(), r.imag(), 4));
+    /* r = a*e; */ ASSERT_TRUE(compare(h_results(22).real(), r.real() * e, 4));
+    ASSERT_TRUE(compare(h_results(22).imag(), r.imag() * e, 4));
+    /* r = a/e; */ ASSERT_TRUE(compare(h_results(23).real(), r.real() / 2, 4));
+    ASSERT_TRUE(compare(h_results(23).imag(), r.imag() / e, 4));
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int & /*i*/) const {
-    Kokkos::complex<double> a(1.5, 2.5);
-    Kokkos::complex<double> b(3.25, 5.75);
+    Kokkos::complex<RealType> a(1.5, 2.5);
+    Kokkos::complex<RealType> b(3.25, 5.75);
     // Basic math complex / complex
     d_results(0) = a + b;
     d_results(1) = a - b;
@@ -222,15 +241,15 @@ struct TestComplexBasicMath {
     d_results(4).real(1.0);
     d_results(4).imag(2.0);
     d_results(4) += a;
-    d_results(5) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(5) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(5) -= a;
-    d_results(6) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(6) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(6) *= a;
-    d_results(7) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(7) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(7) /= a;
 
     // Basic math complex / scalar
-    double c      = 9.3;
+    RealType c    = 9.3;
     d_results(8)  = a + c;
     d_results(9)  = a - c;
     d_results(10) = a * c;
@@ -238,11 +257,11 @@ struct TestComplexBasicMath {
     d_results(12).real(1.0);
     d_results(12).imag(2.0);
     d_results(12) += c;
-    d_results(13) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(13) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(13) -= c;
-    d_results(14) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(14) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(14) *= c;
-    d_results(15) = Kokkos::complex<double>(1.0, 2.0);
+    d_results(15) = Kokkos::complex<RealType>(1.0, 2.0);
     d_results(15) /= c;
 
     // Basic math scalar / complex
@@ -260,18 +279,29 @@ struct TestComplexBasicMath {
 };
 
 TEST(TEST_CATEGORY, complex_basic_math) {
-  TestComplexBasicMath<TEST_EXECSPACE> test;
-  test.testit();
+  TestComplexBasicMath<TEST_EXECSPACE, float> f;
+  f.testit();
+  TestComplexBasicMath<TEST_EXECSPACE, double> d;
+  d.testit();
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  TestComplexBasicMath<TEST_EXECSPACE, Kokkos::Experimental::half_t> h;
+  h.testit();
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  TestComplexBasicMath<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t> bh;
+  bh.testit();
+#endif
 }
 
-template <class ExecSpace>
-struct TestComplexSpecialFunctions {
-  Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_results;
-  typename Kokkos::View<Kokkos::complex<double> *, ExecSpace>::host_mirror_type
-      h_results;
+template <class ExecSpace, class RealType>
+struct TestComplexSpecialFunctions : KokkosTest::FloatingPointComparison {
+  Kokkos::View<Kokkos::complex<RealType> *, ExecSpace> d_results;
+  typename Kokkos::View<Kokkos::complex<RealType> *,
+                        ExecSpace>::host_mirror_type h_results;
 
   void testit() {
-    d_results = Kokkos::View<Kokkos::complex<double> *, ExecSpace>(
+    d_results = Kokkos::View<Kokkos::complex<RealType> *, ExecSpace>(
         "TestComplexSpecialFunctions", 20);
     h_results = Kokkos::create_mirror_view(d_results);
 
@@ -279,85 +309,85 @@ struct TestComplexSpecialFunctions {
     Kokkos::fence();
     Kokkos::deep_copy(h_results, d_results);
 
-    std::complex<double> a(1.5, 2.5);
-    double c = 9.3;
+    std::complex<RealType> a(1.5, 2.5);
+    RealType c = 9.3;
 
-    std::complex<double> r;
+    std::complex<RealType> r;
     r = a;
-    ASSERT_FLOAT_EQ(h_results(0).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(0).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(0).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(0).imag(), r.imag(), 4));
     r = std::sqrt(a);
-    ASSERT_FLOAT_EQ(h_results(1).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(1).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(1).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(1).imag(), r.imag(), 4));
     r = std::pow(a, c);
-    ASSERT_FLOAT_EQ(h_results(2).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(2).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(2).real(), r.real(), 6));
+    ASSERT_TRUE(compare(h_results(2).imag(), r.imag(), 6));
     r = std::abs(a);
-    ASSERT_FLOAT_EQ(h_results(3).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(3).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(3).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(3).imag(), r.imag(), 4));
     r = std::exp(a);
-    ASSERT_FLOAT_EQ(h_results(4).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(4).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(4).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(4).imag(), r.imag(), 4));
     r = Kokkos::exp(a);
-    ASSERT_FLOAT_EQ(h_results(4).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(4).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(4).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(4).imag(), r.imag(), 4));
     r = std::log(a);
-    ASSERT_FLOAT_EQ(h_results(5).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(5).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(5).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(5).imag(), r.imag(), 4));
     r = std::sin(a);
-    ASSERT_FLOAT_EQ(h_results(6).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(6).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(6).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(6).imag(), r.imag(), 4));
     r = std::cos(a);
-    ASSERT_FLOAT_EQ(h_results(7).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(7).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(7).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(7).imag(), r.imag(), 4));
     r = std::tan(a);
-    ASSERT_FLOAT_EQ(h_results(8).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(8).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(8).real(), r.real(), 40));
+    ASSERT_TRUE(compare(h_results(8).imag(), r.imag(), 4));
     r = std::sinh(a);
-    ASSERT_FLOAT_EQ(h_results(9).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(9).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(9).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(9).imag(), r.imag(), 4));
     r = std::cosh(a);
-    ASSERT_FLOAT_EQ(h_results(10).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(10).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(10).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(10).imag(), r.imag(), 4));
     r = std::tanh(a);
-    ASSERT_FLOAT_EQ(h_results(11).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(11).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(11).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(11).imag(), r.imag(), 12));
     r = std::asinh(a);
-    ASSERT_FLOAT_EQ(h_results(12).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(12).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(12).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(12).imag(), r.imag(), 4));
     r = std::acosh(a);
-    ASSERT_FLOAT_EQ(h_results(13).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(13).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(13).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(13).imag(), r.imag(), 4));
     // atanh
     r = std::atanh(a);
-    ASSERT_FLOAT_EQ(h_results(14).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(14).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(14).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(14).imag(), r.imag(), 4));
     r = std::asin(a);
-    ASSERT_FLOAT_EQ(h_results(15).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(15).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(15).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(15).imag(), r.imag(), 4));
     r = std::acos(a);
-    ASSERT_FLOAT_EQ(h_results(16).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(16).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(16).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(16).imag(), r.imag(), 4));
     // atan
     r = std::atan(a);
-    ASSERT_FLOAT_EQ(h_results(17).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(17).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(17).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(17).imag(), r.imag(), 4));
     // log10
     r = std::log10(a);
-    ASSERT_FLOAT_EQ(h_results(18).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(18).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(18).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(18).imag(), r.imag(), 4));
     // norm
     r = std::norm(a);
-    ASSERT_FLOAT_EQ(h_results(19).real(), r.real());
-    ASSERT_FLOAT_EQ(h_results(19).imag(), r.imag());
+    ASSERT_TRUE(compare(h_results(19).real(), r.real(), 4));
+    ASSERT_TRUE(compare(h_results(19).imag(), r.imag(), 4));
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const int & /*i*/) const {
-    Kokkos::complex<double> a(1.5, 2.5);
-    double c = 9.3;
+    Kokkos::complex<RealType> a(1.5, 2.5);
+    RealType c = 9.3;
 
-    d_results(0)  = Kokkos::complex<double>(Kokkos::real(a), Kokkos::imag(a));
+    d_results(0)  = Kokkos::complex<RealType>(Kokkos::real(a), Kokkos::imag(a));
     d_results(1)  = Kokkos::sqrt(a);
     d_results(2)  = Kokkos::pow(a, c);
     d_results(3)  = Kokkos::abs(a);
@@ -380,8 +410,25 @@ struct TestComplexSpecialFunctions {
   }
 };
 
+TEST(TEST_CATEGORY, complex_special_funtions) {
+  TestComplexSpecialFunctions<TEST_EXECSPACE, float> f;
+  f.testit();
+  TestComplexSpecialFunctions<TEST_EXECSPACE, double> d;
+  d.testit();
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  TestComplexSpecialFunctions<TEST_EXECSPACE, Kokkos::Experimental::half_t> h;
+  h.testit();
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  TestComplexSpecialFunctions<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t> bh;
+  bh.testit();
+#endif
+}
+
+template <typename RealType>
 void testComplexIO() {
-  Kokkos::complex<double> z = {3.14, 1.41};
+  Kokkos::complex<RealType> z = {3.14, 1.41};
   std::stringstream ss;
   ss << z;
   ASSERT_EQ(ss.str(), "(3.14,1.41)");
@@ -389,57 +436,77 @@ void testComplexIO() {
   ss.str("1 (2) (3,4)");
   ss.clear();
   ss >> z;
-  ASSERT_EQ(z, (Kokkos::complex<double>{1, 0}));
+  ASSERT_EQ(z, (Kokkos::complex<RealType>{1, 0}));
   ss >> z;
-  ASSERT_EQ(z, (Kokkos::complex<double>{2, 0}));
+  ASSERT_EQ(z, (Kokkos::complex<RealType>{2, 0}));
   ss >> z;
-  ASSERT_EQ(z, (Kokkos::complex<double>{3, 4}));
+  ASSERT_EQ(z, (Kokkos::complex<RealType>{3, 4}));
 }
 
-TEST(TEST_CATEGORY, complex_special_funtions) {
-  TestComplexSpecialFunctions<TEST_EXECSPACE> test;
-  test.testit();
-}
+TEST(TEST_CATEGORY, complex_io) {
+  testComplexIO<float>();
+  testComplexIO<double>();
 
-TEST(TEST_CATEGORY, complex_io) { testComplexIO(); }
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  testComplexIO<Kokkos::Experimental::half_t>();
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  testComplexIO<Kokkos::Experimental::bhalf_t>();
+#endif
+}
 
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<float>>);
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<double>>);
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+static_assert(std::is_trivially_copyable_v<
+              Kokkos::complex<Kokkos::Experimental::half_t>>);
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+static_assert(std::is_trivially_copyable_v<
+              Kokkos::complex<Kokkos::Experimental::bhalf_t>>);
+#endif
 #ifndef KOKKOS_IMPL_32BIT  // FIXME_32BIT
 // error: requested alignment '24' is not a positive power of 2
 static_assert(std::is_trivially_copyable_v<Kokkos::complex<long double>>);
 #endif
 
-template <class ExecSpace>
-struct TestBugPowAndLogComplex {
-  Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_pow;
-  Kokkos::View<Kokkos::complex<double> *, ExecSpace> d_log;
+template <class ExecSpace, class RealType>
+struct TestBugPowAndLogComplex : KokkosTest::FloatingPointComparison {
+  Kokkos::View<Kokkos::complex<RealType> *, ExecSpace> d_pow;
+  Kokkos::View<Kokkos::complex<RealType> *, ExecSpace> d_log;
   TestBugPowAndLogComplex() : d_pow("pow", 2), d_log("log", 2) { test(); }
   void test() {
     Kokkos::parallel_for(Kokkos::RangePolicy<ExecSpace>(0, 1), *this);
     auto h_pow =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d_pow);
-    ASSERT_FLOAT_EQ(h_pow(0).real(), 18);
-    ASSERT_FLOAT_EQ(h_pow(0).imag(), 26);
-    ASSERT_FLOAT_EQ(h_pow(1).real(), -18);
-    ASSERT_FLOAT_EQ(h_pow(1).imag(), 26);
+    ASSERT_TRUE(compare(h_pow(0).real(), 18, 4));
+    ASSERT_TRUE(compare(h_pow(0).imag(), 26, 4));
+    ASSERT_TRUE(compare(h_pow(1).real(), -18, 4));
+    ASSERT_TRUE(compare(h_pow(1).imag(), 26, 4));
     auto h_log =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), d_log);
-    ASSERT_FLOAT_EQ(h_log(0).real(), 1.151292546497023);
-    ASSERT_FLOAT_EQ(h_log(0).imag(), 0.3217505543966422);
-    ASSERT_FLOAT_EQ(h_log(1).real(), 1.151292546497023);
-    ASSERT_FLOAT_EQ(h_log(1).imag(), 2.819842099193151);
+    ASSERT_TRUE(compare(h_log(0).real(), 1.151292546497023, 4));
+    ASSERT_TRUE(compare(h_log(0).imag(), 0.3217505543966422, 4));
+    ASSERT_TRUE(compare(h_log(1).real(), 1.151292546497023, 4));
+    ASSERT_TRUE(compare(h_log(1).imag(), 2.819842099193151, 4));
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    d_pow(0) = Kokkos::pow(Kokkos::complex<double>(+3., 1.), 3.);
-    d_pow(1) = Kokkos::pow(Kokkos::complex<double>(-3., 1.), 3.);
-    d_log(0) = Kokkos::log(Kokkos::complex<double>(+3., 1.));
-    d_log(1) = Kokkos::log(Kokkos::complex<double>(-3., 1.));
+    d_pow(0) = Kokkos::pow(Kokkos::complex<RealType>(+3., 1.), 3.);
+    d_pow(1) = Kokkos::pow(Kokkos::complex<RealType>(-3., 1.), 3.);
+    d_log(0) = Kokkos::log(Kokkos::complex<RealType>(+3., 1.));
+    d_log(1) = Kokkos::log(Kokkos::complex<RealType>(-3., 1.));
   }
 };
 
 TEST(TEST_CATEGORY, complex_issue_3865) {
-  TestBugPowAndLogComplex<TEST_EXECSPACE>();
+  //  TestBugPowAndLogComplex<TEST_EXECSPACE, float>();
+  TestBugPowAndLogComplex<TEST_EXECSPACE, double>();
+  // #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  // TestBugPowAndLogComplex<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+  // #endif
+  // #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  // TestBugPowAndLogComplex<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+  // #endif
 }
 
 TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
@@ -479,11 +546,11 @@ TEST(TEST_CATEGORY, complex_operations_arithmetic_types_overloads) {
                                 Kokkos::complex<long double>>));
 }
 
-template <class ExecSpace>
-struct TestComplexStructuredBindings {
+template <class ExecSpace, class RealType>
+struct TestComplexStructuredBindings : KokkosTest::FloatingPointComparison {
   using exec_space       = ExecSpace;
-  using value_type       = double;
-  using complex_type     = Kokkos::complex<double>;
+  using value_type       = RealType;
+  using complex_type     = Kokkos::complex<RealType>;
   using device_view_type = Kokkos::View<complex_type *, exec_space>;
   using host_view_type   = typename device_view_type::host_mirror_type;
 
@@ -491,7 +558,7 @@ struct TestComplexStructuredBindings {
   host_view_type h_results;
 
   // tuple_size
-  static_assert(std::is_same_v<std::tuple_size<complex_type>::type,
+  static_assert(std::is_same_v<typename std::tuple_size<complex_type>::type,
                                std::integral_constant<size_t, 2>>);
 
   // tuple_element
@@ -544,26 +611,26 @@ struct TestComplexStructuredBindings {
     Kokkos::deep_copy(h_results, d_results);
 
     // get lvalue
-    ASSERT_FLOAT_EQ(h_results[0].real(), 2.);
-    ASSERT_FLOAT_EQ(h_results[0].imag(), 3.);
+    ASSERT_TRUE(compare(h_results[0].real(), 2., 4));
+    ASSERT_TRUE(compare(h_results[0].imag(), 3., 4));
 
     // get rvalue
-    ASSERT_FLOAT_EQ(h_results[1].real(), 2.);
-    ASSERT_FLOAT_EQ(h_results[1].imag(), 3.);
+    ASSERT_TRUE(compare(h_results[1].real(), 2., 4));
+    ASSERT_TRUE(compare(h_results[1].imag(), 3., 4));
 
     // get const lvalue
-    ASSERT_FLOAT_EQ(h_results[2].real(), 5.);
-    ASSERT_FLOAT_EQ(h_results[2].imag(), 7.);
+    ASSERT_TRUE(compare(h_results[2].real(), 5., 4));
+    ASSERT_TRUE(compare(h_results[2].imag(), 7., 4));
 
     // get const rvalue
-    ASSERT_FLOAT_EQ(h_results[3].real(), 5.);
-    ASSERT_FLOAT_EQ(h_results[3].imag(), 7.);
+    ASSERT_TRUE(compare(h_results[3].real(), 5., 4));
+    ASSERT_TRUE(compare(h_results[3].imag(), 7., 4));
 
     // swap real and imaginary
-    ASSERT_FLOAT_EQ(h_results[4].real(), 11.);
-    ASSERT_FLOAT_EQ(h_results[4].imag(), 13.);
-    ASSERT_FLOAT_EQ(h_results[5].real(), 13.);
-    ASSERT_FLOAT_EQ(h_results[5].imag(), 11.);
+    ASSERT_TRUE(compare(h_results[4].real(), 11., 4));
+    ASSERT_TRUE(compare(h_results[4].imag(), 13., 4));
+    ASSERT_TRUE(compare(h_results[5].real(), 13., 4));
+    ASSERT_TRUE(compare(h_results[5].imag(), 11., 4));
   }
 
   KOKKOS_FUNCTION
@@ -612,8 +679,20 @@ struct TestComplexStructuredBindings {
 };
 
 TEST(TEST_CATEGORY, complex_structured_bindings) {
-  TestComplexStructuredBindings<TEST_EXECSPACE> test;
-  test.testit();
+  TestComplexStructuredBindings<TEST_EXECSPACE, float> f;
+  f.testit();
+  TestComplexStructuredBindings<TEST_EXECSPACE, double> d;
+  d.testit();
+
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+  TestComplexStructuredBindings<TEST_EXECSPACE, Kokkos::Experimental::half_t> h;
+  h.testit();
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+  TestComplexStructuredBindings<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>
+      bh;
+  bh.testit();
+#endif
 }
 
 #define CHECK_COMPLEX(_value_, _real_, _imag_) \
@@ -621,30 +700,31 @@ TEST(TEST_CATEGORY, complex_structured_bindings) {
   if (_value_.real() != _real_) return false;  \
   if (_value_.imag() != _imag_) return false;
 
+template <class RealType>
 constexpr bool can_appear_in_constant_expressions() {
-  const Kokkos::complex<double> from_single{1.2};
-  const Kokkos::complex<double> from_both{1.2, 3.4};
-  const Kokkos::complex<double> from_none{};
+  const Kokkos::complex<RealType> from_single{1.2};
+  const Kokkos::complex<RealType> from_both{1.2, 3.4};
+  const Kokkos::complex<RealType> from_none{};
 
   CHECK_COMPLEX(from_single, 1.2, 0.);
   CHECK_COMPLEX(from_both, 1.2, 3.4);
   CHECK_COMPLEX(from_none, 0., 0.);
 
-  Kokkos::complex<double> from_copy_assign;
+  Kokkos::complex<RealType> from_copy_assign;
   from_copy_assign = from_both;
   const auto from_copy_constr(from_both);
 
   CHECK_COMPLEX(from_copy_assign, 1.2, 3.4);
   CHECK_COMPLEX(from_copy_constr, 1.2, 3.4);
 
-  Kokkos::complex<double> from_move_assign;
+  Kokkos::complex<RealType> from_move_assign;
   from_move_assign = std::move(from_both);
   const auto from_move_constr(std::move(from_copy_assign));
 
   CHECK_COMPLEX(from_move_assign, 1.2, 3.4);
   CHECK_COMPLEX(from_move_constr, 1.2, 3.4);
 
-  Kokkos::complex<double> from_real;
+  Kokkos::complex<RealType> from_real;
   from_real = 4.;
 
   CHECK_COMPLEX(from_real, 4., 0.);
@@ -654,29 +734,57 @@ constexpr bool can_appear_in_constant_expressions() {
 
 #undef CHECK_COMPLEX
 
-static_assert(can_appear_in_constant_expressions());
+// TODO find values that can be represented exactly in float, half, bhalf
+// static_assert(can_appear_in_constant_expressions<float>());
+static_assert(can_appear_in_constant_expressions<double>());
+// #ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+// static_assert(
+// can_appear_in_constant_expressions<Kokkos::Experimental::half_t>());
+// #endif
+// #ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+// static_assert(
+// can_appear_in_constant_expressions<Kokkos::Experimental::bhalf_t>());
+// #endif
 
+template <class RealType>
 constexpr bool comparison_in_constant_expression() {
-  static_assert(Kokkos::complex<double>{42., 43.} ==
-                Kokkos::complex<double>{42., 43.});
-  static_assert(Kokkos::complex<double>{42., 43.} !=
-                Kokkos::complex<double>{42., 42.});
+  static_assert(Kokkos::complex<RealType>{42., 43.} ==
+                Kokkos::complex<RealType>{42., 43.});
+  static_assert(Kokkos::complex<RealType>{42., 43.} !=
+                Kokkos::complex<RealType>{42., 42.});
 
-  static_assert(Kokkos::complex<double>{42., 0.} == double{42.});
-  static_assert(Kokkos::complex<double>{42., 43.} != double{42.});
+  static_assert(Kokkos::complex<RealType>{42., 0.} == RealType{42.});
+  static_assert(Kokkos::complex<RealType>{42., 43.} != RealType{42.});
 
-  static_assert(double{42.} == Kokkos::complex<double>{42., 0.});
-  static_assert(double{43.} != Kokkos::complex<double>{42., 0.});
+  static_assert(RealType{42.} == Kokkos::complex<RealType>{42., 0.});
+  static_assert(RealType{43.} != Kokkos::complex<RealType>{42., 0.});
 
   return true;
 }
 
-static_assert(comparison_in_constant_expression());
+static_assert(comparison_in_constant_expression<float>());
+static_assert(comparison_in_constant_expression<double>());
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+static_assert(
+    comparison_in_constant_expression<Kokkos::Experimental::half_t>());
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+static_assert(
+    comparison_in_constant_expression<Kokkos::Experimental::bhalf_t>());
+#endif
 
+template <class RealType>
 constexpr bool test_complex_norm() {
-  return Kokkos::norm(Kokkos::complex<double>{4., 2.}) == 20.;
+  return Kokkos::norm(Kokkos::complex<RealType>{4., 2.}) == 20.;
 }
-static_assert(test_complex_norm());
+static_assert(test_complex_norm<float>());
+static_assert(test_complex_norm<double>());
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+static_assert(test_complex_norm<Kokkos::Experimental::half_t>());
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+static_assert(test_complex_norm<Kokkos::Experimental::bhalf_t>());
+#endif
 
 constexpr bool test_overload_norm() {
   constexpr auto res_int = Kokkos::norm(int(100000));
@@ -691,18 +799,26 @@ constexpr bool test_overload_norm() {
 }
 static_assert(test_overload_norm());
 
+template <class RealType>
 constexpr bool test_complex_conj() {
-  static_assert(Kokkos::conj(Kokkos::complex<double>{1., 1.}) ==
-                Kokkos::complex<double>{1., -1.});
-  static_assert(Kokkos::conj(Kokkos::complex<double>{1., -1.}) ==
-                Kokkos::complex<double>{1., 1.});
-  static_assert(Kokkos::conj(Kokkos::complex<double>{-1., 1.}) ==
-                Kokkos::complex<double>{-1., -1.});
-  static_assert(Kokkos::conj(Kokkos::complex<double>{-1., -1.}) ==
-                Kokkos::complex<double>{-1., 1.});
+  static_assert(Kokkos::conj(Kokkos::complex<RealType>{1., 1.}) ==
+                Kokkos::complex<RealType>{1., -1.});
+  static_assert(Kokkos::conj(Kokkos::complex<RealType>{1., -1.}) ==
+                Kokkos::complex<RealType>{1., 1.});
+  static_assert(Kokkos::conj(Kokkos::complex<RealType>{-1., 1.}) ==
+                Kokkos::complex<RealType>{-1., -1.});
+  static_assert(Kokkos::conj(Kokkos::complex<RealType>{-1., -1.}) ==
+                Kokkos::complex<RealType>{-1., 1.});
   return true;
 }
-static_assert(test_complex_conj());
+static_assert(test_complex_conj<float>());
+static_assert(test_complex_conj<double>());
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+static_assert(test_complex_conj<Kokkos::Experimental::half_t>());
+#endif
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+static_assert(test_complex_conj<Kokkos::Experimental::bhalf_t>());
+#endif
 
 }  // namespace Test
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -19,6 +19,8 @@ import kokkos.core;
 #include <cstdint>
 #include <cfloat>
 
+#include "KokkosTest_Utils.hpp"
+
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || \
     defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENACC)
 #else
@@ -219,104 +221,6 @@ using math_binary_function_return_type_t = typename math_binary_function_return_
 template <class T, class U, class V>
 using math_ternary_function_return_type_t = math_binary_function_return_type_t<
     T, math_binary_function_return_type_t<U, V>>;
-
-struct FloatingPointComparison {
- private:
-  template <class T>
-  KOKKOS_FUNCTION double eps(T) const {
-    return DBL_EPSILON;
-  }
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  KOKKOS_FUNCTION
-  KE::half_t eps(KE::half_t) const {
-// FIXME_NVHPC compile-time error
-#ifdef KOKKOS_COMPILER_NVHPC
-    return 0.0009765625F;
-#else
-    return KE::epsilon<KE::half_t>::value;
-#endif
-  }
-#endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
-  KOKKOS_FUNCTION
-  KE::bhalf_t eps(KE::bhalf_t) const {
-// FIXME_NVHPC compile-time error
-#ifdef KOKKOS_COMPILER_NVHPC
-    return 0.0078125;
-#else
-    return KE::epsilon<KE::bhalf_t>::value;
-#endif
-  }
-#endif
-  KOKKOS_FUNCTION
-  double eps(float) const { return FLT_EPSILON; }
-// POWER9 gives unexpected values with LDBL_EPSILON issues
-// https://stackoverflow.com/questions/68960416/ppc64-long-doubles-machine-epsilon-calculation
-#if defined(KOKKOS_ARCH_POWER9) || defined(KOKKOS_ARCH_POWER8)
-  KOKKOS_FUNCTION
-  double eps(long double) const { return DBL_EPSILON; }
-#else
-  KOKKOS_FUNCTION
-  double eps(long double) const { return LDBL_EPSILON; }
-#endif
-  // Using absolute here instead of abs, since we actually test abs ...
-  template <class T>
-  KOKKOS_FUNCTION std::enable_if_t<std::is_signed_v<T>, T> absolute(
-      T val) const {
-    return val < T(0) ? -val : val;
-  }
-
-  template <class T>
-  KOKKOS_FUNCTION std::enable_if_t<!std::is_signed_v<T>, T> absolute(
-      T val) const {
-    return val;
-  }
-
- public:
-  template <class FPT>
-  KOKKOS_FUNCTION bool compare_near_zero(FPT const& fpv, int ulp) const {
-    auto abs_tol = eps(fpv) * ulp;
-
-    bool ar = absolute(fpv) <= abs_tol;
-    if (!ar) {
-      Kokkos::printf("absolute value exceeds tolerance [|%e| > %e]\n",
-                     (double)fpv, (double)abs_tol);
-    }
-
-    return ar;
-  }
-
-  template <class Lhs, class Rhs>
-  KOKKOS_FUNCTION bool compare(Lhs const& lhs, Rhs const& rhs, int ulp) const {
-    if (lhs == 0) {
-      return compare_near_zero(rhs, ulp);
-    } else if (rhs == 0) {
-      return compare_near_zero(lhs, ulp);
-    } else {
-      auto rel_tol     = (eps(lhs) < eps(rhs) ? eps(lhs) : eps(rhs)) * ulp;
-      double abs_diff  = static_cast<double>(rhs > lhs ? rhs - lhs : lhs - rhs);
-      double min_denom = static_cast<double>(
-          absolute(rhs) < absolute(lhs) ? absolute(rhs) : absolute(lhs));
-      double rel_diff = abs_diff / min_denom;
-      bool ar         = rel_diff <= rel_tol;
-      if (!ar) {
-        Kokkos::printf("relative difference exceeds tolerance [%e > %e]\n",
-                       (double)rel_diff, (double)rel_tol);
-      }
-
-      return ar;
-    }
-  }
-};
-
-struct IntegerComparison {
-  template <class Lhs, class Rhs>
-  KOKKOS_FUNCTION bool compare(Lhs const& lhs, Rhs const& rhs) const {
-    static_assert(std::is_integral_v<Lhs>);
-    static_assert(std::is_integral_v<Rhs>);
-    return lhs == rhs;
-  }
-};
 
 template <class Floating>
 struct ConvertibleTo {
@@ -781,7 +685,7 @@ DEFINE_TYPE_NAME(long double)
 
 template <class Space, class Func, class Arg, std::size_t N,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathUnaryFunction : FloatingPointComparison {
+struct TestMathUnaryFunction : KokkosTest::FloatingPointComparison {
   Arg val_[N];
   Ret res_[N];
   TestMathUnaryFunction(const Arg (&val)[N]) {
@@ -843,7 +747,7 @@ void do_test_half_math_unary_function(const Arg (&x)[N]) {
   do_test_half_math_unary_function<T, TEST_EXECSPACE, MathUnaryFunction_##FUNC>
 
 template <class Space, class Func, class Arg, std::size_t N>
-struct TestIntMathUnaryFunction : IntegerComparison {
+struct TestIntMathUnaryFunction : KokkosTest::IntegerComparison {
   Arg val_[N];
   int res_[N];
   TestIntMathUnaryFunction(const Arg (&val)[N]) {
@@ -907,7 +811,7 @@ void do_test_int_half_math_unary_function(const Arg (&x)[N]) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
-struct TestMathBinaryFunction : FloatingPointComparison {
+struct TestMathBinaryFunction : KokkosTest::FloatingPointComparison {
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
@@ -942,7 +846,7 @@ void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_unary_function_return_type_t<Arg1>>
-struct TestMathBinaryIntFunction : FloatingPointComparison {
+struct TestMathBinaryIntFunction : KokkosTest::FloatingPointComparison {
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
@@ -977,7 +881,7 @@ void do_test_math_binary_int_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathBinaryPtrFunction : FloatingPointComparison {
+struct TestMathBinaryPtrFunction : KokkosTest::FloatingPointComparison {
   Arg val_;
   Ret res_frac_;
   Ret res_int_;
@@ -1056,7 +960,7 @@ void do_test_math_binary_predicate(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathBinaryIntPtrFunction : FloatingPointComparison {
+struct TestMathBinaryIntPtrFunction : KokkosTest::FloatingPointComparison {
   Arg val_;
   int res1_;
   Ret res2_;
@@ -1100,7 +1004,7 @@ void do_test_math_binary_int_ptr_function(Arg x) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
-struct TestMathTernaryIntPtrFunction : FloatingPointComparison {
+struct TestMathTernaryIntPtrFunction : KokkosTest::FloatingPointComparison {
   Arg1 val1_;
   Arg2 val2_;
   int val_;
@@ -1140,7 +1044,7 @@ void do_test_math_ternary_int_ptr_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg1, class Arg2, class Arg3,
           class Ret = math_ternary_function_return_type_t<Arg1, Arg2, Arg3>>
-struct TestMathTernaryFunction : FloatingPointComparison {
+struct TestMathTernaryFunction : KokkosTest::FloatingPointComparison {
   Arg1 val1_;
   Arg2 val2_;
   Arg3 val3_;
@@ -2104,7 +2008,8 @@ TEST(TEST_CATEGORY, mathematical_functions_floating_point_absolute_value) {
 }
 
 template <class Space>
-struct TestFloatingPointRemainderFunction : FloatingPointComparison {
+struct TestFloatingPointRemainderFunction
+    : KokkosTest::FloatingPointComparison {
   TestFloatingPointRemainderFunction() { run(); }
   void run() const {
     int errors = 0;
@@ -2181,7 +2086,8 @@ TEST(TEST_CATEGORY, mathematical_functions_remainder_function) {
 }
 
 template <class Space>
-struct TestIEEEFloatingPointRemainderFunction : FloatingPointComparison {
+struct TestIEEEFloatingPointRemainderFunction
+    : KokkosTest::FloatingPointComparison {
   TestIEEEFloatingPointRemainderFunction() { run(); }
   void run() const {
     int errors = 0;


### PR DESCRIPTION
This PR extends the allowed types in `complex` to include `half_t` and `bhalf_t`.
The main work consisted of extending our testing to include these types.

### Related issues / PRs
<!-- Link any related issues or PRs. -->
First part to resolving #9174
Depends on #9199
Related https://github.com/kokkos/kokkos/pull/9203

### TODO

- [ ] Investigate why some operations need way more ULP than others to pass. This is especially interesting since `ASSERT_FLOAT_EQ` was passing, but [states that it uses 4 ULP](https://google.github.io/googletest/reference/assertions.html#EXPECT_FLOAT_EQ)
- [ ] Improve the printing in case of testfailure... right now we get the line of the assertion failure but it is not easy to see which type that failed for
- [ ] Find non trivial values that can be exactly represented by `half_t` and `bhalf_t` so they can be used in constant expressions
- [ ] Find a way to test `overload_norm`
- [ ] Find a way to define the target values for `log` depending on the precision
- [ ] Check if `floating_point_wrapper` and related functions work as `constexpr`

### Changelog Entry
Extend support of `complex` to `half_t` and `bhalf_t`
