### PR TITLE
Fix using templated functors with parallel_reduce TeamPolicy

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -95,36 +95,36 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return block_size / impl_vector_length();
   }
 
-  template <class FunctorType>
+  template <class FunctorType, class ValueType=void>
   inline int team_size_max(const FunctorType& f,
                            const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType, void>;
+                              TeamPolicyInternal, FunctorType, ValueType>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
         TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_max<closure_type, ValueType>(f);
   }
 
-  template <typename FunctorType, typename ReducerType>
+  template <typename FunctorType, typename ReducerType, typename ValueType=void>
   inline int team_size_max(const FunctorType& f, const ReducerType& reducer,
                            const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, ReducerType, void>;
-    return team_size_max_internal(
+                              TeamPolicyInternal, ReducerType, ValueType>;
+    return team_size_max_internal<ValueType>(
         f, typename functor_analysis_type::Reducer{reducer}, tag);
   }
 
-  template <typename FunctorType, typename ReducerType>
+  template <typename ValueType, typename FunctorType, typename ReducerType>
   inline int team_size_max_internal(const FunctorType& f, const ReducerType&,
                                     const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_max<closure_type>(f);
+    return internal_team_size_max<closure_type, ValueType>(f);
   }
 
   template <class FunctorType>
@@ -144,36 +144,36 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return block_size / impl_vector_length();
   }
 
-  template <class FunctorType>
+  template <class FunctorType, typename ValueType=void>
   inline int team_size_recommended(const FunctorType& f,
                                    const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType, void>;
+                              TeamPolicyInternal, FunctorType, ValueType>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
         TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_recommended<closure_type>(f);
+    return internal_team_size_recommended<closure_type, ValueType>(f);
   }
 
-  template <typename FunctorType, typename ReducerType>
+  template <typename FunctorType, typename ReducerType, typename ValueType=void>
   int team_size_recommended(const FunctorType& f, const ReducerType& reducer,
                             const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, ReducerType, void>;
-    return team_size_recommended_internal(
+                              TeamPolicyInternal, ReducerType, ValueType>;
+    return team_size_recommended_internal<ValueType>(
         f, typename functor_analysis_type::Reducer{reducer}, tag);
   }
 
-  template <typename FunctorType, typename ReducerType>
+  template <typename ValueType, typename FunctorType, typename ReducerType>
   int team_size_recommended_internal(const FunctorType& f, const ReducerType&,
                                      const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_recommended<closure_type>(f);
+    return internal_team_size_recommended<closure_type, ValueType>(f);
   }
 
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
@@ -371,7 +371,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   using member_type = Kokkos::Impl::CudaTeamMember;
 
  protected:
-  template <class ClosureType, class FunctorType, class BlockSizeCallable>
+  template <class ClosureType, class ValueType, class FunctorType, class BlockSizeCallable>
   int internal_team_size_common(const FunctorType& f,
                                 BlockSizeCallable&& block_size_callable) const {
     using closure_type = ClosureType;
@@ -379,7 +379,7 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
         typename Impl::DeduceFunctorPatternInterface<ClosureType>::type;
     using Analysis =
         Impl::FunctorAnalysis<Interface, typename ClosureType::Policy,
-                              FunctorType, void>;
+                              FunctorType, ValueType>;
 
     cudaFuncAttributes attr =
         CudaParallelLaunch<closure_type, typename traits::launch_bounds>::
@@ -399,17 +399,17 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return p2 / impl_vector_length();
   }
 
-  template <class ClosureType, class FunctorType>
+  template <class ClosureType, class ValueType, class FunctorType>
   int internal_team_size_max(const FunctorType& f) const {
-    return internal_team_size_common<ClosureType>(
+    return internal_team_size_common<ClosureType, ValueType>(
         f,
         Kokkos::Impl::cuda_get_max_block_size<FunctorType,
                                               typename traits::launch_bounds>);
   }
 
-  template <class ClosureType, class FunctorType>
+  template <class ClosureType, class ValueType, class FunctorType>
   int internal_team_size_recommended(const FunctorType& f) const {
-    return internal_team_size_common<ClosureType>(
+    return internal_team_size_common<ClosureType, ValueType>(
         f,
         Kokkos::Impl::cuda_get_opt_block_size<FunctorType,
                                               typename traits::launch_bounds>);
@@ -938,7 +938,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_policy.space().impl_internal_space_instance();
 
     if (m_team_size < 0) {
-      m_team_size = arg_policy.team_size_recommended_internal(
+      m_team_size = arg_policy.template team_size_recommended_internal<value_type>(
           arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
           ParallelReduceTag());
       if (m_team_size <= 0)
@@ -1021,14 +1021,14 @@ class ParallelReduce<CombinedFunctorReducerType,
     }
 
     if (m_team_size >
-        arg_policy.team_size_max_internal(m_functor_reducer.get_functor(),
+        arg_policy.template team_size_max_internal<value_type>(m_functor_reducer.get_functor(),
                                           m_functor_reducer.get_reducer(),
                                           ParallelReduceTag())) {
       std::stringstream error;
       error << "Kokkos::parallel_reduce<Cuda>: Requested too large team size. "
                "Requested: "
             << m_team_size << ", Maximum: "
-            << arg_policy.team_size_max_internal(
+            << arg_policy.template team_size_max_internal<value_type>(
                    m_functor_reducer.get_functor(),
                    m_functor_reducer.get_reducer(), ParallelReduceTag());
       Kokkos::Impl::throw_runtime_exception(error.str().c_str());

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Team.hpp
@@ -95,36 +95,39 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return block_size / impl_vector_length();
   }
 
-  template <class FunctorType, class ValueType=void>
+  template <class FunctorType>
   inline int team_size_max(const FunctorType& f,
                            const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType, ValueType>;
+                              TeamPolicyInternal, FunctorType, void>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
         TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_max<closure_type, ValueType>(f);
+    return internal_team_size_max<closure_type,
+                                  typename functor_analysis_type::value_type>(
+        f);
   }
 
-  template <typename FunctorType, typename ReducerType, typename ValueType=void>
+  template <typename FunctorType, typename ReducerType>
   inline int team_size_max(const FunctorType& f, const ReducerType& reducer,
                            const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, ReducerType, ValueType>;
-    return team_size_max_internal<ValueType>(
+                              TeamPolicyInternal, ReducerType, void>;
+    return team_size_max_internal(
         f, typename functor_analysis_type::Reducer{reducer}, tag);
   }
 
-  template <typename ValueType, typename FunctorType, typename ReducerType>
+  template <typename FunctorType, typename ReducerType>
   inline int team_size_max_internal(const FunctorType& f, const ReducerType&,
                                     const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_max<closure_type, ValueType>(f);
+    return internal_team_size_max<closure_type,
+                                  typename ReducerType::value_type>(f);
   }
 
   template <class FunctorType>
@@ -144,36 +147,38 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
     return block_size / impl_vector_length();
   }
 
-  template <class FunctorType, typename ValueType=void>
+  template <class FunctorType>
   inline int team_size_recommended(const FunctorType& f,
                                    const ParallelReduceTag&) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, FunctorType, ValueType>;
+                              TeamPolicyInternal, FunctorType, void>;
     using closure_type = Impl::ParallelReduce<
         CombinedFunctorReducer<FunctorType,
                                typename functor_analysis_type::Reducer>,
         TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_recommended<closure_type, ValueType>(f);
+    return internal_team_size_recommended<
+        closure_type, typename functor_analysis_type::value_type>(f);
   }
 
-  template <typename FunctorType, typename ReducerType, typename ValueType=void>
+  template <typename FunctorType, typename ReducerType>
   int team_size_recommended(const FunctorType& f, const ReducerType& reducer,
                             const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
-                              TeamPolicyInternal, ReducerType, ValueType>;
-    return team_size_recommended_internal<ValueType>(
+                              TeamPolicyInternal, ReducerType, void>;
+    return team_size_recommended_internal(
         f, typename functor_analysis_type::Reducer{reducer}, tag);
   }
 
-  template <typename ValueType, typename FunctorType, typename ReducerType>
+  template <typename FunctorType, typename ReducerType>
   int team_size_recommended_internal(const FunctorType& f, const ReducerType&,
                                      const ParallelReduceTag&) const {
     using closure_type =
         Impl::ParallelReduce<CombinedFunctorReducer<FunctorType, ReducerType>,
                              TeamPolicy<Properties...>, Kokkos::Cuda>;
-    return internal_team_size_recommended<closure_type, ValueType>(f);
+    return internal_team_size_recommended<closure_type,
+                                          typename ReducerType::value_type>(f);
   }
 
   inline static int vector_length_max() { return Impl::CudaTraits::WarpSize; }
@@ -371,7 +376,8 @@ class TeamPolicyInternal<Kokkos::Cuda, Properties...>
   using member_type = Kokkos::Impl::CudaTeamMember;
 
  protected:
-  template <class ClosureType, class ValueType, class FunctorType, class BlockSizeCallable>
+  template <class ClosureType, class ValueType, class FunctorType,
+            class BlockSizeCallable>
   int internal_team_size_common(const FunctorType& f,
                                 BlockSizeCallable&& block_size_callable) const {
     using closure_type = ClosureType;
@@ -938,7 +944,7 @@ class ParallelReduce<CombinedFunctorReducerType,
         m_policy.space().impl_internal_space_instance();
 
     if (m_team_size < 0) {
-      m_team_size = arg_policy.template team_size_recommended_internal<value_type>(
+      m_team_size = arg_policy.team_size_recommended_internal(
           arg_functor_reducer.get_functor(), arg_functor_reducer.get_reducer(),
           ParallelReduceTag());
       if (m_team_size <= 0)
@@ -1021,14 +1027,14 @@ class ParallelReduce<CombinedFunctorReducerType,
     }
 
     if (m_team_size >
-        arg_policy.template team_size_max_internal<value_type>(m_functor_reducer.get_functor(),
+        arg_policy.team_size_max_internal(m_functor_reducer.get_functor(),
                                           m_functor_reducer.get_reducer(),
                                           ParallelReduceTag())) {
       std::stringstream error;
       error << "Kokkos::parallel_reduce<Cuda>: Requested too large team size. "
                "Requested: "
             << m_team_size << ", Maximum: "
-            << arg_policy.template team_size_max_internal<value_type>(
+            << arg_policy.team_size_max_internal(
                    m_functor_reducer.get_functor(),
                    m_functor_reducer.get_reducer(), ParallelReduceTag());
       Kokkos::Impl::throw_runtime_exception(error.str().c_str());

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -60,6 +60,15 @@ struct TestTeamReduceLarge {
   }
 };
 
+TEST(TEST_CATEGORY, team_reduce_large) {
+  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
+                          (2LU << 24) + 1, 1LU << 29};
+  for (const auto range : ranges) {
+    TestTeamReduceLarge<TEST_EXECSPACE> test(range);
+    test.run();
+  }
+}
+
 template <typename ExecutionSpace>
 struct TestTeamReduceTemplatedOperator {
   using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
@@ -82,18 +91,8 @@ struct TestTeamReduceTemplatedOperator {
   }
 };
 
-TEST(TEST_CATEGORY, team_reduce_large) {
-  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
-                          (2LU << 24) + 1, 1LU << 29};
-  for (const auto range : ranges) {
-    TestTeamReduceLarge<TEST_EXECSPACE> test(range);
-    test.run();
-  }
-}
-
 TEST(TEST_CATEGORY, team_reduce_templated_operator) {
-  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
-                          (2LU << 24) + 1, 1LU << 29};
+  std::vector<int> ranges{1, 10, 100};
   for (const auto range : ranges) {
     TestTeamReduceTemplatedOperator<TEST_EXECSPACE> test(range);
     test.run();

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -60,11 +60,42 @@ struct TestTeamReduceLarge {
   }
 };
 
+template <typename ExecutionSpace>
+struct TestTeamReduceTemplatedOperator {
+  using team_policy_t = Kokkos::TeamPolicy<ExecutionSpace>;
+
+  int m_range;
+
+  TestTeamReduceTemplatedOperator(const int range) : m_range(range) {}
+
+  template <typename MemberType>
+  KOKKOS_INLINE_FUNCTION void operator()(const MemberType& t,
+                                         int& update) const {
+    Kokkos::single(Kokkos::PerTeam(t), [&]() { update++; });
+  }
+
+  void run() {
+    int result = 0;
+    Kokkos::parallel_reduce(team_policy_t(m_range, Kokkos::AUTO), *this,
+                            result);
+    EXPECT_EQ(m_range, result);
+  }
+};
+
 TEST(TEST_CATEGORY, team_reduce_large) {
   std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
                           (2LU << 24) + 1, 1LU << 29};
   for (const auto range : ranges) {
     TestTeamReduceLarge<TEST_EXECSPACE> test(range);
+    test.run();
+  }
+}
+
+TEST(TEST_CATEGORY, team_reduce_templated_operator) {
+  std::vector<int> ranges{(2LU << 23) - 1, 2LU << 23, (2LU << 24),
+                          (2LU << 24) + 1, 1LU << 29};
+  for (const auto range : ranges) {
+    TestTeamReduceTemplatedOperator<TEST_EXECSPACE> test(range);
     test.run();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/9210. We just forward the `value_type` to `team_size_max_internal` to make changes minimal. We have done the same in https://github.com/kokkos/kokkos/pull/5976 for HIP already.
Note that this doesn't allow users to call `team_size_max/recommended` with a template functor (which would require user-facing changes following the same approach).