### PR TITLE
Refactor half_t detection

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -429,7 +429,7 @@ struct rand<Generator, unsigned long long> {
   }
 };
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 template <class Generator>
 struct rand<Generator, Kokkos::Experimental::half_t> {
   using half = Kokkos::Experimental::half_t;
@@ -446,9 +446,9 @@ struct rand<Generator, Kokkos::Experimental::half_t> {
     return half(gen.frand(float(start), float(end)));
   }
 };
-#endif  // defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#endif  // !KOKKOS_HALF_T_IS_FLOAT
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <class Generator>
 struct rand<Generator, Kokkos::Experimental::bhalf_t> {
   using bhalf = Kokkos::Experimental::bhalf_t;
@@ -465,7 +465,7 @@ struct rand<Generator, Kokkos::Experimental::bhalf_t> {
     return bhalf(gen.frand(float(start), float(end)));
   }
 };
-#endif  // defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#endif  // !KOKKOS_BHALF_T_IS_FLOAT
 
 template <class Generator>
 struct rand<Generator, float> {

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -265,13 +265,13 @@ struct test_random_scalar {
           variance_expect / (result.variance / num_draws / 3) - 1.0;
       double covariance_eps =
           result.covariance / num_draws / 2 / variance_expect;
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       if (!std::is_same_v<Scalar, Kokkos::Experimental::bhalf_t>) {
 #endif
         EXPECT_LT(std::abs(mean_eps), tolerance);
         EXPECT_LT(std::abs(variance_eps), 1.5 * tolerance);
         EXPECT_LT(std::abs(covariance_eps), 2.0 * tolerance);
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       }
 #endif
     }
@@ -296,7 +296,7 @@ struct test_random_scalar {
       double covariance_eps =
           (result.covariance / HIST_DIM1D - covariance_expect) / mean_expect;
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
       if (std::is_same_v<Scalar, Kokkos::Experimental::half_t>) {
         mean_eps_expect       = 0.0003;
         variance_eps_expect   = 1.0;
@@ -304,13 +304,13 @@ struct test_random_scalar {
       }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       if (!std::is_same_v<Scalar, Kokkos::Experimental::bhalf_t>) {
 #endif
         EXPECT_LT(std::abs(mean_eps), mean_eps_expect);
         EXPECT_LT(std::abs(variance_eps), variance_eps_expect);
         EXPECT_LT(std::abs(covariance_eps), covariance_eps_expect);
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       }
 #endif
 
@@ -342,19 +342,19 @@ struct test_random_scalar {
       double covariance_eps =
           (result.covariance / HIST_DIM1D - covariance_expect) / mean_expect;
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
       if (std::is_same_v<Scalar, Kokkos::Experimental::half_t>) {
         variance_factor = 7;
       }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       if (!std::is_same_v<Scalar, Kokkos::Experimental::bhalf_t>) {
 #endif
         EXPECT_LT(std::abs(mean_eps), tolerance);
         EXPECT_LT(std::abs(variance_eps), variance_factor);
         EXPECT_LT(std::abs(covariance_eps), variance_factor);
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
       }
 #endif
 

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -4,7 +4,6 @@
 #ifndef KOKKOS_CUDA_HALF_HPP_
 #define KOKKOS_CUDA_HALF_HPP_
 
-#include <Kokkos_Half.hpp>
 #include <impl/Kokkos_NvidiaGpuArchitectures.hpp>
 
 #include <cuda_bf16.h>

--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -12,7 +12,7 @@ namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(half_t val) { return val; }
@@ -98,7 +98,7 @@ cast_from_half(half_t val) {
 
 /************************** bhalf conversions *********************************/
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 
 // if architecture is older than Ampere
 #if KOKKOS_IMPL_ARCH_NVIDIA_GPU < 80

--- a/core/src/Cuda/Kokkos_Cuda_Half_Impl_Type.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Impl_Type.hpp
@@ -11,23 +11,17 @@
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 
-#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
-// Make sure no one else tries to define half_t
-#define KOKKOS_IMPL_HALF_TYPE_DEFINED
-
 namespace Kokkos::Impl {
 
 struct half_impl_t {
   using type = __half;
 };
-#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
 struct bhalf_impl_t {
   using type = __nv_bfloat16;
 };
 
 }  // namespace Kokkos::Impl
 
-#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 #endif  // Disables for half_t on cuda: MAXWELL50||MAXWELL52
 
 #endif

--- a/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp
@@ -38,8 +38,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
 }
 
 // Function for bhalf are not available prior to Ampere
-#if defined(KOKKOS_IMPL_BHALF_TYPE_DEFINED) && \
-    (KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80)
+#if !KOKKOS_BHALF_T_IS_FLOAT && (KOKKOS_IMPL_ARCH_NVIDIA_GPU >= 80)
 
 #define KOKKOS_CUDA_BHALF_UNARY_FUNCTION_IMPL(OP, CUDA_NAME) \
   KOKKOS_CUDA_HALF_UNARY_FUNCTION(OP, CUDA_NAME, Kokkos::Experimental::bhalf_t)

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -6,8 +6,6 @@
 
 #if !KOKKOS_HALF_T_IS_FLOAT
 
-#include <Kokkos_Half.hpp>
-
 namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -4,7 +4,7 @@
 #ifndef KOKKOS_HIP_HALF_HPP_
 #define KOKKOS_HIP_HALF_HPP_
 
-#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+#if !KOKKOS_HALF_T_IS_FLOAT
 
 #include <Kokkos_Half.hpp>
 

--- a/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Impl_Type.hpp
@@ -7,10 +7,6 @@
 #include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
 
-#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
-// Make sure no one else tries to define half_t
-#define KOKKOS_IMPL_HALF_TYPE_DEFINED
-
 namespace Kokkos {
 namespace Impl {
 struct half_impl_t {
@@ -18,18 +14,12 @@ struct half_impl_t {
 };
 }  // namespace Impl
 }  // namespace Kokkos
-#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 
-#ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
-// Make sure no one else tries to define bhalf_t
-#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
 namespace Kokkos::Impl {
 struct bhalf_impl_t {
   using type = __hip_bfloat16;
 };
 
 }  // namespace Kokkos::Impl
-
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
 
 #endif  // KOKKOS_ENABLE_HIP

--- a/core/src/Kokkos_Half.hpp
+++ b/core/src/Kokkos_Half.hpp
@@ -9,6 +9,15 @@
 #endif
 
 #include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
+#ifdef KOKKOS_ENABLE_CUDA
+#include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+#include <HIP/Kokkos_HIP_Half_Conversion.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+#include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
+#endif
 #include <impl/Kokkos_Half_NumericTraits.hpp>
 #include <impl/Kokkos_Half_ReductionIdentity.hpp>
 #include <impl/Kokkos_Half_MathematicalFunctions.hpp>

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -681,4 +681,16 @@
 #define KOKKOS_IMPL_EXPORT
 #endif
 
+#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_HALF_T_IS_FLOAT false
+#else
+#define KOKKOS_HALF_T_IS_FLOAT true
+#endif
+
+#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#define KOKKOS_BHALF_T_IS_FLOAT false
+#else
+#define KOKKOS_BHALF_T_IS_FLOAT true
+#endif
+
 #endif  // #ifndef KOKKOS_MACROS_HPP

--- a/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Impl_Type.hpp
@@ -8,24 +8,14 @@
 
 #include <sycl/sycl.hpp>
 
-// Make sure no one else tries to define half_t
-#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
-
 namespace Kokkos::Impl {
 struct half_impl_t {
   using type = sycl::half;
 };
 }  // namespace Kokkos::Impl
-#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
 
-// Make sure no one else tries to define bhalf_t
-#ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
 // FIXME_SYCL Evaluate when to drop the check
 #if __has_include(<sycl/ext/oneapi/bfloat16.hpp>)
-#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
-#define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 namespace Kokkos::Impl {
 struct bhalf_impl_t {
   using type = sycl::ext::oneapi::bfloat16;
@@ -35,13 +25,10 @@ struct bhalf_impl_t {
 // FIXME_SYCL bfloat16 is only supported for compute capability 8.0 or higher
 // on Nvidia GPUs but SYCL_EXT_ONEAPI_BFLOAT16 is defined even for lower compute
 // capability.
-#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
-#define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 namespace Kokkos::Impl {
 struct bhalf_impl_t {
   using type = sycl::ext::oneapi::experimental::bfloat16;
 };
 }  // namespace Kokkos::Impl
 #endif  // test for bfloat16 support
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
 #endif  // KOKKOS_SYCL_HALF_IMPL_TYPE_HPP_

--- a/core/src/decl/Kokkos_Declare_CUDA.hpp
+++ b/core/src/decl/Kokkos_Declare_CUDA.hpp
@@ -6,9 +6,6 @@
 
 #if defined(KOKKOS_ENABLE_CUDA)
 #include <Cuda/Kokkos_Cuda.hpp>
-#include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
-#include <Cuda/Kokkos_Cuda_Half_MathematicalFunctions.hpp>
-#include <Cuda/Kokkos_Cuda_Half_Conversion.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel_MDRange.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel_Range.hpp>
 #include <Cuda/Kokkos_Cuda_Parallel_Team.hpp>

--- a/core/src/decl/Kokkos_Declare_HIP.hpp
+++ b/core/src/decl/Kokkos_Declare_HIP.hpp
@@ -8,9 +8,6 @@
 #include <HIP/Kokkos_HIP.hpp>
 #include <HIP/Kokkos_HIP_Space.hpp>
 #include <HIP/Kokkos_HIP_DeepCopy.hpp>
-#include <HIP/Kokkos_HIP_Half_Impl_Type.hpp>
-#include <HIP/Kokkos_HIP_Half_Conversion.hpp>
-#include <HIP/Kokkos_HIP_Half_MathematicalFunctions.hpp>
 #include <HIP/Kokkos_HIP_Instance.hpp>
 #include <HIP/Kokkos_HIP_MDRangePolicy.hpp>
 #include <HIP/Kokkos_HIP_ParallelFor_Range.hpp>

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -9,9 +9,6 @@
 #ifdef KOKKOS_IMPL_SYCL_GRAPH_SUPPORT
 #include <SYCL/Kokkos_SYCL_GraphNodeKernel.hpp>
 #endif
-#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
-#include <SYCL/Kokkos_SYCL_Half_Conversion.hpp>
-#include <SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp>
 #include <SYCL/Kokkos_SYCL_DeepCopy.hpp>
 #include <SYCL/Kokkos_SYCL_MDRangePolicy.hpp>
 #include <SYCL/Kokkos_SYCL_ParallelFor_Range.hpp>

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -23,21 +23,7 @@ template <class T>
 struct is_bfloat16 : std::false_type {};
 }  // namespace Kokkos::Experimental::Impl
 
-#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
-
-// KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH: A macro to select which
-// floating_pointer_wrapper operator paths should be used. For CUDA, let the
-// compiler conditionally select when device ops are used. For SYCL, we have a
-// full half type on both host and device. For HIP, we have a full half type on
-// host and device only for ROCm 6.4 and later.
-#if defined(__CUDA_ARCH__) ||                                 \
-    (defined(KOKKOS_ENABLE_HIP) &&                            \
-     ((HIP_VERSION_MAJOR > 6 ||                               \
-       (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)) || \
-      defined(__HIP_DEVICE_COMPILE__))) ||                    \
-    defined(KOKKOS_ENABLE_SYCL)
-#define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
-#endif
+#if !KOKKOS_HALF_T_IS_FLOAT
 
 /************************* BEGIN forward declarations *************************/
 namespace Kokkos {
@@ -49,7 +35,7 @@ class floating_point_wrapper;
 
 // Declare half_t (binary16)
 using half_t = Kokkos::Experimental::Impl::floating_point_wrapper<
-    Kokkos::Impl::half_impl_t ::type>;
+    Kokkos::Impl::half_impl_t::type>;
 namespace Impl {
 template <>
 struct is_float16<half_t> : std::true_type {};
@@ -115,7 +101,7 @@ KOKKOS_INLINE_FUNCTION
         cast_from_half(half_t);
 
 // declare bhalf_t
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 using bhalf_t = Kokkos::Experimental::Impl::floating_point_wrapper<
     Kokkos::Impl ::bhalf_impl_t ::type>;
 namespace Impl {
@@ -181,27 +167,27 @@ template <class T>
 KOKKOS_INLINE_FUNCTION
     std::enable_if_t<std::is_same_v<T, unsigned long long>, T>
         cast_from_bhalf(bhalf_t);
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
     T x, const Kokkos::Impl::half_impl_t::type&);
 
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
     T x, const Kokkos::Impl::bhalf_impl_t::type&);
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 
 template <class T>
 static KOKKOS_INLINE_FUNCTION T
 cast_from_wrapper(const Kokkos::Experimental::half_t& x);
 
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <class T>
 static KOKKOS_INLINE_FUNCTION T
 cast_from_wrapper(const Kokkos::Experimental::bhalf_t& x);
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 /************************** END forward declarations **************************/
 
 namespace Impl {
@@ -251,7 +237,7 @@ inline constexpr BitComparisonWrapper<FloatType> exponent_mask;
 template <typename FloatType>
 inline constexpr BitComparisonWrapper<FloatType> fraction_mask;
 
-#ifdef KOKKOS_IMPL_HALF_TYPE_DEFINED
+#if !KOKKOS_HALF_T_IS_FLOAT
 template <>
 inline constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
     exponent_mask<Kokkos::Experimental::half_t>{0b0'11111'0000000000};
@@ -260,7 +246,7 @@ inline constexpr BitComparisonWrapper<Kokkos::Experimental::half_t>
     fraction_mask<Kokkos::Experimental::half_t>{0b0'00000'1111111111};
 #endif
 
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <>
 inline constexpr BitComparisonWrapper<Kokkos::Experimental::bhalf_t>
     exponent_mask<Kokkos::Experimental::bhalf_t>{0b0'11111111'0000000};
@@ -889,13 +875,13 @@ static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t cast_to_wrapper(
   return Kokkos::Experimental::cast_to_half(x);
 }
 
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <class T>
 static KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t cast_to_wrapper(
     T x, const Kokkos::Impl::bhalf_impl_t::type&) {
   return Kokkos::Experimental::cast_to_bhalf(x);
 }
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 
 template <class T>
 static KOKKOS_INLINE_FUNCTION T
@@ -903,24 +889,22 @@ cast_from_wrapper(const Kokkos::Experimental::half_t& x) {
   return Kokkos::Experimental::cast_from_half<T>(x);
 }
 
-#ifdef KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <class T>
 static KOKKOS_INLINE_FUNCTION T
 cast_from_wrapper(const Kokkos::Experimental::bhalf_t& x) {
   return Kokkos::Experimental::cast_from_bhalf<T>(x);
 }
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 
 }  // namespace Experimental
 }  // namespace Kokkos
 
-#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
+#endif
 
 // If none of the above actually did anything and defined a half precision type
 // define a fallback implementation here using float
-#ifndef KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_IMPL_HALF_TYPE_DEFINED
-#define KOKKOS_HALF_T_IS_FLOAT true
+#if KOKKOS_HALF_T_IS_FLOAT
 namespace Kokkos {
 namespace Impl {
 struct half_impl_t {
@@ -973,14 +957,9 @@ cast_from_half(half_t val) {
 
 }  // namespace Experimental
 }  // namespace Kokkos
+#endif
 
-#else
-#define KOKKOS_HALF_T_IS_FLOAT false
-#endif  // KOKKOS_IMPL_HALF_TYPE_DEFINED
-
-#ifndef KOKKOS_IMPL_BHALF_TYPE_DEFINED
-#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
-#define KOKKOS_BHALF_T_IS_FLOAT true
+#if KOKKOS_BHALF_T_IS_FLOAT
 namespace Kokkos {
 namespace Impl {
 struct bhalf_impl_t {
@@ -1031,8 +1010,6 @@ cast_from_bhalf(bhalf_t val) {
 }
 }  // namespace Experimental
 }  // namespace Kokkos
-#else
-#define KOKKOS_BHALF_T_IS_FLOAT false
-#endif  // KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#endif
 
 #endif  // KOKKOS_HALF_FLOATING_POINT_WRAPPER_HPP_

--- a/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
+++ b/core/src/impl/Kokkos_Half_FloatingPointWrapper.hpp
@@ -10,6 +10,17 @@
 #include <type_traits>
 #include <iosfwd>  // istream & ostream for extraction and insertion ops
 #include <string>
+#include <cstdint>
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include <Cuda/Kokkos_Cuda_Half_Impl_Type.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+#include <HIP/Kokkos_HIP_Half_Impl_Type.hpp>
+#endif
+#ifdef KOKKOS_ENABLE_SYCL
+#include <SYCL/Kokkos_SYCL_Half_Impl_Type.hpp>
+#endif
 
 namespace Kokkos::Experimental::Impl {
 /// @brief templated struct for determining if half_t is an alias to float.

--- a/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
+++ b/core/src/impl/Kokkos_Half_MathematicalFunctions.hpp
@@ -28,14 +28,14 @@
 // clang-format off
 namespace Kokkos {
 // BEGIN macro definitions
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
   #define KOKKOS_IMPL_MATH_H_FUNC_WRAPPER(MACRO, FUNC, /*MAYBE_RET*/...) \
     MACRO(FUNC, Kokkos::Experimental::half_t __VA_OPT__(,) __VA_ARGS__)
 #else
   #define KOKKOS_IMPL_MATH_H_FUNC_WRAPPER(MACRO, FUNC, ...)
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
   #define KOKKOS_IMPL_MATH_B_FUNC_WRAPPER(MACRO, FUNC, /*MAYBE_RET*/...) \
     MACRO(FUNC, Kokkos::Experimental::bhalf_t __VA_OPT__(,) __VA_ARGS__)
 #else
@@ -266,7 +266,7 @@ KOKKOS_IMPL_MATH_HALF_FUNC_WRAPPER(KOKKOS_IMPL_MATH_BINARY_FUNCTION_HALF, copysi
 // Classification and comparison functions
 // fpclassify
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isfinite(Kokkos::Experimental::half_t x) {
@@ -283,7 +283,7 @@ KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::half_t x) {
 }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isfinite(Kokkos::Experimental::bhalf_t x) {
@@ -300,7 +300,7 @@ KOKKOS_INLINE_FUNCTION bool isfinite(Kokkos::Experimental::bhalf_t x) {
 }
 #endif
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isinf(Kokkos::Experimental::half_t x) {
@@ -320,7 +320,7 @@ KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::half_t x) {
 }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isinf(Kokkos::Experimental::bhalf_t x) {
@@ -340,7 +340,7 @@ KOKKOS_INLINE_FUNCTION bool isinf(Kokkos::Experimental::bhalf_t x) {
 }
 #endif
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isnan(Kokkos::Experimental::half_t x) {
@@ -360,7 +360,7 @@ KOKKOS_INLINE_FUNCTION bool isnan(Kokkos::Experimental::half_t x) {
 }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 namespace Impl {
 template <bool fallback = true>
 KOKKOS_INLINE_FUNCTION bool impl_isnan(Kokkos::Experimental::bhalf_t x) {
@@ -448,14 +448,14 @@ KOKKOS_INLINE_FUNCTION fp16_t nextafter_half_helper(fp16_t from, fp16_t to) {
 }
 } // namespace Impl
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t nextafter(Kokkos::Experimental::half_t from,
                                                               Kokkos::Experimental::half_t to) {
   return Impl::nextafter_half_helper(from, to);
 }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimental::bhalf_t from,
                                                                Kokkos::Experimental::bhalf_t to) {
   return Impl::nextafter_half_helper(from, to);
@@ -463,7 +463,7 @@ KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t nextafter(Kokkos::Experimen
 #endif
 #endif  // !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isnormal(Kokkos::Experimental::half_t x) {
 #if defined(KOKKOS_ENABLE_HIP)
     // FIXME_HIP
@@ -476,7 +476,7 @@ KOKKOS_INLINE_FUNCTION bool isnormal(Kokkos::Experimental::half_t x) {
 }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool isnormal(Kokkos::Experimental::bhalf_t x) {
 #if defined(KOKKOS_ENABLE_HIP)
     // FIXME_HIP
@@ -504,23 +504,23 @@ KOKKOS_INLINE_FUNCTION bool isnormal(Kokkos::Experimental::bhalf_t x) {
     }                                                                      \
   }
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_IMPL_HALF_MATH_FPCLASSIFY(Kokkos::Experimental::half_t)
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_IMPL_HALF_MATH_FPCLASSIFY(Kokkos::Experimental::bhalf_t)
 #endif
 
 #undef KOKKOS_IMPL_HALF_MATH_FPCLASSIFY
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool signbit(Kokkos::Experimental::half_t x) {
   constexpr std::uint16_t sign_mask = 1u<<15;
   return (Kokkos::bit_cast<std::uint16_t>(x) & sign_mask) != 0;
 }
 #endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 KOKKOS_INLINE_FUNCTION bool signbit(Kokkos::Experimental::bhalf_t x) {
   constexpr std::uint16_t sign_mask = 1u<<15;
   return (Kokkos::bit_cast<std::uint16_t>(x) & sign_mask) != 0;

--- a/core/src/impl/Kokkos_Half_NumericTraits.hpp
+++ b/core/src/impl/Kokkos_Half_NumericTraits.hpp
@@ -47,7 +47,7 @@
 //           2**15 * (1 + 0.9990234375) =
 //           65504.0
 //
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 /// \brief: Infinity
 ///
 /// Binary16 encoding:
@@ -258,7 +258,7 @@ struct Kokkos::Impl::max_exponent_helper<
 ////////////// END HALF_T (binary16) limits //////////////
 
 ////////////// BEGIN BHALF_T (bfloat16) limits //////////////
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 /// \brief: Infinity
 ///
 /// Bfloat16 encoding:

--- a/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
+++ b/core/src/impl/Kokkos_Half_ReductionIdentity.hpp
@@ -6,7 +6,7 @@
 
 #include <Kokkos_ReductionIdentity.hpp>
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 template <>
 struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
   KOKKOS_FUNCTION static Experimental::half_t sum() noexcept { return 0; }
@@ -30,7 +30,7 @@ struct Kokkos::reduction_identity<Kokkos::Experimental::half_t> {
 };
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <>
 struct Kokkos::reduction_identity<Kokkos::Experimental::bhalf_t> {
   KOKKOS_FUNCTION static Experimental::bhalf_t sum() noexcept { return 0; }

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -60,4 +60,12 @@
 #endif
 // clang-format on
 
+#if !(defined(KOKKOS_ARCH_MAXWELL50) || defined(KOKKOS_ARCH_MAXWELL52))
+#define KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#if defined(__CUDA_ARCH__)
+#define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+#endif
+#endif
+
 #endif /* KOKKOS_CUDA_SETUP_HPP_ */

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -40,6 +40,15 @@ static_assert(false,
 #define KOKKOS_IMPL_HIP_UNIFIED_MEMORY
 #endif
 
+#define KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+
+#if (HIP_VERSION_MAJOR > 6 ||                               \
+     (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)) || \
+    defined(__HIP_DEVICE_COMPILE__)
+#define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+#endif
+
 #endif  // #if defined( KOKKOS_ENABLE_HIP )
 
 #endif

--- a/core/src/setup/Kokkos_Setup_SYCL.hpp
+++ b/core/src/setup/Kokkos_Setup_SYCL.hpp
@@ -23,4 +23,18 @@
 #endif
 // clang-format on
 
+#define KOKKOS_IMPL_HALF_TYPE_DEFINED
+#define KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
+
+// FIXME_SYCL bfloat16 is only supported for compute capability 8.0 or higher
+// on Nvidia GPUs but SYCL_EXT_ONEAPI_BFLOAT16 is defined even for lower compute
+// capability.
+#if __has_include( \
+    <sycl/ext/oneapi/bfloat16.hpp>) || (defined(SYCL_EXT_ONEAPI_BFLOAT16) && defined(KOKKOS_ARCH_INTEL_GPU))
+#define KOKKOS_IMPL_BHALF_TYPE_DEFINED
+#define KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
+#endif
+
+#define KOKKOS_HALF_IS_FULL_TYPE_ON_ARCH
+
 #endif

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -22,7 +22,7 @@ struct FloatingPointComparison {
     return DBL_EPSILON;
   }
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
   KOKKOS_FUNCTION static Kokkos::Experimental::half_t eps(
       Kokkos::Experimental::half_t) {
 // FIXME_NVHPC compile-time error
@@ -34,7 +34,7 @@ struct FloatingPointComparison {
   }
 #endif
 
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
   KOKKOS_FUNCTION
   Kokkos::Experimental::bhalf_t static eps(Kokkos::Experimental::bhalf_t) {
 // FIXME_NVHPC compile-time error

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -4,8 +4,6 @@
 #ifndef TESTHALFCONVERSION_HPP_
 #define TESTHALFCONVERSION_HPP_
 
-#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
-
 namespace Test {
 
 template <class T>

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
-
 #ifndef TESTHALFOPERATOR_HPP_
 #define TESTHALFOPERATOR_HPP_
 namespace Test {

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -409,11 +409,11 @@ struct Functor_TestHalfOperators {
   }
   // END: Binary Arithmetic test helpers
 
-#if !defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
   using half_impl_type = typename half_type::impl_type;
 #else
   using half_impl_type = half_type;
-#endif  // !defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#endif  // !KOKKOS_HALF_T_IS_FLOAT
 
   KOKKOS_FUNCTION
   void operator()(Batch0, int) const {

--- a/core/unit_test/TestHalfOperators.hpp
+++ b/core/unit_test/TestHalfOperators.hpp
@@ -3,6 +3,9 @@
 
 #ifndef TESTHALFOPERATOR_HPP_
 #define TESTHALFOPERATOR_HPP_
+
+#include <cstring>  // std::memcpy
+
 namespace Test {
 using namespace Kokkos::Experimental;
 using ExecutionSpace = TEST_EXECSPACE;

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -33,12 +33,12 @@ namespace KE = Kokkos::Experimental;
 template <class>
 struct math_unary_function_return_type;
 // Floating-point types
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 template <> struct math_unary_function_return_type<KE::half_t> { using type = KE::half_t; };
-#endif // defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#endif // !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <> struct math_unary_function_return_type<KE::bhalf_t> { using type = KE::bhalf_t; };
-#endif // defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#endif // !KOKKOS_BHALF_T_IS_FLOAT
 template <> struct math_unary_function_return_type<      float> { using type =       float; };
 template <> struct math_unary_function_return_type<     double> { using type =      double; };
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
@@ -58,7 +58,7 @@ template <class T>
 using math_unary_function_return_type_t = typename math_unary_function_return_type<T>::type;
 template <class, class>
 struct math_binary_function_return_type;
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 template <> struct math_binary_function_return_type<KE::half_t, KE::half_t> { using type = KE::half_t; };
 template <> struct math_binary_function_return_type<short, KE::half_t> { using type = double; };
 template <> struct math_binary_function_return_type<unsigned short, KE::half_t> { using type = double; };
@@ -68,8 +68,8 @@ template <> struct math_binary_function_return_type<long, KE::half_t> { using ty
 template <> struct math_binary_function_return_type<unsigned long, KE::half_t> { using type = double; };
 template <> struct math_binary_function_return_type<long long, KE::half_t> { using type = double; };
 template <> struct math_binary_function_return_type<unsigned long long, KE::half_t> { using type = double; };
-#endif // defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#endif // !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 template <> struct math_binary_function_return_type<KE::bhalf_t, KE::bhalf_t> { using type = KE::bhalf_t; };
 template <> struct math_binary_function_return_type<KE::half_t, KE::bhalf_t> { using type = KE::half_t; };
 template <> struct math_binary_function_return_type<short, KE::bhalf_t> { using type = double; };
@@ -80,7 +80,7 @@ template <> struct math_binary_function_return_type<long, KE::bhalf_t> { using t
 template <> struct math_binary_function_return_type<unsigned long, KE::bhalf_t> { using type = double; };
 template <> struct math_binary_function_return_type<long long, KE::bhalf_t> { using type = double; };
 template <> struct math_binary_function_return_type<unsigned long long, KE::bhalf_t> { using type = double; };
-#endif // defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#endif // !KOKKOS_BHALF_T_IS_FLOAT
 template <> struct math_binary_function_return_type<             float,              float> { using type =       float; };
 template <> struct math_binary_function_return_type<             float,             double> { using type =      double; };
 template <> struct math_binary_function_return_type<             float,               bool> { using type =      double; };
@@ -671,10 +671,10 @@ DEFINE_TYPE_NAME(long long)
 DEFINE_TYPE_NAME(unsigned int)
 DEFINE_TYPE_NAME(unsigned long)
 DEFINE_TYPE_NAME(unsigned long long)
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
 DEFINE_TYPE_NAME(KE::half_t)
 #endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
 DEFINE_TYPE_NAME(KE::bhalf_t)
 #endif
 DEFINE_TYPE_NAME(float)
@@ -1829,13 +1829,13 @@ TEST(TEST_CATEGORY,
   TEST_MATH_FUNCTION(logb)({123.45l, 6789.0l});
 #endif
 
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && KOKKOS_HALF_T_IS_FLOAT
+#if KOKKOS_HALF_T_IS_FLOAT
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       0, static_cast<KE::half_t>(1.f));
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       1, static_cast<KE::half_t>(2.f));
 #endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && KOKKOS_BHALF_T_IS_FLOAT
+#if KOKKOS_BHALF_T_IS_FLOAT
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
       0, static_cast<KE::bhalf_t>(1.f));
   do_test_math_binary_function<TEST_EXECSPACE, kk_nextafter>(
@@ -2816,7 +2816,7 @@ KE::half_t ref_test_fallback_half(KE::half_t) {
   // When SYCL is enabled, half_t is available on both the GPU and the CPU.
   return KE::half_t(0.f);
 #elif defined(KOKKOS_ENABLE_CUDA)
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && KOKKOS_HALF_T_IS_FLOAT
+#if KOKKOS_HALF_T_IS_FLOAT
   return KE::half_t(1.f);
 #else
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Cuda>) {
@@ -2996,11 +2996,11 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
                   "not implemented yet";
 #else
   bool skipped = true;
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
   skipped      = false;
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
 #endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
   skipped = false;
   TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
 #endif

--- a/core/unit_test/TestNumericTraits.hpp
+++ b/core/unit_test/TestNumericTraits.hpp
@@ -45,12 +45,12 @@ struct extrema {
   DEFINE_EXTREMA(unsigned long, 0UL, ULONG_MAX)
   DEFINE_EXTREMA(long long, LLONG_MIN, LLONG_MAX)
   DEFINE_EXTREMA(unsigned long long, 0ULL, ULLONG_MAX)
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+#if !KOKKOS_HALF_T_IS_FLOAT
   DEFINE_EXTREMA(Kokkos::Experimental::half_t,
                  Kokkos::Experimental::half_t(-65504.0f),
                  Kokkos::Experimental::half_t(65504.0f))
 #endif
-#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+#if !KOKKOS_BHALF_T_IS_FLOAT
   DEFINE_EXTREMA(Kokkos::Experimental::bhalf_t,
                  Kokkos::Experimental::bhalf_t(-3.38953139e38f),
                  Kokkos::Experimental::bhalf_t(3.38953139e38f))


### PR DESCRIPTION
For module builds, we need to define `KOKKOS_HALF_T_IS_FLOAT/KOKKOS_BHALF_T_IS_FLOAT` in `Kokkos_Macros.hpp` which is also more in line with other feature detection mechanisms.
It also turns out that a standalone `Kokkos_Half.hpp` wasn't configured correctly.