### PR TITLE
SYCL: skip grid-stride loop when not needed for MDRange

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -51,13 +51,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
-    const sycl::range<3> global_range = range.get_global_range();
-    const sycl::range<3> local_range  = range.get_local_range();
-    const sycl::nd_range sycl_swapped_range{
-        sycl::range<3>{global_range[2], global_range[1], global_range[0]},
-        sycl::range<3>{local_range[2], local_range[1], local_range[0]}};
+    auto cgh_lambda = [&, range](sycl::handler& cgh) {
+      const sycl::range<3> global_range = range.get_global_range();
+      const sycl::range<3> local_range  = range.get_local_range();
+      const sycl::nd_range sycl_swapped_range{
+          sycl::range<3>{global_range[2], global_range[1], global_range[0]},
+          sycl::range<3>{local_range[2], local_range[1], local_range[0]}};
 
-    auto cgh_lambda = [&, sycl_swapped_range](sycl::handler& cgh) {
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       cgh.depends_on(memcpy_event);
 #else
@@ -93,7 +93,6 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
 #ifdef KOKKOS_IMPL_SYCL_GRAPH_SUPPORT
     if constexpr (Policy::is_graph_kernel::value) {
-      // graph capture attaches the kernel lambda; no event to return
       sycl_attach_kernel_to_node(*this, cgh_lambda);
       return {};
     } else

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -35,9 +35,10 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
   array_type m_upper;
   array_type m_extent;  // tile_size * num_tiles
 
-  template <typename FunctorWrapper>
+  template <bool UseStride, typename FunctorWrapper>
   sycl::event sycl_direct_launch(const FunctorWrapper& functor_wrapper,
-                                 const sycl::event& memcpy_event) const {
+                                 const sycl::event& memcpy_event,
+                                 const sycl::nd_range<3>& range) const {
     // Convenience references
     const Kokkos::SYCL& space = m_policy.space();
     sycl::queue& q            = space.sycl_queue();
@@ -50,16 +51,13 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     desul::ensure_sycl_lock_arrays_on_device(q);
 
-    const auto range =
-        Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
+    const sycl::range<3> global_range = range.get_global_range();
+    const sycl::range<3> local_range  = range.get_local_range();
+    const sycl::nd_range sycl_swapped_range{
+        sycl::range<3>{global_range[2], global_range[1], global_range[0]},
+        sycl::range<3>{local_range[2], local_range[1], local_range[0]}};
 
-    auto cgh_lambda = [&, range](sycl::handler& cgh) {
-      const sycl::range<3> global_range = range.get_global_range();
-      const sycl::range<3> local_range  = range.get_local_range();
-      const sycl::nd_range sycl_swapped_range{
-          sycl::range<3>{global_range[2], global_range[1], global_range[0]},
-          sycl::range<3>{local_range[2], local_range[1], local_range[0]}};
-
+    auto cgh_lambda = [&, sycl_swapped_range](sycl::handler& cgh) {
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       cgh.depends_on(memcpy_event);
 #else
@@ -83,8 +81,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
         const index_type n_global_z = item.get_group_range(0);
 
         Kokkos::Impl::DeviceIterate<Policy::rank, array_index_type, index_type,
-                                    Policy::inner_direction, true, FunctorType,
-                                    typename Policy::work_tag>(
+                                    Policy::inner_direction, UseStride,
+                                    FunctorType, typename Policy::work_tag>(
             lower_bound, upper_bound, extent, functor_wrapper.get_functor(),
             {n_global_x, n_global_y, n_global_z},
             {n_local_x, n_local_y, n_local_z}, {global_x, global_y, global_z},
@@ -95,6 +93,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
 #ifdef KOKKOS_IMPL_SYCL_GRAPH_SUPPORT
     if constexpr (Policy::is_graph_kernel::value) {
+      // graph capture attaches the kernel lambda; no event to return
       sycl_attach_kernel_to_node(*this, cgh_lambda);
       return {};
     } else
@@ -150,8 +149,73 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     auto functor_wrapper =
         Impl::make_sycl_function_wrapper(m_functor, indirectKernelMem);
-    sycl::event event =
-        sycl_direct_launch(functor_wrapper, functor_wrapper.get_copy_event());
+
+    // Compute launch range once and determine if a grid-stride loop is needed
+    const auto range =
+        Kokkos::Impl::compute_device_launch_params(m_policy, m_max_grid_size);
+    const sycl::range<3> local_range = range.get_local_range();
+
+    bool need_grid_stride = true;
+
+    if constexpr (Policy::rank == 1) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+          static_cast<std::size_t>(m_extent[0])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 2) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+              static_cast<std::size_t>(m_extent[0]) &&
+          (m_max_grid_size[1] * local_range[1]) >=
+              static_cast<std::size_t>(m_extent[1])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 3) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+              static_cast<std::size_t>(m_extent[0]) &&
+          (m_max_grid_size[1] * local_range[1]) >=
+              static_cast<std::size_t>(m_extent[1]) &&
+          (m_max_grid_size[2] * local_range[2]) >=
+              static_cast<std::size_t>(m_extent[2])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 4) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+              static_cast<std::size_t>(m_extent[0] * m_extent[1]) &&
+          (m_max_grid_size[1] * local_range[1]) >=
+              static_cast<std::size_t>(m_extent[2]) &&
+          (m_max_grid_size[2] * local_range[2]) >=
+              static_cast<std::size_t>(m_extent[3])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 5) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+              static_cast<std::size_t>(m_extent[0] * m_extent[1]) &&
+          (m_max_grid_size[1] * local_range[1]) >=
+              static_cast<std::size_t>(m_extent[2] * m_extent[3]) &&
+          (m_max_grid_size[2] * local_range[2]) >=
+              static_cast<std::size_t>(m_extent[4])) {
+        need_grid_stride = false;
+      }
+    } else if constexpr (Policy::rank == 6) {
+      if ((m_max_grid_size[0] * local_range[0]) >=
+              static_cast<std::size_t>(m_extent[0] * m_extent[1]) &&
+          (m_max_grid_size[1] * local_range[1]) >=
+              static_cast<std::size_t>(m_extent[2] * m_extent[3]) &&
+          (m_max_grid_size[2] * local_range[2]) >=
+              static_cast<std::size_t>(m_extent[4] * m_extent[5])) {
+        need_grid_stride = false;
+      }
+    }
+
+    sycl::event event;
+    if (need_grid_stride) {
+      event = sycl_direct_launch<true>(functor_wrapper,
+                                       functor_wrapper.get_copy_event(), range);
+    } else {
+      event = sycl_direct_launch<false>(
+          functor_wrapper, functor_wrapper.get_copy_event(), range);
+    }
+
     functor_wrapper.register_event(event);
   }
 


### PR DESCRIPTION
Analogous to https://github.com/kokkos/kokkos/pull/9142 for SYCL. Copilot wrote the code since I wanted to try it and it seemed simple enough. I did some cleanup.

before:
```
1: OverlapMDRangePolicy/N:200/M:10000/R:10                                                                                                                                        0.058 s         0.058 s            12       0.0106696     5.34192m               0.0101212                  5.08093m    5.08321m          5.041u
1: MDRangeStencil_2D_MDRange_LayoutRight/size:512/tile_size:0/iterations:1/manual_time                                                                                            0.076 ms        0.078 ms            1              1          8         32
1: MDRangeStencil_3D_MDRange_LayoutLeft/size:128/tile_size:0/iterations:1/manual_time                                                                                             0.093 ms        0.094 ms            1              1         32          2          4
1: MDRangeStencil_4D_MDRange_LayoutRight/size:32/tile_size:0/iterations:1/manual_time                                                                                             0.073 ms        0.074 ms            1              1          2          2          2         16
      Start  4: Kokkos_PerformanceTest_MDRangePolicy_Stream
4: Test command: /home/darndt/kokkos/build/core/perf_test/Kokkos_PerformanceTest_MDRangePolicy_Stream "--benchmark_counters_tabular=true" "--benchmark_out=Kokkos_PerformanceTest_MDRangePolicy_Stream_2026-06-05_T19-10-24.json"
4: Running /home/darndt/kokkos/build/core/perf_test/Kokkos_PerformanceTest_MDRangePolicy_Stream
4: MDRangePolicy_Set<1>/22/manual_time        0.508 ms        0.508 ms         1529 1.78503k/s    907.039
4: MDRangePolicy_Set<3>/22/manual_time        0.613 ms        0.613 ms         1221 1.48012k/s    907.039
4: MDRangePolicy_Set<6>/22/manual_time         2.84 ms         2.84 ms          247  319.439/s    907.039
4: MDRangePolicy_Triad<1>/22/manual_time       1.38 ms         1.38 ms          510 1.96657k/s   2.72112k
4: MDRangePolicy_Triad<3>/22/manual_time       1.62 ms         1.62 ms          429 1.68467k/s   2.72112k
4: MDRangePolicy_Triad<6>/22/manual_time       3.81 ms         3.81 ms          185  714.687/s   2.72112k
 4/12 Test  #4: Kokkos_PerformanceTest_MDRangePolicy_Stream ...   Passed    6.58 sec

```
after:
```
1: OverlapMDRangePolicy/N:200/M:10000/R:10                                                                                                                                        0.058 s         0.058 s            12       0.0104729      5.3311m               0.0101351                  5.07832m    5.07214m          5.248u
1: MDRangeStencil_2D_MDRange_LayoutRight/size:512/tile_size:0/iterations:1/manual_time                                                                                            0.063 ms        0.064 ms            1              1          8         32
1: MDRangeStencil_3D_MDRange_LayoutLeft/size:128/tile_size:0/iterations:1/manual_time                                                                                             0.078 ms        0.078 ms            1              1         32          2          4
1: MDRangeStencil_4D_MDRange_LayoutRight/size:32/tile_size:0/iterations:1/manual_time                                                                                             0.079 ms        0.080 ms            1              1          2          2          2         16
      Start  4: Kokkos_PerformanceTest_MDRangePolicy_Stream
4: Test command: /home/darndt/kokkos/build/core/perf_test/Kokkos_PerformanceTest_MDRangePolicy_Stream "--benchmark_counters_tabular=true" "--benchmark_out=Kokkos_PerformanceTest_MDRangePolicy_Stream_2026-06-05_T19-10-24.json"
4: Running /home/darndt/kokkos/build/core/perf_test/Kokkos_PerformanceTest_MDRangePolicy_Stream
4: MDRangePolicy_Set<1>/22/manual_time        0.521 ms        0.521 ms         1492 1.74044k/s    907.039
4: MDRangePolicy_Set<3>/22/manual_time        0.640 ms        0.640 ms         1120 1.41771k/s    907.039
4: MDRangePolicy_Set<6>/22/manual_time         2.07 ms         2.07 ms          344  439.084/s    907.039
4: MDRangePolicy_Triad<1>/22/manual_time       1.38 ms         1.38 ms          511 1.96756k/s   2.72112k
4: MDRangePolicy_Triad<3>/22/manual_time       1.60 ms         1.60 ms          439 1.69945k/s   2.72112k
4: MDRangePolicy_Triad<6>/22/manual_time       3.09 ms         3.09 ms          227  880.916/s   2.72112k
 4/12 Test  #4: Kokkos_PerformanceTest_MDRangePolicy_Stream ...   Passed    6.25 sec
```

So we see quite some improvement for `MDRangeStencil_3D_MDRange_LayoutLeft, `MDRangePolicy_Triad<6>` and `MDRangePolicy_Set<6>/22/manual_time` while the other times stay more or less the same.