### PR TITLE
Add a function to print floating point number on device

### DIFF
--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -10,6 +10,7 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include <cstdint>
 #include <type_traits>
 #include <limits>
 
@@ -59,10 +60,71 @@ KOKKOS_IMPL_DEFINE_TRAIT(max_exponent10, max_exponent10,  floating_point)
 
 #undef KOKKOS_IMPL_DEFINE_TRAIT
 
-}  // namespace Kokkos
-
 #ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NUMERIC_TRAITS
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE
 #undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_NUMERIC_TRAITS
 #endif
+
+#define KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT(TRAIT) \
+  namespace Impl {                                   \
+  template <class T, class Enable = void>            \
+  struct TRAIT##_helper {};                          \
+  }                                                  \
+  template <class T>                                 \
+  struct TRAIT : Impl::TRAIT##_helper<T> {};         \
+  template <class T>                                 \
+  inline constexpr auto TRAIT##_v = TRAIT<T>::value; \
+  namespace Experimental {                           \
+  using Kokkos::TRAIT;                               \
+  using Kokkos::TRAIT##_v;                           \
+  }
+
+#define KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT_TYPE(TRAIT) \
+  namespace Impl {                                        \
+  template <class T, class Enable = void>                 \
+  struct TRAIT##_helper {};                               \
+  }                                                       \
+  template <class T>                                      \
+  struct TRAIT : Impl::TRAIT##_helper<T> {};              \
+  template <class T>                                      \
+  using TRAIT##_t = typename TRAIT<T>::type;              \
+  namespace Experimental {                                \
+  using Kokkos::TRAIT;                                    \
+  using Kokkos::TRAIT##_t;                                \
+  }
+
+KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT_TYPE(equivalent_int)
+KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT(mantissa_bits)
+KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT(exponent_bits)
+
+#undef KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT
+#undef KOKKOS_IMPL_DEFINE_NON_STANDARD_TRAIT_TYPE
+
+}  // namespace Kokkos
+
+template <>
+struct Kokkos::Impl::equivalent_int_helper<float> {
+  using type = uint32_t;
+};
+template <>
+struct Kokkos::Impl::mantissa_bits_helper<float> {
+  static constexpr int value = 23;
+};
+template <>
+struct Kokkos::Impl::exponent_bits_helper<float> {
+  static constexpr int value = 8;
+};
+
+template <>
+struct Kokkos::Impl::equivalent_int_helper<double> {
+  using type = uint64_t;
+};
+template <>
+struct Kokkos::Impl::mantissa_bits_helper<double> {
+  static constexpr int value = 52;
+};
+template <>
+struct Kokkos::Impl::exponent_bits_helper<double> {
+  static constexpr int value = 11;
+};
 #endif

--- a/core/src/Kokkos_NumericTraits.hpp
+++ b/core/src/Kokkos_NumericTraits.hpp
@@ -108,11 +108,11 @@ struct Kokkos::Impl::equivalent_int_helper<float> {
 };
 template <>
 struct Kokkos::Impl::mantissa_bits_helper<float> {
-  static constexpr int value = 23;
+  static constexpr unsigned int value = 23;
 };
 template <>
 struct Kokkos::Impl::exponent_bits_helper<float> {
-  static constexpr int value = 8;
+  static constexpr unsigned int value = 8;
 };
 
 template <>
@@ -121,10 +121,10 @@ struct Kokkos::Impl::equivalent_int_helper<double> {
 };
 template <>
 struct Kokkos::Impl::mantissa_bits_helper<double> {
-  static constexpr int value = 52;
+  static constexpr unsigned int value = 52;
 };
 template <>
 struct Kokkos::Impl::exponent_bits_helper<double> {
-  static constexpr int value = 11;
+  static constexpr unsigned int value = 11;
 };
 #endif

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -132,7 +132,7 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
 
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
-  // Extract sign, mantissa and exponent
+  // Extract sign and exponent
   uint_t sign = u & (uint_t(1) << (mantissa_bits + exponent_bits));
   uint_t exp  = ((u & (exp_mask << mantissa_bits))) >> mantissa_bits;
 
@@ -322,7 +322,7 @@ struct DecimalRepresentation {
         if (src_idx < size) {
           dividend += buffer[src_idx++];
         }
-        if (dividend != 0 && dividend / divisor != 0) {
+        if (dividend != 0 && dividend >= divisor) {
           break;
         } else {
           if (first_pass) {
@@ -512,20 +512,12 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     return {first + len, {}};
   }
 
-  // Normalize number
+  // Normalize number if needed (subnormals don't need normalization)
   if (exp != 0) {
-    // Normal number
     // Apply implicit leading 1
     mantissa |= (uint_t(1) << mantissa_bits);
     // Take implicit 1 into account for the exponent
     --exp;
-  } else {
-    if (!mantissa) {
-      // Zeroes
-      strcpy(out, "0.000000e+00");
-      return {first + len, {}};
-    }
-    // Subnormals (no need to normalize)
   }
 
   BaseTwoExponent<FloatType, exp_precision> base;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -110,9 +110,7 @@ KOKKOS_INLINE_FUNCTION constexpr char *strncat(char *dest, const char *src,
 //</editor-fold>
 
 //<editor-fold desc="Character conversions">
-template <class Unsigned, std::enable_if_t<std::is_integral_v<Unsigned> &&
-                                               std::is_unsigned_v<Unsigned>,
-                                           int> = 0>
+template <std::unsigned_integral Unsigned>
 KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   unsigned int const base = 10;
   unsigned int n          = 1;
@@ -123,10 +121,7 @@ KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   return n;
 }
 
-template <class FloatType,
-          std::enable_if_t<std::is_same_v<FloatType, double> ||
-                               std::is_same_v<FloatType, float>,
-                           int> = 0>
+template <std::floating_point FloatType>
 KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   using uint_t            = Kokkos::equivalent_int_t<FloatType>;
   const int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -304,8 +304,8 @@ struct DecimalRepresentation {
   KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
     KOKKOS_ASSERT(exp <= max_div);
 
-    uint64_t dividend   = 0x0lu;
-    uint64_t divisor    = 0x1lu << exp;
+    uint64_t dividend   = 0x0llu;
+    uint64_t divisor    = 0x1llu << exp;
     std::size_t src_idx = 0;
     std::size_t res_idx = 0;
 
@@ -346,8 +346,8 @@ struct DecimalRepresentation {
   KOKKOS_FUNCTION void multiply_by_power_of_two(int exp) {
     KOKKOS_ASSERT(exp <= max_mul);
 
-    uint64_t multiplior = 0x1lu << exp;
-    uint64_t carry      = 0lu;
+    uint64_t multiplior = 0x1llu << exp;
+    uint64_t carry      = 0llu;
 
     for (int i = size - 1; i >= 0; --i) {
       uint64_t tmp = buffer[i] * multiplior + carry;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -284,7 +284,12 @@ struct DecimalRepresentation {
       return 0;
     }
 
-    uint8_t shifted_out = buffer[size - shift];
+    uint8_t shifted_out;
+    if (shift <= size) {
+      shifted_out = buffer[size - shift];
+    } else {
+      shifted_out = 0;
+    }
 
     int j = size - 1;
     while (j >= shift) {

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <type_traits>
 #include <Kokkos_BitManipulation.hpp>
-#include <Kokkos_Assert.hpp>
 #include <Kokkos_Printf.hpp>
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -124,11 +124,11 @@ KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
 template <std::floating_point FloatType>
 KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   using uint_t            = Kokkos::equivalent_int_t<FloatType>;
-  const int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
-  const int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+  constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
-  const uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
-  const uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
+  constexpr uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
+  constexpr uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
 
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
@@ -241,8 +241,8 @@ struct DecimalRepresentation {
   // This can't be higher than 60 since we need to be able to store up to
   // (2^max_div - 1) * 9 in the remainder, bigger number wouldn't fit in a
   // uint64_t
-  static const int max_div = 60;
-  static const int max_mul = 60;
+  static constexpr int max_div = 60;
+  static constexpr int max_mul = 60;
 
   // Print buffer for debugging purpose
   void print() {
@@ -256,14 +256,14 @@ struct DecimalRepresentation {
 
   // Round number up (equivalent to adding 10 ^ (exp10 - size))
   KOKKOS_FUNCTION void round_up(size_t index = size - 1) {
-    int carry = true;
+    bool carry = true;
     int i     = index;
 
     while (i >= 0 && carry) {
       if (++buffer[i] > 9) {
         buffer[i] = 0;
       } else {
-        carry = 0;
+        carry = false;
       }
       --i;
     }
@@ -426,7 +426,8 @@ struct BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
 
   KOKKOS_FUNCTION void generate_nth_exp(int exp2_target) {
     if (exp2_target < exp2) {
-      // Divide 60 by 60 until we can reach the target with one smaller step
+      // Divide max_div by max_div until we can reach the target with one
+      // smaller step
       while (exp2 - max_div > exp2_target) {
         DecimalRepresentation<FloatType, size>::divide_by_power_of_two(max_div);
         exp2 -= max_div;
@@ -464,19 +465,19 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
                 std::is_same_v<FloatType, float>);
 
   using uint_t            = Kokkos::equivalent_int_t<FloatType>;
-  const int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
-  const int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+  constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
-  const uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
-  const uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
+  constexpr uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
+  constexpr uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
 
   // Number of decimal digits used for internal computation
-  // This numbers don't depends from the input type, only from the number of
-  // output digits.
+  // These numbers don't depend on the input type, but on the number of output
+  // digits.
   // They were found empirically so that `to_chars_f` has the same output as
   // std::printf("%e")
-  const int precision     = 18;
-  const int exp_precision = 22;
+  constexpr int precision     = 18;
+  constexpr int exp_precision = 22;
 
   std::ptrdiff_t const len = to_chars_len(f);
   if (last - first < len) {
@@ -595,8 +596,6 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
 
   to_chars_i(out, last, abs_exp);
   out += exp_len;
-
-  *out++ = '\0';
 
   return {first + len, {}};
 }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <Kokkos_BitManipulation.hpp>
 #include <Kokkos_Assert.hpp>
+#include <Kokkos_Printf.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -560,7 +561,6 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
       // `buffer[6]` is an  odd number.
       // This is the `tie to even` part of the rounding.
       need_round = (decimal.buffer[precision - 1] % 2) == 1;
-      Kokkos::printf("Tie to even\n");
     } else {
       need_round = true;
     }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -186,6 +186,7 @@ KOKKOS_FUNCTION constexpr void to_chars_impl(char *first, unsigned int len,
 // define values of portable error conditions that correspond to the POSIX error
 // codes
 enum class errc {
+  ok              = 0,
   value_too_large = 75  // equivalent POSIX error is EOVERFLOW
 };
 struct to_chars_result {

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -530,9 +530,9 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   // Inf and NaN
   if (exp == exp_mask) {
     if (mantissa) {
-      strcpy(out, "nan");
+      Kokkos::Impl::strcpy(out, "nan");
     } else {
-      strcpy(out, "inf");
+      Kokkos::Impl::strcpy(out, "inf");
     }
     return {first + len, {}};
   }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -121,7 +121,10 @@ KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   return n;
 }
 
-template <std::floating_point FloatType>
+template <class FloatType,
+          std::enable_if_t<std::is_same_v<FloatType, double> ||
+                               std::is_same_v<FloatType, float>,
+                           int> = 0>
 KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   using uint_t                = Kokkos::equivalent_int_t<FloatType>;
   constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -6,7 +6,10 @@
 
 #include <Kokkos_Macros.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
+#include <Kokkos_BitManipulation.hpp>
+#include <Kokkos_Assert.hpp>
 
 namespace Kokkos {
 namespace Impl {
@@ -107,18 +110,69 @@ KOKKOS_INLINE_FUNCTION constexpr char *strncat(char *dest, const char *src,
 //</editor-fold>
 
 //<editor-fold desc="Character conversions">
-template <class Unsigned>
+template <class Unsigned, std::enable_if_t<std::is_integral_v<Unsigned> &&
+                                               std::is_unsigned_v<Unsigned>,
+                                           int> = 0>
 KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   unsigned int const base = 10;
-  static_assert(std::is_integral_v<Unsigned>, "implementation bug");
-  static_assert(std::is_unsigned_v<Unsigned>, "implementation bug");
-  unsigned int n = 1;
+  unsigned int n          = 1;
   while (val >= base) {
     val /= base;
     ++n;
   }
   return n;
 }
+
+template <class FloatType,
+          std::enable_if_t<std::is_same_v<FloatType, double> ||
+                               std::is_same_v<FloatType, float>,
+                           int> = 0>
+KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
+  using uint_t            = Kokkos::equivalent_int_t<FloatType>;
+  const int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  const int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+
+  const uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
+  const uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
+
+  uint_t u = Kokkos::bit_cast<uint_t>(f);
+
+  // Extract double infos
+  uint_t sign = u & (uint_t(1) << (mantissa_bits + exponent_bits));
+  uint_t exp  = ((u & (exp_mask << mantissa_bits))) >> mantissa_bits;
+
+  unsigned int ret = 0;
+
+  ret += sign ? 1 : 0;
+  if (exp == exp_mask) {
+    // 'inf' and 'nan' are both 3 chars
+    return ret + 3;
+  }
+
+  // Only a single format is supported:
+  //  - 1 significant number
+  //  - 1 decimal point ('.')
+  //  - 6 fractional numbers
+  //  - 1 exponent marker ('e')
+  //  - 1 exponent sign ('+' or '-')
+  //  - 2 digits padded with 0 for the exponent if it is between -99 and 99, 3
+  //  digits if it is bigger
+
+  if constexpr (std::is_same_v<FloatType, double>) {
+    // Check whether the exponent has two or three decimal digits by comparing
+    // with the double that is the tipping point:
+    //  - 0x2b617f7d402b1834 is the first number that rounds to 1.0000000e-99,
+    //  previous number 0x2b617f7d402b1833 rounds to 9.9999999e-100
+    //  - 0x54b249ad163d7d25 is the last number that rounds to 9.9999999e+99,
+    //  0x54b249ad163d7d26 rounds to 1.0000000e+100
+    u = u & (exp_mask << mantissa_bits | mantissa_mask);
+    if ((u != 0 && u < 0x2b617f7d402b1834) || u > 0x54b249ad163d7d25) {
+      return ret + 13;
+    }
+  }
+  return ret + 12;
+}
+
 template <class Unsigned>
 KOKKOS_FUNCTION constexpr void to_chars_impl(char *first, unsigned int len,
                                              Unsigned val) {
@@ -170,6 +224,386 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
   // NOLINTEND(bugprone-invalid-enum-default-initialization)
 }
 //</editor-fold>
+
+/*
+ * Decimal representation of floating point numbers
+ */
+template <typename FloatType, std::size_t size>
+struct DecimalRepresentation {
+  using uint_t = Kokkos::equivalent_int_t<FloatType>;
+
+  // Buffer that contains the decimal representation of a number in scientific
+  // notation
+  uint8_t buffer[size];
+  // Exponent of the decimal representation stored
+  int exp10;
+  // For instance, if the number stored is 2^10, `buffer` contains
+  // "102400000..." and `exp10` is 3
+
+  KOKKOS_FUNCTION constexpr DecimalRepresentation() : buffer{0}, exp10{0} {}
+
+  // This can't be higher than 60 since we need to be able to store up to
+  // (2^max_div - 1) * 9 in the remainder, bigger number wouldn't fit in a
+  // uint64_t
+  static const int max_div = 60;
+  static const int max_mul = 60;
+
+  // Print buffer for debugging purpose
+  void print() {
+    char tmp[size + 1];
+    for (int i = 0; i < size; ++i) {
+      tmp[i] = buffer[i] + '0';
+    }
+    tmp[size] = '\0';
+    Kokkos::printf("%se%i", tmp, exp10);
+  }
+
+  // Round number up (equivalent to adding 10 ^ (exp10 - size))
+  KOKKOS_FUNCTION void round_up(size_t index = size - 1) {
+    int carry = true;
+    int i     = index;
+
+    while (i >= 0 && carry) {
+      if (++buffer[i] > 9) {
+        buffer[i] = 0;
+      } else {
+        carry = 0;
+      }
+      --i;
+    }
+
+    // Initial number had the form "999....999", rounds to "100....000" with
+    // `exp10`+1
+    if (carry) {
+      shift_right(1);
+    }
+  }
+
+  // Shift the decimal representation in buffer shift time to the right,
+  // inserting `insert` as the leading numbers. Returns the decimal
+  // representation of the most significant number that was shifted out
+  KOKKOS_FUNCTION uint8_t shift_right(uint8_t insert, int shift = 1) {
+    if (shift < 1) {
+      // nothing to do
+      return 0;
+    }
+
+    uint8_t shifted_out = buffer[size - shift];
+
+    int j = size - 1;
+    while (j >= shift) {
+      buffer[j] = buffer[j - shift];
+      --j;
+    }
+    while (j >= 0) {
+      buffer[j] = insert;
+      --j;
+    }
+
+    exp10 += shift;
+    return shifted_out;
+  }
+
+  // Divide decimal number by 2^exp
+  KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
+    KOKKOS_ASSERT(exp <= max_div);
+
+    uint64_t dividend   = 0x0lu;
+    uint64_t divisor    = 0x1lu << exp;
+    std::size_t src_idx = 0;
+    std::size_t res_idx = 0;
+
+    bool first_pass = true;
+
+    do {
+      do {
+        dividend *= 10;
+        if (src_idx < size) {
+          dividend += buffer[src_idx++];
+        }
+        if (dividend != 0 && dividend / divisor != 0) {
+          break;
+        } else {
+          if (first_pass) {
+            --exp10;
+          }
+          if (dividend != 0 && !first_pass) {
+            buffer[res_idx++] = 0;
+          }
+        }
+      } while (dividend != 0 && res_idx < size);
+
+      first_pass = false;
+
+      if (res_idx < size) {
+        buffer[res_idx++] = dividend / divisor;
+        dividend %= divisor;
+      }
+    } while (res_idx < size);
+
+    if (dividend * 2 > divisor) {
+      round_up();
+    }
+  }
+
+  // Multiply decimal number by 2^exp
+  KOKKOS_FUNCTION void multiply_by_power_of_two(int exp) {
+    KOKKOS_ASSERT(exp <= max_mul);
+
+    uint64_t multiplior = 0x1lu << exp;
+    uint64_t carry      = 0lu;
+
+    for (int i = size - 1; i >= 0; --i) {
+      uint64_t tmp = buffer[i] * multiplior + carry;
+      buffer[i]    = tmp % 10;
+      carry        = tmp / 10;
+    }
+
+    uint8_t discarded = 0;
+    // Continue adding the carry to the computed number
+    while (carry > 0) {
+      discarded = shift_right(carry % 10);
+      carry /= 10;
+    }
+
+    // Round if the last digit shifted out was >= 5
+    if (discarded >= 5) {
+      round_up();
+    }
+  }
+
+  template <size_t size_r>
+  KOKKOS_FUNCTION DecimalRepresentation<FloatType, size> &operator+=(
+      DecimalRepresentation<FloatType, size_r> rhs) {
+    KOKKOS_ASSERT(rhs.exp10 == exp10);
+
+    int carry = 0;
+    for (int i = size - 1; i >= 0; --i) {
+      buffer[i] += rhs.buffer[i] + carry;
+      if (buffer[i] > 9) {
+        carry = 1;
+        buffer[i] -= 10;
+      } else {
+        carry = 0;
+      }
+    }
+
+    if (carry) {
+      if (shift_right(1) >= 5) {
+        round_up();
+      }
+    }
+
+    return *this;
+  }
+};
+
+/**
+ * Decimal representation of a power of two
+ */
+template <class FloatType, std::size_t size>
+struct BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
+  using DecimalRepresentation<FloatType, size>::buffer;
+  using DecimalRepresentation<FloatType, size>::exp10;
+  using DecimalRepresentation<FloatType, size>::max_div;
+  using DecimalRepresentation<FloatType, size>::max_mul;
+
+  static constexpr int bias =
+      (typename Kokkos::equivalent_int_t<FloatType>(1)
+       << (Kokkos::exponent_bits<FloatType>::value - 1)) +
+      Kokkos::mantissa_bits<FloatType>::value - 2;
+
+  // Exponent of the power stored in `buffer`
+  // Stored with the total bias added
+  int exp2;
+
+  // Initialize with the decimal representation of 2^0 = 1
+  KOKKOS_FUNCTION constexpr BaseTwoExponent() {
+    DecimalRepresentation<FloatType, size>::buffer[0] = 1;
+    exp2                                              = bias;
+  }
+
+  void print() {
+    DecimalRepresentation<FloatType, size>::print();
+    Kokkos::printf(" = 2^%i", exp2 - bias);
+  }
+
+  KOKKOS_FUNCTION void generate_nth_exp(int exp2_target) {
+    if (exp2_target < exp2) {
+      // Divide 60 by 60 until we can reach the target with one smaller step
+      while (exp2 - max_div > exp2_target) {
+        DecimalRepresentation<FloatType, size>::divide_by_power_of_two(max_div);
+        exp2 -= max_div;
+      }
+
+      // Last division needed to reach the target
+      if (exp2 != exp2_target) {
+        DecimalRepresentation<FloatType, size>::divide_by_power_of_two(
+            exp2 - exp2_target);
+        exp2 -= (exp2 - exp2_target);
+      }
+    } else if (exp2_target > exp2) {
+      // Multiply max_mul by max_mul until we can reach the target with one
+      // smaller step
+      while (exp2 + max_mul < exp2_target) {
+        DecimalRepresentation<FloatType, size>::multiply_by_power_of_two(
+            max_mul);
+        exp2 += max_mul;
+      }
+
+      // Last multiplication needed to reach the target
+      if (exp2 != exp2_target) {
+        DecimalRepresentation<FloatType, size>::multiply_by_power_of_two(
+            exp2_target - exp2);
+      }
+    }
+    exp2 = exp2_target;
+  }
+};
+
+template <typename FloatType>
+KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
+                                           FloatType f) {
+  static_assert(std::is_same_v<FloatType, double> ||
+                std::is_same_v<FloatType, float>);
+
+  using uint_t            = Kokkos::equivalent_int_t<FloatType>;
+  const int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  const int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+
+  const uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
+  const uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
+
+  // Number of decimal digits used for internal computation
+  // This numbers don't depends from the input type, only from the number of
+  // output digits.
+  // They were found empirically so that `to_chars_f` has the same output as
+  // std::printf("%e")
+  const int precision     = 18;
+  const int exp_precision = 22;
+
+  std::ptrdiff_t const len = to_chars_len(f);
+  if (last - first < len) {
+    return {last, errc::value_too_large};
+  }
+  uint_t u = Kokkos::bit_cast<uint_t>(f);
+
+  // Extract double informations
+  uint_t sign     = u & (uint_t(1) << (mantissa_bits + exponent_bits));
+  uint_t mantissa = u & mantissa_mask;
+  uint_t exp      = (u >> mantissa_bits) & exp_mask;
+
+  char *out = first;
+
+  // Add sign to output if needed
+  if (sign) {
+    *out++ = '-';
+  }
+
+  // Inf and NaN
+  if (exp == exp_mask) {
+    if (mantissa) {
+      strcpy(out, "nan");
+    } else {
+      strcpy(out, "inf");
+    }
+    return {first + len, {}};
+  }
+
+  // Normalize number
+  if (exp != 0) {
+    // Normal number
+    // Apply implicit leading 1
+    mantissa |= (uint_t(1) << mantissa_bits);
+    // Take implicit 1 into account for the exponent
+    --exp;
+  } else {
+    if (!mantissa) {
+      // Zeroes
+      strcpy(out, "0.000000e+00");
+      return {first + len, {}};
+    }
+    // Subnormals (no need to normalize)
+  }
+
+  BaseTwoExponent<FloatType, exp_precision> base;
+
+  // Buffer that will contain the decimal representation of the result
+  DecimalRepresentation<FloatType, precision> decimal;
+
+  // Loop over each bit of the mantissa, add the corresponding power of 2 if
+  // the bit is set
+  for (uint64_t mask = 0x1; mask < (uint_t(1) << (mantissa_bits + 1));
+       mask <<= 1, ++exp) {
+    if (mantissa & mask) {
+      base.generate_nth_exp(exp);
+
+      // Shift the buffer if current power of 2 has a greater base 10 exponent
+      // than the current computed number
+      int shift = base.exp10 - decimal.exp10;
+      if (shift > 0) {
+        if (decimal.shift_right(0, shift) >= 5) {
+          decimal.round_up();
+        }
+      }
+
+      decimal.exp10 = base.exp10;
+
+      // Add current power of two with number
+      decimal += base;
+    }
+  }
+
+  // Round to nearest, tie to even
+  int need_round = false;
+  if (decimal.buffer[7] >= 5) {
+    if (decimal.buffer[7] == 5) {
+      // In case the last digit is 5, we round up if:
+      //  - we find a non zero digit after `buffer[7]`
+      //  - we find no non zero digit after `buffer[7]` but `buffer[6]` is an
+      //  odd number.
+      //  This is the `tie to even` part of the rounding.
+      //  (this is also where the lack of precision is causing this
+      //  implementation to sometime output wrong results)
+      bool all_zero = true;
+      for (int i = 8; i < precision && all_zero; ++i) {
+        all_zero = decimal.buffer[i] == 0;
+      }
+      need_round = !all_zero || ((decimal.buffer[6] % 2) == 1);
+    } else {
+      need_round = true;
+    }
+  }
+
+  if (need_round) {
+    decimal.round_up(6);
+  }
+
+  // Copy the significand to the output
+  *out++ = decimal.buffer[0] + '0';
+  *out++ = '.';
+  for (int i = 1; i < 7; ++i) {
+    *out++ = decimal.buffer[i] + '0';
+  }
+
+  // Write exponent
+  *out++ = 'e';
+  *out++ = decimal.exp10 >= 0 ? '+' : '-';
+
+  unsigned int abs_exp = decimal.exp10 >= 0 ? decimal.exp10 : -decimal.exp10;
+  int exp_len          = to_chars_len(abs_exp);
+  // Add a leading '0' if exp length is smaller than 2
+  if (exp_len < 2) {
+    *out++ = '0';
+  }
+
+  to_chars_i(out, last, abs_exp);
+  out += exp_len;
+
+  *out++ = '\0';
+
+  return {first + len, {}};
+}
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -288,7 +288,7 @@ struct DecimalRepresentation {
     }
   }
 
-  // Shift the decimal representation in buffer shift time to the right,
+  // Shift the decimal representation in buffer `shift` time to the right,
   // inserting `insert` as the leading numbers.
   KOKKOS_FUNCTION void shift_right(uint8_t shift, int insert) {
     if (shift < 1) {
@@ -354,7 +354,7 @@ struct DecimalRepresentation {
       first_pass = false;
 
       if (res_idx < size) {
-        buffer[res_idx++] = dividend / divisor;
+        buffer[res_idx++] = dividend >> exp;
         dividend %= divisor;
       }
     } while (res_idx < size);
@@ -370,7 +370,7 @@ struct DecimalRepresentation {
     rem -= carry;
 
     for (int i = size - 1; i >= 0; --i) {
-      uint64_t tmp = buffer[i] * multiplior + carry;
+      uint64_t tmp = ((uint64_t)(buffer[i]) << exp) + carry;
       buffer[i]    = tmp % 10;
       carry        = tmp / 10;
     }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -122,11 +122,11 @@ KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   return n;
 }
 
-template <class FloatType,
-          std::enable_if_t<std::is_same_v<FloatType, double> ||
-                               std::is_same_v<FloatType, float>,
-                           int> = 0>
+template <typename FloatType>
 KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
+  static_assert(std::is_same_v<FloatType, double> ||
+                std::is_same_v<FloatType, float>);
+
   using uint_t                = Kokkos::equivalent_int_t<FloatType>;
   constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
   constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
@@ -148,7 +148,8 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
     return ret + 3;
   }
 
-  // Only a single format is supported:
+  // Only a single format is supported (which is the default output of
+  // printf("%e", d);):
   //  - 1 significant number
   //  - 1 decimal point ('.')
   //  - 6 fractional numbers
@@ -226,34 +227,33 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
 //</editor-fold>
 
 /*
- * Decimal representation of floating point numbers
+ * Decimal representation of a floating point number
  */
 template <typename FloatType, std::size_t size>
-struct DecimalRepresentation {
+class DecimalRepresentation {
+ public:
   // Buffer that contains the decimal representation of a number in scientific
-  // notation
+  // notation (without decimal separator)
   uint8_t buffer[size];
   // Exponent of the decimal representation stored
   int exp10;
   // For instance, if the number stored is 2^10, `buffer` contains
   // "102400000..." and `exp10` is 3
 
-  // rem is the part of the floating point number that is beyond the decimal
-  // representation. It is always comprised between 0 and 1. For instance, if
-  // size is 3, if the number stored is 2^-6 = 0.015625:
+ protected:
+  // frac is the fractional part of the floating point number that is beyond
+  // the decimal representation. It is always included between 0 and 1
+  // (excluded).
+  // For instance, if size is 3, and the number stored is 2^-6 = 0.015625:
   //  - exp10 = -2
   //  - buffer = 156
-  //  - rem = 0.25
-  double rem;
+  //  - frac = 0.25
+  double frac;
 
+ public:
+  // Initialize with decimal representation of 0.
   KOKKOS_FUNCTION constexpr DecimalRepresentation()
-      : buffer{0}, exp10{0}, rem{0} {}
-
-  // This can't be higher than 60 since we need to be able to store up to
-  // (2^max_div - 1) * 9 in the remainder/carry, bigger exponent would overflow
-  // an uint64_t
-  static constexpr int max_div = 60;
-  static constexpr int max_mul = 60;
+      : buffer{0}, exp10{0}, frac{0} {}
 
   // Print buffer for debugging purpose
   KOKKOS_FUNCTION void print() const {
@@ -264,43 +264,23 @@ struct DecimalRepresentation {
       tmp[i] = buffer[i - 1] + '0';
     }
     tmp[size + 1] = '\0';
-    Kokkos::printf("%se%+03i (%e)", tmp, exp10, rem);
+    Kokkos::printf("%se%+03i (%e)", tmp, exp10, frac);
   }
 
-  // Round number up (equivalent to adding 10 ^ (exp10 - size))
-  KOKKOS_FUNCTION void round_up() {
-    bool carry = true;
-    int i      = size - 1;
-
-    while (i >= 0 && carry) {
-      if (++buffer[i] > 9) {
-        buffer[i] = 0;
-      } else {
-        carry = false;
-      }
-      --i;
-    }
-
-    // Initial number had the form "999....999", rounds to "100....000" with
-    // `exp10`+1
-    if (carry) {
-      shift_right(1, 1);
-    }
-  }
+ protected:
+  // This can't be higher than 60 since we need to be able to store up to
+  // (2^max_div - 1) * 9 in the remainder/carry: bigger exponent would overflow
+  // an uint64_t
+  static constexpr int max_div = 60;
+  static constexpr int max_mul = 60;
 
   // Shift the decimal representation in buffer `shift` time to the right,
   // inserting `insert` as the leading numbers.
   KOKKOS_FUNCTION void shift_right(uint8_t shift, int insert) {
-    if (shift < 1) {
-      // nothing to do
-      return;
-    }
-
     for (int i = size - 1; i >= 0; --i) {
+      // Add discarded digit to the remainder if the curent cell is shifted out
       if (std::size_t(i) + shift >= size) {
-        // Add discarded digit to the remainder
-        rem += buffer[i];
-        rem /= 10;
+        frac = (buffer[i] + frac) / 10.;
       }
 
       if (i >= shift) {
@@ -312,7 +292,7 @@ struct DecimalRepresentation {
 
     if (shift > size) {
       for (int i = size; i < shift; ++i) {
-        rem /= 10;
+        frac = insert + frac / 10.;
       }
     }
 
@@ -320,54 +300,46 @@ struct DecimalRepresentation {
   }
 
   // Divide decimal number by 2^exp
+  // Returns garbage if exp > max_div
   KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
     uint64_t dividend   = 0x0llu;
     uint64_t divisor    = 0x1llu << exp;
     std::size_t src_idx = 0;
     std::size_t res_idx = 0;
 
-    bool first_pass = true;
-
     do {
-      do {
-        dividend *= 10;
+      // Update dividend with the next digit (coming either from the decimal
+      // buffer or from `frac`)
+      dividend *= 10;
+      if (src_idx < size) {
+        dividend += buffer[src_idx++];
+      } else {
+        frac *= 10.;
+        dividend += (uint64_t)frac;
+        frac -= (uint64_t)frac;
+      }
 
-        if (src_idx < size) {
-          dividend += buffer[src_idx++];
-        } else {
-          rem *= 10.;
-          dividend += (uint64_t)rem;
-          rem -= (double)((uint64_t)rem);
-        }
-
-        if (dividend != 0 && dividend >= divisor) {
-          break;
-        }
-
-        if (first_pass) {
-          --exp10;
-        } else if (dividend != 0) {
-          buffer[res_idx++] = 0;
-        }
-      } while (dividend != 0 && res_idx < size);
-
-      first_pass = false;
-
-      if (res_idx < size) {
+      if (dividend < divisor && res_idx == 0) {
+        // As long as we haven't found a non-zero digit, we don't output 0, we
+        // only track the exponent of the futur most significant digit
+        --exp10;
+      } else {
+        // Otherwise, buffer receive the result of the division and dividend
+        // the remainder
         buffer[res_idx++] = dividend >> exp;
-        dividend %= divisor;
+        dividend &= divisor - 1;
       }
     } while (res_idx < size);
 
-    rem = ((double)dividend + rem) / (double)divisor;
+    frac = ((double)dividend + frac) / (double)divisor;
   }
 
   // Multiply decimal number by 2^exp
+  // Returns garbage if exp > max_mul
   KOKKOS_FUNCTION void multiply_by_power_of_two(int exp) {
-    uint64_t multiplior = 0x1llu << exp;
-    rem *= multiplior;
-    uint64_t carry = rem;
-    rem -= carry;
+    frac *= 0x1llu << exp;
+    uint64_t carry = frac;
+    frac -= carry;
 
     for (int i = size - 1; i >= 0; --i) {
       uint64_t tmp = ((uint64_t)(buffer[i]) << exp) + carry;
@@ -377,14 +349,48 @@ struct DecimalRepresentation {
 
     // Continue adding the carry to the computed number
     while (carry > 0) {
-      shift_right(1, carry % 10);
+      shift_right(1, carry % 10);  // shift_right update the exponent
       carry /= 10;
     }
   }
 
-  template <size_t size_r>
+ public:
+  // Rounds the number up or down according to the fractional part contained in
+  // `frac`, respecting the "round to nearest, ties to even" convention
+  KOKKOS_FUNCTION void round() {
+    int round_up = false;
+    if (frac >= .5) {
+      if (frac == .5) {
+        // In case `frac` is exactly 0.5, we round up if `buffer[6]` is an odd
+        // number, down otherwise.
+        // This is the `tie to even` part of the rounding.
+        round_up = (buffer[size - 1] % 2) == 1;
+      } else {
+        round_up = true;
+      }
+    }
+    frac = 0.;
+
+    if (!round_up) {
+      return;
+    }
+
+    // Add 1 to the decimal representation (the carry can propagate)
+    for (int i = size - 1; i >= 0; --i) {
+      if (++buffer[i] > 9) {
+        buffer[i] = 0;
+      } else {
+        return;
+      }
+    }
+
+    // If we reach this point, initial number had the form "999....999": rounds
+    // to "100....000" with `exp10`+1
+    shift_right(1, 1);
+  }
+
   KOKKOS_FUNCTION DecimalRepresentation<FloatType, size> &operator+=(
-      DecimalRepresentation<FloatType, size_r> rhs) {
+      DecimalRepresentation<FloatType, size> rhs) {
     // Shift operands to ensure both have the same exponent
     if (rhs.exp10 < exp10) {
       rhs.shift_right(exp10 - rhs.exp10, 0);
@@ -392,11 +398,14 @@ struct DecimalRepresentation {
       shift_right(rhs.exp10 - exp10, 0);
     }
 
-    rem += rhs.rem;
-    int carry = rem;
-    rem -= carry;
+    // frac < 1, thus carry can be 0 or 1 only
+    frac += rhs.frac;
+    int carry = frac;
+    frac -= carry;
 
     for (int i = size - 1; i >= 0; --i) {
+      // buffer[i] <= 9, rhs.buffer[i] <= 9, carry <= 1: the sum can never be
+      // bigger than 19, the new carry can't be bigger than 1.
       buffer[i] += rhs.buffer[i] + carry;
       if (buffer[i] > 9) {
         carry = 1;
@@ -418,12 +427,16 @@ struct DecimalRepresentation {
  * Decimal representation of a power of two
  */
 template <class FloatType, std::size_t size>
-struct BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
-  using DecimalRepresentation<FloatType, size>::buffer;
-  using DecimalRepresentation<FloatType, size>::exp10;
-  using DecimalRepresentation<FloatType, size>::max_div;
-  using DecimalRepresentation<FloatType, size>::max_mul;
+class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
+ protected:
+  using decimal = DecimalRepresentation<FloatType, size>;
+  using decimal::buffer;
+  using decimal::exp10;
+  using decimal::max_div;
+  using decimal::max_mul;
 
+  // Exponent bias (different from the IEEE754 one, to take subnormals into
+  // account)
   static constexpr int bias =
       (typename Kokkos::equivalent_int_t<FloatType>(1)
        << (Kokkos::exponent_bits<FloatType>::value - 1)) +
@@ -433,45 +446,45 @@ struct BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
   // Stored with the total bias added
   int exp2;
 
+ public:
   // Initialize with the decimal representation of 2^0 = 1
   KOKKOS_FUNCTION constexpr BaseTwoExponent() {
-    DecimalRepresentation<FloatType, size>::buffer[0] = 1;
-    exp2                                              = bias;
+    decimal::buffer[0] = 1;
+    exp2               = bias;
   }
 
   KOKKOS_FUNCTION void print() const {
-    DecimalRepresentation<FloatType, size>::print();
+    decimal::print();
     Kokkos::printf(" = 2^%i", exp2 - bias);
   }
 
+  // Generate the decimal representation of 2 ^ exp2_target, using the current
+  // representation as the basis for the computation
   KOKKOS_FUNCTION void generate_nth_exp(int exp2_target) {
     if (exp2_target < exp2) {
       // Divide max_div by max_div until we can reach the target with one
       // smaller step
       while (exp2 - max_div > exp2_target) {
-        DecimalRepresentation<FloatType, size>::divide_by_power_of_two(max_div);
+        decimal::divide_by_power_of_two(max_div);
         exp2 -= max_div;
       }
 
       // Last division needed to reach the target
       if (exp2 != exp2_target) {
-        DecimalRepresentation<FloatType, size>::divide_by_power_of_two(
-            exp2 - exp2_target);
+        decimal::divide_by_power_of_two(exp2 - exp2_target);
         exp2 -= (exp2 - exp2_target);
       }
     } else if (exp2_target > exp2) {
       // Multiply max_mul by max_mul until we can reach the target with one
       // smaller step
       while (exp2 + max_mul < exp2_target) {
-        DecimalRepresentation<FloatType, size>::multiply_by_power_of_two(
-            max_mul);
+        decimal::multiply_by_power_of_two(max_mul);
         exp2 += max_mul;
       }
 
       // Last multiplication needed to reach the target
       if (exp2 != exp2_target) {
-        DecimalRepresentation<FloatType, size>::multiply_by_power_of_two(
-            exp2_target - exp2);
+        decimal::multiply_by_power_of_two(exp2_target - exp2);
       }
     }
     exp2 = exp2_target;
@@ -501,7 +514,7 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
   // Extract sign, mantissa and exponent
-  uint_t sign     = u & (uint_t(1) << (mantissa_bits + exponent_bits));
+  uint_t sign     = u >> (mantissa_bits + exponent_bits);
   uint_t mantissa = u & mantissa_mask;
   uint_t exp      = (u >> mantissa_bits) & exp_mask;
 
@@ -530,9 +543,11 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     --exp;
   }
 
+  // Decimal representation of the power of twos that will be added together to
+  // compute the result
   BaseTwoExponent<FloatType, precision> base;
 
-  // Buffer that will contain the decimal representation of the result
+  // Decimal representation of the result
   DecimalRepresentation<FloatType, precision> decimal;
 
   bool found_set_bit = false;
@@ -553,24 +568,9 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     }
   }
 
-  // Round to nearest, tie to even
-  int need_round = false;
-  if (decimal.rem >= .5) {
-    if (decimal.rem == .5) {
-      // In case the remainder is exactly 0.5, we round up if
-      // `buffer[6]` is an  odd number.
-      // This is the `tie to even` part of the rounding.
-      need_round = (decimal.buffer[precision - 1] % 2) == 1;
-    } else {
-      need_round = true;
-    }
-  }
+  decimal.round();
 
-  if (need_round) {
-    decimal.round_up();
-  }
-
-  // Copy the significand to the output
+  // Copy the digits to the output (add decimal separator)
   *out++ = decimal.buffer[0] + '0';
   *out++ = '.';
   for (int i = 1; i < precision; ++i) {
@@ -578,16 +578,14 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   }
 
   // Write exponent
-  *out++ = 'e';
-  *out++ = decimal.exp10 >= 0 ? '+' : '-';
-
+  *out++               = 'e';
+  *out++               = decimal.exp10 >= 0 ? '+' : '-';
   unsigned int abs_exp = decimal.exp10 >= 0 ? decimal.exp10 : -decimal.exp10;
   int exp_len          = to_chars_len(abs_exp);
   // Add a leading '0' if exp length is smaller than 2
   if (exp_len < 2) {
     *out++ = '0';
   }
-
   to_chars_i(out, last, abs_exp);
   out += exp_len;
 

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -126,15 +126,14 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   static_assert(std::is_same_v<FloatType, double> ||
                 std::is_same_v<FloatType, float>);
 
-  using uint_t                = Kokkos::equivalent_int_t<FloatType>;
-  constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
-  constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+  using uint_t                         = Kokkos::equivalent_int_t<FloatType>;
+  constexpr unsigned int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  constexpr unsigned int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
-  constexpr uint_t exp_mask = (uint_t(1) << exponent_bits) - 1;
-
-  uint_t u = Kokkos::bit_cast<uint_t>(f);
+  constexpr uint_t exp_mask = (uint_t(1) << exponent_bits) - uint_t(1);
 
   // Extract sign and exponent
+  uint_t u    = Kokkos::bit_cast<uint_t>(f);
   uint_t sign = u >> (mantissa_bits + exponent_bits);
   uint_t exp  = (u >> mantissa_bits) & exp_mask;
 
@@ -153,8 +152,8 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   //  - 6 fractional numbers
   //  - 1 exponent marker ('e')
   //  - 1 exponent sign ('+' or '-')
-  //  - 2 digits padded with 0 for the exponent if it is between -99 and 99, 3
-  //  digits if it is bigger
+  //  - 2 digits, padded with 0, for the exponent if it is between -99 and 99, 3
+  //  digits if it is smaller than -99 or bigger than 99.
 
   if constexpr (std::is_same_v<FloatType, double>) {
     // Check whether the exponent has two or three decimal digits by comparing
@@ -206,7 +205,6 @@ struct to_chars_result {
 template <class Integral>
 KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
                                                      Integral value) {
-  // NOLINTBEGIN(bugprone-invalid-enum-default-initialization)
   using Unsigned = std::conditional_t<sizeof(Integral) <= sizeof(unsigned int),
                                       unsigned int, unsigned long long>;
   Unsigned unsigned_val = value;  // NOLINT(bugprone-signed-char-misuse)
@@ -225,19 +223,20 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
   }
   to_chars_impl(first, len, unsigned_val);
   return {first + len, {}};
-  // NOLINTEND(bugprone-invalid-enum-default-initialization)
 }
 //</editor-fold>
 
 /*
  * Decimal representation of a floating point number
  */
-template <typename FloatType, std::size_t size>
+template <typename FloatType, std::size_t precision>
 class DecimalRepresentation {
  public:
+  using uint_t = Kokkos::equivalent_int_t<FloatType>;
+
   // Buffer that contains the decimal representation of a number in scientific
   // notation (without decimal separator)
-  uint8_t buffer[size];
+  uint8_t buffer[precision];
   // Exponent of the decimal representation stored
   int exp10;
   // For instance, if the number stored is 2^10, `buffer` contains
@@ -247,7 +246,7 @@ class DecimalRepresentation {
   // frac is the fractional part of the floating point number that is beyond
   // the decimal representation. It is always included between 0 and 1
   // (excluded).
-  // For instance, if size is 3, and the number stored is 2^-6 = 0.015625:
+  // For instance, if precision is 3 and the number stored is 2^-6 = 0.015625:
   //  - exp10 = -2
   //  - buffer = 156
   //  - frac = 0.25
@@ -260,13 +259,13 @@ class DecimalRepresentation {
 
   // Print buffer for debugging purpose
   KOKKOS_FUNCTION void print() const {
-    char tmp[size + 2];
+    char tmp[precision + 2];
     tmp[0] = buffer[0] + '0';
     tmp[1] = '.';
-    for (std::size_t i = 2; i < size + 1; ++i) {
+    for (std::size_t i = 2; i < precision + 1; ++i) {
       tmp[i] = buffer[i - 1] + '0';
     }
-    tmp[size + 1] = '\0';
+    tmp[precision + 1] = '\0';
     Kokkos::printf("%se%+03i (%e)", tmp, exp10, frac);
   }
 
@@ -274,15 +273,15 @@ class DecimalRepresentation {
   // This can't be higher than 60 since we need to be able to store up to
   // (2^max_div - 1) * 9 in the remainder/carry: bigger exponent would overflow
   // an uint64_t
-  static constexpr int max_div = 60;
-  static constexpr int max_mul = 60;
+  static constexpr uint_t max_div = 60;
+  static constexpr uint_t max_mul = 60;
 
   // Shift the decimal representation in buffer `shift` time to the right,
   // inserting `insert` as the leading numbers.
   KOKKOS_FUNCTION void shift_right(int shift, uint8_t insert) {
-    for (int i = size - 1; i >= 0; --i) {
+    for (int i = precision - 1; i >= 0; --i) {
       // Add discarded digit to the remainder if the curent cell is shifted out
-      if (std::size_t(i) + std::size_t(shift) >= size) {
+      if (std::size_t(i) + std::size_t(shift) >= precision) {
         frac = (buffer[i] + frac) / 10.;
       }
 
@@ -293,8 +292,8 @@ class DecimalRepresentation {
       }
     }
 
-    if (std::size_t(shift) > size) {
-      for (int i = size; i < shift; ++i) {
+    if (std::size_t(shift) > precision) {
+      for (int i = precision; i < shift; ++i) {
         frac = (insert + frac) / 10.;
       }
     }
@@ -304,7 +303,7 @@ class DecimalRepresentation {
 
   // Divide decimal number by 2^exp
   // Returns garbage if exp > max_div
-  KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
+  KOKKOS_FUNCTION void divide_by_power_of_two(uint_t exp) {
     uint64_t dividend   = 0x0llu;
     uint64_t divisor    = 0x1llu << exp;
     std::size_t src_idx = 0;
@@ -314,7 +313,7 @@ class DecimalRepresentation {
       // Update dividend with the next digit (coming either from the decimal
       // buffer or from `frac`)
       dividend *= 10;
-      if (src_idx < size) {
+      if (src_idx < precision) {
         dividend += buffer[src_idx++];
       } else {
         frac *= 10.;
@@ -323,36 +322,40 @@ class DecimalRepresentation {
       }
 
       if (dividend < divisor && res_idx == 0) {
-        // As long as we haven't found a non-zero digit, we don't output 0, we
+        // As long as we haven't found a non-zero digit, we don't output 0: we
         // only track the exponent of the future most significant digit
         --exp10;
       } else {
-        // Otherwise, buffer receive the result of the division and dividend
+        // Otherwise, buffer receives the result of the division and dividend
         // the remainder
         buffer[res_idx++] = dividend >> exp;
+        // divisor is a power of two: use optimisation x % 2^n == x & (2^n - 1)
         dividend &= divisor - 1;
       }
-    } while (res_idx < size);
+    } while (res_idx < precision);
 
     frac = ((double)dividend + frac) / (double)divisor;
   }
 
   // Multiply decimal number by 2^exp
   // Returns garbage if exp > max_mul
-  KOKKOS_FUNCTION void multiply_by_power_of_two(int exp) {
-    frac *= 0x1llu << exp;
+  KOKKOS_FUNCTION void multiply_by_power_of_two(uint_t exp) {
+    const uint64_t multiplier = 0x1llu << exp;
+
+    frac *= multiplier;
     uint64_t carry = frac;
     frac -= carry;
 
-    for (int i = size - 1; i >= 0; --i) {
-      uint64_t tmp = ((uint64_t)(buffer[i]) << exp) + carry;
+    // Multiply each digit of the input by 2^n
+    for (int i = precision - 1; i >= 0; --i) {
+      uint64_t tmp = (uint64_t)(buffer[i]) * multiplier + carry;
       buffer[i]    = tmp % 10;
       carry        = tmp / 10;
     }
 
     // Continue adding the carry to the computed number
     while (carry > 0) {
-      shift_right(1, carry % 10);  // shift_right update the exponent
+      shift_right(1, carry % 10);  // shift_right updates the exponent
       carry /= 10;
     }
   }
@@ -367,7 +370,7 @@ class DecimalRepresentation {
         // In case `frac` is exactly 0.5, we round up if `buffer[6]` is an odd
         // number, down otherwise.
         // This is the `tie to even` part of the rounding.
-        round_up = (buffer[size - 1] % 2) == 1;
+        round_up = (buffer[precision - 1] % 2) == 1;
       } else {
         round_up = true;
       }
@@ -379,7 +382,7 @@ class DecimalRepresentation {
     }
 
     // Add 1 to the decimal representation (the carry can propagate)
-    for (int i = size - 1; i >= 0; --i) {
+    for (int i = precision - 1; i >= 0; --i) {
       if (++buffer[i] > 9) {
         buffer[i] = 0;
       } else {
@@ -392,8 +395,8 @@ class DecimalRepresentation {
     shift_right(1, 1);
   }
 
-  KOKKOS_FUNCTION DecimalRepresentation<FloatType, size> &operator+=(
-      DecimalRepresentation<FloatType, size> rhs) {
+  KOKKOS_FUNCTION DecimalRepresentation<FloatType, precision> &operator+=(
+      DecimalRepresentation<FloatType, precision> rhs) {
     // Shift operands to ensure both have the same exponent
     if (rhs.exp10 < exp10) {
       rhs.shift_right(exp10 - rhs.exp10, 0);
@@ -406,7 +409,7 @@ class DecimalRepresentation {
     int carry = frac;
     frac -= carry;
 
-    for (int i = size - 1; i >= 0; --i) {
+    for (int i = precision - 1; i >= 0; --i) {
       // buffer[i] <= 9, rhs.buffer[i] <= 9, carry <= 1: the sum can never be
       // bigger than 19, the new carry can't be bigger than 1.
       buffer[i] += rhs.buffer[i] + carry;
@@ -429,10 +432,11 @@ class DecimalRepresentation {
 /**
  * Decimal representation of a power of two
  */
-template <class FloatType, std::size_t size>
-class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
+template <class FloatType, std::size_t precision>
+class BaseTwoExponent : public DecimalRepresentation<FloatType, precision> {
  protected:
-  using decimal = DecimalRepresentation<FloatType, size>;
+  using uint_t  = Kokkos::equivalent_int_t<FloatType>;
+  using decimal = DecimalRepresentation<FloatType, precision>;
   using decimal::buffer;
   using decimal::exp10;
   using decimal::max_div;
@@ -440,13 +444,13 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
 
   // Exponent bias (different from the IEEE754 one, to take subnormals into
   // account)
-  static constexpr int bias = (typename Kokkos::equivalent_int_t<FloatType>(1)
-                               << (Kokkos::exponent_bits_v<FloatType> - 1)) +
-                              Kokkos::mantissa_bits_v<FloatType> - 2;
+  static constexpr uint_t bias =
+      (uint_t(1) << (Kokkos::exponent_bits_v<FloatType> - 1)) +
+      Kokkos::mantissa_bits_v<FloatType> - 2;
 
   // Exponent of the power stored in `buffer`
   // Stored with the total bias added
-  int exp2;
+  uint_t exp2;
 
  public:
   // Initialize with the decimal representation of 2^0 = 1
@@ -457,16 +461,16 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
 
   KOKKOS_FUNCTION void print() const {
     decimal::print();
-    Kokkos::printf(" = 2^%i", exp2 - bias);
+    Kokkos::printf(" = 2^%i", (int)exp2 - (int)bias);
   }
 
   // Generate the decimal representation of 2 ^ exp2_target, using the current
   // representation as the basis for the computation
-  KOKKOS_FUNCTION void generate_nth_exp(int exp2_target) {
+  KOKKOS_FUNCTION void generate_nth_exp(uint_t exp2_target) {
     if (exp2_target < exp2) {
       // Divide max_div by max_div until we can reach the target with one
       // smaller step
-      while (exp2 - max_div > exp2_target) {
+      while (exp2 > exp2_target + max_div) {
         decimal::divide_by_power_of_two(max_div);
         exp2 -= max_div;
       }
@@ -499,26 +503,27 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   static_assert(std::is_same_v<FloatType, double> ||
                 std::is_same_v<FloatType, float>);
 
-  using uint_t                = Kokkos::equivalent_int_t<FloatType>;
-  constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
-  constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
+  using uint_t                         = Kokkos::equivalent_int_t<FloatType>;
+  constexpr unsigned int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
+  constexpr unsigned int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
   constexpr uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
   constexpr uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
 
   // Number of decimal digits outputed
-  constexpr int precision = 7;
+  constexpr std::size_t precision = 7;
 
+  // Check that we have enough space to output the result
   std::ptrdiff_t const len = to_chars_len(f);
   if (last - first < len) {
     return {last, errc::value_too_large};
   }
-  uint_t u = Kokkos::bit_cast<uint_t>(f);
 
-  // Extract sign, mantissa and exponent
+  // Extract sign, exponent and mantissa
+  uint_t u        = Kokkos::bit_cast<uint_t>(f);
   uint_t sign     = u >> (mantissa_bits + exponent_bits);
-  uint_t mantissa = u & mantissa_mask;
   uint_t exp      = (u >> mantissa_bits) & exp_mask;
+  uint_t mantissa = u & mantissa_mask;
 
   char *out = first;
 
@@ -545,7 +550,7 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     --exp;
   }
 
-  // Decimal representation of the power of twos that will be added together to
+  // Decimal representation of the powers of two that will be added together to
   // compute the result
   BaseTwoExponent<FloatType, precision> base;
 
@@ -555,9 +560,8 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   bool found_set_bit = false;
   // Loop over each bit of the mantissa, add the corresponding power of 2 if
   // the bit is set
-  for (uint64_t mask = 0x1; mask < (uint_t(1) << (mantissa_bits + 1));
-       mask <<= 1, ++exp) {
-    if (mantissa & mask) {
+  while (mantissa) {
+    if (mantissa & uint_t(1)) {
       base.generate_nth_exp(exp);
 
       if (!found_set_bit) {
@@ -568,30 +572,35 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
         decimal += base;
       }
     }
+
+    mantissa >>= 1u;
+    ++exp;
   }
 
   decimal.round();
 
-  // Copy the digits to the output (add decimal separator)
+  // Copy the digits to the output, with decimal separator
   *out++ = decimal.buffer[0] + '0';
   *out++ = '.';
-  for (int i = 1; i < precision; ++i) {
+  for (std::size_t i = 1; i < precision; ++i) {
     *out++ = decimal.buffer[i] + '0';
   }
 
   // Write exponent
-  *out++               = 'e';
-  *out++               = decimal.exp10 >= 0 ? '+' : '-';
-  unsigned int abs_exp = decimal.exp10 >= 0 ? decimal.exp10 : -decimal.exp10;
-  int exp_len          = to_chars_len(abs_exp);
-  // Add a leading '0' if exp length is smaller than 2
-  if (exp_len < 2) {
+  *out++ = 'e';
+  int abs_exp;
+  if (decimal.exp10 >= 0) {
+    *out++  = '+';
+    abs_exp = decimal.exp10;
+  } else {
+    *out++  = '-';
+    abs_exp = -decimal.exp10;
+  }
+  if (abs_exp <= 9) {
+    // Pad with 0 if exp is only 1 digit long
     *out++ = '0';
   }
-  to_chars_i(out, last, abs_exp);
-  out += exp_len;
-
-  return {first + len, {}};
+  return {to_chars_i(out, last, abs_exp).ptr, {}};
 }
 
 }  // namespace Impl

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -310,7 +310,7 @@ struct DecimalRepresentation {
 
   // Divide decimal number by 2^exp
   KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
-    KOKKOS_ASSERT(exp <= max_div);
+    KOKKOS_EXPECTS(exp <= max_div);
 
     uint64_t dividend   = 0x0llu;
     uint64_t divisor    = 0x1llu << exp;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -132,7 +132,7 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
 
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
-  // Extract double infos
+  // Extract sign, mantissa and exponent
   uint_t sign = u & (uint_t(1) << (mantissa_bits + exponent_bits));
   uint_t exp  = ((u & (exp_mask << mantissa_bits))) >> mantissa_bits;
 
@@ -490,7 +490,7 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   }
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
-  // Extract double informations
+  // Extract sign, mantissa and exponent
   uint_t sign     = u & (uint_t(1) << (mantissa_bits + exponent_bits));
   uint_t mantissa = u & mantissa_mask;
   uint_t exp      = (u >> mantissa_bits) & exp_mask;

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -136,12 +136,12 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
   // Extract sign and exponent
-  uint_t sign = u & (uint_t(1) << (mantissa_bits + exponent_bits));
+  uint_t sign = u >> (mantissa_bits + exponent_bits);
   uint_t exp  = ((u & (exp_mask << mantissa_bits))) >> mantissa_bits;
 
   unsigned int ret = 0;
 
-  ret += sign ? 1 : 0;
+  ret += sign;
   if (exp == exp_mask) {
     // 'inf' and 'nan' are both 3 chars
     return ret + 3;
@@ -291,7 +291,7 @@ class DecimalRepresentation {
 
     if (shift > size) {
       for (int i = size; i < shift; ++i) {
-        frac = insert + frac / 10.;
+        frac = (insert + frac) / 10.;
       }
     }
 
@@ -320,7 +320,7 @@ class DecimalRepresentation {
 
       if (dividend < divisor && res_idx == 0) {
         // As long as we haven't found a non-zero digit, we don't output 0, we
-        // only track the exponent of the futur most significant digit
+        // only track the exponent of the future most significant digit
         --exp10;
       } else {
         // Otherwise, buffer receive the result of the division and dividend
@@ -436,10 +436,9 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
 
   // Exponent bias (different from the IEEE754 one, to take subnormals into
   // account)
-  static constexpr int bias =
-      (typename Kokkos::equivalent_int_t<FloatType>(1)
-       << (Kokkos::exponent_bits<FloatType>::value - 1)) +
-      Kokkos::mantissa_bits<FloatType>::value - 2;
+  static constexpr int bias = (typename Kokkos::equivalent_int_t<FloatType>(1)
+                               << (Kokkos::exponent_bits_v<FloatType> - 1)) +
+                              Kokkos::mantissa_bits_v<FloatType> - 2;
 
   // Exponent of the power stored in `buffer`
   // Stored with the total bias added
@@ -471,7 +470,6 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
       // Last division needed to reach the target
       if (exp2 != exp2_target) {
         decimal::divide_by_power_of_two(exp2 - exp2_target);
-        exp2 -= (exp2 - exp2_target);
       }
     } else if (exp2_target > exp2) {
       // Multiply max_mul by max_mul until we can reach the target with one

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -229,8 +229,6 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
  */
 template <typename FloatType, std::size_t size>
 struct DecimalRepresentation {
-  using uint_t = Kokkos::equivalent_int_t<FloatType>;
-
   // Buffer that contains the decimal representation of a number in scientific
   // notation
   uint8_t buffer[size];
@@ -239,28 +237,39 @@ struct DecimalRepresentation {
   // For instance, if the number stored is 2^10, `buffer` contains
   // "102400000..." and `exp10` is 3
 
-  KOKKOS_FUNCTION constexpr DecimalRepresentation() : buffer{0}, exp10{0} {}
+  // rem is the part of the floating point number that is beyond the decimal
+  // representation. It is always comprised between 0 and 1. For instance, if
+  // size is 3, if the number stored is 2^-6 = 0.015625:
+  //  - exp10 = -2
+  //  - buffer = 156
+  //  - rem = 0.25
+  double rem;
+
+  KOKKOS_FUNCTION constexpr DecimalRepresentation()
+      : buffer{0}, exp10{0}, rem{0} {}
 
   // This can't be higher than 60 since we need to be able to store up to
-  // (2^max_div - 1) * 9 in the remainder, bigger number wouldn't fit in a
-  // uint64_t
+  // (2^max_div - 1) * 9 in the remainder/carry, bigger exponent would overflow
+  // an uint64_t
   static constexpr int max_div = 60;
   static constexpr int max_mul = 60;
 
   // Print buffer for debugging purpose
-  void print() {
-    char tmp[size + 1];
-    for (int i = 0; i < size; ++i) {
-      tmp[i] = buffer[i] + '0';
+  KOKKOS_FUNCTION void print() const {
+    char tmp[size + 2];
+    tmp[0] = buffer[0] + '0';
+    tmp[1] = '.';
+    for (std::size_t i = 2; i < size + 1; ++i) {
+      tmp[i] = buffer[i - 1] + '0';
     }
-    tmp[size] = '\0';
-    Kokkos::printf("%se%i", tmp, exp10);
+    tmp[size + 1] = '\0';
+    Kokkos::printf("%se%+03i (%e)", tmp, exp10, rem);
   }
 
   // Round number up (equivalent to adding 10 ^ (exp10 - size))
-  KOKKOS_FUNCTION void round_up(size_t index = size - 1) {
+  KOKKOS_FUNCTION void round_up() {
     bool carry = true;
-    int i      = index;
+    int i      = size - 1;
 
     while (i >= 0 && carry) {
       if (++buffer[i] > 9) {
@@ -279,39 +288,38 @@ struct DecimalRepresentation {
   }
 
   // Shift the decimal representation in buffer shift time to the right,
-  // inserting `insert` as the leading numbers. Returns the decimal
-  // representation of the most significant number that was shifted out
-  KOKKOS_FUNCTION uint8_t shift_right(uint8_t shift, int insert) {
+  // inserting `insert` as the leading numbers.
+  KOKKOS_FUNCTION void shift_right(uint8_t shift, int insert) {
     if (shift < 1) {
       // nothing to do
-      return 0;
+      return;
     }
 
-    uint8_t shifted_out;
-    if (shift <= size) {
-      shifted_out = buffer[size - shift];
-    } else {
-      shifted_out = 0;
+    for (int i = size - 1; i >= 0; --i) {
+      if (std::size_t(i) + shift >= size) {
+        // Add discarded digit to the remainder
+        rem += buffer[i];
+        rem /= 10;
+      }
+
+      if (i >= shift) {
+        buffer[i] = buffer[i - shift];
+      } else {
+        buffer[i] = insert;
+      }
     }
 
-    int j = size - 1;
-    while (j >= shift) {
-      buffer[j] = buffer[j - shift];
-      --j;
-    }
-    while (j >= 0) {
-      buffer[j] = insert;
-      --j;
+    if (shift > size) {
+      for (int i = size; i < shift; ++i) {
+        rem /= 10;
+      }
     }
 
     exp10 += shift;
-    return shifted_out;
   }
 
   // Divide decimal number by 2^exp
   KOKKOS_FUNCTION void divide_by_power_of_two(int exp) {
-    KOKKOS_EXPECTS(exp <= max_div);
-
     uint64_t dividend   = 0x0llu;
     uint64_t divisor    = 0x1llu << exp;
     std::size_t src_idx = 0;
@@ -322,18 +330,23 @@ struct DecimalRepresentation {
     do {
       do {
         dividend *= 10;
+
         if (src_idx < size) {
           dividend += buffer[src_idx++];
+        } else {
+          rem *= 10.;
+          dividend += (uint64_t)rem;
+          rem -= (double)((uint64_t)rem);
         }
+
         if (dividend != 0 && dividend >= divisor) {
           break;
-        } else {
-          if (first_pass) {
-            --exp10;
-          }
-          if (dividend != 0 && !first_pass) {
-            buffer[res_idx++] = 0;
-          }
+        }
+
+        if (first_pass) {
+          --exp10;
+        } else if (dividend != 0) {
+          buffer[res_idx++] = 0;
         }
       } while (dividend != 0 && res_idx < size);
 
@@ -345,17 +358,15 @@ struct DecimalRepresentation {
       }
     } while (res_idx < size);
 
-    if (dividend * 2 > divisor) {
-      round_up();
-    }
+    rem = ((double)dividend + rem) / (double)divisor;
   }
 
   // Multiply decimal number by 2^exp
   KOKKOS_FUNCTION void multiply_by_power_of_two(int exp) {
-    KOKKOS_ASSERT(exp <= max_mul);
-
     uint64_t multiplior = 0x1llu << exp;
-    uint64_t carry      = 0llu;
+    rem *= multiplior;
+    uint64_t carry = rem;
+    rem -= carry;
 
     for (int i = size - 1; i >= 0; --i) {
       uint64_t tmp = buffer[i] * multiplior + carry;
@@ -363,25 +374,27 @@ struct DecimalRepresentation {
       carry        = tmp / 10;
     }
 
-    uint8_t discarded = 0;
     // Continue adding the carry to the computed number
     while (carry > 0) {
-      discarded = shift_right(1, carry % 10);
+      shift_right(1, carry % 10);
       carry /= 10;
-    }
-
-    // Round if the last digit shifted out was >= 5
-    if (discarded >= 5) {
-      round_up();
     }
   }
 
   template <size_t size_r>
   KOKKOS_FUNCTION DecimalRepresentation<FloatType, size> &operator+=(
       DecimalRepresentation<FloatType, size_r> rhs) {
-    KOKKOS_ASSERT(rhs.exp10 == exp10);
+    // Shift operands to ensure both have the same exponent
+    if (rhs.exp10 < exp10) {
+      rhs.shift_right(exp10 - rhs.exp10, 0);
+    } else if (exp10 < rhs.exp10) {
+      shift_right(rhs.exp10 - exp10, 0);
+    }
 
-    int carry = 0;
+    rem += rhs.rem;
+    int carry = rem;
+    rem -= carry;
+
     for (int i = size - 1; i >= 0; --i) {
       buffer[i] += rhs.buffer[i] + carry;
       if (buffer[i] > 9) {
@@ -393,9 +406,7 @@ struct DecimalRepresentation {
     }
 
     if (carry) {
-      if (shift_right(1, 1) >= 5) {
-        round_up();
-      }
+      shift_right(1, 1);
     }
 
     return *this;
@@ -427,7 +438,7 @@ struct BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
     exp2                                              = bias;
   }
 
-  void print() {
+  KOKKOS_FUNCTION void print() const {
     DecimalRepresentation<FloatType, size>::print();
     Kokkos::printf(" = 2^%i", exp2 - bias);
   }
@@ -479,13 +490,8 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   constexpr uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
   constexpr uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
 
-  // Number of decimal digits used for internal computation
-  // These numbers don't depend on the input type, but on the number of output
-  // digits.
-  // They were found empirically so that `to_chars_f` has the same output as
-  // std::printf("%e")
-  constexpr int precision     = 18;
-  constexpr int exp_precision = 22;
+  // Number of decimal digits outputed
+  constexpr int precision = 7;
 
   std::ptrdiff_t const len = to_chars_len(f);
   if (last - first < len) {
@@ -523,11 +529,12 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     --exp;
   }
 
-  BaseTwoExponent<FloatType, exp_precision> base;
+  BaseTwoExponent<FloatType, precision> base;
 
   // Buffer that will contain the decimal representation of the result
   DecimalRepresentation<FloatType, precision> decimal;
 
+  bool found_set_bit = false;
   // Loop over each bit of the mantissa, add the corresponding power of 2 if
   // the bit is set
   for (uint64_t mask = 0x1; mask < (uint_t(1) << (mantissa_bits + 1));
@@ -535,51 +542,38 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
     if (mantissa & mask) {
       base.generate_nth_exp(exp);
 
-      // Shift the buffer if current power of 2 has a greater base 10 exponent
-      // than the current computed number
-      int shift = base.exp10 - decimal.exp10;
-      if (shift > 0) {
-        if (decimal.shift_right(shift, 0) >= 5) {
-          decimal.round_up();
-        }
+      if (!found_set_bit) {
+        decimal       = base;
+        found_set_bit = true;
+      } else {
+        // Add current power of two with number
+        decimal += base;
       }
-
-      decimal.exp10 = base.exp10;
-
-      // Add current power of two with number
-      decimal += base;
     }
   }
 
   // Round to nearest, tie to even
   int need_round = false;
-  if (decimal.buffer[7] >= 5) {
-    if (decimal.buffer[7] == 5) {
-      // In case the last digit is 5, we round up if:
-      //  - we find a non zero digit after `buffer[7]`
-      //  - we find no non zero digit after `buffer[7]` but `buffer[6]` is an
-      //  odd number.
-      //  This is the `tie to even` part of the rounding.
-      //  (this is also where the lack of precision is causing this
-      //  implementation to sometime output wrong results)
-      bool all_zero = true;
-      for (int i = 8; i < precision && all_zero; ++i) {
-        all_zero = decimal.buffer[i] == 0;
-      }
-      need_round = !all_zero || ((decimal.buffer[6] % 2) == 1);
+  if (decimal.rem >= .5) {
+    if (decimal.rem == .5) {
+      // In case the remainder is exactly 0.5, we round up if
+      // `buffer[6]` is an  odd number.
+      // This is the `tie to even` part of the rounding.
+      need_round = (decimal.buffer[precision - 1] % 2) == 1;
+      Kokkos::printf("Tie to even\n");
     } else {
       need_round = true;
     }
   }
 
   if (need_round) {
-    decimal.round_up(6);
+    decimal.round_up();
   }
 
   // Copy the significand to the output
   *out++ = decimal.buffer[0] + '0';
   *out++ = '.';
-  for (int i = 1; i < 7; ++i) {
+  for (int i = 1; i < precision; ++i) {
     *out++ = decimal.buffer[i] + '0';
   }
 

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -275,10 +275,10 @@ class DecimalRepresentation {
 
   // Shift the decimal representation in buffer `shift` time to the right,
   // inserting `insert` as the leading numbers.
-  KOKKOS_FUNCTION void shift_right(uint8_t shift, int insert) {
+  KOKKOS_FUNCTION void shift_right(int shift, uint8_t insert) {
     for (int i = size - 1; i >= 0; --i) {
       // Add discarded digit to the remainder if the curent cell is shifted out
-      if (std::size_t(i) + shift >= size) {
+      if (std::size_t(i) + std::size_t(shift) >= size) {
         frac = (buffer[i] + frac) / 10.;
       }
 
@@ -289,7 +289,7 @@ class DecimalRepresentation {
       }
     }
 
-    if (shift > size) {
+    if (std::size_t(shift) > size) {
       for (int i = size; i < shift; ++i) {
         frac = (insert + frac) / 10.;
       }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -130,14 +130,13 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
   constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
   constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
-  constexpr uint_t exp_mask      = (uint_t(1) << exponent_bits) - 1;
-  constexpr uint_t mantissa_mask = (uint_t(1) << mantissa_bits) - 1;
+  constexpr uint_t exp_mask = (uint_t(1) << exponent_bits) - 1;
 
   uint_t u = Kokkos::bit_cast<uint_t>(f);
 
   // Extract sign and exponent
   uint_t sign = u >> (mantissa_bits + exponent_bits);
-  uint_t exp  = ((u & (exp_mask << mantissa_bits))) >> mantissa_bits;
+  uint_t exp  = (u >> mantissa_bits) & exp_mask;
 
   unsigned int ret = 0;
 
@@ -164,8 +163,13 @@ KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
     //  previous number 0x2b617f7d402b1833 rounds to 9.9999999e-100
     //  - 0x54b249ad163d7d25 is the last number that rounds to 9.9999999e+99,
     //  0x54b249ad163d7d26 rounds to 1.0000000e+100
-    u = u & (exp_mask << mantissa_bits | mantissa_mask);
+    u &= (uint_t(1) << (mantissa_bits + exponent_bits)) - uint_t(1);
+#ifdef KOKKOS_ENABLE_SYCL
+    // FIXME: `u != 0` doesn't have the correct value in SYCL when f == -0.
+    if (f != 0 && (u < 0x2b617f7d402b1834 || u > 0x54b249ad163d7d25)) {
+#else
     if ((u != 0 && u < 0x2b617f7d402b1834) || u > 0x54b249ad163d7d25) {
+#endif
       return ret + 13;
     }
   }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -123,7 +123,7 @@ KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
 
 template <std::floating_point FloatType>
 KOKKOS_FUNCTION unsigned int to_chars_len(FloatType f) {
-  using uint_t            = Kokkos::equivalent_int_t<FloatType>;
+  using uint_t                = Kokkos::equivalent_int_t<FloatType>;
   constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
   constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
@@ -257,7 +257,7 @@ struct DecimalRepresentation {
   // Round number up (equivalent to adding 10 ^ (exp10 - size))
   KOKKOS_FUNCTION void round_up(size_t index = size - 1) {
     bool carry = true;
-    int i     = index;
+    int i      = index;
 
     while (i >= 0 && carry) {
       if (++buffer[i] > 9) {
@@ -271,14 +271,14 @@ struct DecimalRepresentation {
     // Initial number had the form "999....999", rounds to "100....000" with
     // `exp10`+1
     if (carry) {
-      shift_right(1);
+      shift_right(1, 1);
     }
   }
 
   // Shift the decimal representation in buffer shift time to the right,
   // inserting `insert` as the leading numbers. Returns the decimal
   // representation of the most significant number that was shifted out
-  KOKKOS_FUNCTION uint8_t shift_right(uint8_t insert, int shift = 1) {
+  KOKKOS_FUNCTION uint8_t shift_right(uint8_t shift, int insert) {
     if (shift < 1) {
       // nothing to do
       return 0;
@@ -358,7 +358,7 @@ struct DecimalRepresentation {
     uint8_t discarded = 0;
     // Continue adding the carry to the computed number
     while (carry > 0) {
-      discarded = shift_right(carry % 10);
+      discarded = shift_right(1, carry % 10);
       carry /= 10;
     }
 
@@ -385,7 +385,7 @@ struct DecimalRepresentation {
     }
 
     if (carry) {
-      if (shift_right(1) >= 5) {
+      if (shift_right(1, 1) >= 5) {
         round_up();
       }
     }
@@ -464,7 +464,7 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
   static_assert(std::is_same_v<FloatType, double> ||
                 std::is_same_v<FloatType, float>);
 
-  using uint_t            = Kokkos::equivalent_int_t<FloatType>;
+  using uint_t                = Kokkos::equivalent_int_t<FloatType>;
   constexpr int mantissa_bits = Kokkos::mantissa_bits_v<FloatType>;
   constexpr int exponent_bits = Kokkos::exponent_bits_v<FloatType>;
 
@@ -539,7 +539,7 @@ KOKKOS_FUNCTION to_chars_result to_chars_f(char *first, char *last,
       // than the current computed number
       int shift = base.exp10 - decimal.exp10;
       if (shift > 0) {
-        if (decimal.shift_right(0, shift) >= 5) {
+        if (decimal.shift_right(shift, 0) >= 5) {
           decimal.round_up();
         }
       }

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -470,6 +470,7 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
       // Last division needed to reach the target
       if (exp2 != exp2_target) {
         decimal::divide_by_power_of_two(exp2 - exp2_target);
+        exp2 = exp2_target;
       }
     } else if (exp2_target > exp2) {
       // Multiply max_mul by max_mul until we can reach the target with one
@@ -482,9 +483,9 @@ class BaseTwoExponent : public DecimalRepresentation<FloatType, size> {
       // Last multiplication needed to reach the target
       if (exp2 != exp2_target) {
         decimal::multiply_by_power_of_two(exp2_target - exp2);
+        exp2 = exp2_target;
       }
     }
-    exp2 = exp2_target;
   }
 };
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -164,6 +164,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       MathematicalFunctions2
       MathematicalFunctions3
       MathematicalSpecialFunctions
+      FloatPrinting
     )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -28,16 +28,20 @@ struct TestFloatPrinting {
 
     int errors = 0;
     char buffer[BUFFER_SIZE];
-    char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
-    *ptr      = '\0';
-    if (buffer + strlen(ref) != ptr) {
+    char* ptr      = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
+    *ptr           = '\0';
+    int ref_length = strlen(ref);
+    if (buffer + ref_length != ptr) {
       Kokkos::printf("Error %s:%i:\n", file, line);
-      Kokkos::printf("  %lx != %lx\n", buffer + strlen(ref), ptr);
+      Kokkos::printf(
+          "  String size of reference (%s) is %i while size of result (%s) is "
+          "%lu\n",
+          ref, ref_length, buffer, ptr - buffer);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s 0x%x\n", ref,
+        Kokkos::printf("For float %s (0x%x)\n", ref,
                        Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s 0x%lx\n", ref,
+        Kokkos::printf("For double %s (0x%lx)\n", ref,
                        Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;
@@ -47,10 +51,10 @@ struct TestFloatPrinting {
       Kokkos::printf("Error %s:%i:\n", file, line);
       Kokkos::printf("  %s != %s\n", buffer, ref);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s 0x%x\n", ref,
+        Kokkos::printf("For float %s (0x%x)\n", ref,
                        Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s 0x%lx\n", ref,
+        Kokkos::printf("For double %s (0x%lx)\n", ref,
                        Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -210,7 +210,6 @@ void test_all_floats() {
 
         ASSERT_TRUE(check(f));
 
-        ++counter;
         uint64_t tmp = Kokkos::atomic_inc_fetch(&total());
         if (tmp % 1'000'000 == 0) {
           Kokkos::printf("%f%% (%llu/%llu) - %e\n",
@@ -238,7 +237,6 @@ void do_random_test() {
 
         ASSERT_TRUE(check(d));
 
-        ++counter;
         uint64_t tmp = Kokkos::atomic_inc_fetch(&total());
         if (tmp % 1'000'000 == 0) {
           Kokkos::printf("%f%% (%llu/%llu) - %e\n",

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <gtest/gtest.h>
+#include <Kokkos_Random.hpp>
 
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
@@ -32,13 +33,21 @@ struct TestFloatPrinting {
     *ptr      = '\0';
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
-      Kokkos::printf("For float %s\n", ref);
+      if constexpr (std::is_same_v<FloatType, float>) {
+        Kokkos::printf("For float %s\n", ref);
+      } else {
+        Kokkos::printf("For double %s\n", ref);
+      }
       ++errors;
     }
 
     if (strcmp(buffer, ref) != 0) {
       Kokkos::printf("Error: %s != %s\n", buffer, ref);
-      Kokkos::printf("For float %s\n", ref);
+      if constexpr (std::is_same_v<FloatType, float>) {
+        Kokkos::printf("For float %s\n", ref);
+      } else {
+        Kokkos::printf("For double %s\n", ref);
+      }
       ++errors;
     }
 
@@ -101,6 +110,13 @@ struct TestFloatPrinting {
                                   "9.999999e+85");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9f),
                                   "1.000000e+86");
+
+      // Numbers that were incorrectly displayed at some point during the
+      // debugging process
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x0000080000000003),
+                                  "4.345847e-311");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x00072800000002AF),
+                                  "9.951990e-309");
     }
 
     if constexpr (std::is_same_v<FloatType, float>) {
@@ -116,7 +132,75 @@ struct TestFloatPrinting {
   }
 };
 
+#ifdef FULL_TEST
+int check(double d) {
+  char ref[30];
+  char ref_string[30];
+  sprintf(ref_string, "%%5.%ie", 7 - 1);
+
+  double ref_number = d;
+  sprintf(ref, ref_string, ref_number);
+
+  bool ret = false;
+
+  if (std::isnan(d) || std::isinf(d)) {
+    return ret;
+  }
+
+  char buffer[25];
+  using Kokkos::Impl::to_chars_f;
+  to_chars_f(buffer, buffer + 25, d);
+
+  for (int i = 0; i < 10; ++i) {
+    if (ref[i] != buffer[i]) {
+      printf("0x%lx\n", std::bit_cast<uint64_t>(d));
+      printf("%s !=\n", ref);
+      printf("%s\n", buffer);
+
+      for (int j = 0; j < i; ++j) {
+        printf(" ");
+      }
+      printf("^\n");
+      ret = true;
+      break;
+    }
+  }
+
+  return ret;
+}
+
+void do_random_test() {
+  Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE> random_pool(/*seed=*/12345);
+
+  // Don't check negative numbers, implementation is simple enough, bugs should
+  // be caught by the standard tests
+  uint64_t max = 0x1llu << 28;
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<TEST_EXECSPACE>(0, max),
+      KOKKOS_LAMBDA(uint64_t counter) {
+        auto generator = random_pool.get_state();
+
+        double d = Kokkos::bit_cast<double>(generator.urand64());
+
+        // do not forget to release the state of the engine
+        random_pool.free_state(generator);
+        ASSERT_EQ(check(d), 0);
+
+        ++counter;
+
+        if (counter % 1'000'000 == 0) {
+          Kokkos::printf("%f%% - %e\n", (double)counter / (double)max * 100.,
+                         d);
+        }
+      });
+}
+#endif
+
 TEST(TEST_CATEGORY, FloatPrinting) {
   TestFloatPrinting<TEST_EXECSPACE, double>();
   TestFloatPrinting<TEST_EXECSPACE, float>();
+
+#ifdef FULL_TEST
+  do_random_test();
+#endif
 }

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -15,8 +15,12 @@ struct TestFloatPrinting {
     ASSERT_EQ(errors, 0);
   }
 
+#define CHECK(val, ref) to_chars_helper_f(val, ref, __FILE__, __LINE__)
+
   KOKKOS_FUNCTION constexpr int to_chars_helper_f(FloatType val,
-                                                  char const* ref) const {
+                                                  char const* ref,
+                                                  char const* file,
+                                                  int line) const {
     using Kokkos::Impl::strcmp;
     using Kokkos::Impl::strlen;
     using Kokkos::Impl::to_chars_f;
@@ -27,7 +31,8 @@ struct TestFloatPrinting {
     char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
     *ptr      = '\0';
     if (buffer + strlen(ref) != ptr) {
-      Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
+      Kokkos::printf("Error %s:%i:\n", file, line);
+      Kokkos::printf("  %lx != %lx\n", buffer + strlen(ref), ptr);
       if constexpr (std::is_same_v<FloatType, float>) {
         Kokkos::printf("For float %s 0x%x\n", ref,
                        Kokkos::bit_cast<uint32_t>(val));
@@ -39,7 +44,8 @@ struct TestFloatPrinting {
     }
 
     if (strcmp(buffer, ref) != 0) {
-      Kokkos::printf("Error: %s != %s\n", buffer, ref);
+      Kokkos::printf("Error %s:%i:\n", file, line);
+      Kokkos::printf("  %s != %s\n", buffer, ref);
       if constexpr (std::is_same_v<FloatType, float>) {
         Kokkos::printf("For float %s 0x%x\n", ref,
                        Kokkos::bit_cast<uint32_t>(val));
@@ -54,91 +60,86 @@ struct TestFloatPrinting {
   }
 
   KOKKOS_FUNCTION void operator()(int, int& errors) const {
-    errors += to_chars_helper_f(Kokkos::infinity_v<FloatType>, "inf");
-    errors += to_chars_helper_f(-Kokkos::infinity_v<FloatType>, "-inf");
-    errors += to_chars_helper_f(Kokkos::quiet_NaN_v<FloatType>, "nan");
-    errors += to_chars_helper_f(-Kokkos::quiet_NaN_v<FloatType>, "-nan");
-    errors += to_chars_helper_f(Kokkos::signaling_NaN_v<FloatType>, "nan");
-    errors += to_chars_helper_f(-Kokkos::signaling_NaN_v<FloatType>, "-nan");
-    errors += to_chars_helper_f(FloatType(0.), "0.000000e+00");
-    errors += to_chars_helper_f(FloatType(-0.), "-0.000000e+00");
-    errors += to_chars_helper_f(FloatType(1.), "1.000000e+00");
-    errors += to_chars_helper_f(FloatType(-1.), "-1.000000e+00");
-    errors += to_chars_helper_f(FloatType(1.2), "1.200000e+00");
-    errors += to_chars_helper_f(FloatType(-1.2), "-1.200000e+00");
-    errors += to_chars_helper_f(FloatType(5.), "5.000000e+00");
-    errors += to_chars_helper_f(FloatType(50.), "5.000000e+01");
-    errors += to_chars_helper_f(FloatType(0.5), "5.000000e-01");
-    errors += to_chars_helper_f(FloatType(6e20), "6.000000e+20");
-    errors += to_chars_helper_f(FloatType(6e37), "6.000000e+37");
+    errors += CHECK(Kokkos::infinity_v<FloatType>, "inf");
+    errors += CHECK(-Kokkos::infinity_v<FloatType>, "-inf");
+    errors += CHECK(Kokkos::quiet_NaN_v<FloatType>, "nan");
+    errors += CHECK(-Kokkos::quiet_NaN_v<FloatType>, "-nan");
+#if !(defined(KOKKOS_COMPILER_NVHPC) && defined(KOKKOS_ENABLE_OPENACC))
+    // With nvhpc + OpenACC, signaling NaN becomes +inf when copied into a
+    // variable
+    errors += CHECK(Kokkos::signaling_NaN_v<FloatType>, "nan");
+#endif
+    errors += CHECK(-Kokkos::signaling_NaN_v<FloatType>, "-nan");
+    errors += CHECK(FloatType(0.), "0.000000e+00");
+    errors += CHECK(FloatType(-0.), "-0.000000e+00");
+    errors += CHECK(FloatType(1.), "1.000000e+00");
+    errors += CHECK(FloatType(-1.), "-1.000000e+00");
+    errors += CHECK(FloatType(1.2), "1.200000e+00");
+    errors += CHECK(FloatType(-1.2), "-1.200000e+00");
+    errors += CHECK(FloatType(5.), "5.000000e+00");
+    errors += CHECK(FloatType(50.), "5.000000e+01");
+    errors += CHECK(FloatType(0.5), "5.000000e-01");
+    errors += CHECK(FloatType(6e20), "6.000000e+20");
+    errors += CHECK(FloatType(6e37), "6.000000e+37");
 
     // Because of ties-to-even, 10000005 should be rounded down and 10000015
     // should be rounded up.
-    errors += to_chars_helper_f(FloatType(10000005.0), "1.000000e+07");
-    errors += to_chars_helper_f(FloatType(10000015.0), "1.000002e+07");
+    errors += CHECK(FloatType(10000005.0), "1.000000e+07");
+    errors += CHECK(FloatType(10000015.0), "1.000002e+07");
 
     if constexpr (std::is_same_v<FloatType, double>) {
-      errors += to_chars_helper_f(FloatType(1e100), "1.000000e+100");
-      errors +=
-          to_chars_helper_f(Kokkos::denorm_min_v<FloatType>, "4.940656e-324");
-      errors +=
-          to_chars_helper_f(-Kokkos::denorm_min_v<FloatType>, "-4.940656e-324");
-      errors +=
-          to_chars_helper_f(Kokkos::finite_max_v<FloatType>, "1.797693e+308");
-      errors +=
-          to_chars_helper_f(-Kokkos::finite_max_v<FloatType>, "-1.797693e+308");
+      errors += CHECK(FloatType(1e100), "1.000000e+100");
+      errors += CHECK(Kokkos::denorm_min_v<FloatType>, "4.940656e-324");
+      errors += CHECK(-Kokkos::denorm_min_v<FloatType>, "-4.940656e-324");
+      errors += CHECK(Kokkos::finite_max_v<FloatType>, "1.797693e+308");
+      errors += CHECK(-Kokkos::finite_max_v<FloatType>, "-1.797693e+308");
 
       // Numbers just before or after the point were we go from 12 characters
       // to 13.
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1835),
-                                  "1.000000e-99");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1834),
-                                  "1.000000e-99");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1833),
-                                  "9.999999e-100");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1832),
-                                  "9.999999e-100");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x2b617f7d402b1835), "1.000000e-99");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x2b617f7d402b1834), "1.000000e-99");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x2b617f7d402b1833), "9.999999e-100");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x2b617f7d402b1832), "9.999999e-100");
 
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d24),
-                                  "9.999999e+99");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d25),
-                                  "9.999999e+99");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d26),
-                                  "1.000000e+100");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d27),
-                                  "1.000000e+100");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x54b249ad163d7d24), "9.999999e+99");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x54b249ad163d7d25), "9.999999e+99");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x54b249ad163d7d26), "1.000000e+100");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x54b249ad163d7d27), "1.000000e+100");
 
       // Round to nearest, ties to even: 0x51c9bcdf962a0f9f is exactly
       // "9.9999995E85", it should round up)
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9e),
-                                  "9.999999e+85");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9f),
-                                  "1.000000e+86");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9e), "9.999999e+85");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9f), "1.000000e+86");
 
       // Numbers that were incorrectly displayed at some point during the
       // debugging process
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x0000080000000003),
-                                  "4.345847e-311");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x00072800000002AF),
-                                  "9.951990e-309");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x1cef5f80c024cc14),
-                                  "2.597821e-169");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x0000080000000003), "4.345847e-311");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x00072800000002AF), "9.951990e-309");
+      errors +=
+          CHECK(Kokkos::bit_cast<double>(0x1cef5f80c024cc14), "2.597821e-169");
     }
 
     if constexpr (std::is_same_v<FloatType, float>) {
-      errors +=
-          to_chars_helper_f(Kokkos::denorm_min_v<FloatType>, "1.401298e-45");
-      errors +=
-          to_chars_helper_f(-Kokkos::denorm_min_v<FloatType>, "-1.401298e-45");
-      errors +=
-          to_chars_helper_f(Kokkos::finite_max_v<FloatType>, "3.402823e+38");
-      errors +=
-          to_chars_helper_f(-Kokkos::finite_max_v<FloatType>, "-3.402823e+38");
+      errors += CHECK(Kokkos::denorm_min_v<FloatType>, "1.401298e-45");
+      errors += CHECK(-Kokkos::denorm_min_v<FloatType>, "-1.401298e-45");
+      errors += CHECK(Kokkos::finite_max_v<FloatType>, "3.402823e+38");
+      errors += CHECK(-Kokkos::finite_max_v<FloatType>, "-3.402823e+38");
 
       // Numbers that were incorrectly displayed at some point during the
       // debugging process
-      errors +=
-          to_chars_helper_f(Kokkos::bit_cast<float>(0x9aab), "5.548441e-41");
+      errors += CHECK(Kokkos::bit_cast<float>(0x9aab), "5.548441e-41");
     }
   }
 };

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+template <class Space, class FloatType>
+struct TestFloatPrinting {
+  TestFloatPrinting() { run(); }
+  void run() const {
+    int errors = 0;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    ASSERT_EQ(errors, 0);
+  }
+
+  KOKKOS_FUNCTION constexpr int to_chars_helper_f(FloatType val,
+                                                  char const* ref) const {
+    using Kokkos::Impl::strcmp;
+    using Kokkos::Impl::strlen;
+    using Kokkos::Impl::to_chars_f;
+    constexpr int BUFFER_SIZE = 21;
+
+    int errors = 0;
+    char buffer[BUFFER_SIZE];
+    char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
+    if (buffer + strlen(ref) != ptr) {
+      Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
+      Kokkos::printf("For float %s 0x%lx\n", ref,
+                     Kokkos::bit_cast<uint64_t>(val));
+      ++errors;
+    }
+
+    if (strcmp(buffer, ref) != 0) {
+      Kokkos::printf("Error: %s != %s\n", buffer, ref);
+      // Kokkos::printf("For float %s\n", ref);
+      Kokkos::printf("For float %s 0x%lx\n", ref,
+                     Kokkos::bit_cast<uint64_t>(val));
+      ++errors;
+    }
+
+    return errors;
+  }
+
+  KOKKOS_FUNCTION void operator()(int, int& errors) const {
+    errors += to_chars_helper_f(Kokkos::infinity_v<FloatType>, "inf");
+    errors += to_chars_helper_f(-Kokkos::infinity_v<FloatType>, "-inf");
+    errors += to_chars_helper_f(Kokkos::quiet_NaN_v<FloatType>, "nan");
+    errors += to_chars_helper_f(-Kokkos::quiet_NaN_v<FloatType>, "-nan");
+    errors += to_chars_helper_f(Kokkos::signaling_NaN_v<FloatType>, "nan");
+    errors += to_chars_helper_f(-Kokkos::signaling_NaN_v<FloatType>, "-nan");
+    errors += to_chars_helper_f(FloatType(0.), "0.000000e+00");
+    errors += to_chars_helper_f(FloatType(-0.), "-0.000000e+00");
+    errors += to_chars_helper_f(FloatType(1.), "1.000000e+00");
+    errors += to_chars_helper_f(FloatType(-1.), "-1.000000e+00");
+    errors += to_chars_helper_f(FloatType(1.2), "1.200000e+00");
+    errors += to_chars_helper_f(FloatType(-1.2), "-1.200000e+00");
+    errors += to_chars_helper_f(FloatType(5.), "5.000000e+00");
+    errors += to_chars_helper_f(FloatType(50.), "5.000000e+01");
+    errors += to_chars_helper_f(FloatType(0.5), "5.000000e-01");
+    errors += to_chars_helper_f(FloatType(6e20), "6.000000e+20");
+    errors += to_chars_helper_f(FloatType(6e37), "6.000000e+37");
+
+    if constexpr (std::is_same_v<FloatType, double>) {
+      errors += to_chars_helper_f(FloatType(1e100), "1.000000e+100");
+      errors +=
+          to_chars_helper_f(Kokkos::denorm_min_v<FloatType>, "4.940656e-324");
+      errors +=
+          to_chars_helper_f(-Kokkos::denorm_min_v<FloatType>, "-4.940656e-324");
+      errors +=
+          to_chars_helper_f(Kokkos::finite_max_v<FloatType>, "1.797693e+308");
+      errors +=
+          to_chars_helper_f(-Kokkos::finite_max_v<FloatType>, "-1.797693e+308");
+
+      // Numbers just before or after the point were we go from 12 characters
+      // to 13.
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1835),
+                                  "1.000000e-99");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1834),
+                                  "1.000000e-99");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1833),
+                                  "9.999999e-100");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1832),
+                                  "9.999999e-100");
+
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d24),
+                                  "9.999999e+99");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d25),
+                                  "9.999999e+99");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d26),
+                                  "1.000000e+100");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d27),
+                                  "1.000000e+100");
+
+      // Round to nearest, ties to even: 0x51c9bcdf962a0f9f is exactly
+      // "9.9999995E85", it should round up)
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9e),
+                                  "9.999999e+85");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x51c9bcdf962a0f9f),
+                                  "1.000000e+86");
+    }
+
+    if constexpr (std::is_same_v<FloatType, float>) {
+      errors +=
+          to_chars_helper_f(Kokkos::denorm_min_v<FloatType>, "1.401298e-45");
+      errors +=
+          to_chars_helper_f(-Kokkos::denorm_min_v<FloatType>, "-1.401298e-45");
+      errors +=
+          to_chars_helper_f(Kokkos::finite_max_v<FloatType>, "3.402823e+38");
+      errors +=
+          to_chars_helper_f(-Kokkos::finite_max_v<FloatType>, "-3.402823e+38");
+    }
+  }
+};
+
+TEST(TEST_CATEGORY, FloatPrinting) {
+  TestFloatPrinting<TEST_EXECSPACE, double>();
+  // TestFloatPrinting<TEST_EXECSPACE, float>();
+}

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -34,9 +34,9 @@ struct TestFloatPrinting {
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s\n", ref);
+        Kokkos::printf("For float %s 0x%x\n", ref, Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s\n", ref);
+        Kokkos::printf("For double %s 0x%lx\n", ref, Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;
     }
@@ -44,9 +44,9 @@ struct TestFloatPrinting {
     if (strcmp(buffer, ref) != 0) {
       Kokkos::printf("Error: %s != %s\n", buffer, ref);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s\n", ref);
+        Kokkos::printf("For float %s 0x%x\n", ref, Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s\n", ref);
+        Kokkos::printf("For double %s 0x%lx\n", ref, Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;
     }
@@ -91,13 +91,13 @@ struct TestFloatPrinting {
 
       // Numbers just before or after the point were we go from 12 characters
       // to 13.
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1835),
-                                  "1.000000e-99");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1834),
                                   "1.000000e-99");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1833),
-                                  "9.999999e-100");
+                                  "1.000000e-99");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1832),
+                                  "9.999999e-100");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1831),
                                   "9.999999e-100");
 
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d24),
@@ -122,6 +122,8 @@ struct TestFloatPrinting {
                                   "4.345847e-311");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x00072800000002AF),
                                   "9.951990e-309");
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x1cef5f80c024cc14),
+                                  "2.597822e-169");
     }
 
     if constexpr (std::is_same_v<FloatType, float>) {
@@ -133,10 +135,16 @@ struct TestFloatPrinting {
           to_chars_helper_f(Kokkos::finite_max_v<FloatType>, "3.402823e+38");
       errors +=
           to_chars_helper_f(-Kokkos::finite_max_v<FloatType>, "-3.402823e+38");
+
+      // Numbers that were incorrectly displayed at some point during the
+      // debugging process
+      errors += to_chars_helper_f(Kokkos::bit_cast<float>(0x9aab),
+                                  "5.548441e-41");
     }
   }
 };
 
+//#define FLOAT_DEVELOPMENT_TESTS
 #ifdef FLOAT_DEVELOPMENT_TESTS
 // This test will check that the output of Kokkos::to_chars_f(d) is identical
 // to the result of std::printf("%e", d) for a fraction of the existing double,
@@ -144,7 +152,8 @@ struct TestFloatPrinting {
 // take hours), so it should only be run when checking the results of changes
 // in Kokkos::to_chars_f and not when doing standard CI.
 // It can only run on host since it needs to run sprintf().
-bool check(double d) {
+template <typename T>
+bool check(T d) {
   bool ret = true;
 
   char ref[30] = {};
@@ -159,7 +168,11 @@ bool check(double d) {
     if (ref[i] != buffer[i]) {
       char err[512];
       char* err_buf = err;
-      err_buf += sprintf(err_buf, "0x%lx\n", std::bit_cast<uint64_t>(d));
+      if constexpr (std::is_same_v<T, float>) {
+        err_buf += sprintf(err_buf, "0x%x\n", Kokkos::bit_cast<uint32_t>(d));
+      } else {
+        err_buf += sprintf(err_buf, "0x%lx\n", Kokkos::bit_cast<uint64_t>(d));
+      }
       err_buf += sprintf(err_buf, "%s !=\n", ref);
       err_buf += sprintf(err_buf, "%s\n", buffer);
 
@@ -178,11 +191,35 @@ bool check(double d) {
   return ret;
 }
 
+void test_all_floats() {
+  uint32_t max = ~0x0u;
+
+  Kokkos::View<uint64_t, Kokkos::DefaultHostExecutionSpace::memory_space> total(
+      "total", 1);
+
+  Kokkos::deep_copy(total, 0);
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, max),
+      KOKKOS_LAMBDA(uint32_t counter) {
+        float f = Kokkos::bit_cast<float>(counter);
+
+        ASSERT_TRUE(check(f));
+
+        ++counter;
+        uint64_t tmp = Kokkos::atomic_inc_fetch(&total());
+        if (tmp % 1'000'000 == 0) {
+          Kokkos::printf("%f%% (%llu/%llu) - %e\n",
+                         (double)tmp / (double)max * 100., tmp, max, f);
+        }
+      });
+}
+
 void do_random_test() {
   Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> random_pool(
       /*seed=*/12345);
 
-  uint64_t max = 0x1llu << 35;
+  uint64_t max = 0x1llu << 30;
   Kokkos::View<uint64_t, Kokkos::DefaultHostExecutionSpace::memory_space> total(
       "total", 1);
 
@@ -195,7 +232,9 @@ void do_random_test() {
         double d       = Kokkos::bit_cast<double>(generator.urand64());
         random_pool.free_state(generator);
 
-        EXPECT_TRUE(check(d));
+        bool b = check(d);
+        ASSERT_TRUE(b);
+        KOKKOS_ASSERT(b);
 
         ++counter;
         uint64_t tmp = Kokkos::atomic_inc_fetch(&total());
@@ -212,6 +251,7 @@ TEST(TEST_CATEGORY, FloatPrinting) {
   TestFloatPrinting<TEST_EXECSPACE, float>();
 
 #ifdef FLOAT_DEVELOPMENT_TESTS
+  test_all_floats();
   do_random_test();
 #endif
 }

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -29,6 +29,7 @@ struct TestFloatPrinting {
     int errors = 0;
     char buffer[BUFFER_SIZE];
     char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
+    *ptr = '\0';
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
       Kokkos::printf("For float %s\n", ref);

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -73,6 +73,11 @@ struct TestFloatPrinting {
     errors += to_chars_helper_f(FloatType(6e20), "6.000000e+20");
     errors += to_chars_helper_f(FloatType(6e37), "6.000000e+37");
 
+    // Because of ties-to-even, 10000005 should be rounded down and 10000015
+    // should be rounded up.
+    errors += to_chars_helper_f(FloatType(10000005.0), "1.000000e+07");
+    errors += to_chars_helper_f(FloatType(10000015.0), "1.000002e+07");
+
     if constexpr (std::is_same_v<FloatType, double>) {
       errors += to_chars_helper_f(FloatType(1e100), "1.000000e+100");
       errors +=
@@ -132,65 +137,71 @@ struct TestFloatPrinting {
   }
 };
 
-#ifdef FULL_TEST
-int check(double d) {
-  char ref[30];
-  char ref_string[30];
-  sprintf(ref_string, "%%5.%ie", 7 - 1);
+#ifdef FLOAT_DEVELOPMENT_TESTS
+// This test will check that the output of Kokkos::to_chars_f(d) is identical
+// to the result of std::printf("%e", d) for a fraction of the existing double,
+// it can be very long (even when testing only 1/2^31 doubles, it will still
+// take hours), so it should only be run when checking the results of changes
+// in Kokkos::to_chars_f and not when doing standard CI.
+// It can only run on host since it needs to run sprintf().
+bool check(double d) {
+  bool ret = true;
 
-  double ref_number = d;
-  sprintf(ref, ref_string, ref_number);
+  char ref[30] = {};
+  sprintf(ref, "%e", d);
 
-  bool ret = false;
-
-  if (std::isnan(d) || std::isinf(d)) {
-    return ret;
-  }
-
-  char buffer[25];
+  char buffer[30] = {};
   using Kokkos::Impl::to_chars_f;
-  to_chars_f(buffer, buffer + 25, d);
+  to_chars_f(buffer, buffer + 30, d);
 
-  for (int i = 0; i < 10; ++i) {
+  int i = 0;
+  while (ref[i] != '\0') {
     if (ref[i] != buffer[i]) {
-      printf("0x%lx\n", std::bit_cast<uint64_t>(d));
-      printf("%s !=\n", ref);
-      printf("%s\n", buffer);
+      char err[512];
+      char* err_buf = err;
+      err_buf += sprintf(err_buf, "0x%lx\n", std::bit_cast<uint64_t>(d));
+      err_buf += sprintf(err_buf, "%s !=\n", ref);
+      err_buf += sprintf(err_buf, "%s\n", buffer);
 
       for (int j = 0; j < i; ++j) {
-        printf(" ");
+        err_buf += sprintf(err_buf, " ");
       }
-      printf("^\n");
-      ret = true;
+      err_buf += sprintf(err_buf, "^\n");
+      printf("%s", err);
+
+      ret = false;
       break;
     }
+    ++i;
   }
 
   return ret;
 }
 
 void do_random_test() {
-  Kokkos::Random_XorShift64_Pool<TEST_EXECSPACE> random_pool(/*seed=*/12345);
+  Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> random_pool(
+      /*seed=*/12345);
 
-  // Don't check negative numbers, implementation is simple enough, bugs should
-  // be caught by the standard tests
-  uint64_t max = 0x1llu << 28;
+  uint64_t max = 0x1llu << 35;
+  Kokkos::View<uint64_t, Kokkos::DefaultHostExecutionSpace::memory_space> total(
+      "total", 1);
+
+  Kokkos::deep_copy(total, 0);
+
   Kokkos::parallel_for(
-      Kokkos::RangePolicy<TEST_EXECSPACE>(0, max),
+      Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, max),
       KOKKOS_LAMBDA(uint64_t counter) {
         auto generator = random_pool.get_state();
-
-        double d = Kokkos::bit_cast<double>(generator.urand64());
-
-        // do not forget to release the state of the engine
+        double d       = Kokkos::bit_cast<double>(generator.urand64());
         random_pool.free_state(generator);
-        ASSERT_EQ(check(d), 0);
+
+        EXPECT_TRUE(check(d));
 
         ++counter;
-
-        if (counter % 1'000'000 == 0) {
-          Kokkos::printf("%f%% - %e\n", (double)counter / (double)max * 100.,
-                         d);
+        uint64_t tmp = Kokkos::atomic_inc_fetch(&total());
+        if (tmp % 1'000'000 == 0) {
+          Kokkos::printf("%f%% (%llu/%llu) - %e\n",
+                         (double)tmp / (double)max * 100., tmp, max, d);
         }
       });
 }
@@ -200,7 +211,7 @@ TEST(TEST_CATEGORY, FloatPrinting) {
   TestFloatPrinting<TEST_EXECSPACE, double>();
   TestFloatPrinting<TEST_EXECSPACE, float>();
 
-#ifdef FULL_TEST
+#ifdef FLOAT_DEVELOPMENT_TESTS
   do_random_test();
 #endif
 }

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -29,7 +29,7 @@ struct TestFloatPrinting {
     int errors = 0;
     char buffer[BUFFER_SIZE];
     char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
-    *ptr = '\0';
+    *ptr      = '\0';
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
       Kokkos::printf("For float %s\n", ref);

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -34,9 +34,11 @@ struct TestFloatPrinting {
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s 0x%x\n", ref, Kokkos::bit_cast<uint32_t>(val));
+        Kokkos::printf("For float %s 0x%x\n", ref,
+                       Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s 0x%lx\n", ref, Kokkos::bit_cast<uint64_t>(val));
+        Kokkos::printf("For double %s 0x%lx\n", ref,
+                       Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;
     }
@@ -44,9 +46,11 @@ struct TestFloatPrinting {
     if (strcmp(buffer, ref) != 0) {
       Kokkos::printf("Error: %s != %s\n", buffer, ref);
       if constexpr (std::is_same_v<FloatType, float>) {
-        Kokkos::printf("For float %s 0x%x\n", ref, Kokkos::bit_cast<uint32_t>(val));
+        Kokkos::printf("For float %s 0x%x\n", ref,
+                       Kokkos::bit_cast<uint32_t>(val));
       } else {
-        Kokkos::printf("For double %s 0x%lx\n", ref, Kokkos::bit_cast<uint64_t>(val));
+        Kokkos::printf("For double %s 0x%lx\n", ref,
+                       Kokkos::bit_cast<uint64_t>(val));
       }
       ++errors;
     }
@@ -91,13 +95,13 @@ struct TestFloatPrinting {
 
       // Numbers just before or after the point were we go from 12 characters
       // to 13.
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1835),
+                                  "1.000000e-99");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1834),
                                   "1.000000e-99");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1833),
-                                  "1.000000e-99");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1832),
                                   "9.999999e-100");
-      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1831),
+      errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x2b617f7d402b1832),
                                   "9.999999e-100");
 
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x54b249ad163d7d24),
@@ -123,7 +127,7 @@ struct TestFloatPrinting {
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x00072800000002AF),
                                   "9.951990e-309");
       errors += to_chars_helper_f(Kokkos::bit_cast<double>(0x1cef5f80c024cc14),
-                                  "2.597822e-169");
+                                  "2.597821e-169");
     }
 
     if constexpr (std::is_same_v<FloatType, float>) {
@@ -138,13 +142,13 @@ struct TestFloatPrinting {
 
       // Numbers that were incorrectly displayed at some point during the
       // debugging process
-      errors += to_chars_helper_f(Kokkos::bit_cast<float>(0x9aab),
-                                  "5.548441e-41");
+      errors +=
+          to_chars_helper_f(Kokkos::bit_cast<float>(0x9aab), "5.548441e-41");
     }
   }
 };
 
-//#define FLOAT_DEVELOPMENT_TESTS
+// #define FLOAT_DEVELOPMENT_TESTS
 #ifdef FLOAT_DEVELOPMENT_TESTS
 // This test will check that the output of Kokkos::to_chars_f(d) is identical
 // to the result of std::printf("%e", d) for a fraction of the existing double,
@@ -232,9 +236,7 @@ void do_random_test() {
         double d       = Kokkos::bit_cast<double>(generator.urand64());
         random_pool.free_state(generator);
 
-        bool b = check(d);
-        ASSERT_TRUE(b);
-        KOKKOS_ASSERT(b);
+        ASSERT_TRUE(check(d));
 
         ++counter;
         uint64_t tmp = Kokkos::atomic_inc_fetch(&total());

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -31,16 +31,13 @@ struct TestFloatPrinting {
     char* ptr = to_chars_f(buffer, buffer + BUFFER_SIZE, val).ptr;
     if (buffer + strlen(ref) != ptr) {
       Kokkos::printf("Error: %lx != %lx\n", buffer + strlen(ref), ptr);
-      Kokkos::printf("For float %s 0x%lx\n", ref,
-                     Kokkos::bit_cast<uint64_t>(val));
+      Kokkos::printf("For float %s\n", ref);
       ++errors;
     }
 
     if (strcmp(buffer, ref) != 0) {
       Kokkos::printf("Error: %s != %s\n", buffer, ref);
-      // Kokkos::printf("For float %s\n", ref);
-      Kokkos::printf("For float %s 0x%lx\n", ref,
-                     Kokkos::bit_cast<uint64_t>(val));
+      Kokkos::printf("For float %s\n", ref);
       ++errors;
     }
 
@@ -120,5 +117,5 @@ struct TestFloatPrinting {
 
 TEST(TEST_CATEGORY, FloatPrinting) {
   TestFloatPrinting<TEST_EXECSPACE, double>();
-  // TestFloatPrinting<TEST_EXECSPACE, float>();
+  TestFloatPrinting<TEST_EXECSPACE, float>();
 }

--- a/core/unit_test/TestFloatPrinting.hpp
+++ b/core/unit_test/TestFloatPrinting.hpp
@@ -3,13 +3,8 @@
 
 #include <gtest/gtest.h>
 #include <Kokkos_Random.hpp>
-
 #include <Kokkos_Macros.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-#else
 #include <Kokkos_Core.hpp>
-#endif
 
 template <class Space, class FloatType>
 struct TestFloatPrinting {


### PR DESCRIPTION
This PR adds two functions:
 - an overload of `to_chars_len` taking float and double (it gives the size of the string needed to display the float taken as input)
 - `to_chars_f`: a function taking a double and printing its decimal representation in the char array passed as argument.
And the corresponding tests.

It is possible to make a much simpler implementation using `pow10` and `modf`, but it has two problems:
 - it doesn't return the same output as `libc::printf`,
 - it doesn't return the same output on every backends.

### Related issues / PRs
The `to_chars_f` function is needed for the future testing framework, which will build error messages on the device and use `ErrorReporter` to retrieve this messages back to the host.

### Changelog Entry
Not sure if changelog entry is needed since this functions are destined to stay in `Impl` and should be used/seen by users.
