### PR TITLE
Make the flag argument in simd constructors optional

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -805,9 +805,9 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_pd(ptr);
@@ -815,9 +815,9 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
       m_value = _mm256_loadu_pd(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm256_maskload_pd(
         ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)));
   }
@@ -1170,9 +1170,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                         gen(std::integral_constant<Impl::simd_size_t, 1>()),
                         gen(std::integral_constant<Impl::simd_size_t, 2>()),
                         gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm_load_ps(ptr);
@@ -1180,9 +1180,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
       m_value = _mm_loadu_ps(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)));
   }
 
@@ -1524,9 +1524,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_ps(ptr);
@@ -1534,9 +1534,9 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
       m_value = _mm256_loadu_ps(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value =
         _mm256_maskload_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)));
   }
@@ -1884,9 +1884,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
@@ -1894,9 +1894,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
       m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask));
   }
 
@@ -2226,9 +2226,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr));
@@ -2236,9 +2236,9 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
       m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask));
   }
 
@@ -2565,9 +2565,9 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
@@ -2575,9 +2575,9 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
       m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
   }
@@ -2922,9 +2922,9 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType) noexcept {
+      const value_type* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
@@ -2932,9 +2932,9 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
       m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
   }

--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -805,19 +805,20 @@ class basic_simd<double, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_pd(ptr);
     } else {
       m_value = _mm256_loadu_pd(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm256_maskload_pd(
         ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)));
   }
@@ -1170,19 +1171,20 @@ class basic_simd<float, simd_abi::avx2_fixed_size<4>> {
                         gen(std::integral_constant<Impl::simd_size_t, 1>()),
                         gen(std::integral_constant<Impl::simd_size_t, 2>()),
                         gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm_load_ps(ptr);
     } else {
       m_value = _mm_loadu_ps(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm_maskload_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)));
   }
 
@@ -1524,19 +1526,20 @@ class basic_simd<float, simd_abi::avx2_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_ps(ptr);
     } else {
       m_value = _mm256_loadu_ps(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value =
         _mm256_maskload_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)));
   }
@@ -1884,19 +1887,20 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm_load_si128(reinterpret_cast<__m128i const*>(ptr));
     } else {
       m_value = _mm_loadu_si128(reinterpret_cast<__m128i const*>(ptr));
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm_maskload_epi32(ptr, static_cast<__m128i>(mask));
   }
 
@@ -2226,19 +2230,20 @@ class basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<__m256i const*>(ptr));
     } else {
       m_value = _mm256_loadu_si256(reinterpret_cast<__m256i const*>(ptr));
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm256_maskload_epi32(ptr, static_cast<__m256i>(mask));
   }
 
@@ -2565,19 +2570,20 @@ class basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
     } else {
       m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
   }
@@ -2922,19 +2928,20 @@ class basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> {
             gen(std::integral_constant<Impl::simd_size_t, 1>()),
             gen(std::integral_constant<Impl::simd_size_t, 2>()),
             gen(std::integral_constant<Impl::simd_size_t, 3>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_si256(reinterpret_cast<const __m256i*>(ptr));
     } else {
       m_value = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(ptr));
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = _mm256_maskload_epi64(reinterpret_cast<long long const*>(ptr),
                                     static_cast<__m256i>(mask));
   }

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -339,9 +339,9 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_pd(ptr);
@@ -349,9 +349,9 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
       m_value = _mm512_loadu_pd(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_pd(static_cast<__mmask8>(mask), ptr);
@@ -742,9 +742,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_ps(ptr);
@@ -752,9 +752,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
       m_value = _mm256_loadu_ps(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_ps(static_cast<__mmask8>(mask), ptr);
@@ -1123,9 +1123,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_ps(ptr);
@@ -1133,9 +1133,9 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
       m_value = _mm512_loadu_ps(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_ps(static_cast<__mmask16>(mask), ptr);
@@ -1503,9 +1503,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value =
@@ -1515,9 +1515,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
           _mm256_maskz_loadu_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_epi32(static_cast<__mmask8>(mask), ptr);
@@ -1880,9 +1880,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_epi32(ptr);
@@ -1891,9 +1891,9 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       m_value = _mm512_maskz_loadu_epi32(static_cast<__mmask16>(mask), ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi32(static_cast<__mmask16>(mask), ptr);
@@ -2255,9 +2255,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value =
@@ -2267,9 +2267,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
           _mm256_maskz_loadu_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_epi32(static_cast<__mmask8>(mask), ptr);
@@ -2626,9 +2626,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_epi32(ptr);
@@ -2637,9 +2637,9 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       m_value = _mm512_maskz_loadu_epi32(static_cast<__mmask16>(mask), ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi32(static_cast<__mmask16>(mask), ptr);
@@ -2996,9 +2996,9 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_si512(ptr);
@@ -3006,9 +3006,9 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
       m_value = _mm512_loadu_si512(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi64(static_cast<__mmask8>(mask), ptr);
@@ -3368,9 +3368,9 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_si512(ptr);
@@ -3378,9 +3378,9 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
       m_value = _mm512_loadu_si512(ptr);
     }
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     if constexpr (std::is_same_v<FlagType,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi64(static_cast<__mmask8>(mask), ptr);

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -339,20 +339,21 @@ class basic_simd<double, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_pd(ptr);
     } else {
       m_value = _mm512_loadu_pd(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_pd(static_cast<__mmask8>(mask), ptr);
     } else {
@@ -742,20 +743,21 @@ class basic_simd<float, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_load_ps(ptr);
     } else {
       m_value = _mm256_loadu_ps(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_ps(static_cast<__mmask8>(mask), ptr);
     } else {
@@ -1123,20 +1125,21 @@ class basic_simd<float, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_ps(ptr);
     } else {
       m_value = _mm512_loadu_ps(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_ps(static_cast<__mmask16>(mask), ptr);
     } else {
@@ -1503,10 +1506,10 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value =
           _mm256_maskz_load_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
@@ -1515,10 +1518,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> {
           _mm256_maskz_loadu_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_epi32(static_cast<__mmask8>(mask), ptr);
     } else {
@@ -1880,10 +1884,10 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_epi32(ptr);
     } else {
@@ -1891,10 +1895,11 @@ class basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> {
       m_value = _mm512_maskz_loadu_epi32(static_cast<__mmask16>(mask), ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi32(static_cast<__mmask16>(mask), ptr);
     } else {
@@ -2255,10 +2260,10 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value =
           _mm256_maskz_load_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
@@ -2267,10 +2272,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> {
           _mm256_maskz_loadu_epi32(static_cast<__mmask8>(mask_type(true)), ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm256_maskz_load_epi32(static_cast<__mmask8>(mask), ptr);
     } else {
@@ -2626,10 +2632,10 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
             gen(std::integral_constant<Impl::simd_size_t, 13>()),
             gen(std::integral_constant<Impl::simd_size_t, 14>()),
             gen(std::integral_constant<Impl::simd_size_t, 15>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_epi32(ptr);
     } else {
@@ -2637,10 +2643,11 @@ class basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> {
       m_value = _mm512_maskz_loadu_epi32(static_cast<__mmask16>(mask), ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi32(static_cast<__mmask16>(mask), ptr);
     } else {
@@ -2996,20 +3003,21 @@ class basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_si512(ptr);
     } else {
       m_value = _mm512_loadu_si512(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi64(static_cast<__mmask8>(mask), ptr);
     } else {
@@ -3368,20 +3376,21 @@ class basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> {
             gen(std::integral_constant<Impl::simd_size_t, 5>()),
             gen(std::integral_constant<Impl::simd_size_t, 6>()),
             gen(std::integral_constant<Impl::simd_size_t, 7>()))) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_load_si512(ptr);
     } else {
       m_value = _mm512_loadu_si512(ptr);
     }
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
-    if constexpr (std::is_same_v<FlagType,
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
+    if constexpr (std::is_same_v<simd_flags<Flags...>,
                                  simd_flags<simd_alignment_vector_aligned>>) {
       m_value = _mm512_maskz_load_epi64(static_cast<__mmask8>(mask), ptr);
     } else {

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -433,14 +433,14 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_f64(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<float64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -798,14 +798,14 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_f32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1_f32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<float32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1154,14 +1154,14 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_f32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<float32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1521,14 +1521,14 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1_s32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<int32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1883,14 +1883,14 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_s32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_s32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<int32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2255,14 +2255,14 @@ class basic_simd<std::uint32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_u32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1_u32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<uint32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2613,14 +2613,14 @@ class basic_simd<std::uint32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_u32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_u32(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<uint32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2981,14 +2981,14 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_s64(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<int64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -3344,14 +3344,14 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_u64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = vld1q_u64(ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = static_cast<uint64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -433,14 +433,15 @@ class basic_simd<double, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_f64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_f64(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<float64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -798,14 +799,15 @@ class basic_simd<float, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_f32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1_f32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<float32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1154,14 +1156,15 @@ class basic_simd<float, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_f32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_f32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<float32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1521,14 +1524,15 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_s32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1_s32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<int32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -1883,14 +1887,15 @@ class basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_s32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_s32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<int32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2255,14 +2260,15 @@ class basic_simd<std::uint32_t, simd_abi::neon_fixed_size<2>> {
     m_value = vset_lane_u32(gen(std::integral_constant<Impl::simd_size_t, 1>()),
                             m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1_u32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<uint32x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2613,14 +2619,15 @@ class basic_simd<std::uint32_t, simd_abi::neon_fixed_size<4>> {
     m_value = vsetq_lane_u32(
         gen(std::integral_constant<Impl::simd_size_t, 3>()), m_value, 3);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_u32(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<uint32x4_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -2981,14 +2988,15 @@ class basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_s64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_s64(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<int64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));
@@ -3344,14 +3352,15 @@ class basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> {
     m_value = vsetq_lane_u64(
         gen(std::integral_constant<Impl::simd_size_t, 1>()), m_value, 1);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = vld1q_u64(ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = static_cast<uint64x2_t>(basic_simd([=](Impl::simd_size_t i) {
       return (mask[i]) ? ptr[i] : value_type();
     }));

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -3259,14 +3259,14 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
 
   template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, simd_flags<Flags...> = {}) noexcept
-      : base_type(ptr, FlagType{}) {}
+      value_type const* ptr, simd_flags<Flags...> flags = {}) noexcept
+      : base_type(ptr, flags) {}
 
   template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
       const value_type* ptr, mask_type const& mask,
-      simd_flags<Flags...> = {}) noexcept
-      : base_type(ptr, mask, FlagType{}) {}
+      simd_flags<Flags...> flags = {}) noexcept
+      : base_type(ptr, mask, flags) {}
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(
       basic_simd<std::uint64_t, abi_type> const& other) noexcept

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -488,14 +488,15 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -928,14 +929,15 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -1361,14 +1363,15 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -1858,14 +1861,15 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -2317,14 +2321,15 @@ class basic_simd<std::int64_t,
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -2799,14 +2804,15 @@ class basic_simd<std::uint64_t,
 #endif
   }
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept {
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -3251,14 +3257,15 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       G&& gen) noexcept
       : base_type(gen) {}
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType = {}) noexcept
+      value_type const* ptr, simd_flags<Flags...> = {}) noexcept
       : base_type(ptr, FlagType{}) {}
 
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept
+      const value_type* ptr, mask_type const& mask,
+      simd_flags<Flags...> = {}) noexcept
       : base_type(ptr, mask, FlagType{}) {}
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -488,14 +488,14 @@ class basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -928,14 +928,14 @@ class basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -1361,14 +1361,14 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -1858,14 +1858,14 @@ class basic_simd<std::uint32_t, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> {
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b32(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -2317,14 +2317,14 @@ class basic_simd<std::int64_t,
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -2799,14 +2799,14 @@ class basic_simd<std::uint64_t,
 #endif
   }
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept {
+      value_type const* ptr, FlagType = {}) noexcept {
     m_value = svld1(svptrue_b64(), ptr);
   }
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept {
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = svld1(static_cast<vls_bool_t>(mask), ptr);
   }
 
@@ -3251,14 +3251,14 @@ class basic_simd<std::int32_t, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       G&& gen) noexcept
       : base_type(gen) {}
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      value_type const* ptr, FlagType) noexcept
+      value_type const* ptr, FlagType = {}) noexcept
       : base_type(ptr, FlagType{}) {}
 
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      const value_type* ptr, mask_type const& mask, FlagType) noexcept
+      const value_type* ptr, mask_type const& mask, FlagType = {}) noexcept
       : base_type(ptr, mask, FlagType{}) {}
 
   KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION explicit basic_simd(

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -190,13 +190,13 @@ class basic_simd<T, simd_abi::scalar> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
       : m_value(gen(0)) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      T const* ptr, FlagType = {}) noexcept
+      T const* ptr, simd_flags<Flags...> = {}) noexcept
       : m_value(*ptr) {}
-  template <typename FlagType = simd_flags<>>
+  template <typename... Flags>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      T const* ptr, mask_type const& mask, FlagType = {}) noexcept {
+      T const* ptr, mask_type const& mask, simd_flags<Flags...> = {}) noexcept {
     m_value = (mask) ? *ptr : T();
   }
 

--- a/simd/src/Kokkos_SIMD_Scalar.hpp
+++ b/simd/src/Kokkos_SIMD_Scalar.hpp
@@ -190,13 +190,13 @@ class basic_simd<T, simd_abi::scalar> {
   // NOLINTNEXTLINE(bugprone-forwarding-reference-overload)
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(G&& gen) noexcept
       : m_value(gen(0)) {}
-  template <typename FlagType>
-  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(T const* ptr,
-                                                            FlagType) noexcept
-      : m_value(*ptr) {}
-  template <typename FlagType>
+  template <typename FlagType = simd_flags<>>
   KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
-      T const* ptr, mask_type const& mask, FlagType) noexcept {
+      T const* ptr, FlagType = {}) noexcept
+      : m_value(*ptr) {}
+  template <typename FlagType = simd_flags<>>
+  KOKKOS_FORCEINLINE_FUNCTION constexpr explicit basic_simd(
+      T const* ptr, mask_type const& mask, FlagType = {}) noexcept {
     m_value = (mask) ? *ptr : T();
   }
 

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -27,7 +27,19 @@ inline void host_test_simd_traits() {
   static_assert(std::is_nothrow_move_assignable_v<simd_type>);
   static_assert(std::is_nothrow_move_constructible_v<simd_type>);
 
+  constexpr size_t alignment = simd_type::size() * sizeof(DataType);
+
+  alignas(alignment) DataType values[simd_type::size()] = {};
+
+  typename simd_type::mask_type mask(true);
+
   simd_type default_simd, result;
+  [[maybe_unused]] simd_type ptr_simd(values);
+  [[maybe_unused]] simd_type ptr_flag_simd(
+      values, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_mask_simd(values, mask);
+  [[maybe_unused]] simd_type ptr_mask_flag_simd(
+      values, mask, Kokkos::Experimental::simd_flag_default);
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));
@@ -141,7 +153,19 @@ template <typename Abi, typename DataType>
 KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
   using simd_type = Kokkos::Experimental::basic_simd<DataType, Abi>;
 
+  constexpr size_t alignment = simd_type::size() * sizeof(DataType);
+
+  alignas(alignment) DataType values[simd_type::size()] = {};
+
+  typename simd_type::mask_type mask(true);
+
   simd_type default_simd, result;
+  [[maybe_unused]] simd_type ptr_simd(values);
+  [[maybe_unused]] simd_type ptr_flag_simd(
+      values, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_mask_simd(values, mask);
+  [[maybe_unused]] simd_type ptr_mask_flag_simd(
+      values, mask, Kokkos::Experimental::simd_flag_default);
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));

--- a/simd/unit_tests/include/TestSIMD_Construction.hpp
+++ b/simd/unit_tests/include/TestSIMD_Construction.hpp
@@ -37,9 +37,13 @@ inline void host_test_simd_traits() {
   [[maybe_unused]] simd_type ptr_simd(values);
   [[maybe_unused]] simd_type ptr_flag_simd(
       values, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_flag_aligned_simd(
+      values, Kokkos::Experimental::simd_flag_aligned);
   [[maybe_unused]] simd_type ptr_mask_simd(values, mask);
   [[maybe_unused]] simd_type ptr_mask_flag_simd(
       values, mask, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_mask_flag_aligned_simd(
+      values, mask, Kokkos::Experimental::simd_flag_aligned);
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));
@@ -163,9 +167,13 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_traits() {
   [[maybe_unused]] simd_type ptr_simd(values);
   [[maybe_unused]] simd_type ptr_flag_simd(
       values, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_flag_aligned_simd(
+      values, Kokkos::Experimental::simd_flag_aligned);
   [[maybe_unused]] simd_type ptr_mask_simd(values, mask);
   [[maybe_unused]] simd_type ptr_mask_flag_simd(
       values, mask, Kokkos::Experimental::simd_flag_default);
+  [[maybe_unused]] simd_type ptr_mask_flag_aligned_simd(
+      values, mask, Kokkos::Experimental::simd_flag_aligned);
   simd_type test_simd(KOKKOS_LAMBDA(std::size_t i) { return (i % 2 == 0); });
   simd_type copy_simd(test_simd);
   simd_type move_simd(std::move(copy_simd));


### PR DESCRIPTION
This PR makes the flag argument in simd constructors optional, with a default value of `simd_flag_default` (`simd_flags<>`).
This is aligned with the C++26 standard (https://eel.is/c++draft/simd.ctor#10) and avoids having to spell out `simd vec(ptr, Kokkos::Experimental::simd_flag_default)` when using the default flag.

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

simd: make the flag argument in constructors optional