### PR TITLE
Jenkins CI: Don't build SYCL image with OpenCL support

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -61,7 +61,6 @@ RUN cd /tmp && git clone https://github.com/intel/llvm.git -b v6.2.0 --depth=1 &
       -DUR_BUILD_TESTS=OFF \
       -DUR_ENABLE_TRACING=ON \
       -DUR_BUILD_ADAPTER_CUDA=ON \
-      -DUR_BUILD_ADAPTER_OPENCL=ON \
       -DCMAKE_BUILD_TYPE=Release && \
     cmake --build build_ur -j 8 && \
     cp -r build_ur/lib/* /opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib/ && \


### PR DESCRIPTION
Fixes https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-9222/7/stages/?selected-node=221.