### PR TITLE
Fix usage of unqualified HIP symbols in Experimental namespace

### DIFF
--- a/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
+++ b/algorithms/src/std_algorithms/impl/Kokkos_InclusiveScan.hpp
@@ -150,8 +150,9 @@ OutputIteratorType inclusive_scan_default_op_exespace_impl(
 #if defined(KOKKOS_ENABLE_ROCTHRUST)
 template <class InputIteratorType, class OutputIteratorType>
 OutputIteratorType inclusive_scan_default_op_exespace_impl(
-    const std::string& label, const HIP& ex, InputIteratorType first_from,
-    InputIteratorType last_from, OutputIteratorType first_dest) {
+    const std::string& label, const Kokkos::HIP& ex,
+    InputIteratorType first_from, InputIteratorType last_from,
+    OutputIteratorType first_dest) {
   const auto thrust_ex = thrust::hip::par.on(ex.hip_stream());
 
   Kokkos::Profiling::pushRegion(label + " via thrust::inclusive_scan");
@@ -240,9 +241,9 @@ OutputIteratorType inclusive_scan_custom_binary_op_exespace_impl(
 #if defined(KOKKOS_ENABLE_ROCTHRUST)
 template <class InputIteratorType, class OutputIteratorType, class BinaryOpType>
 OutputIteratorType inclusive_scan_custom_binary_op_exespace_impl(
-    const std::string& label, const HIP& ex, InputIteratorType first_from,
-    InputIteratorType last_from, OutputIteratorType first_dest,
-    BinaryOpType binary_op) {
+    const std::string& label, const Kokkos::HIP& ex,
+    InputIteratorType first_from, InputIteratorType last_from,
+    OutputIteratorType first_dest, BinaryOpType binary_op) {
   const auto thrust_ex = thrust::hip::par.on(ex.hip_stream());
 
   Kokkos::Profiling::pushRegion(label + " via thrust::inclusive_scan");


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/9232. Using unqualified HIP symbols in an `Experimental` namespace implicitly pulled in the deprecated symbols.