### PR TITLE
[Algorigthms][Random] Fix: signed integer overflow UB

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1199,8 +1199,6 @@ class Random_XorShift1024 {
     // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
     const uint32_t urange =
         static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
-    if (urange <= static_cast<uint32_t>(MAX_RAND))
-      return rand(static_cast<int>(urange)) + start;
     return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -957,7 +957,6 @@ class Random_XorShift64 {
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
       return rand64(static_cast<int64_t>(urange)) + start;
     return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
-    return rand64(end - staddrt) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1208,7 +1207,6 @@ class Random_XorShift1024 {
     if (urange <= static_cast<uint32_t>(MAX_RAND))
       return rand(static_cast<int>(urange)) + start;
     return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
-    return rand(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -949,7 +949,8 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
@@ -1220,7 +1221,8 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
@@ -1515,7 +1517,8 @@ class Random_SFC64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -931,8 +931,6 @@ class Random_XorShift64 {
     // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
     const uint32_t urange =
         static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
-    if (urange <= static_cast<uint32_t>(MAX_RAND))
-      return rand(static_cast<int>(urange)) + start;
     return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -949,9 +949,7 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start >
-    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
-    // streams identical for previously-valid inputs.
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
@@ -1222,9 +1220,7 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    // Unsigned subtraction avoids signed-overflow UB when end-start >
-    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
-    // streams identical for previously-valid inputs.
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
@@ -1498,7 +1494,12 @@ class Random_SFC64 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    return rand(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    const uint32_t urange =
+        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
+    if (urange <= static_cast<uint32_t>(MAX_RAND))
+      return rand(static_cast<int>(urange)) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1514,7 +1515,12 @@ class Random_SFC64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    return rand64(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT64_MAX.
+    const uint64_t urange =
+        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
+    if (urange <= static_cast<uint64_t>(MAX_RAND64))
+      return rand64(static_cast<int64_t>(urange)) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -785,7 +785,7 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
     auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
 #else
-    auto item          = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    auto item           = sycl::ext::oneapi::experimental::this_nd_item<3>();
 #endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1511,8 +1511,6 @@ class Random_SFC64 {
     // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
-    if (urange <= static_cast<uint64_t>(MAX_RAND64))
-      return rand64(static_cast<int64_t>(urange)) + start;
     return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -785,7 +785,7 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
     auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
 #else
-    auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    auto item          = sycl::ext::oneapi::experimental::this_nd_item<3>();
 #endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1491,8 +1491,6 @@ class Random_SFC64 {
     // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
     const uint32_t urange =
         static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
-    if (urange <= static_cast<uint32_t>(MAX_RAND))
-      return rand(static_cast<int>(urange)) + start;
     return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1221,8 +1221,6 @@ class Random_XorShift1024 {
     // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
-    if (urange <= static_cast<uint64_t>(MAX_RAND64))
-      return rand64(static_cast<int64_t>(urange)) + start;
     return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -951,8 +951,6 @@ class Random_XorShift64 {
     // INT64_MAX.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
-    if (urange <= static_cast<uint64_t>(MAX_RAND64))
-      return rand64(static_cast<int64_t>(urange)) + start;
     return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -928,7 +928,12 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    return rand(end - start) + start;
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    const uint32_t urange =
+        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
+    if (urange <= static_cast<uint32_t>(MAX_RAND))
+      return rand(static_cast<int>(urange)) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -944,7 +949,14 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    return rand64(end - start) + start;
+       // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
+    // streams identical for previously-valid inputs.
+    const uint64_t urange =
+        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
+    if (urange <= static_cast<uint64_t>(MAX_RAND64))
+      return rand64(static_cast<int64_t>(urange)) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));return rand64(end - staddrt) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1189,7 +1201,12 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-    return rand(end - start) + start;
+     // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    const uint32_t urange =
+        static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
+    if (urange <= static_cast<uint32_t>(MAX_RAND))
+      return rand(static_cast<int>(urange)) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));return rand(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1205,7 +1222,14 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-    return rand64(end - start) + start;
+     // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
+    // streams identical for previously-valid inputs.
+    const uint64_t urange =
+        static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
+    if (urange <= static_cast<uint64_t>(MAX_RAND64))
+      return rand64(static_cast<int64_t>(urange)) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -785,7 +785,7 @@ struct Random_UniqueIndex<Kokkos::Device<Kokkos::SYCL, MemorySpace>> {
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
     auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
 #else
-    auto item           = sycl::ext::oneapi::experimental::this_nd_item<3>();
+    auto item = sycl::ext::oneapi::experimental::this_nd_item<3>();
 #endif
     std::size_t threadIdx[3] = {item.get_local_id(2), item.get_local_id(1),
                                 item.get_local_id(0)};
@@ -949,14 +949,15 @@ class Random_XorShift64 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-       // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
     // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
     // streams identical for previously-valid inputs.
     const uint64_t urange =
         static_cast<uint64_t>(end) - static_cast<uint64_t>(start);
     if (urange <= static_cast<uint64_t>(MAX_RAND64))
       return rand64(static_cast<int64_t>(urange)) + start;
-    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));return rand64(end - staddrt) + start;
+    return static_cast<int64_t>(urand64(urange) + static_cast<uint64_t>(start));
+    return rand64(end - staddrt) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1201,12 +1202,13 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int rand(const int& start, const int& end) {
-     // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
+    // Unsigned subtraction avoids signed-overflow UB when end-start > INT_MAX.
     const uint32_t urange =
         static_cast<uint32_t>(end) - static_cast<uint32_t>(start);
     if (urange <= static_cast<uint32_t>(MAX_RAND))
       return rand(static_cast<int>(urange)) + start;
-    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));return rand(end - start) + start;
+    return static_cast<int>(urand(urange) + static_cast<uint32_t>(start));
+    return rand(end - start) + start;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -1222,7 +1224,7 @@ class Random_XorShift1024 {
 
   KOKKOS_INLINE_FUNCTION
   int64_t rand64(const int64_t& start, const int64_t& end) {
-     // Unsigned subtraction avoids signed-overflow UB when end-start >
+    // Unsigned subtraction avoids signed-overflow UB when end-start >
     // INT64_MAX. The signed path is preserved when the range fits, keeping PRNG
     // streams identical for previously-valid inputs.
     const uint64_t urange =

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -679,8 +679,12 @@ void test_rand_range_overflow() {
       "test_rand_range_overflow_64", Kokkos::RangePolicy<exec_space>(0, 1000),
       KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
         auto gen = pool.get_state();
+        constexpr int64_t start64 =
+            -typename GeneratorPool::generator_type::MAX_RAND64 - 1;
+        constexpr int64_t end64 =
+            typename GeneratorPool::generator_type::MAX_RAND64;
         for (int k = 0; k < 64; ++k)
-          if (gen.rand64(INT64_MIN, INT64_MAX) != INT64_MIN) ++n;
+          if (gen.rand64(start64, end64) != start64) ++n;
         pool.free_state(gen);
       },
       n_nonmin64);

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -652,6 +652,39 @@ void test_offset_stream() {
       << "Second half of reference streams doesn't match streams of pool B";
 }
 
+// Test rand/rand64 with ranges that previously caused signed-overflow UB.
+template <class GeneratorPool>
+void test_rand_range_overflow() {
+  using exec_space = typename GeneratorPool::device_type::execution_space;
+
+  GeneratorPool pool(42);
+
+  int64_t n_nonmin32 = 0;
+  Kokkos::parallel_reduce(
+      "test_rand_range_overflow_32", Kokkos::RangePolicy<exec_space>(0, 1000),
+      KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
+        auto gen = pool.get_state();
+        for (int k = 0; k < 64; ++k)
+          if (gen.rand(INT_MIN, INT_MAX) != INT_MIN) ++n;
+        pool.free_state(gen);
+      },
+      n_nonmin32);
+  EXPECT_GT(n_nonmin32, 0) << "rand(INT_MIN,INT_MAX) always returned INT_MIN";
+
+  int64_t n_nonmin64 = 0;
+  Kokkos::parallel_reduce(
+      "test_rand_range_overflow_64", Kokkos::RangePolicy<exec_space>(0, 1000),
+      KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
+        auto gen = pool.get_state();
+        for (int k = 0; k < 64; ++k)
+          if (gen.rand64(INT64_MIN, INT64_MAX) != INT64_MIN) ++n;
+        pool.free_state(gen);
+      },
+      n_nonmin64);
+  EXPECT_GT(n_nonmin64, 0)
+      << "rand64(INT64_MIN,INT64_MAX) always returned INT64_MIN";
+}
+
 }  // namespace AlgoRandomImpl
 
 TEST(TEST_CATEGORY, Random_XorShift64) {
@@ -712,6 +745,24 @@ TEST(TEST_CATEGORY, Random_SFC64) {
                                   Kokkos::Random_SFC64_Pool<ExecutionSpace>>(
       10000)
       .run();
+}
+
+TEST(TEST_CATEGORY, Random_XorShift64_rand_range_overflow) {
+  AlgoRandomImpl::test_rand_range_overflow<
+      Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE>>();
+}
+
+TEST(TEST_CATEGORY, Random_XorShift1024_rand_range_overflow) {
+  AlgoRandomImpl::test_rand_range_overflow<
+      Kokkos::Random_XorShift1024_Pool<TEST_EXECSPACE>>();
+}
+
+TEST(TEST_CATEGORY, Random_SFC64_rand_range_overflow) {
+#if defined(KOKKOS_ENABLE_SYCL)
+  GTEST_SKIP() << "Failing on Intel GPUs";  // FIXME_SYCL
+#endif
+  AlgoRandomImpl::test_rand_range_overflow<
+      Kokkos::Random_SFC64_Pool<TEST_EXECSPACE>>();
 }
 
 TEST(TEST_CATEGORY, Multi_streams) {

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -664,8 +664,11 @@ void test_rand_range_overflow() {
       "test_rand_range_overflow_32", Kokkos::RangePolicy<exec_space>(0, 1000),
       KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
         auto gen = pool.get_state();
+        constexpr int start32 =
+            -typename GeneratorPool::generator_type::MAX_RAND - 1;
+        constexpr int end32 = typename GeneratorPool::generator_type::MAX_RAND;
         for (int k = 0; k < 64; ++k)
-          if (gen.rand(INT_MIN, INT_MAX) != INT_MIN) ++n;
+          if (gen.rand(start32, end32) != start32) ++n;
         pool.free_state(gen);
       },
       n_nonmin32);

--- a/algorithms/unit_tests/TestRandom.hpp
+++ b/algorithms/unit_tests/TestRandom.hpp
@@ -656,6 +656,12 @@ void test_offset_stream() {
 template <class GeneratorPool>
 void test_rand_range_overflow() {
   using exec_space = typename GeneratorPool::device_type::execution_space;
+  using gen_type   = typename GeneratorPool::generator_type;
+
+  constexpr int32_t start32 = -gen_type::MAX_RAND - 1;
+  constexpr int32_t end32   = gen_type::MAX_RAND;
+  constexpr int64_t start64 = -gen_type::MAX_RAND64 - 1;
+  constexpr int64_t end64   = gen_type::MAX_RAND64;
 
   GeneratorPool pool(42);
 
@@ -664,9 +670,6 @@ void test_rand_range_overflow() {
       "test_rand_range_overflow_32", Kokkos::RangePolicy<exec_space>(0, 1000),
       KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
         auto gen = pool.get_state();
-        constexpr int start32 =
-            -typename GeneratorPool::generator_type::MAX_RAND - 1;
-        constexpr int end32 = typename GeneratorPool::generator_type::MAX_RAND;
         for (int k = 0; k < 64; ++k)
           if (gen.rand(start32, end32) != start32) ++n;
         pool.free_state(gen);
@@ -679,10 +682,6 @@ void test_rand_range_overflow() {
       "test_rand_range_overflow_64", Kokkos::RangePolicy<exec_space>(0, 1000),
       KOKKOS_LAMBDA(int /*i*/, int64_t& n) {
         auto gen = pool.get_state();
-        constexpr int64_t start64 =
-            -typename GeneratorPool::generator_type::MAX_RAND64 - 1;
-        constexpr int64_t end64 =
-            typename GeneratorPool::generator_type::MAX_RAND64;
         for (int k = 0; k < 64; ++k)
           if (gen.rand64(start64, end64) != start64) ++n;
         pool.free_state(gen);


### PR DESCRIPTION
This patch fixes signed integer overflow detected by ASan/UBSan while running tests from Trilinos Tpetra package.
- [ctest-TpetraCore_gem-crashes.log](https://github.com/user-attachments/files/28443360/ctest-TpetraCore_gem-crashes.log)

### Related issues / PRs

- https://github.com/trilinos/Trilinos/pull/15310

### Bug Fixes

- Fixed signed integer overflow UB in `Random_XorShift64` and `Random_XorShift1024` range overloads `rand(int, int)` and `rand64(int64_t, int64_t)` when `end - start` exceeds `INT_MAX` / `INT64_MAX`. Subtraction is now performed in unsigned arithmetic to avoid undefined behaviour. The signed path is preserved unchanged for ranges that fit in the signed domain, so PRNG streams are backward-compatible for previously-valid inputs.

### Changelog hint

Fix signed integer overflow UB in random generators’ range functions https://github.com/kokkos/kokkos/pull/9216
Note: The internal range computation now uses unsigned arithmetic to avoid overflow, which may change the generated pseudo-random sequences for integer types when the range spans extremely large values (e.g. [INT64_MIN, INT64_MAX]).
