### PR TITLE
Introduce `KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE` macro

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -200,16 +200,6 @@
 #define KOKKOS_ENABLE_ASM 1
 #endif
 
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
-#if !defined(_WIN32)
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
-  inline __attribute__((always_inline))
-#define KOKKOS_IMPL_HOST_FORCEINLINE __attribute__((always_inline))
-#else
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION inline
-#endif
-#endif
-
 #if defined(__MIC__)
 // Compiling for Xeon Phi
 #endif
@@ -230,12 +220,6 @@
 // #define KOKKOS_ENABLE_PRAGMA_LOOPCOUNT 1
 // #define KOKKOS_ENABLE_PRAGMA_VECTOR 1
 
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
-  inline __attribute__((always_inline))
-#define KOKKOS_IMPL_HOST_FORCEINLINE __attribute__((always_inline))
-#endif
-
 #if !defined(KOKKOS_IMPL_ALIGN_PTR)
 #define KOKKOS_IMPL_ALIGN_PTR(size) __attribute__((aligned(size)))
 #endif
@@ -250,12 +234,6 @@
 // #define KOKKOS_ENABLE_PRAGMA_IVDEP 1
 // #define KOKKOS_ENABLE_PRAGMA_LOOPCOUNT 1
 // #define KOKKOS_ENABLE_PRAGMA_VECTOR 1
-
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
-  inline __attribute__((always_inline))
-#define KOKKOS_IMPL_HOST_FORCEINLINE __attribute__((always_inline))
-#endif
 
 #define KOKKOS_RESTRICT __restrict__
 
@@ -274,12 +252,6 @@
 // #define KOKKOS_ENABLE_PRAGMA_IVDEP 1
 // #define KOKKOS_ENABLE_PRAGMA_LOOPCOUNT 1
 // #define KOKKOS_ENABLE_PRAGMA_VECTOR 1
-
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
-  inline __attribute__((always_inline))
-#define KOKKOS_IMPL_HOST_FORCEINLINE __attribute__((always_inline))
-#endif
 
 #if !defined(KOKKOS_IMPL_ALIGN_PTR)
 #define KOKKOS_IMPL_ALIGN_PTR(size) __attribute__((aligned(size)))
@@ -307,20 +279,24 @@
 //----------------------------------------------------------------------------
 // Define function marking macros if compiler specific macros are undefined:
 
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
-#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION inline
+#if !defined(KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE)
+#if defined(_MSC_VER)
+#define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE [[msvc::forceinline]]
+#elif defined(__GNUC__) || defined(__clang__)
+#define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE [[gnu::always_inline]]
+#else
+#define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE
+#endif
 #endif
 
-#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE)
-#define KOKKOS_IMPL_HOST_FORCEINLINE inline
+#if !defined(KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION)
+#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION \
+  KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE inline
 #endif
 
 #if !defined(KOKKOS_IMPL_FORCEINLINE_FUNCTION)
-#define KOKKOS_IMPL_FORCEINLINE_FUNCTION KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
-#endif
-
-#if !defined(KOKKOS_IMPL_FORCEINLINE)
-#define KOKKOS_IMPL_FORCEINLINE KOKKOS_IMPL_HOST_FORCEINLINE
+#define KOKKOS_IMPL_FORCEINLINE_FUNCTION \
+  KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE inline
 #endif
 
 #if !defined(KOKKOS_IMPL_INLINE_FUNCTION)

--- a/core/src/impl/KokkosExp_IterateTileGPU.hpp
+++ b/core/src/impl/KokkosExp_IterateTileGPU.hpp
@@ -288,8 +288,9 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return Flat hardware thread ID (packed) or global index (unpacked)
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_begin() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION
+      KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE constexpr index_type
+      my_begin() const noexcept {
     static_assert(RIdx < 6);
     if constexpr (Rank < 4) {
       // No packed index
@@ -326,8 +327,9 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return product of the extents (packed) or upper bound (unpacked)
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_end() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION
+      KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE constexpr index_type
+      my_end() const noexcept {
     static_assert(RIdx < 6);
     if constexpr (is_packed_index<RIdx>()) {
       if constexpr (RIdx % 2 == 0) {
@@ -346,8 +348,9 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return The stride used for this rank index
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_stride() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION
+      KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE constexpr index_type
+      my_stride() const noexcept {
     // revisit the need for static_cast<index_type>
     static_assert(RIdx < 6);
     if constexpr (Rank < 4) {
@@ -392,8 +395,9 @@ struct DeviceIterate {
   // \tparam RIdx rank index
   // \return global thread index
   template <unsigned RIdx>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE constexpr index_type
-  my_thIdx() const noexcept {
+  KOKKOS_IMPL_DEVICE_FUNCTION
+      KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE constexpr index_type
+      my_thIdx() const noexcept {
     static_assert(RIdx < 6);
     if constexpr (Rank < 4) {
       // No packed index
@@ -424,8 +428,8 @@ struct DeviceIterate {
   }
 
   template <size_t... R, typename... Idxs>
-  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE bool check_bounds(
-      std::index_sequence<R...>, Idxs... idxs) const {
+  KOKKOS_IMPL_DEVICE_FUNCTION KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE bool
+  check_bounds(std::index_sequence<R...>, Idxs... idxs) const {
     if constexpr (IterateDir == Iterate::Left) {
       return ((idxs < static_cast<index_type>(m_upper[R])) && ...);
     } else {

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -46,7 +46,7 @@
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
-#define KOKKOS_IMPL_FORCEINLINE __forceinline__
+#define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline
 #define KOKKOS_IMPL_FUNCTION __device__ __host__
 #define KOKKOS_IMPL_HOST_FUNCTION __host__

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -46,6 +46,7 @@
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
+#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline
 #define KOKKOS_IMPL_FUNCTION __device__ __host__

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -23,6 +23,7 @@ static_assert(false,
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
+#define KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline
 #define KOKKOS_IMPL_FUNCTION __device__ __host__

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -23,6 +23,7 @@ static_assert(false,
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
+#define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__
 #define KOKKOS_IMPL_INLINE_FUNCTION __device__ __host__ inline
 #define KOKKOS_IMPL_FUNCTION __device__ __host__
 #define KOKKOS_IMPL_HOST_FUNCTION __host__


### PR DESCRIPTION
* Transition `KOKKOS_IMPL_[HOST_]FORCEINLINE_FUNCTION` to C++11-style attribute syntax
* Enable force inlining with MSVC
* Drop `KOKKOS_IMPL_[HOST_]FORCEINLINE` macros
* Introduce new `KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE` macro
* Consolidate definition of `KOKKOS_IMPL_[HOST_]FORCEINLINE_FUNCTION` instead of doing for each compiler

This PR serves as preparation work for #9212 
In follow up work I will propose to drop `KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION` and replace it with `KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE`.  All uses are in `simd/`.