### PR TITLE
Compile-time annotation of scratch space levels

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -12,6 +12,8 @@ static_assert(false,
 #include <Kokkos_Macros.hpp>
 #if defined(KOKKOS_ENABLE_CUDA)
 
+#include <cuda/annotated_ptr>
+
 #include <Kokkos_Core_fwd.hpp>
 
 #include <iosfwd>
@@ -208,16 +210,16 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
 template <>
 struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 0> {
   KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
-    KOKKOS_IF_ON_DEVICE((__builtin_assume(__isShared(p));))
-    return p;
+    return cuda::associate_access_property(p,
+                                           cuda::access_property::shared{});
   }
 };
 
 template <>
 struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 1> {
   KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
-    KOKKOS_IF_ON_DEVICE((__builtin_assume(__isGlobal(p));))
-    return p;
+    return cuda::associate_access_property(p,
+                                           cuda::access_property::global{});
   }
 };
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -203,6 +203,24 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
   enum : bool { accessible = true };
 };
 
+// Compile-time-level scratch annotation gives device codegen the pointer's
+// address-space provenance for scratch allocations.
+template <>
+struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 0> {
+  KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
+    KOKKOS_IF_ON_DEVICE((__builtin_assume(__isShared(p));))
+    return p;
+  }
+};
+
+template <>
+struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 1> {
+  KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
+    KOKKOS_IF_ON_DEVICE((__builtin_assume(__isGlobal(p));))
+    return p;
+  }
+};
+
 }  // namespace Impl
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda.hpp
+++ b/core/src/Cuda/Kokkos_Cuda.hpp
@@ -210,16 +210,14 @@ struct MemorySpaceAccess<Kokkos::CudaSpace,
 template <>
 struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 0> {
   KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
-    return cuda::associate_access_property(p,
-                                           cuda::access_property::shared{});
+    return cuda::associate_access_property(p, cuda::access_property::shared{});
   }
 };
 
 template <>
 struct ScratchPointerAnnotation<ScratchMemorySpace<Cuda>, 1> {
   KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) {
-    return cuda::associate_access_property(p,
-                                           cuda::access_property::global{});
+    return cuda::associate_access_property(p, cuda::access_property::global{});
   }
 };
 

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -11,12 +11,24 @@ static_assert(false,
 
 #include <cstdio>
 #include <cstddef>
+#include <type_traits>
 #include <Kokkos_Core_fwd.hpp>
 #include <Kokkos_Concepts.hpp>
 
 /*--------------------------------------------------------------------------*/
 
 namespace Kokkos {
+
+namespace Impl {
+
+// Customization point for backend-specific address-space hints on
+// compile-time-level scratch allocations.
+template <class MemorySpace, int Level>
+struct ScratchPointerAnnotation {
+  KOKKOS_FORCEINLINE_FUNCTION static void* annotate(void* p) { return p; }
+};
+
+}  // namespace Impl
 
 /** \brief  Scratch memory space associated with an execution space.
  *
@@ -68,6 +80,36 @@ class ScratchMemorySpace {
                                                           level);
   }
 
+  // Compile-time-level overloads with tag-dispatch.
+  template <typename IntType, int Level>
+  KOKKOS_INLINE_FUNCTION void* get_shmem(
+      const IntType& size, std::integral_constant<int, Level>) const {
+    return get_shmem_common_annotated</*alignment_requested*/ false, Level>(
+        size, 1);
+  }
+
+  template <typename IntType, int Level>
+  KOKKOS_INLINE_FUNCTION void* get_shmem_aligned(
+      const IntType& size, const ptrdiff_t alignment,
+      std::integral_constant<int, Level>) const {
+    return get_shmem_common_annotated</*alignment_requested*/ true, Level>(
+        size, alignment);
+  }
+
+  // Compile-time-level overloads with explicit template parameters.
+  template <int Level, typename IntType>
+  KOKKOS_INLINE_FUNCTION void* get_shmem(const IntType& size) const {
+    return get_shmem_common_annotated</*alignment_requested*/ false, Level>(
+        size, 1);
+  }
+
+  template <int Level, typename IntType>
+  KOKKOS_INLINE_FUNCTION void* get_shmem_aligned(
+      const IntType& size, const ptrdiff_t alignment) const {
+    return get_shmem_common_annotated</*alignment_requested*/ true, Level>(
+        size, alignment);
+  }
+
  private:
   template <bool alignment_requested, typename IntType>
   KOKKOS_INLINE_FUNCTION void* get_shmem_common(
@@ -110,6 +152,16 @@ class ScratchMemorySpace {
       m_iter += increment;
     }
     return tmp;
+  }
+
+  template <bool alignment_requested, int Level, typename IntType>
+  KOKKOS_INLINE_FUNCTION void* get_shmem_common_annotated(
+      const IntType& size, const ptrdiff_t alignment) const {
+    static_assert(Level == 0 || Level == 1,
+                  "ScratchMemorySpace level must be 0 or 1");
+    return Impl::ScratchPointerAnnotation<ScratchMemorySpace<ExecSpace>,
+                                          Level>::annotate(
+        get_shmem_common<alignment_requested>(size, alignment, Level));
   }
 
  public:

--- a/core/src/Kokkos_ScratchSpace.hpp
+++ b/core/src/Kokkos_ScratchSpace.hpp
@@ -159,9 +159,10 @@ class ScratchMemorySpace {
       const IntType& size, const ptrdiff_t alignment) const {
     static_assert(Level == 0 || Level == 1,
                   "ScratchMemorySpace level must be 0 or 1");
-    return Impl::ScratchPointerAnnotation<ScratchMemorySpace<ExecSpace>,
-                                          Level>::annotate(
-        get_shmem_common<alignment_requested>(size, alignment, Level));
+    return Impl::ScratchPointerAnnotation<
+        ScratchMemorySpace<ExecSpace>,
+        Level>::annotate(get_shmem_common<alignment_requested>(size, alignment,
+                                                               Level));
   }
 
  public:

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -690,6 +690,7 @@ if(Kokkos_ENABLE_CUDA)
     CoreUnitTest_Cuda3
     SOURCES
     UnitTestMainInit.cpp
+    cuda/TestCuda_ScratchPointerAnnotation.cpp
     cuda/TestCuda_TeamScratchStreams.cpp
     ${Cuda_SOURCES3}
     cuda/TestCuda_Spaces.cpp

--- a/core/unit_test/TestTeam.hpp
+++ b/core/unit_test/TestTeam.hpp
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <cstdio>
+#include <cstdint>
 #include <sstream>
 #include <iostream>
 #include <cmath>
+#include <type_traits>
 
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
@@ -1480,6 +1482,76 @@ struct TestTeamBroadcast<ExecSpace, ScheduleType, T,
     // least significant digit, which gives a typical walk distance
     // sqrt(league_size) Add 4x for larger sigma
     compare_test(expected_result, total, 4.0 * std::sqrt(league_size));
+  }
+};
+
+template <class ExecSpace, int Level>
+struct TestCompileTimeScratchLevelOverloadsFunctor {
+  using member_type    = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+  using flag_view_type = Kokkos::View<int, ExecSpace>;
+
+  flag_view_type m_flag;
+
+  KOKKOS_FUNCTION void operator()(const member_type &team) const {
+    constexpr int allocation_size = 16;
+    constexpr int alignment       = 8;
+
+    const auto &scratch = team.team_shmem();
+
+    auto *tag = static_cast<int *>(scratch.get_shmem(
+        allocation_size, std::integral_constant<int, Level>{}));
+    auto *explicit_level =
+        static_cast<int *>(scratch.template get_shmem<Level>(allocation_size));
+    auto *aligned_tag      = static_cast<int *>(scratch.get_shmem_aligned(
+        allocation_size, alignment, std::integral_constant<int, Level>{}));
+    auto *aligned_explicit = static_cast<int *>(
+        scratch.template get_shmem_aligned<Level>(allocation_size, alignment));
+
+    if ((reinterpret_cast<std::uintptr_t>(aligned_tag) % alignment != 0) ||
+        (reinterpret_cast<std::uintptr_t>(aligned_explicit) % alignment != 0)) {
+      m_flag() = 1;
+      return;
+    }
+
+    // Unique values detect overlapping allocations from the four overloads.
+    *tag              = 1;
+    *explicit_level   = 2;
+    *aligned_tag      = 3;
+    *aligned_explicit = 4;
+
+    if (*tag + *explicit_level + *aligned_tag + *aligned_explicit != 10) {
+      m_flag() = 2;
+    }
+  }
+};
+
+template <class ExecSpace>
+struct TestCompileTimeScratchLevelOverloads {
+  TestCompileTimeScratchLevelOverloads() {
+    run<0>();
+#if defined(KOKKOS_ENABLE_THREADS)
+    if constexpr (!std::is_same_v<ExecSpace, Kokkos::Threads>) run<1>();
+#else
+    run<1>();
+#endif
+  }
+
+  template <int Level>
+  void run() {
+    constexpr int scratch_size = 64;
+
+    Kokkos::View<int, ExecSpace> flag("flag");
+    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
+    policy.set_scratch_size(Level, Kokkos::PerTeam(scratch_size));
+
+    Kokkos::parallel_for(
+        "compile_time_scratch_level_overloads", policy,
+        TestCompileTimeScratchLevelOverloadsFunctor<ExecSpace, Level>{flag});
+    Kokkos::fence();
+
+    int host_flag = 0;
+    Kokkos::deep_copy(host_flag, flag);
+    ASSERT_EQ(host_flag, 0) << "scratch level " << Level;
   }
 };
 

--- a/core/unit_test/TestTeamScratch.hpp
+++ b/core/unit_test/TestTeamScratch.hpp
@@ -3,83 +3,10 @@
 
 #ifndef KOKKOS_TEST_TEAM_SCRATCH_HPP
 #define KOKKOS_TEST_TEAM_SCRATCH_HPP
-#include <type_traits>
 
 #include <TestTeam.hpp>
 
 namespace Test {
-
-namespace {
-
-template <class ExecSpace, int Level>
-struct TestCompileTimeScratchLevelOverloadsFunctor {
-  using member_type    = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
-  using flag_view_type = Kokkos::View<int, ExecSpace>;
-
-  flag_view_type m_flag;
-
-  KOKKOS_FUNCTION void operator()(const member_type &team) const {
-    constexpr int allocation_size = 16;
-    constexpr int alignment       = 8;
-
-    const auto &scratch = team.team_shmem();
-
-    auto *tag = static_cast<int *>(scratch.get_shmem(
-        allocation_size, std::integral_constant<int, Level>{}));
-    auto *explicit_level =
-        static_cast<int *>(scratch.template get_shmem<Level>(allocation_size));
-    auto *aligned_tag      = static_cast<int *>(scratch.get_shmem_aligned(
-        allocation_size, alignment, std::integral_constant<int, Level>{}));
-    auto *aligned_explicit = static_cast<int *>(
-        scratch.template get_shmem_aligned<Level>(allocation_size, alignment));
-
-    if ((reinterpret_cast<uintptr_t>(aligned_tag) % alignment != 0) ||
-        (reinterpret_cast<uintptr_t>(aligned_explicit) % alignment != 0)) {
-      m_flag() = 1;
-      return;
-    }
-
-    // Unique values detect overlapping allocations from the four overloads.
-    *tag              = 1;
-    *explicit_level   = 2;
-    *aligned_tag      = 3;
-    *aligned_explicit = 4;
-
-    if (*tag + *explicit_level + *aligned_tag + *aligned_explicit != 10) {
-      m_flag() = 2;
-    }
-  }
-};
-
-template <class ExecSpace>
-struct TestCompileTimeScratchLevelOverloads {
-  TestCompileTimeScratchLevelOverloads() {
-    // Test levels separately because host backends may alias their backing
-    // storage.
-    run<0>();
-    run<1>();
-  }
-
-  template <int Level>
-  void run() {
-    constexpr int scratch_size = 64;
-
-    Kokkos::View<int, ExecSpace> flag("flag");
-    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
-    policy.set_scratch_size(Level, Kokkos::PerTeam(scratch_size));
-
-    Kokkos::parallel_for(
-        "compile_time_scratch_level_overloads", policy,
-        TestCompileTimeScratchLevelOverloadsFunctor<ExecSpace, Level>{flag});
-    Kokkos::fence();
-
-    int host_flag = 0;
-    Kokkos::deep_copy(host_flag, flag);
-    ASSERT_EQ(host_flag, 0) << "scratch level " << Level;
-  }
-};
-
-}  // namespace
 
 TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();

--- a/core/unit_test/TestTeamScratch.hpp
+++ b/core/unit_test/TestTeamScratch.hpp
@@ -3,9 +3,83 @@
 
 #ifndef KOKKOS_TEST_TEAM_SCRATCH_HPP
 #define KOKKOS_TEST_TEAM_SCRATCH_HPP
+#include <type_traits>
+
 #include <TestTeam.hpp>
 
 namespace Test {
+
+namespace {
+
+template <class ExecSpace, int Level>
+struct TestCompileTimeScratchLevelOverloadsFunctor {
+  using member_type    = typename Kokkos::TeamPolicy<ExecSpace>::member_type;
+  using flag_view_type = Kokkos::View<int, ExecSpace>;
+
+  flag_view_type m_flag;
+
+  KOKKOS_FUNCTION void operator()(const member_type &team) const {
+    constexpr int allocation_size = 16;
+    constexpr int alignment       = 8;
+
+    const auto &scratch = team.team_shmem();
+
+    auto *tag = static_cast<int *>(scratch.get_shmem(
+        allocation_size, std::integral_constant<int, Level>{}));
+    auto *explicit_level =
+        static_cast<int *>(scratch.template get_shmem<Level>(allocation_size));
+    auto *aligned_tag      = static_cast<int *>(scratch.get_shmem_aligned(
+        allocation_size, alignment, std::integral_constant<int, Level>{}));
+    auto *aligned_explicit = static_cast<int *>(
+        scratch.template get_shmem_aligned<Level>(allocation_size, alignment));
+
+    if ((reinterpret_cast<uintptr_t>(aligned_tag) % alignment != 0) ||
+        (reinterpret_cast<uintptr_t>(aligned_explicit) % alignment != 0)) {
+      m_flag() = 1;
+      return;
+    }
+
+    // Unique values detect overlapping allocations from the four overloads.
+    *tag              = 1;
+    *explicit_level   = 2;
+    *aligned_tag      = 3;
+    *aligned_explicit = 4;
+
+    if (*tag + *explicit_level + *aligned_tag + *aligned_explicit != 10) {
+      m_flag() = 2;
+    }
+  }
+};
+
+template <class ExecSpace>
+struct TestCompileTimeScratchLevelOverloads {
+  TestCompileTimeScratchLevelOverloads() {
+    // Test levels separately because host backends may alias their backing
+    // storage.
+    run<0>();
+    run<1>();
+  }
+
+  template <int Level>
+  void run() {
+    constexpr int scratch_size = 64;
+
+    Kokkos::View<int, ExecSpace> flag("flag");
+    Kokkos::TeamPolicy<ExecSpace> policy(1, 1);
+    policy.set_scratch_size(Level, Kokkos::PerTeam(scratch_size));
+
+    Kokkos::parallel_for(
+        "compile_time_scratch_level_overloads", policy,
+        TestCompileTimeScratchLevelOverloadsFunctor<ExecSpace, Level>{flag});
+    Kokkos::fence();
+
+    int host_flag = 0;
+    Kokkos::deep_copy(host_flag, flag);
+    ASSERT_EQ(host_flag, 0) << "scratch level " << Level;
+  }
+};
+
+}  // namespace
 
 TEST(TEST_CATEGORY, team_shared_request) {
   TestSharedTeam<TEST_EXECSPACE, Kokkos::Schedule<Kokkos::Static> >();
@@ -32,6 +106,10 @@ TEST(TEST_CATEGORY, multi_level_scratch) {
                             Kokkos::Schedule<Kokkos::Static> >();
   TestMultiLevelScratchTeam<TEST_EXECSPACE,
                             Kokkos::Schedule<Kokkos::Dynamic> >();
+}
+
+TEST(TEST_CATEGORY, scratch_compile_time_level_overloads) {
+  TestCompileTimeScratchLevelOverloads<TEST_EXECSPACE>();
 }
 
 struct DummyTeamParallelForFunctor {

--- a/core/unit_test/cuda/TestCuda_ScratchPointerAnnotation.cpp
+++ b/core/unit_test/cuda/TestCuda_ScratchPointerAnnotation.cpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include <cuda/memory>
+
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
@@ -19,27 +21,39 @@ struct CudaScratchPointerAnnotationFunctor {
   using execution_space = TEST_EXECSPACE;
   using memory_space    = typename execution_space::memory_space;
   using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
-  using pointer_view_type = Kokkos::View<std::uintptr_t[4], memory_space>;
-  using result_view_type  = Kokkos::View<int[4], memory_space>;
+  using pointer_view_type = Kokkos::View<std::uintptr_t[8], memory_space>;
+  using result_view_type  = Kokkos::View<int[8], memory_space>;
 
   pointer_view_type m_pointers;
   result_view_type m_results;
 
   KOKKOS_FUNCTION void operator()(const member_type &team) const {
     constexpr int allocation_size = 16;
+    constexpr int alignment       = 8;
 
     // Round-trip the pointers through global memory and another thread so the
-    // predicates validate the runtime address spaces independently of annotations.
+    // predicates validate the runtime address spaces independently of
+    // annotations.
     if (team.team_rank() == 0) {
       const auto &scratch = team.team_shmem();
       m_pointers(0)       = reinterpret_cast<std::uintptr_t>(
           scratch.get_shmem(allocation_size, std::integral_constant<int, 0>{}));
       m_pointers(1) = reinterpret_cast<std::uintptr_t>(
           scratch.get_shmem<0>(allocation_size));
-      m_pointers(2) = reinterpret_cast<std::uintptr_t>(
-          scratch.get_shmem(allocation_size, std::integral_constant<int, 1>{}));
+      m_pointers(2) =
+          reinterpret_cast<std::uintptr_t>(scratch.get_shmem_aligned(
+              allocation_size, alignment, std::integral_constant<int, 0>{}));
       m_pointers(3) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem_aligned<0>(allocation_size, alignment));
+      m_pointers(4) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem(allocation_size, std::integral_constant<int, 1>{}));
+      m_pointers(5) = reinterpret_cast<std::uintptr_t>(
           scratch.get_shmem<1>(allocation_size));
+      m_pointers(6) =
+          reinterpret_cast<std::uintptr_t>(scratch.get_shmem_aligned(
+              allocation_size, alignment, std::integral_constant<int, 1>{}));
+      m_pointers(7) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem_aligned<1>(allocation_size, alignment));
     }
 
     team.team_barrier();
@@ -48,14 +62,35 @@ struct CudaScratchPointerAnnotationFunctor {
       const auto *level_0_tag = reinterpret_cast<const void *>(m_pointers(0));
       const auto *level_0_explicit =
           reinterpret_cast<const void *>(m_pointers(1));
-      const auto *level_1_tag = reinterpret_cast<const void *>(m_pointers(2));
-      const auto *level_1_explicit =
+      const auto *level_0_aligned_tag =
+          reinterpret_cast<const void *>(m_pointers(2));
+      const auto *level_0_aligned_explicit =
           reinterpret_cast<const void *>(m_pointers(3));
+      const auto *level_1_tag = reinterpret_cast<const void *>(m_pointers(4));
+      const auto *level_1_explicit =
+          reinterpret_cast<const void *>(m_pointers(5));
+      const auto *level_1_aligned_tag =
+          reinterpret_cast<const void *>(m_pointers(6));
+      const auto *level_1_aligned_explicit =
+          reinterpret_cast<const void *>(m_pointers(7));
 
-      KOKKOS_IF_ON_DEVICE((m_results(0) = __isShared(level_0_tag) != 0;
-                           m_results(1) = __isShared(level_0_explicit) != 0;
-                           m_results(2) = __isGlobal(level_1_tag) != 0;
-                           m_results(3) = __isGlobal(level_1_explicit) != 0;))
+      KOKKOS_IF_ON_DEVICE(
+          (m_results(0) = cuda::device::is_address_from(
+               level_0_tag, cuda::device::address_space::shared);
+           m_results(1) = cuda::device::is_address_from(
+               level_0_explicit, cuda::device::address_space::shared);
+           m_results(2) = cuda::device::is_address_from(
+               level_0_aligned_tag, cuda::device::address_space::shared);
+           m_results(3) = cuda::device::is_address_from(
+               level_0_aligned_explicit, cuda::device::address_space::shared);
+           m_results(4) = cuda::device::is_address_from(
+               level_1_tag, cuda::device::address_space::global);
+           m_results(5) = cuda::device::is_address_from(
+               level_1_explicit, cuda::device::address_space::global);
+           m_results(6) = cuda::device::is_address_from(
+               level_1_aligned_tag, cuda::device::address_space::global);
+           m_results(7) = cuda::device::is_address_from(
+               level_1_aligned_explicit, cuda::device::address_space::global);))
     }
   }
 };
@@ -65,15 +100,15 @@ struct CudaScratchPointerAnnotationFunctor {
 TEST(TEST_CATEGORY, scratch_pointer_address_spaces) {
   using execution_space   = TEST_EXECSPACE;
   using memory_space      = typename execution_space::memory_space;
-  using pointer_view_type = Kokkos::View<std::uintptr_t[4], memory_space>;
-  using result_view_type  = Kokkos::View<int[4], memory_space>;
+  using pointer_view_type = Kokkos::View<std::uintptr_t[8], memory_space>;
+  using result_view_type  = Kokkos::View<int[8], memory_space>;
 
   pointer_view_type pointers("scratch pointers");
   result_view_type results("address space results");
 
   Kokkos::TeamPolicy<execution_space> policy(1, 2);
-  policy.set_scratch_size(0, Kokkos::PerTeam(32));
-  policy.set_scratch_size(1, Kokkos::PerTeam(32));
+  policy.set_scratch_size(0, Kokkos::PerTeam(64));
+  policy.set_scratch_size(1, Kokkos::PerTeam(64));
 
   Kokkos::parallel_for("scratch_pointer_address_spaces", policy,
                        CudaScratchPointerAnnotationFunctor{pointers, results});
@@ -83,8 +118,12 @@ TEST(TEST_CATEGORY, scratch_pointer_address_spaces) {
       Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, results);
   EXPECT_EQ(results_host(0), 1) << "tag-dispatched level 0 pointer";
   EXPECT_EQ(results_host(1), 1) << "explicit level 0 pointer";
-  EXPECT_EQ(results_host(2), 1) << "tag-dispatched level 1 pointer";
-  EXPECT_EQ(results_host(3), 1) << "explicit level 1 pointer";
+  EXPECT_EQ(results_host(2), 1) << "tag-dispatched aligned level 0 pointer";
+  EXPECT_EQ(results_host(3), 1) << "explicit aligned level 0 pointer";
+  EXPECT_EQ(results_host(4), 1) << "tag-dispatched level 1 pointer";
+  EXPECT_EQ(results_host(5), 1) << "explicit level 1 pointer";
+  EXPECT_EQ(results_host(6), 1) << "tag-dispatched aligned level 1 pointer";
+  EXPECT_EQ(results_host(7), 1) << "explicit aligned level 1 pointer";
 }
 
 }  // namespace Test

--- a/core/unit_test/cuda/TestCuda_ScratchPointerAnnotation.cpp
+++ b/core/unit_test/cuda/TestCuda_ScratchPointerAnnotation.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <cstdint>
+#include <type_traits>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+#include <TestCuda_Category.hpp>
+
+namespace Test {
+namespace {
+
+struct CudaScratchPointerAnnotationFunctor {
+  using execution_space = TEST_EXECSPACE;
+  using memory_space    = typename execution_space::memory_space;
+  using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
+  using pointer_view_type = Kokkos::View<std::uintptr_t[4], memory_space>;
+  using result_view_type  = Kokkos::View<int[4], memory_space>;
+
+  pointer_view_type m_pointers;
+  result_view_type m_results;
+
+  KOKKOS_FUNCTION void operator()(const member_type &team) const {
+    constexpr int allocation_size = 16;
+
+    // Round-trip the pointers through global memory and another thread so the
+    // predicates validate the runtime address spaces independently of annotations.
+    if (team.team_rank() == 0) {
+      const auto &scratch = team.team_shmem();
+      m_pointers(0)       = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem(allocation_size, std::integral_constant<int, 0>{}));
+      m_pointers(1) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem<0>(allocation_size));
+      m_pointers(2) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem(allocation_size, std::integral_constant<int, 1>{}));
+      m_pointers(3) = reinterpret_cast<std::uintptr_t>(
+          scratch.get_shmem<1>(allocation_size));
+    }
+
+    team.team_barrier();
+
+    if (team.team_rank() == 1) {
+      const auto *level_0_tag = reinterpret_cast<const void *>(m_pointers(0));
+      const auto *level_0_explicit =
+          reinterpret_cast<const void *>(m_pointers(1));
+      const auto *level_1_tag = reinterpret_cast<const void *>(m_pointers(2));
+      const auto *level_1_explicit =
+          reinterpret_cast<const void *>(m_pointers(3));
+
+      KOKKOS_IF_ON_DEVICE((m_results(0) = __isShared(level_0_tag) != 0;
+                           m_results(1) = __isShared(level_0_explicit) != 0;
+                           m_results(2) = __isGlobal(level_1_tag) != 0;
+                           m_results(3) = __isGlobal(level_1_explicit) != 0;))
+    }
+  }
+};
+
+}  // namespace
+
+TEST(TEST_CATEGORY, scratch_pointer_address_spaces) {
+  using execution_space   = TEST_EXECSPACE;
+  using memory_space      = typename execution_space::memory_space;
+  using pointer_view_type = Kokkos::View<std::uintptr_t[4], memory_space>;
+  using result_view_type  = Kokkos::View<int[4], memory_space>;
+
+  pointer_view_type pointers("scratch pointers");
+  result_view_type results("address space results");
+
+  Kokkos::TeamPolicy<execution_space> policy(1, 2);
+  policy.set_scratch_size(0, Kokkos::PerTeam(32));
+  policy.set_scratch_size(1, Kokkos::PerTeam(32));
+
+  Kokkos::parallel_for("scratch_pointer_address_spaces", policy,
+                       CudaScratchPointerAnnotationFunctor{pointers, results});
+  Kokkos::fence();
+
+  auto results_host =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, results);
+  EXPECT_EQ(results_host(0), 1) << "tag-dispatched level 0 pointer";
+  EXPECT_EQ(results_host(1), 1) << "explicit level 0 pointer";
+  EXPECT_EQ(results_host(2), 1) << "tag-dispatched level 1 pointer";
+  EXPECT_EQ(results_host(3), 1) << "explicit level 1 pointer";
+}
+
+}  // namespace Test


### PR DESCRIPTION
This PR is intentionally a draft PR for now because it offers a few approaches to compile-time annotation of scratch space levels, and the ultimate decision may be to keep only one of them. It's also semi-incomplete but it's an intentional start. It's also missing formal unit testing (which I'd add before taking it out of a draft state, I just didn't want to spend time on it yet).

Main motivation: the routines to acquire scratch memory out of a "team member" take the scratch level as a runtime parameter, but I've seen in practice a `0` or `1` is baked into the code. Most of the time (looking at CUDA) the compiler can keep track of if it's a shared memory pointer or a global memory pointer (generating LDS/STS or LDG/STG in the SASS as appropriate), but in particularly complicated kernels it can lose track of this information. This causes it to generate more general LD/ST instructions instead, which are empirically lower performance. I've attached a sample code below.

As a point of conversation, this draft PR has two designs for specifying a compile-time scratch level (on top of the existing approach; no existing code is broken). It has an abstraction under the hood where each backend can specify its own way to "mark up" a pointer, which can "help" the compiler. ~For the CUDA backend, this is `__builtin_assume(__isShared(p))` and `__builtin_assume(__isGlobal(p))`.~

This is now more CUDA C++-friendly and uses [`cuda::associate_access_property`](https://nvidia.github.io/cccl/unstable/libcudacxx/extended_api/memory_access_properties/associate_access_property.html) (once I could spell it correctly, thanks Daniel), as opposed to the original implementation that used  `__builtin_assume(__isShared(p))` and `__builtin_assume(__isGlobal(p))`, as well as [`is_address_from`](https://nvidia.github.io/cccl/unstable/libcudacxx/extended_api/memory/is_address_from.html) as part of the verification that the annotation worked properly. 

Examples for `get_shmem`; `get_shmem_aligned` is also implemented.

Existing interface:
```cpp
member.team_scratch(/*level*/ 1).get_shmem(m_per_team_bytes);
```

Proposed form 1, use ` std::integral_constant` as a bonus argument... admittedly in it's current form it's incomplete.
```cpp
member.team_scratch(/*level*/ 1).get_shmem(m_per_team_bytes, std::integral_constant<int, 1>{});
```

Proposed form 2, template parameter to `get_shmem`

```cpp
member.team_scratch(/*level*/ 1).template get_shmem<1>(m_per_team_bytes);
```

Outstanding work could/would be:

 * A third proposed form, `get_shmem_level0` and `get_shmem_level1` (easy)
 * Threading this into `team_scratch(/*level*/ 1)` as well, so the `get_shmem` interface could drop these details... but one self-consistency plumbing nightmare at a time.

**I'm not married to any of these designs.** I just wanted to get a conversation going.

### Related issues / PRs

I'm aware of https://github.com/kokkos/kokkos/pull/5879 which also explored marking up pointers in an arguably more robust way, keeping the memory space as an active part of a `ScratchMemorySpace` state as opposed to just a compiler nudge. This is meant to be simpler/complimentary/less inherently robust but also less of a design conversation, in theory...

### Changelog Entry

Unsure?