### PR TITLE
Drop pointless `KOKKOS_INLINE_FUNCTION` uses in SYCL

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -12,79 +12,65 @@
 namespace Kokkos::Experimental {
 
 /************************** half conversions **********************************/
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(half_t val) { return val; }
+inline half_t cast_to_half(half_t val) { return val; }
 
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(float val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(double val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(short val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(unsigned short val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(int val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(unsigned int val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(long long val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(unsigned long long val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(long val) { return half_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(unsigned long val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(float val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(double val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(short val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(unsigned short val) {
+  return half_t::impl_type(val);
+}
+inline half_t cast_to_half(int val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(unsigned int val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(long long val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(unsigned long long val) {
+  return half_t::impl_type(val);
+}
+inline half_t cast_to_half(long val) { return half_t::impl_type(val); }
+inline half_t cast_to_half(unsigned long val) { return half_t::impl_type(val); }
 
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, float>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, float>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, double>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, short>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, short>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned short>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned short>, T> cast_from_half(
+    half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, int>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, int>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned int>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned int>, T> cast_from_half(
+    half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long long>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, long long>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<std::is_same_v<T, unsigned long long>, T>
-    cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned long long>, T> cast_from_half(
+    half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, long>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
-cast_from_half(half_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned long>, T> cast_from_half(
+    half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 
@@ -96,81 +82,69 @@ cast_from_half(half_t val) {
 namespace Kokkos::Experimental {
 
 /************************** bhalf conversions *********************************/
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
+inline bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(unsigned short val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(int val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(unsigned int val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(long long val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(unsigned long long val) {
+inline bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(unsigned short val) {
   return bhalf_t::impl_type(val);
 }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(long val) { return bhalf_t::impl_type(val); }
-KOKKOS_INLINE_FUNCTION
-bhalf_t cast_to_bhalf(unsigned long val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(int val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(unsigned int val) {
+  return bhalf_t::impl_type(val);
+}
+inline bhalf_t cast_to_bhalf(long long val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(unsigned long long val) {
+  return bhalf_t::impl_type(val);
+}
+inline bhalf_t cast_to_bhalf(long val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(unsigned long val) {
+  return bhalf_t::impl_type(val);
+}
 
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, float>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, float>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, double>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, short>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, short>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned short>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned short>, T> cast_from_bhalf(
+    bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, int>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, int>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned int>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned int>, T> cast_from_bhalf(
+    bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long long>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, long long>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION
-    std::enable_if_t<std::is_same_v<T, unsigned long long>, T>
-    cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned long long>, T> cast_from_bhalf(
+    bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, long>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, long>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, unsigned long>, T>
-cast_from_bhalf(bhalf_t val) {
+std::enable_if_t<std::is_same_v<T, unsigned long>, T> cast_from_bhalf(
+    bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 }  // namespace Kokkos::Experimental

--- a/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
@@ -10,34 +10,33 @@ namespace Kokkos {
 namespace Impl {
 #ifdef KOKKOS_IMPL_SYCL_HALF_TYPE_DEFINED
 
-#define KOKKOS_SYCL_HALF_UNARY_FUNCTION(OP)              \
-  KOKKOS_INLINE_FUNCTION Experimental::half_t impl_##OP( \
-      Experimental::half_t x) {                          \
-    return sycl::OP(Experimental::half_t::impl_type(x)); \
-  }
-
-#define KOKKOS_SYCL_HALF_BINARY_FUNCTION(OP)             \
-  KOKKOS_INLINE_FUNCTION Experimental::half_t impl_##OP( \
-      Experimental::half_t x, Experimental::half_t y) {  \
-    return static_cast<Experimental::half_t>(            \
-        sycl::OP(Experimental::half_t::impl_type(x),     \
-                 Experimental::half_t::impl_type(y)));   \
-  }
-
-#define KOKKOS_SYCL_HALF_TERNARY_INT_PTR_FUNCTION(OP)           \
-  KOKKOS_INLINE_FUNCTION Experimental::half_t impl_##OP(        \
-      Experimental::half_t x, Experimental::half_t y, int* z) { \
-    return static_cast<Experimental::half_t>(                   \
-        sycl::OP(Experimental::half_t::impl_type(x),            \
-                 Experimental::half_t::impl_type(y), z));       \
-  }
-
-#define KOKKOS_SYCL_HALF_UNARY_PREDICATE(OP)                      \
-  KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::half_t x) { \
+#define KOKKOS_SYCL_HALF_UNARY_FUNCTION(OP)                       \
+  inline Experimental::half_t impl_##OP(Experimental::half_t x) { \
     return sycl::OP(Experimental::half_t::impl_type(x));          \
   }
 
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::half_t impl_test_fallback_half(
+#define KOKKOS_SYCL_HALF_BINARY_FUNCTION(OP)                      \
+  inline Experimental::half_t impl_##OP(Experimental::half_t x,   \
+                                        Experimental::half_t y) { \
+    return static_cast<Experimental::half_t>(                     \
+        sycl::OP(Experimental::half_t::impl_type(x),              \
+                 Experimental::half_t::impl_type(y)));            \
+  }
+
+#define KOKKOS_SYCL_HALF_TERNARY_INT_PTR_FUNCTION(OP)                     \
+  inline Experimental::half_t impl_##OP(Experimental::half_t x,           \
+                                        Experimental::half_t y, int* z) { \
+    return static_cast<Experimental::half_t>(                             \
+        sycl::OP(Experimental::half_t::impl_type(x),                      \
+                 Experimental::half_t::impl_type(y), z));                 \
+  }
+
+#define KOKKOS_SYCL_HALF_UNARY_PREDICATE(OP)             \
+  inline bool impl_##OP(Experimental::half_t x) {        \
+    return sycl::OP(Experimental::half_t::impl_type(x)); \
+  }
+
+inline Kokkos::Experimental::half_t impl_test_fallback_half(
     Kokkos::Experimental::half_t) {
   return Kokkos::Experimental::half_t(0.f);
 }
@@ -110,29 +109,28 @@ KOKKOS_SYCL_HALF_UNARY_FUNCTION(rsqrt)
 
 #ifdef KOKKOS_IMPL_SYCL_BHALF_TYPE_DEFINED
 
-#define KOKKOS_SYCL_BHALF_UNARY_FUNCTION(OP)              \
-  KOKKOS_INLINE_FUNCTION Experimental::bhalf_t impl_##OP( \
-      Experimental::bhalf_t x) {                          \
-    return sycl::ext::oneapi::experimental::OP(           \
-        Experimental::bhalf_t::impl_type(x));             \
+#define KOKKOS_SYCL_BHALF_UNARY_FUNCTION(OP)                        \
+  inline Experimental::bhalf_t impl_##OP(Experimental::bhalf_t x) { \
+    return sycl::ext::oneapi::experimental::OP(                     \
+        Experimental::bhalf_t::impl_type(x));                       \
   }
 
-#define KOKKOS_SYCL_BHALF_BINARY_FUNCTION(OP)             \
-  KOKKOS_INLINE_FUNCTION Experimental::bhalf_t impl_##OP( \
-      Experimental::bhalf_t x, Experimental::bhalf_t y) { \
-    return static_cast<Experimental::bhalf_t>(            \
-        sycl::ext::oneapi::experimental::OP(              \
-            Experimental::bhalf_t::impl_type(x),          \
-            Experimental::bhalf_t::impl_type(y)));        \
+#define KOKKOS_SYCL_BHALF_BINARY_FUNCTION(OP)                       \
+  inline Experimental::bhalf_t impl_##OP(Experimental::bhalf_t x,   \
+                                         Experimental::bhalf_t y) { \
+    return static_cast<Experimental::bhalf_t>(                      \
+        sycl::ext::oneapi::experimental::OP(                        \
+            Experimental::bhalf_t::impl_type(x),                    \
+            Experimental::bhalf_t::impl_type(y)));                  \
   }
 
-#define KOKKOS_SYCL_BHALF_UNARY_PREDICATE(OP)                      \
-  KOKKOS_INLINE_FUNCTION bool impl_##OP(Experimental::bhalf_t x) { \
-    return sycl::ext::oneapi::experimental::OP(                    \
-        Experimental::bhalf_t::impl_type(x));                      \
+#define KOKKOS_SYCL_BHALF_UNARY_PREDICATE(OP)      \
+  inline bool impl_##OP(Experimental::bhalf_t x) { \
+    return sycl::ext::oneapi::experimental::OP(    \
+        Experimental::bhalf_t::impl_type(x));      \
   }
 
-KOKKOS_INLINE_FUNCTION Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
     Kokkos::Experimental::bhalf_t) {
   return Kokkos::Experimental::bhalf_t(0.f);
 }

--- a/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_MathematicalFunctions.hpp
@@ -130,7 +130,7 @@ KOKKOS_SYCL_HALF_UNARY_FUNCTION(rsqrt)
         Experimental::bhalf_t::impl_type(x));      \
   }
 
-Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
+inline Kokkos::Experimental::bhalf_t impl_test_fallback_bhalf(
     Kokkos::Experimental::bhalf_t) {
   return Kokkos::Experimental::bhalf_t(0.f);
 }

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -473,12 +473,12 @@ ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType1 arg_begin,
       thread, iType(arg_begin), iType(arg_end));
 }
 
-Impl::ThreadSingleStruct<Impl::SYCLTeamMember> PerTeam(
+inline Impl::ThreadSingleStruct<Impl::SYCLTeamMember> PerTeam(
     const Impl::SYCLTeamMember& thread) {
   return Impl::ThreadSingleStruct<Impl::SYCLTeamMember>(thread);
 }
 
-Impl::VectorSingleStruct<Impl::SYCLTeamMember> PerThread(
+inline Impl::VectorSingleStruct<Impl::SYCLTeamMember> PerThread(
     const Impl::SYCLTeamMember& thread) {
   return Impl::VectorSingleStruct<Impl::SYCLTeamMember>(thread);
 }

--- a/core/src/SYCL/Kokkos_SYCL_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Team.hpp
@@ -34,43 +34,33 @@ class SYCLTeamMember {
   int m_league_size;
 
  public:
-  KOKKOS_INLINE_FUNCTION
   const execution_space::scratch_memory_space& team_shmem() const {
     return m_team_shared.set_team_thread_mode(0, 1, 0);
   }
 
-  KOKKOS_INLINE_FUNCTION
   const execution_space::scratch_memory_space& team_scratch(
       const int level) const {
     return m_team_shared.set_team_thread_mode(level, 1, 0);
   }
 
-  KOKKOS_INLINE_FUNCTION
   const execution_space::scratch_memory_space& thread_scratch(
       const int level) const {
     return m_team_shared.set_team_thread_mode(level, team_size(), team_rank());
   }
 
-  KOKKOS_INLINE_FUNCTION int league_rank() const { return m_league_rank; }
-  KOKKOS_INLINE_FUNCTION int league_size() const { return m_league_size; }
-  KOKKOS_INLINE_FUNCTION int team_rank() const {
-    return m_item.get_local_id(0);
-  }
-  KOKKOS_INLINE_FUNCTION int team_size() const {
-    return m_item.get_local_range(0);
-  }
-  KOKKOS_INLINE_FUNCTION void team_barrier() const {
-    sycl::group_barrier(m_item.get_group());
-  }
+  int league_rank() const { return m_league_rank; }
+  int league_size() const { return m_league_size; }
+  int team_rank() const { return m_item.get_local_id(0); }
+  int team_size() const { return m_item.get_local_range(0); }
+  void team_barrier() const { sycl::group_barrier(m_item.get_group()); }
 
-  KOKKOS_INLINE_FUNCTION const sycl::nd_item<2>& item() const { return m_item; }
+  const sycl::nd_item<2>& item() const { return m_item; }
 
   //--------------------------------------------------------------------------
 
   template <class ValueType>
-  KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<std::is_trivially_copyable_v<ValueType>>
-      team_broadcast(ValueType& val, const int thread_id) const {
+  std::enable_if_t<std::is_trivially_copyable_v<ValueType>> team_broadcast(
+      ValueType& val, const int thread_id) const {
     val = sycl::group_broadcast(m_item.get_group(), val,
                                 sycl::id<2>(thread_id, 0));
   }
@@ -78,9 +68,8 @@ class SYCLTeamMember {
   // FIXME_SYCL remove/adapt this overload once the Intel oneAPI implementation
   // is conforming to the SYCL2020 standard (allowing trivially-copyable types)
   template <class ValueType>
-  KOKKOS_INLINE_FUNCTION
-      std::enable_if_t<!std::is_trivially_copyable_v<ValueType>>
-      team_broadcast(ValueType& val, const int thread_id) const {
+  std::enable_if_t<!std::is_trivially_copyable_v<ValueType>> team_broadcast(
+      ValueType& val, const int thread_id) const {
     // Wait for shared data write until all threads arrive here
     sycl::group_barrier(m_item.get_group());
     if (m_item.get_local_id(1) == 0 &&
@@ -93,8 +82,8 @@ class SYCLTeamMember {
   }
 
   template <class Closure, class ValueType>
-  KOKKOS_INLINE_FUNCTION void team_broadcast(Closure const& f, ValueType& val,
-                                             const int thread_id) const {
+  void team_broadcast(Closure const& f, ValueType& val,
+                      const int thread_id) const {
     f(val);
     team_broadcast(val, thread_id);
   }
@@ -103,15 +92,15 @@ class SYCLTeamMember {
   /**\brief  Reduction across a team
    */
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
-  team_reduce(ReducerType const& reducer) const noexcept {
+  std::enable_if_t<is_reducer<ReducerType>::value> team_reduce(
+      ReducerType const& reducer) const noexcept {
     team_reduce(reducer, reducer.reference());
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
-  team_reduce(ReducerType const& reducer,
-              typename ReducerType::value_type& value) const noexcept {
+  std::enable_if_t<is_reducer<ReducerType>::value> team_reduce(
+      ReducerType const& reducer,
+      typename ReducerType::value_type& value) const noexcept {
     using value_type = typename ReducerType::value_type;
     using wrapped_reducer_type =
         typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
@@ -122,8 +111,7 @@ class SYCLTeamMember {
   }
 
   template <typename WrappedReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrappedReducerType>::value>
-  impl_team_reduce(
+  std::enable_if_t<is_reducer<WrappedReducerType>::value> impl_team_reduce(
       WrappedReducerType const& wrapped_reducer,
       typename WrappedReducerType::value_type& value) const noexcept {
     using value_type = typename WrappedReducerType::value_type;
@@ -211,8 +199,7 @@ class SYCLTeamMember {
    *  non-deterministic.
    */
   template <typename Type>
-  KOKKOS_INLINE_FUNCTION Type team_scan(const Type& input_value,
-                                        Type* const global_accum) const {
+  Type team_scan(const Type& input_value, Type* const global_accum) const {
     Type value                 = input_value;
     auto sg                    = m_item.get_sub_group();
     const auto sub_group_range = sg.get_local_range()[0];
@@ -294,22 +281,22 @@ class SYCLTeamMember {
    *    reduction_total = dev.team_scan( value ) + value ;
    */
   template <typename Type>
-  KOKKOS_INLINE_FUNCTION Type team_scan(const Type& value) const {
+  Type team_scan(const Type& value) const {
     return this->template team_scan<Type>(value, nullptr);
   }
 
   //----------------------------------------
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
-  vector_reduce(ReducerType const& reducer) const {
+  std::enable_if_t<is_reducer<ReducerType>::value> vector_reduce(
+      ReducerType const& reducer) const {
     vector_reduce(reducer, reducer.reference());
   }
 
   template <typename ReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
-  vector_reduce(ReducerType const& reducer,
-                typename ReducerType::value_type& value) const {
+  std::enable_if_t<is_reducer<ReducerType>::value> vector_reduce(
+      ReducerType const& reducer,
+      typename ReducerType::value_type& value) const {
     using value_type = typename ReducerType::value_type;
     using wrapped_reducer_type =
         typename Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
@@ -320,9 +307,9 @@ class SYCLTeamMember {
   }
 
   template <typename WrappedReducerType>
-  KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<WrappedReducerType>::value>
-  impl_vector_reduce(WrappedReducerType const& wrapped_reducer,
-                     typename WrappedReducerType::value_type& value) const {
+  std::enable_if_t<is_reducer<WrappedReducerType>::value> impl_vector_reduce(
+      WrappedReducerType const& wrapped_reducer,
+      typename WrappedReducerType::value_type& value) const {
     const auto tidx1   = m_item.get_local_id(1);
     const auto grange1 = m_item.get_local_range(1);
 
@@ -354,7 +341,6 @@ class SYCLTeamMember {
   //----------------------------------------
   // Private for the driver
 
-  KOKKOS_INLINE_FUNCTION
   SYCLTeamMember(sycl::local_ptr<void> shared, const std::size_t shared_begin,
                  const std::size_t shared_size,
                  sycl::global_ptr<void> scratch_level_1_ptr,
@@ -394,12 +380,10 @@ struct TeamThreadRangeBoundariesStruct<iType, SYCLTeamMember> {
   const iType start;
   const iType end;
 
-  KOKKOS_INLINE_FUNCTION
   TeamThreadRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                   iType arg_count)
       : member(arg_thread), start(0), end(arg_count) {}
 
-  KOKKOS_INLINE_FUNCTION
   TeamThreadRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                   iType arg_begin, iType arg_end)
       : member(arg_thread), start(arg_begin), end(arg_end) {}
@@ -412,12 +396,10 @@ struct TeamVectorRangeBoundariesStruct<iType, SYCLTeamMember> {
   const iType start;
   const iType end;
 
-  KOKKOS_INLINE_FUNCTION
   TeamVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                   const iType& arg_count)
       : member(arg_thread), start(0), end(arg_count) {}
 
-  KOKKOS_INLINE_FUNCTION
   TeamVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                   const iType& arg_begin, const iType& arg_end)
       : member(arg_thread), start(arg_begin), end(arg_end) {}
@@ -430,12 +412,10 @@ struct ThreadVectorRangeBoundariesStruct<iType, SYCLTeamMember> {
   const index_type start;
   const index_type end;
 
-  KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                     index_type arg_count)
       : member(arg_thread), start(static_cast<index_type>(0)), end(arg_count) {}
 
-  KOKKOS_INLINE_FUNCTION
   ThreadVectorRangeBoundariesStruct(const SYCLTeamMember& arg_thread,
                                     index_type arg_begin, index_type arg_end)
       : member(arg_thread), start(arg_begin), end(arg_end) {}
@@ -444,16 +424,15 @@ struct ThreadVectorRangeBoundariesStruct<iType, SYCLTeamMember> {
 }  // namespace Impl
 
 template <typename iType>
-KOKKOS_INLINE_FUNCTION
-    Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
-    TeamThreadRange(const Impl::SYCLTeamMember& thread, iType count) {
+Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
+TeamThreadRange(const Impl::SYCLTeamMember& thread, iType count) {
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, count);
 }
 
 template <typename iType1, typename iType2>
-KOKKOS_INLINE_FUNCTION Impl::TeamThreadRangeBoundariesStruct<
-    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
+Impl::TeamThreadRangeBoundariesStruct<std::common_type_t<iType1, iType2>,
+                                      Impl::SYCLTeamMember>
 TeamThreadRange(const Impl::SYCLTeamMember& thread, iType1 begin, iType2 end) {
   using iType = std::common_type_t<iType1, iType2>;
   return Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
@@ -461,16 +440,15 @@ TeamThreadRange(const Impl::SYCLTeamMember& thread, iType1 begin, iType2 end) {
 }
 
 template <typename iType>
-KOKKOS_INLINE_FUNCTION
-    Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
-    TeamVectorRange(const Impl::SYCLTeamMember& thread, const iType& count) {
+Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
+TeamVectorRange(const Impl::SYCLTeamMember& thread, const iType& count) {
   return Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, count);
 }
 
 template <typename iType1, typename iType2>
-KOKKOS_INLINE_FUNCTION Impl::TeamVectorRangeBoundariesStruct<
-    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
+Impl::TeamVectorRangeBoundariesStruct<std::common_type_t<iType1, iType2>,
+                                      Impl::SYCLTeamMember>
 TeamVectorRange(const Impl::SYCLTeamMember& thread, const iType1& begin,
                 const iType2& end) {
   using iType = std::common_type_t<iType1, iType2>;
@@ -479,16 +457,15 @@ TeamVectorRange(const Impl::SYCLTeamMember& thread, const iType1& begin,
 }
 
 template <typename iType>
-KOKKOS_INLINE_FUNCTION
-    Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
-    ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType count) {
+Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>
+ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType count) {
   return Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>(
       thread, count);
 }
 
 template <typename iType1, typename iType2>
-KOKKOS_INLINE_FUNCTION Impl::ThreadVectorRangeBoundariesStruct<
-    std::common_type_t<iType1, iType2>, Impl::SYCLTeamMember>
+Impl::ThreadVectorRangeBoundariesStruct<std::common_type_t<iType1, iType2>,
+                                        Impl::SYCLTeamMember>
 ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType1 arg_begin,
                   iType2 arg_end) {
   using iType = std::common_type_t<iType1, iType2>;
@@ -496,13 +473,11 @@ ThreadVectorRange(const Impl::SYCLTeamMember& thread, iType1 arg_begin,
       thread, iType(arg_begin), iType(arg_end));
 }
 
-KOKKOS_INLINE_FUNCTION
 Impl::ThreadSingleStruct<Impl::SYCLTeamMember> PerTeam(
     const Impl::SYCLTeamMember& thread) {
   return Impl::ThreadSingleStruct<Impl::SYCLTeamMember>(thread);
 }
 
-KOKKOS_INLINE_FUNCTION
 Impl::VectorSingleStruct<Impl::SYCLTeamMember> PerThread(
     const Impl::SYCLTeamMember& thread) {
   return Impl::VectorSingleStruct<Impl::SYCLTeamMember>(thread);
@@ -517,10 +492,9 @@ Impl::VectorSingleStruct<Impl::SYCLTeamMember> PerThread(
  * The range [0..N) is mapped to all threads of the calling thread team.
  */
 template <typename iType, class Closure>
-KOKKOS_INLINE_FUNCTION void parallel_for(
-    const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_boundaries,
-    const Closure& closure) {
+void parallel_for(const Impl::TeamThreadRangeBoundariesStruct<
+                      iType, Impl::SYCLTeamMember>& loop_boundaries,
+                  const Closure& closure) {
   for (iType i = loop_boundaries.start +
                  loop_boundaries.member.item().get_local_id(0);
        i < loop_boundaries.end;
@@ -539,10 +513,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
  *  performed and put into result.
  */
 template <typename iType, class Closure, class ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember>& loop_boundaries,
-                const Closure& closure, const ReducerType& reducer) {
+std::enable_if_t<Kokkos::is_reducer<ReducerType>::value> parallel_reduce(
+    const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
+        loop_boundaries,
+    const Closure& closure, const ReducerType& reducer) {
   using value_type            = typename ReducerType::value_type;
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
@@ -575,10 +549,10 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
  *  performed and put into result.
  */
 template <typename iType, class Closure, typename ValueType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
-parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember>& loop_boundaries,
-                const Closure& closure, ValueType& result) {
+std::enable_if_t<!Kokkos::is_reducer<ValueType>::value> parallel_reduce(
+    const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
+        loop_boundaries,
+    const Closure& closure, ValueType& result) {
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
       TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
@@ -613,10 +587,9 @@ parallel_reduce(const Impl::TeamThreadRangeBoundariesStruct<
  */
 // This is the same code as in CUDA.
 template <typename iType, typename FunctorType, typename ValueType>
-KOKKOS_INLINE_FUNCTION void parallel_scan(
-    const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_bounds,
-    const FunctorType& lambda, ValueType& return_val) {
+void parallel_scan(const Impl::TeamThreadRangeBoundariesStruct<
+                       iType, Impl::SYCLTeamMember>& loop_bounds,
+                   const FunctorType& lambda, ValueType& return_val) {
   // Extract ValueType from the Closure
   using closure_value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
@@ -654,10 +627,9 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 }
 
 template <typename iType, class FunctorType>
-KOKKOS_INLINE_FUNCTION void parallel_scan(
-    const Impl::TeamThreadRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_bounds,
-    const FunctorType& lambda) {
+void parallel_scan(const Impl::TeamThreadRangeBoundariesStruct<
+                       iType, Impl::SYCLTeamMember>& loop_bounds,
+                   const FunctorType& lambda) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, FunctorType,
       void>::value_type;
@@ -667,10 +639,9 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 }
 
 template <typename iType, class Closure>
-KOKKOS_INLINE_FUNCTION void parallel_for(
-    const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_boundaries,
-    const Closure& closure) {
+void parallel_for(const Impl::TeamVectorRangeBoundariesStruct<
+                      iType, Impl::SYCLTeamMember>& loop_boundaries,
+                  const Closure& closure) {
   const iType tidx0 = loop_boundaries.member.item().get_local_id(0);
   const iType tidx1 = loop_boundaries.member.item().get_local_id(1);
 
@@ -683,10 +654,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
 }
 
 template <typename iType, class Closure, class ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember>& loop_boundaries,
-                const Closure& closure, const ReducerType& reducer) {
+std::enable_if_t<Kokkos::is_reducer<ReducerType>::value> parallel_reduce(
+    const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
+        loop_boundaries,
+    const Closure& closure, const ReducerType& reducer) {
   using value_type            = typename ReducerType::value_type;
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
@@ -716,10 +687,10 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
 }
 
 template <typename iType, class Closure, typename ValueType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<!Kokkos::is_reducer<ValueType>::value>
-parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember>& loop_boundaries,
-                const Closure& closure, ValueType& result) {
+std::enable_if_t<!Kokkos::is_reducer<ValueType>::value> parallel_reduce(
+    const Impl::TeamVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
+        loop_boundaries,
+    const Closure& closure, ValueType& result) {
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
       TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
@@ -757,10 +728,9 @@ parallel_reduce(const Impl::TeamVectorRangeBoundariesStruct<
  * The range [0..N) is mapped to all vector lanes of the calling thread.
  */
 template <typename iType, class Closure>
-KOKKOS_INLINE_FUNCTION void parallel_for(
-    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_boundaries,
-    const Closure& closure) {
+void parallel_for(const Impl::ThreadVectorRangeBoundariesStruct<
+                      iType, Impl::SYCLTeamMember>& loop_boundaries,
+                  const Closure& closure) {
   const iType tidx1   = loop_boundaries.member.item().get_local_id(1);
   const iType grange1 = loop_boundaries.member.item().get_local_range(1);
 
@@ -791,10 +761,10 @@ KOKKOS_INLINE_FUNCTION void parallel_for(
  *  constructed value.
  */
 template <typename iType, class Closure, class ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<is_reducer<ReducerType>::value>
-parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember> const& loop_boundaries,
-                Closure const& closure, ReducerType const& reducer) {
+std::enable_if_t<is_reducer<ReducerType>::value> parallel_reduce(
+    Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember> const&
+        loop_boundaries,
+    Closure const& closure, ReducerType const& reducer) {
   using value_type            = typename ReducerType::value_type;
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
@@ -830,10 +800,10 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
  *  constructed value.
  */
 template <typename iType, class Closure, typename ValueType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<!is_reducer<ValueType>::value>
-parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
-                    iType, Impl::SYCLTeamMember> const& loop_boundaries,
-                Closure const& closure, ValueType& result) {
+std::enable_if_t<!is_reducer<ValueType>::value> parallel_reduce(
+    Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember> const&
+        loop_boundaries,
+    Closure const& closure, ValueType& result) {
   using functor_analysis_type = typename Impl::FunctorAnalysis<
       Impl::FunctorPatternInterface::REDUCE,
       TeamPolicy<typename Impl::SYCLTeamMember::execution_space>, Closure,
@@ -868,10 +838,10 @@ parallel_reduce(Impl::ThreadVectorRangeBoundariesStruct<
  *  The last call to closure has final == true.
  */
 template <typename iType, class Closure, typename ReducerType>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<Kokkos::is_reducer<ReducerType>::value>
-parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
-                  iType, Impl::SYCLTeamMember>& loop_boundaries,
-              const Closure& closure, const ReducerType& reducer) {
+std::enable_if_t<Kokkos::is_reducer<ReducerType>::value> parallel_scan(
+    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
+        loop_boundaries,
+    const Closure& closure, const ReducerType& reducer) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
       void>::value_type;
@@ -941,10 +911,9 @@ parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
  *  The last call to closure has final == true.
  */
 template <typename iType, class Closure>
-KOKKOS_INLINE_FUNCTION void parallel_scan(
-    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_boundaries,
-    const Closure& closure) {
+void parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                       iType, Impl::SYCLTeamMember>& loop_boundaries,
+                   const Closure& closure) {
   using value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
       void>::value_type;
@@ -961,10 +930,9 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
  *  The last call to closure has final == true.
  */
 template <typename iType, class Closure, typename ValueType>
-KOKKOS_INLINE_FUNCTION void parallel_scan(
-    const Impl::ThreadVectorRangeBoundariesStruct<iType, Impl::SYCLTeamMember>&
-        loop_boundaries,
-    const Closure& closure, ValueType& return_val) {
+void parallel_scan(const Impl::ThreadVectorRangeBoundariesStruct<
+                       iType, Impl::SYCLTeamMember>& loop_boundaries,
+                   const Closure& closure, ValueType& return_val) {
   // Extract ValueType from the Closure
   using closure_value_type = typename Kokkos::Impl::FunctorAnalysis<
       Kokkos::Impl::FunctorPatternInterface::SCAN, void, Closure,
@@ -983,23 +951,20 @@ KOKKOS_INLINE_FUNCTION void parallel_scan(
 namespace Kokkos {
 
 template <class FunctorType>
-KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::SYCLTeamMember>& single_struct,
-    const FunctorType& lambda) {
+void single(const Impl::VectorSingleStruct<Impl::SYCLTeamMember>& single_struct,
+            const FunctorType& lambda) {
   if (single_struct.team_member.item().get_local_id(1) == 0) lambda();
 }
 
 template <class FunctorType>
-KOKKOS_INLINE_FUNCTION void single(
-    const Impl::ThreadSingleStruct<Impl::SYCLTeamMember>& single_struct,
-    const FunctorType& lambda) {
+void single(const Impl::ThreadSingleStruct<Impl::SYCLTeamMember>& single_struct,
+            const FunctorType& lambda) {
   if (single_struct.team_member.item().get_local_linear_id() == 0) lambda();
 }
 
 template <class FunctorType, class ValueType>
-KOKKOS_INLINE_FUNCTION void single(
-    const Impl::VectorSingleStruct<Impl::SYCLTeamMember>& single_struct,
-    const FunctorType& lambda, ValueType& val) {
+void single(const Impl::VectorSingleStruct<Impl::SYCLTeamMember>& single_struct,
+            const FunctorType& lambda, ValueType& val) {
   const sycl::nd_item<2> item = single_struct.team_member.item();
   const auto grange1          = item.get_local_range(1);
   const auto sg               = item.get_sub_group();
@@ -1018,9 +983,8 @@ KOKKOS_INLINE_FUNCTION void single(
 }
 
 template <class FunctorType, class ValueType>
-KOKKOS_INLINE_FUNCTION void single(
-    const Impl::ThreadSingleStruct<Impl::SYCLTeamMember>& single_struct,
-    const FunctorType& lambda, ValueType& val) {
+void single(const Impl::ThreadSingleStruct<Impl::SYCLTeamMember>& single_struct,
+            const FunctorType& lambda, ValueType& val) {
   if (single_struct.team_member.item().get_local_linear_id() == 0) lambda(val);
   single_struct.team_member.team_broadcast(val, 0);
 }

--- a/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_UniqueToken.hpp
@@ -33,7 +33,6 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
       : m_locks(Kokkos::Impl::sycl_global_unique_token_locks()) {}
 
   /// \brief upper bound for acquired values, i.e. 0 <= value < size()
-  KOKKOS_INLINE_FUNCTION
   size_type size() const noexcept { return m_locks.extent(0); }
 
  protected:
@@ -49,7 +48,6 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
 
  private:
   /// \brief acquire value such that 0 <= value < size()
-  KOKKOS_INLINE_FUNCTION
   size_type impl_acquire() const {
 #if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
     KOKKOS_COMPILER_INTEL_LLVM >= 20250000
@@ -81,14 +79,12 @@ class UniqueToken<SYCL, UniqueTokenScope::Global> {
 
  public:
   /// \brief acquire value such that 0 <= value < size()
-  KOKKOS_INLINE_FUNCTION
   size_type acquire() const {
     KOKKOS_IF_ON_DEVICE(return impl_acquire();)
     KOKKOS_IF_ON_HOST(return 0;)
   }
 
   /// \brief release an acquired value
-  KOKKOS_INLINE_FUNCTION
   void release(size_type idx) const noexcept {
     // Make sure my writes are visible to the next lock owner
     desul::atomic_thread_fence(desul::MemoryOrderRelease(),


### PR DESCRIPTION
`KOKKOS_FUNCTION` expands to nothing with SYCL.  We generally were not using it in the backend implementation backends but there were a few places where it snuck in.
This PR replaces `KOKKOS_INLINE_FUNCTION -> inline` on non-templated function and just drop the `inline` specifier on templated ones and on [member functions defined within the class body](https://kokkos.org/kokkos-core-wiki/developer-guides/coding-standards.html#dont-use-inline-when-defining-a-function-within-the-class-definition).