### PR TITLE
Deprecate Experimental HIP and SYCL symbols

### DIFF
--- a/core/src/decl/Kokkos_Declare_HIP.hpp
+++ b/core/src/decl/Kokkos_Declare_HIP.hpp
@@ -24,14 +24,20 @@
 #include <HIP/Kokkos_HIP_UniqueToken.hpp>
 #include <HIP/Kokkos_HIP_ZeroMemset.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
 namespace Kokkos {
 namespace Experimental {
-using HIPSpace           = ::Kokkos::HIPSpace;
-using HIPHostPinnedSpace = ::Kokkos::HIPHostPinnedSpace;
-using HIPManagedSpace    = ::Kokkos::HIPManagedSpace;
-using HIP                = ::Kokkos::HIP;
+using HIPSpace KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::HIPSpace instead!") =
+    ::Kokkos::HIPSpace;
+using HIPHostPinnedSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::HIPHostPinnedSpace instead!") = ::Kokkos::HIPHostPinnedSpace;
+using HIPManagedSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::HIPManagedSpace instead!") = ::Kokkos::HIPManagedSpace;
+using HIP KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::HIP instead!") =
+    ::Kokkos::HIP;
 }  // namespace Experimental
 }  // namespace Kokkos
+#endif
 #endif
 
 #endif

--- a/core/src/decl/Kokkos_Declare_SYCL.hpp
+++ b/core/src/decl/Kokkos_Declare_SYCL.hpp
@@ -24,14 +24,20 @@
 #include <SYCL/Kokkos_SYCL_UniqueToken.hpp>
 #include <SYCL/Kokkos_SYCL_ZeroMemset.hpp>
 
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
 namespace Kokkos {
 namespace Experimental {
-using SYCLDeviceUSMSpace = ::Kokkos::SYCLDeviceUSMSpace;
-using SYCLHostUSMSpace   = ::Kokkos::SYCLHostUSMSpace;
-using SYCLSharedUSMSpace = ::Kokkos::SYCLSharedUSMSpace;
-using SYCL               = ::Kokkos::SYCL;
+using SYCLDeviceUSMSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::SYCLDeviceUSMSpace instead!") = ::Kokkos::SYCLDeviceUSMSpace;
+using SYCLHostUSMSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::SYCLHostUSMSpace instead!") = ::Kokkos::SYCLHostUSMSpace;
+using SYCLSharedUSMSpace KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::SYCLSharedUSMSpace instead!") = ::Kokkos::SYCLSharedUSMSpace;
+using SYCL KOKKOS_DEPRECATED_WITH_COMMENT("Use Kokkos::SYCL instead!") =
+    ::Kokkos::SYCL;
 }  // namespace Experimental
 }  // namespace Kokkos
+#endif
 
 #endif
 


### PR DESCRIPTION
This came up in a Slcak discussion with @lucbv noting that the `HIP` and `SYCL` aliases in the `Experimental` namespace are still not deprecated.