### PR TITLE
Fix "missing typename" issue with llvm/15.0.7 nightly jobs

### DIFF
--- a/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
+++ b/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp
@@ -19,7 +19,7 @@ void test_create_mirror_view_and_copy() {
   original_view_type original_view("original_view", N);
   Kokkos::deep_copy(original_view, 1);
   auto original_view_copy = Kokkos::create_mirror_view_and_copy(original_view);
-  using copy_memory_space = decltype(original_view_copy)::memory_space;
+  using copy_memory_space = typename decltype(original_view_copy)::memory_space;
   static_assert(std::is_same_v<
                 decltype(original_view_copy),
                 typename Kokkos::Impl::MirrorViewType<


### PR DESCRIPTION
Add "typename"in TestCreateMirrorViewAndCopy.hpp test file to workaround llvm/15.0.7 compilation error that showed up in nightly Trilinos integration testing:

```
18:20:05 /home/jenkins/blake-new/workspace/KokkosEco_Trilinos_Blake_LLVM1507_Serial_debug-new_view-dep_code5_off/Trilinos/kokkos/core/unit_test/view/TestCreateMirrorViewAndCopy.hpp:22:29: error: missing 'typename' prior to dependent type name 'decltype(original_view_copy)::memory_space'
18:20:05   using copy_memory_space = decltype(original_view_copy)::memory_space;
```

Occurred after changes merged from #9185

<!-- Provide a short summary of the changes in this pull request. -->

<!-- Link any related issues or PRs. -->

### Changelog Entry
  - Not required
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:


-->
