### PR TITLE
Drop `KOKKOS_IMPL_FORCEINLINE` attribute in `Impl::DeviceIterate`

### DIFF
--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -246,8 +246,7 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return Flat hardware thread ID (packed) or global index (unpacked)
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_begin() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION constexpr index_type my_begin() const noexcept {
     static_assert(RIdx < 6);
     if constexpr (Rank < 4) {
       // No packed index
@@ -284,8 +283,7 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return product of the extents (packed) or upper bound (unpacked)
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_end() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION constexpr index_type my_end() const noexcept {
     static_assert(RIdx < 6);
     if constexpr (is_packed_index<RIdx>()) {
       if constexpr (RIdx % 2 == 0) {
@@ -304,8 +302,7 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return The stride used for this rank index
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_stride() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION constexpr index_type my_stride() const noexcept {
     // revisit the need for static_cast<index_type>
     static_assert(RIdx < 6);
     if constexpr (Rank < 4) {


### PR DESCRIPTION
Related to #9223 
It is unclear why these attribute had been added here in the first place.
I propose to just drop them.
I intend to drop the `KOKKOS_IMPL_FORCEINLINE` macro in follow up work.