### PR TITLE
Spell out `__forceinline__` in CUDA/HIP shuffle ops

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Vectorization.hpp
@@ -31,7 +31,7 @@ constexpr unsigned shfl_all_mask = 0xffffffffu;
 template <class Derived>
 struct in_place_shfl_op {
   // CRTP boilerplate
-  __device__ KOKKOS_IMPL_FORCEINLINE const Derived& self() const noexcept {
+  __device__ __forceinline__ const Derived& self() const noexcept {
     return *static_cast<Derived const*>(this);
   }
 
@@ -111,9 +111,8 @@ struct in_place_shfl_op {
 
 struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(unsigned mask, T& val, int lane,
+                                          int width) const noexcept {
     (void)mask;
     (void)val;
     (void)lane;
@@ -122,29 +121,26 @@ struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   }
 };
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl(Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl(Args&&... args) noexcept {
   in_place_shfl_fn{}((Args&&)args...);
 }
 
 struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(unsigned mask, T& val, int lane,
+                                          int width) const noexcept {
     return __shfl_up_sync(mask, val, lane, width);
   }
 };
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_up(
-    Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl_up(Args&&... args) noexcept {
   in_place_shfl_up_fn{}((Args&&)args...);
 }
 
 struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(unsigned mask, T& val,
-                                                  int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(unsigned mask, T& val, int lane,
+                                          int width) const noexcept {
     (void)mask;
     (void)val;
     (void)lane;
@@ -153,8 +149,7 @@ struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   }
 };
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_down(
-    Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl_down(Args&&... args) noexcept {
   in_place_shfl_down_fn{}((Args&&)args...);
 }
 

--- a/core/src/HIP/Kokkos_HIP_Vectorization.hpp
+++ b/core/src/HIP/Kokkos_HIP_Vectorization.hpp
@@ -19,7 +19,7 @@ namespace Impl {
 template <class Derived>
 struct in_place_shfl_op {
   // CRTP boilerplate
-  __device__ KOKKOS_IMPL_FORCEINLINE const Derived& self() const noexcept {
+  __device__ __forceinline__ const Derived& self() const noexcept {
     return *static_cast<Derived const*>(this);
   }
 
@@ -86,45 +86,43 @@ struct in_place_shfl_op {
 
 struct in_place_shfl_fn : in_place_shfl_op<in_place_shfl_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(T& val, int lane,
+                                          int width) const noexcept {
     auto return_val = __shfl(val, lane, width);
     return return_val;
   }
 };
 
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl(Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl(Args&&... args) noexcept {
   in_place_shfl_fn{}((Args&&)args...);
 }
 
 struct in_place_shfl_up_fn : in_place_shfl_op<in_place_shfl_up_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(T& val, int lane,
+                                          int width) const noexcept {
     auto return_val = __shfl_up(val, lane, width);
     return return_val;
   }
 };
 
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_up(
-    Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl_up(Args&&... args) noexcept {
   in_place_shfl_up_fn{}((Args&&)args...);
 }
 
 struct in_place_shfl_down_fn : in_place_shfl_op<in_place_shfl_down_fn> {
   template <class T>
-  __device__ KOKKOS_IMPL_FORCEINLINE T do_shfl_op(T& val, int lane,
-                                                  int width) const noexcept {
+  __device__ __forceinline__ T do_shfl_op(T& val, int lane,
+                                          int width) const noexcept {
     auto return_val = __shfl_down(val, lane, width);
     return return_val;
   }
 };
 
 template <class... Args>
-__device__ KOKKOS_IMPL_FORCEINLINE void in_place_shfl_down(
-    Args&&... args) noexcept {
+__device__ __forceinline__ void in_place_shfl_down(Args&&... args) noexcept {
   in_place_shfl_down_fn{}((Args&&)args...);
 }
 


### PR DESCRIPTION
Related to #9223 
The `KOKKOS_IMPL_FORCEINLINE` macro was not meant for broader use.
Here I propose to "expand" it in CUDA and HIP internals where we were already spelling out `__device__` function annotations.
I am exploring potential removing that macro in follow up work.