### PR TITLE
Cleanup `KOKKOS_[IMPL_]FORCEINLINE_FUNCTION` not meant to be used

### DIFF
--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -26,29 +26,29 @@ struct EmulateCUDADim3 {
 #endif
 
 template <class Tag, class Functor, class... Args>
-KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<std::is_void_v<Tag>>
-_tag_invoke(Functor const& f, Args&&... args) {
+KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<std::is_void_v<Tag>> _tag_invoke(
+    Functor const& f, Args&&... args) {
   f((Args&&)args...);
 }
 
 template <class Tag, class Functor, class... Args>
-KOKKOS_IMPL_FORCEINLINE_FUNCTION std::enable_if_t<!std::is_void_v<Tag>>
-_tag_invoke(Functor const& f, Args&&... args) {
+KOKKOS_FORCEINLINE_FUNCTION std::enable_if_t<!std::is_void_v<Tag>> _tag_invoke(
+    Functor const& f, Args&&... args) {
   f(Tag{}, (Args&&)args...);
 }
 
 template <class Tag, class Functor, class T, size_t N, size_t... Idxs,
           class... Args>
-KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array_helper(
+KOKKOS_FORCEINLINE_FUNCTION void _tag_invoke_array_helper(
     Functor const& f, T (&vals)[N], std::integer_sequence<size_t, Idxs...>,
     Args&&... args) {
   _tag_invoke<Tag>(f, vals[Idxs]..., (Args&&)args...);
 }
 
 template <class Tag, class Functor, class T, size_t N, class... Args>
-KOKKOS_IMPL_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
-                                                        T (&vals)[N],
-                                                        Args&&... args) {
+KOKKOS_FORCEINLINE_FUNCTION void _tag_invoke_array(Functor const& f,
+                                                   T (&vals)[N],
+                                                   Args&&... args) {
   _tag_invoke_array_helper<Tag>(f, vals, std::make_index_sequence<N>{},
                                 (Args&&)args...);
 }


### PR DESCRIPTION
`KOKKOS_IMPL_FORCEINLINE_FUNCTION`  was never meant to be used directly.
Replace it with `KOKKOS_FORCEINLINE_FUNCTION`. 