### PR TITLE
Add gtest like EXPECT_* macros for use on device

### DIFF
--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -102,6 +102,18 @@ class ErrorReporter {
     }
   }
 
+  KOKKOS_INLINE_FUNCTION
+  report_type *emplace_report(int reporter_id = 0) const {
+    int idx = Kokkos::atomic_fetch_inc(&m_numReportsAttempted());
+
+    if (idx >= 0 && (idx < m_reports.extent_int(0))) {
+      m_reporters(idx) = reporter_id;
+      return &m_reports(idx);
+    } else {
+      return nullptr;
+    }
+  }
+
  private:
   Kokkos::View<int, device_type> m_numReportsAttempted;
   Kokkos::View<report_type *, device_type> m_reports;

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -229,4 +229,4 @@ void ErrorReporter_test_resize() {
 TEST(TEST_CATEGORY, ErrorReporter_resize) { ErrorReporter_test_resize(); }
 
 }  // namespace Test
-#endif  // #ifndef KOKKOS_TEST_ERROR_REPORTING_HPP
+#endif  // #ifndef KOKKOS_TEST_EXPERIMENTAL_ERROR_REPORTER_HPP

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -242,7 +242,7 @@ class StaticString {
 
   KOKKOS_FUNCTION constexpr std::size_t size() const { return m_size; }
 
-  KOKKOS_FUNCTION constexpr std::size_t is_full() const { return is_full(); }
+  KOKKOS_FUNCTION constexpr bool is_full() const { return m_is_full; }
 
   // Append cstring
   KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -5,7 +5,7 @@
 #define KOKKOS_STRING_MANIPULATION_HPP
 
 #include <Kokkos_Macros.hpp>
-#include <Kokkos_Half.hpp>
+#include <impl/Kokkos_Half_FloatingPointWrapper.hpp>
 #include <concepts>
 #include <cstddef>
 #include <ostream>

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -5,7 +5,10 @@
 #define KOKKOS_STRING_MANIPULATION_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_Half.hpp>
+#include <concepts>
 #include <cstddef>
+#include <ostream>
 #include <type_traits>
 
 namespace Kokkos {
@@ -107,18 +110,34 @@ KOKKOS_INLINE_FUNCTION constexpr char *strncat(char *dest, const char *src,
 //</editor-fold>
 
 //<editor-fold desc="Character conversions">
-template <class Unsigned>
+template <std::unsigned_integral Unsigned>
 KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Unsigned val) {
   unsigned int const base = 10;
-  static_assert(std::is_integral_v<Unsigned>, "implementation bug");
-  static_assert(std::is_unsigned_v<Unsigned>, "implementation bug");
-  unsigned int n = 1;
+  unsigned int n          = 1;
   while (val >= base) {
     val /= base;
     ++n;
   }
   return n;
 }
+
+template <std::signed_integral Signed>
+KOKKOS_FUNCTION constexpr unsigned int to_chars_len(Signed val) {
+  using Unsigned = std::conditional_t<sizeof(Signed) <= sizeof(unsigned int),
+                                      unsigned int, unsigned long long>;
+  Unsigned unsigned_val;
+  int n = 0;
+
+  if (val < 0) {
+    unsigned_val = Unsigned(~val) + Unsigned(1);
+    ++n;
+  } else {
+    unsigned_val = val;  // NOLINT(bugprone-signed-char-misuse)
+  }
+
+  return n + to_chars_len(unsigned_val);
+}
+
 template <class Unsigned>
 KOKKOS_FUNCTION constexpr void to_chars_impl(char *first, unsigned int len,
                                              Unsigned val) {
@@ -136,7 +155,7 @@ KOKKOS_FUNCTION constexpr void to_chars_impl(char *first, unsigned int len,
 
 // define values of portable error conditions that correspond to the POSIX error
 // codes
-enum class errc {
+enum class errc : int {
   value_too_large = 75  // equivalent POSIX error is EOVERFLOW
 };
 struct to_chars_result {
@@ -161,6 +180,7 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
       unsigned_val = Unsigned(~value) + Unsigned(1);
     }
   }
+
   std::ptrdiff_t const len = to_chars_len(unsigned_val);
   if (last - first < len) {
     return {last, errc::value_too_large};
@@ -169,7 +189,168 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
   return {first + len, {}};
   // NOLINTEND(bugprone-invalid-enum-default-initialization)
 }
+
 //</editor-fold>
+
+template <std::size_t capacity>
+class StaticString {
+  // Need room to guarantee we can at least print the trunc pattern
+  static_assert(capacity >= 3, "capacity too low for StaticString");
+
+  char m_data[capacity];
+  // String can be full even with size < capacity if we tried to add something
+  // that was too big
+  bool m_is_full;
+  std::size_t m_size;
+
+  /*
+   * This function is called when one's try to add more characters than there
+   * is room for in a string.
+   * It adds '...\0' at the end of the string.
+   */
+  KOKKOS_FUNCTION constexpr void trunc() {
+    m_is_full = true;
+
+    std::size_t start_pattern_idx;
+
+    if (m_size < capacity - 4) {
+      start_pattern_idx = m_size;
+    } else {
+      start_pattern_idx = capacity - 4;
+    }
+
+    m_data[start_pattern_idx]     = '.';
+    m_data[start_pattern_idx + 1] = '.';
+    m_data[start_pattern_idx + 2] = '.';
+    m_data[start_pattern_idx + 3] = '\0';
+  }
+
+ public:
+  // Constructors
+  KOKKOS_FUNCTION constexpr StaticString() : m_is_full(false), m_size(0) {
+    m_data[0] = '\0';
+  }
+
+  KOKKOS_FUNCTION constexpr StaticString(const char *init)
+      : m_is_full(false), m_size(0) {
+    m_data[0] = '\0';
+    *this << (init);
+  }
+
+  // Accessors
+  KOKKOS_FUNCTION constexpr const char *c_str() const { return m_data; }
+
+  KOKKOS_FUNCTION constexpr std::size_t size() const { return m_size; }
+
+  KOKKOS_FUNCTION constexpr std::size_t is_full() const { return is_full(); }
+
+  // Append cstring
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(
+      const char *string) {
+    if (m_is_full) {
+      return *this;
+    }
+
+    while (*string != '\0' && m_size < capacity) {
+      m_data[m_size++] = *string++;
+    }
+
+    if (m_size >= capacity) {
+      trunc();
+    } else {
+      m_data[m_size] = '\0';
+    }
+
+    return *this;
+  }
+
+  // Append int value
+  template <std::integral Integer>
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(Integer val) {
+    if (m_is_full) {
+      return *this;
+    }
+
+    // +1 because we need room for the '\0'
+    std::size_t needed_size = to_chars_len(val) + 1;
+    // Comparison written this way to avoid risk of overflowing size_t
+    if ((needed_size > capacity) || (capacity - needed_size < m_size)) {
+      trunc();
+    } else {
+      to_chars_i(m_data + m_size, m_data + capacity, val);
+      m_size += needed_size - 1;
+      m_data[m_size] = '\0';
+    }
+
+    return *this;
+  }
+
+  // Append float value
+  template <std::floating_point FloatType>
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(FloatType val) {
+    /*
+    if (m_is_full) {
+      return *this;
+    }
+
+    // +1 because we need room for the '\0'
+    int needed_size = to_chars_len(val) + 1;
+    // Comparison written this way to avoid risk of overflowing size_t
+    if ((needed_size > capacity) || (capacity - needed_size < m_size)) {
+      trunc();
+    } else {
+      to_chars_f(m_data + m_size, m_data + capacity, val);
+      m_size += needed_size - 1;
+      m_data[m_size] = '\0';
+    }
+
+    return *this;
+    */
+
+    // TODO: merge #9244
+    *this << (long long int)val;
+    return *this;
+  }
+
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+  // Append half value
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(
+      Kokkos::Experimental::half_t val) {
+    *this << cast_from_half<float>(val);
+    return *this;
+  }
+#endif
+
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+  // Append bhalf value
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(
+      Kokkos::Experimental::bhalf_t val) {
+    *this << cast_from_bhalf<float>(val);
+    return *this;
+  }
+#endif
+
+  // Append boolean value
+  KOKKOS_FUNCTION constexpr StaticString<capacity> &operator<<(bool val) {
+    if (m_is_full) {
+      return *this;
+    }
+
+    if (val) {
+      *this << "True";
+    } else {
+      *this << "False";
+    }
+
+    return *this;
+  }
+
+  friend std::ostream &operator<<(std::ostream &os,
+                                  const StaticString<capacity> &ss) {
+    os << ss.c_str();
+    return os;
+  }
+};
 
 }  // namespace Impl
 }  // namespace Kokkos

--- a/core/src/impl/Kokkos_StringManipulation.hpp
+++ b/core/src/impl/Kokkos_StringManipulation.hpp
@@ -195,7 +195,7 @@ KOKKOS_FUNCTION constexpr to_chars_result to_chars_i(char *first, char *last,
 template <std::size_t capacity>
 class StaticString {
   // Need room to guarantee we can at least print the trunc pattern
-  static_assert(capacity >= 3, "capacity too low for StaticString");
+  static_assert(capacity >= 4, "capacity too low for StaticString");
 
   char m_data[capacity];
   // String can be full even with size < capacity if we tried to add something

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -162,6 +162,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       MathematicalFunctions2
       MathematicalFunctions3
       MathematicalSpecialFunctions
+      StringManipulationRuntime
       KokkosTest_Utils
     )
       set(file ${dir}/Test${Tag}_${Name}.cpp)

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -162,6 +162,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       MathematicalFunctions2
       MathematicalFunctions3
       MathematicalSpecialFunctions
+      KokkosTest_Utils
     )
       set(file ${dir}/Test${Tag}_${Name}.cpp)
       # Write to a temporary intermediate file and call configure_file to avoid

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -104,12 +104,187 @@ struct FloatingPointComparison {
 
 struct IntegerComparison {
   template <class Lhs, class Rhs>
-  KOKKOS_FUNCTION bool compare(Lhs const& lhs, Rhs const& rhs) const {
+  KOKKOS_FUNCTION static bool compare(Lhs const& lhs, Rhs const& rhs) {
     static_assert(std::is_integral_v<Lhs>);
     static_assert(std::is_integral_v<Rhs>);
     return lhs == rhs;
   }
 };
 
+namespace Impl {
+// Print the value of t deducing a sensible format from its type T.
+template <typename T>
+constexpr KOKKOS_FUNCTION void print_arg_value(T t) {
+  using type = std::remove_cvref_t<T>;
+  if constexpr (std::is_same_v<T, char*> || std::is_same_v<T, const char*>) {
+    if (t != nullptr) {
+      // FIXME This is not 100% safe, as there is no guarantee that a char* is
+      // a pointer to a C-style string
+      Kokkos::printf("\"%s\"", t);
+    } else {
+      Kokkos::printf("NULL");
+    }
+  } else if constexpr (std::is_pointer_v<type>) {
+    if (t != nullptr) {
+      Kokkos::printf("%p", t);
+    } else {
+      Kokkos::printf("NULL");
+    }
+  } else if constexpr (std::is_same_v<type, bool>) {
+    if (t) {
+      Kokkos::printf("true");
+    } else {
+      Kokkos::printf("false");
+    }
+  } else if constexpr (std::is_integral_v<type>) {
+    if constexpr (std::is_unsigned_v<type>) {
+      Kokkos::printf("%u", t);
+    } else {
+      Kokkos::printf("%i", t);
+    }
+  } else if constexpr (std::is_floating_point_v<type>) {
+    Kokkos::printf("%f", t);
+  } else if constexpr (std::is_enum_v<type>) {
+    Kokkos::printf("%i", t);
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+  } else if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t> ||
+                       std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
+#if (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
+    // Bit cast is not available for half types with msvc
+    Kokkos::printf("%f", static_cast<float>(t));
+#else
+    Kokkos::printf("%f (0x%X)", static_cast<float>(t),
+                   Kokkos::bit_cast<uint16_t, T>(t));
+#endif
+#endif
+  } else {
+    Kokkos::abort("Unknown type, can't display value.");
+  }
+}
+}  // namespace Impl
+
+// Dumbed down version of gtest's EXPECT_ functions, usable on the device
+// (needs to be used inside test defined with KOKKOS_DEVICE_TEST)
+// FIXME the printf can get interleaved when executing in parallel, the whole
+// error message should be constructed at once in a string and displayed in a
+// printf, but there is no robust enough implementation of string on GPU to do
+// that portably
+#define KOKKOS_EXPECT_EQ(arg1, arg2)                                         \
+  do {                                                                       \
+    if (!((arg1) == (arg2))) {                                               \
+      errors += 1;                                                           \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                \
+      Kokkos::printf("Expected equality of these values:\n");                \
+      Kokkos::printf("  " KOKKOS_IMPL_STRINGIFY(arg1) "\n    Which is: ");   \
+      KokkosTest::Impl::print_arg_value(arg1);                               \
+      Kokkos::printf("\n  " KOKKOS_IMPL_STRINGIFY(arg2) "\n    Which is: "); \
+      KokkosTest::Impl::print_arg_value(arg2);                               \
+      Kokkos::printf("\n");                                                  \
+    }                                                                        \
+  } while (false)
+
+#define KOKKOS_EXPECT_NE(arg1, arg2)                                 \
+  do {                                                               \
+    if (!((arg1) != (arg2))) {                                       \
+      errors += 1;                                                   \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);        \
+      Kokkos::printf("Expected: (" KOKKOS_IMPL_STRINGIFY(            \
+          arg1) ") != (" KOKKOS_IMPL_STRINGIFY(arg2) "), actual: "); \
+      KokkosTest::Impl::print_arg_value(arg1);                       \
+      Kokkos::printf(" vs ");                                        \
+      KokkosTest::Impl::print_arg_value(arg2);                       \
+      Kokkos::printf("\n");                                          \
+    }                                                                \
+  } while (false)
+
+#define KOKKOS_EXPECT_TRUE(arg)                               \
+  do {                                                        \
+    if (!(arg)) {                                             \
+      errors += 1;                                            \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__); \
+      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(      \
+          arg) "\n  Actual: false\nExpected: true\n");        \
+    }                                                         \
+  } while (false)
+
+#define KOKKOS_EXPECT_FALSE(arg)                              \
+  do {                                                        \
+    if (!!(arg)) {                                            \
+      errors += 1;                                            \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__); \
+      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(      \
+          arg) "\n  Actual: true\nExpected: false\n");        \
+    }                                                         \
+  } while (false)
+
+// clang-format off
+#define KOKKOS_EXPECT_NEAR_ULPS(float1, float2, ulps)           \
+  do {                                                          \
+    if (!KokkosTest::FloatingPointComparison                    \
+            ::compare(float1, float2, ulps)) {                  \
+      errors += 1;                                              \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);   \
+      Kokkos::printf("Expected: " KOKKOS_IMPL_STRINGIFY(float1) \
+           " within %i ulps of " KOKKOS_IMPL_STRINGIFY(float2)  \
+           ",\n  Actual: ", ulps);                              \
+      KokkosTest::Impl::print_arg_value(float1);                \
+      Kokkos::printf(" vs ");                                   \
+      KokkosTest::Impl::print_arg_value(float2);                \
+      Kokkos::printf("\n");                                     \
+    }                                                           \
+  } while (false)
+// clang-format on
+
+#if __FINITE_MATH_ONLY__
+// Nothing to test if NaN and infinite are disabled at compilation
+#define KOKKOS_EXPECT_NAN(arg)
+#define KOKKOS_EXPECT_INF(arg)
+#else
+#define KOKKOS_EXPECT_NAN(arg)                                                \
+  do {                                                                        \
+    if (!Kokkos::isnan(arg)) {                                                \
+      errors += 1;                                                            \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                 \
+      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(arg) "\n  Actual: "); \
+      KokkosTest::Impl::print_arg_value(arg);                                 \
+      Kokkos::printf("\nExpected: NaN\n");                                    \
+    }                                                                         \
+  } while (false)
+
+#define KOKKOS_EXPECT_INF(arg)                                                \
+  do {                                                                        \
+    if (!Kokkos::isinf(arg)) {                                                \
+      errors += 1;                                                            \
+      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                 \
+      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(arg) "\n  Actual: "); \
+      KokkosTest::Impl::print_arg_value(arg);                                 \
+      Kokkos::printf("\nExpected: +/-Inf\n");                                 \
+    }                                                                         \
+  } while (false)
+#endif
+
+/**
+ * Create a test that will run on the device, first template argument is the
+ * execution space where the test need to run, can take up to one extra
+ * template argument.
+ */
+#define KOKKOS_DEVICE_TEST(TestName, ...)                                      \
+  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>                   \
+  struct [[nodiscard]] TestName {                                              \
+    [[nodiscard]] int run() const {                                            \
+      int errors = 0;                                                          \
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<TestSpace>(0, 1), *this,     \
+                              errors);                                         \
+      return errors;                                                           \
+    }                                                                          \
+    KOKKOS_FUNCTION void operator()(int, int& errors) const;                   \
+  };                                                                           \
+                                                                               \
+  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>                   \
+  KOKKOS_FUNCTION void                                                         \
+  TestName<TestSpace __VA_OPT__(, ) __VA_ARGS__>::operator()(int, int& errors) \
+      const
+
 }  // namespace KokkosTest
+
 #endif

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -114,121 +114,243 @@ struct IntegerComparison {
 };
 
 template <size_t string_capacity>
-struct ErrorLog {
+struct TestLog {
   Kokkos::Impl::StaticString<string_capacity> error_message;
 };
 
-// Dumbed down version of gtest's EXPECT_ functions, usable on the device
-// (needs to be used inside test defined with KOKKOS_DEVICE_TEST)
+template <class Space, size_t string_capacity>
+struct TestReporter {
+  using Log = KokkosTest::TestLog<string_capacity>;
+  using Reporter = Kokkos::Experimental::ErrorReporter<Log, Space>;
 
-// clang-format off
-#define KOKKOS_EXPECT_EQ(arg1, arg2)                                         \
-  do {                                                                       \
-    if (!((arg1) == (arg2))) {                                               \
-      auto* log = m_error_reporter.emplace_report();                         \
-      if (log == nullptr) { break; }                                         \
-      log->error_message << __FILE__ ":" << __LINE__ <<                      \
-      ": Failure\nExpected equality of these values:\n  "                    \
-      KOKKOS_IMPL_STRINGIFY(arg1) << "\n    Which is: " << arg1 <<           \
-      "\n  " KOKKOS_IMPL_STRINGIFY(arg2) "\n    Which is: " << arg2 << "\n"; \
-    }                                                                        \
-  } while (false)
+  TestReporter() : m_reporter(10) {}
 
-#define KOKKOS_EXPECT_NE(arg1, arg2)                                      \
-  do {                                                                    \
-    if (!((arg1) != (arg2))) {                                            \
-      auto* log = m_error_reporter.emplace_report();                      \
-      if (log == nullptr) { break; }                                      \
-      log->error_message << __FILE__ ":" << __LINE__ <<                   \
-      ": Failure\nExpected: (" KOKKOS_IMPL_STRINGIFY(arg1) << ") != ("    \
-      KOKKOS_IMPL_STRINGIFY(arg2) "), actual: " << arg1 << " vs " << arg2 \
-      << "\n";                                                            \
-    }                                                                     \
-  } while (false)
+  TestReporter(int size) : m_reporter(size) {}
 
-#define KOKKOS_EXPECT_TRUE(arg)                                      \
-  do {                                                               \
-    if (!(arg)) {                                                    \
-      auto* log = m_error_reporter.emplace_report();                 \
-      if (log == nullptr) { break; }                                 \
-      log->error_message << __FILE__ ":" << __LINE__ <<              \
-      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg)             \
-      "\n  Actual: false\n  Expected: true\n";                       \
-    }                                                                \
-  } while(false)
+  private:
+  Reporter m_reporter;
 
-#define KOKKOS_EXPECT_FALSE(arg)                                     \
-  do {                                                               \
-    if (!!(arg)) {                                                   \
-      auto* log = m_error_reporter.emplace_report();                 \
-      if (log == nullptr) { break; }                                 \
-      log->error_message << __FILE__ ":" << __LINE__ <<              \
-      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg)             \
-      "\n  Actual: true\n  Expected: false\n";                       \
-    }                                                                \
-  } while(false)
+  public:
+  KOKKOS_FUNCTION Log* emplace_report() const {
+    return m_reporter.emplace_report();
+  }
 
-#define KOKKOS_EXPECT_NEAR_ULPS(float1, float2, ulps)                          \
-  do {                                                                         \
-    if (!KokkosTest::FloatingPointComparison::compare(float1, float2, ulps)) { \
-      auto* log = m_error_reporter.emplace_report();                           \
-      if (log == nullptr) { break; }                                           \
-      log->error_message << __FILE__ ":" << __LINE__ <<                        \
-      ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1)                    \
-      " within %i ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "     \
-      << float1 << " vs " << float2 << "\n";                                   \
-    }                                                                          \
-  } while(false)
+  int print_errors(std::ostream& os = std::cerr) {
+    std::vector<int> reporters;
+    std::vector<Log> reports;
+    std::tie(reporters, reports) = m_reporter.get_reports();
+    for (int i = 0; i < m_reporter.num_reports(); ++i) {
+      os << reports[i].error_message << std::endl;
+    }
+    int ret = m_reporter.num_report_attempts();
+    m_reporter.clear();
+  
+    return ret;
+  }
+};
+
+namespace Impl {
+  template <size_t capacity>
+  struct OptionalString {
+    using String = Kokkos::Impl::StaticString<capacity>;
+    String *m_ss;
+
+    KOKKOS_FUNCTION OptionalString(String *ss = nullptr) : m_ss(ss) {}
+
+    template <typename Arg>
+    KOKKOS_FUNCTION OptionalString<capacity>& operator<<(const Arg& arg) {
+      if (m_ss != nullptr) {
+        *m_ss << arg;
+      }
+      return *this;
+    }
+  };
+
+  template <class Space, size_t string_capacity, class T1, class T2>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_eq(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg1,
+      const T1 arg1_val,
+      const char* arg2,
+      const T2 arg2_val) {
+    if (!((arg1_val) == (arg2_val))) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nExpected equality of these values:\n  " << arg1 << 
+        "\n    Which is: " << arg1_val << "\n  " << arg2 
+        << "\n    Which is: " << arg2_val << "\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class T1, class T2>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_ne(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg1,
+      const T1 arg1_val,
+      const char* arg2,
+      const T2 arg2_val) {
+    if (!((arg1_val) != (arg2_val))) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nExpected: (" << arg1 << ") != ("
+        << arg2 << "), actual: " << arg1_val << " vs " << arg2_val
+        << "\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class T>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_true(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg,
+      const T arg_val) {
+    if (!(arg_val)) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nValue of: " << arg <<
+        "\n  Actual: false\n  Expected: true\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class T>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_false(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg,
+      const T arg_val) {
+    if (!!(arg_val)) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nValue of: " << arg <<
+        "\n  Actual: true\n  Expected: false\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class Float1, class Float2>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_near_ulps(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* float1,
+      const Float1 float1_val,
+      const char* float2,
+      const Float2 float2_val,
+      int ulps) {
+    if (!KokkosTest::FloatingPointComparison::compare(float1_val, float2_val, ulps)) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) {
+        log->error_message << file << ":" << line<<
+        ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1)
+        " within " << ulps << " ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "
+        << float1_val << " vs " << float2_val << "\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class T>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_nan(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg,
+      const T arg_val) {
+    if (!Kokkos::isnan(arg_val)) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nValue of: " << arg << 
+        "\n  Actual: " << arg_val << "\nExpected: NaN\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+
+  template <class Space, size_t string_capacity, class T>
+  KOKKOS_FUNCTION OptionalString<string_capacity> expect_inf(
+      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+      const char* file,
+      int line,
+      const char* arg,
+      const T arg_val) {
+    if (!Kokkos::isinf(arg_val)) {
+      auto* log = test_reporter.emplace_report();
+      if (log != nullptr) { 
+        log->error_message << file << ":" << line <<
+        ": Failure\nValue of: " << arg << 
+        "\n  Actual: " << arg_val << "\nExpected: Inf\n";
+
+        return OptionalString<string_capacity>(&log->error_message);
+      }
+    }
+    return OptionalString<string_capacity>();
+  }
+}
+
+#define KOKKOS_EXPECT_EQ(test_reporter, arg1, arg2)              \
+  KokkosTest::Impl::expect_eq(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg1), arg1, KOKKOS_IMPL_STRINGIFY(arg2), arg2)
+
+#define KOKKOS_EXPECT_NE(test_reporter, arg1, arg2)              \
+  KokkosTest::Impl::expect_ne(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg1), arg1, KOKKOS_IMPL_STRINGIFY(arg2), arg2)
+
+#define KOKKOS_EXPECT_TRUE(test_reporter, arg)                     \
+  KokkosTest::Impl::expect_true(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg), arg)
+
+#define KOKKOS_EXPECT_FALSE(test_reporter, arg)                     \
+  KokkosTest::Impl::expect_false(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg), arg)
+
+#define KOKKOS_EXPECT_NEAR_ULPS(test_reporter, float1, float2, ulps)    \
+  KokkosTest::Impl::expect_near_ulps(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(float1), float1, KOKKOS_IMPL_STRINGIFY(float2), float2, ulps)
 
 #if __FINITE_MATH_ONLY__
 // Nothing to test if NaN and infinite are disabled at compilation
-#define KOKKOS_EXPECT_NAN(arg)
-#define KOKKOS_EXPECT_INF(arg)
+#define KOKKOS_EXPECT_NAN(test_reporter, arg)
+#define KOKKOS_EXPECT_INF(test_reporter, arg)
 #else
-#define KOKKOS_EXPECT_NAN(arg)                           \
-  do {                                                   \
-    if (!Kokkos::isnan(arg)) {                           \
-      auto* log = m_error_reporter.emplace_report();     \
-      if (log == nullptr) { break; }                     \
-      log->error_message << __FILE__ ":" << __LINE__ <<  \
-      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg) \
-      "\n  Actual: " << arg << "\nExpected: NaN\n";      \
-    }                                                    \
-  } while (false)
+#define KOKKOS_EXPECT_NAN(test_reporter, arg)                     \
+  KokkosTest::Impl::expect_nan(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg), arg)
 
-#define KOKKOS_EXPECT_INF(arg)                           \
-  do {                                                   \
-    if (!Kokkos::isinf(arg)) {                           \
-      auto* log = m_error_reporter.emplace_report();     \
-      if (log == nullptr) { break; }                     \
-      log->error_message << __FILE__ ":" << __LINE__ <<  \
-      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg) \
-      "\n  Actual: " << arg << "\nExpected: +/-Inf\n";   \
-    }                                                    \
-  } while (false)
+#define KOKKOS_EXPECT_INF(test_reporter, arg)                     \
+  KokkosTest::Impl::expect_inf(test_reporter, __FILE__, __LINE__, \
+      KOKKOS_IMPL_STRINGIFY(arg), arg)
 #endif
-// clang-format on
 
-#define KOKKOS_DEFINE_ERROR_REPORTER(string_capacity, ...)            \
-  using Log = KokkosTest::ErrorLog<string_capacity>;                  \
-  Kokkos::Experimental::ErrorReporter<Log __VA_OPT__(, ) __VA_ARGS__> \
-      m_error_reporter
-
-#define KOKKOS_INIT_ERROR_REPORTER(max_errors) m_error_reporter(max_errors)
-
-#define KOKKOS_RETRIEVE_ERRORS(ret)                                \
-  do {                                                             \
-    std::vector<int> reporters;                                    \
-    std::vector<Log> reports;                                      \
-    std::tie(reporters, reports) = m_error_reporter.get_reports(); \
-    for (int i = 0; i < m_error_reporter.num_reports(); ++i) {     \
-      std::cout << reports[i].error_message << std::endl;          \
-    }                                                              \
-    ret = m_error_reporter.num_report_attempts();                  \
-  } while (false)
-
-// TODO: allow parametrization of error reporter capacity
-// TODO: allow parametrization of ErrorLog capacity
 /**
  * Create a test that will run on the device, first template argument is the
  * execution space where the test need to run, can take up to one extra
@@ -237,15 +359,11 @@ struct ErrorLog {
 #define KOKKOS_DEVICE_TEST(TestName, ...)                                \
   template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>             \
   struct [[nodiscard]] TestName {                                        \
-    KOKKOS_DEFINE_ERROR_REPORTER(2048, TestSpace);                       \
-    TestName() : KOKKOS_INIT_ERROR_REPORTER(10) {}                       \
+    KokkosTest::TestReporter<TestSpace, 2048> m_test_reporter;           \
                                                                          \
-    [[nodiscard]] int run() const {                                      \
+    [[nodiscard]] int run() {                                            \
       Kokkos::parallel_for(Kokkos::RangePolicy<TestSpace>(0, 1), *this); \
-                                                                         \
-      int ret;                                                           \
-      KOKKOS_RETRIEVE_ERRORS(ret);                                       \
-      return ret;                                                        \
+      return m_test_reporter.print_errors();                             \
     }                                                                    \
     KOKKOS_FUNCTION void operator()(int) const;                          \
   };                                                                     \
@@ -255,5 +373,7 @@ struct ErrorLog {
   TestName<TestSpace __VA_OPT__(, ) __VA_ARGS__>::operator()(int) const
 
 }  // namespace KokkosTest
+
+
 
 #endif

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -13,6 +13,8 @@ import kokkos.core;
 
 #include <type_traits>
 
+#include <../../containers/src/Kokkos_ErrorReporter.hpp>
+
 namespace KokkosTest {
 
 struct FloatingPointComparison {
@@ -111,179 +113,146 @@ struct IntegerComparison {
   }
 };
 
-namespace Impl {
-// Print the value of t deducing a sensible format from its type T.
-template <typename T>
-constexpr KOKKOS_FUNCTION void print_arg_value(T t) {
-  using type = std::remove_cvref_t<T>;
-  if constexpr (std::is_same_v<T, char*> || std::is_same_v<T, const char*>) {
-    if (t != nullptr) {
-      // FIXME This is not 100% safe, as there is no guarantee that a char* is
-      // a pointer to a C-style string
-      Kokkos::printf("\"%s\"", t);
-    } else {
-      Kokkos::printf("NULL");
-    }
-  } else if constexpr (std::is_pointer_v<type>) {
-    if (t != nullptr) {
-      Kokkos::printf("%p", t);
-    } else {
-      Kokkos::printf("NULL");
-    }
-  } else if constexpr (std::is_same_v<type, bool>) {
-    if (t) {
-      Kokkos::printf("true");
-    } else {
-      Kokkos::printf("false");
-    }
-  } else if constexpr (std::is_integral_v<type>) {
-    if constexpr (std::is_unsigned_v<type>) {
-      Kokkos::printf("%u", t);
-    } else {
-      Kokkos::printf("%i", t);
-    }
-  } else if constexpr (std::is_floating_point_v<type>) {
-    Kokkos::printf("%f", t);
-  } else if constexpr (std::is_enum_v<type>) {
-    Kokkos::printf("%i", t);
-#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
-  } else if constexpr (std::is_same_v<T, Kokkos::Experimental::half_t> ||
-                       std::is_same_v<T, Kokkos::Experimental::bhalf_t>) {
-#if (defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    // Bit cast is not available for half types with msvc
-    Kokkos::printf("%f", static_cast<float>(t));
-#else
-    Kokkos::printf("%f (0x%X)", static_cast<float>(t),
-                   Kokkos::bit_cast<uint16_t, T>(t));
-#endif
-#endif
-  } else {
-    Kokkos::abort("Unknown type, can't display value.");
-  }
-}
-}  // namespace Impl
+template <size_t string_capacity>
+struct ErrorLog {
+  Kokkos::Impl::StaticString<string_capacity> error_message;
+};
 
 // Dumbed down version of gtest's EXPECT_ functions, usable on the device
 // (needs to be used inside test defined with KOKKOS_DEVICE_TEST)
-// FIXME the printf can get interleaved when executing in parallel, the whole
-// error message should be constructed at once in a string and displayed in a
-// printf, but there is no robust enough implementation of string on GPU to do
-// that portably
+
+// clang-format off
 #define KOKKOS_EXPECT_EQ(arg1, arg2)                                         \
   do {                                                                       \
     if (!((arg1) == (arg2))) {                                               \
-      errors += 1;                                                           \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                \
-      Kokkos::printf("Expected equality of these values:\n");                \
-      Kokkos::printf("  " KOKKOS_IMPL_STRINGIFY(arg1) "\n    Which is: ");   \
-      KokkosTest::Impl::print_arg_value(arg1);                               \
-      Kokkos::printf("\n  " KOKKOS_IMPL_STRINGIFY(arg2) "\n    Which is: "); \
-      KokkosTest::Impl::print_arg_value(arg2);                               \
-      Kokkos::printf("\n");                                                  \
+      auto* log = m_error_reporter.emplace_report();                         \
+      if (log == nullptr) { break; }                                         \
+      log->error_message << __FILE__ ":" << __LINE__ <<                      \
+      ": Failure\nExpected equality of these values:\n  "                    \
+      KOKKOS_IMPL_STRINGIFY(arg1) << "\n    Which is: " << arg1 <<           \
+      "\n  " KOKKOS_IMPL_STRINGIFY(arg2) "\n    Which is: " << arg2 << "\n"; \
     }                                                                        \
   } while (false)
 
-#define KOKKOS_EXPECT_NE(arg1, arg2)                                 \
+#define KOKKOS_EXPECT_NE(arg1, arg2)                                      \
+  do {                                                                    \
+    if (!((arg1) != (arg2))) {                                            \
+      auto* log = m_error_reporter.emplace_report();                      \
+      if (log == nullptr) { break; }                                      \
+      log->error_message << __FILE__ ":" << __LINE__ <<                   \
+      ": Failure\nExpected: (" KOKKOS_IMPL_STRINGIFY(arg1) << ") != ("    \
+      KOKKOS_IMPL_STRINGIFY(arg2) "), actual: " << arg1 << " vs " << arg2 \
+      << "\n";                                                            \
+    }                                                                     \
+  } while (false)
+
+#define KOKKOS_EXPECT_TRUE(arg)                                      \
   do {                                                               \
-    if (!((arg1) != (arg2))) {                                       \
-      errors += 1;                                                   \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);        \
-      Kokkos::printf("Expected: (" KOKKOS_IMPL_STRINGIFY(            \
-          arg1) ") != (" KOKKOS_IMPL_STRINGIFY(arg2) "), actual: "); \
-      KokkosTest::Impl::print_arg_value(arg1);                       \
-      Kokkos::printf(" vs ");                                        \
-      KokkosTest::Impl::print_arg_value(arg2);                       \
-      Kokkos::printf("\n");                                          \
+    if (!(arg)) {                                                    \
+      auto* log = m_error_reporter.emplace_report();                 \
+      if (log == nullptr) { break; }                                 \
+      log->error_message << __FILE__ ":" << __LINE__ <<              \
+      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg)             \
+      "\n  Actual: false\n  Expected: true\n";                       \
     }                                                                \
-  } while (false)
+  } while(false)
 
-#define KOKKOS_EXPECT_TRUE(arg)                               \
-  do {                                                        \
-    if (!(arg)) {                                             \
-      errors += 1;                                            \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__); \
-      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(      \
-          arg) "\n  Actual: false\nExpected: true\n");        \
-    }                                                         \
-  } while (false)
+#define KOKKOS_EXPECT_FALSE(arg)                                     \
+  do {                                                               \
+    if (!!(arg)) {                                                   \
+      auto* log = m_error_reporter.emplace_report();                 \
+      if (log == nullptr) { break; }                                 \
+      log->error_message << __FILE__ ":" << __LINE__ <<              \
+      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg)             \
+      "\n  Actual: true\n  Expected: false\n";                       \
+    }                                                                \
+  } while(false)
 
-#define KOKKOS_EXPECT_FALSE(arg)                              \
-  do {                                                        \
-    if (!!(arg)) {                                            \
-      errors += 1;                                            \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__); \
-      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(      \
-          arg) "\n  Actual: true\nExpected: false\n");        \
-    }                                                         \
-  } while (false)
-
-// clang-format off
-#define KOKKOS_EXPECT_NEAR_ULPS(float1, float2, ulps)           \
-  do {                                                          \
-    if (!KokkosTest::FloatingPointComparison                    \
-            ::compare(float1, float2, ulps)) {                  \
-      errors += 1;                                              \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);   \
-      Kokkos::printf("Expected: " KOKKOS_IMPL_STRINGIFY(float1) \
-           " within %i ulps of " KOKKOS_IMPL_STRINGIFY(float2)  \
-           ",\n  Actual: ", ulps);                              \
-      KokkosTest::Impl::print_arg_value(float1);                \
-      Kokkos::printf(" vs ");                                   \
-      KokkosTest::Impl::print_arg_value(float2);                \
-      Kokkos::printf("\n");                                     \
-    }                                                           \
-  } while (false)
-// clang-format on
+#define KOKKOS_EXPECT_NEAR_ULPS(float1, float2, ulps)                          \
+  do {                                                                         \
+    if (!KokkosTest::FloatingPointComparison::compare(float1, float2, ulps)) { \
+      auto* log = m_error_reporter.emplace_report();                           \
+      if (log == nullptr) { break; }                                           \
+      log->error_message << __FILE__ ":" << __LINE__ <<                        \
+      ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1)                    \
+      " within %i ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "     \
+      << float1 << " vs " << float2 << "\n";                                   \
+    }                                                                          \
+  } while(false)
 
 #if __FINITE_MATH_ONLY__
 // Nothing to test if NaN and infinite are disabled at compilation
 #define KOKKOS_EXPECT_NAN(arg)
 #define KOKKOS_EXPECT_INF(arg)
 #else
-#define KOKKOS_EXPECT_NAN(arg)                                                \
-  do {                                                                        \
-    if (!Kokkos::isnan(arg)) {                                                \
-      errors += 1;                                                            \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                 \
-      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(arg) "\n  Actual: "); \
-      KokkosTest::Impl::print_arg_value(arg);                                 \
-      Kokkos::printf("\nExpected: NaN\n");                                    \
-    }                                                                         \
+#define KOKKOS_EXPECT_NAN(arg)                           \
+  do {                                                   \
+    if (!Kokkos::isnan(arg)) {                           \
+      auto* log = m_error_reporter.emplace_report();     \
+      if (log == nullptr) { break; }                     \
+      log->error_message << __FILE__ ":" << __LINE__ <<  \
+      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg) \
+      "\n  Actual: " << arg << "\nExpected: NaN\n";      \
+    }                                                    \
   } while (false)
 
-#define KOKKOS_EXPECT_INF(arg)                                                \
-  do {                                                                        \
-    if (!Kokkos::isinf(arg)) {                                                \
-      errors += 1;                                                            \
-      Kokkos::printf("%s:%i: Failure\n", __FILE__, __LINE__);                 \
-      Kokkos::printf("Value of: " KOKKOS_IMPL_STRINGIFY(arg) "\n  Actual: "); \
-      KokkosTest::Impl::print_arg_value(arg);                                 \
-      Kokkos::printf("\nExpected: +/-Inf\n");                                 \
-    }                                                                         \
+#define KOKKOS_EXPECT_INF(arg)                           \
+  do {                                                   \
+    if (!Kokkos::isinf(arg)) {                           \
+      auto* log = m_error_reporter.emplace_report();     \
+      if (log == nullptr) { break; }                     \
+      log->error_message << __FILE__ ":" << __LINE__ <<  \
+      ": Failure\nValue of: " KOKKOS_IMPL_STRINGIFY(arg) \
+      "\n  Actual: " << arg << "\nExpected: +/-Inf\n";   \
+    }                                                    \
   } while (false)
 #endif
+// clang-format on
 
+#define KOKKOS_DEFINE_ERROR_REPORTER(string_capacity, ...)            \
+  using Log = KokkosTest::ErrorLog<string_capacity>;                  \
+  Kokkos::Experimental::ErrorReporter<Log __VA_OPT__(, ) __VA_ARGS__> \
+      m_error_reporter
+
+#define KOKKOS_INIT_ERROR_REPORTER(max_errors) m_error_reporter(max_errors)
+
+#define KOKKOS_RETRIEVE_ERRORS(ret)                                \
+  do {                                                             \
+    std::vector<int> reporters;                                    \
+    std::vector<Log> reports;                                      \
+    std::tie(reporters, reports) = m_error_reporter.get_reports(); \
+    for (int i = 0; i < m_error_reporter.num_reports(); ++i) {     \
+      std::cout << reports[i].error_message << std::endl;          \
+    }                                                              \
+    ret = m_error_reporter.num_report_attempts();                  \
+  } while (false)
+
+// TODO: allow parametrization of error reporter capacity
+// TODO: allow parametrization of ErrorLog capacity
 /**
  * Create a test that will run on the device, first template argument is the
  * execution space where the test need to run, can take up to one extra
  * template argument.
  */
-#define KOKKOS_DEVICE_TEST(TestName, ...)                                      \
-  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>                   \
-  struct [[nodiscard]] TestName {                                              \
-    [[nodiscard]] int run() const {                                            \
-      int errors = 0;                                                          \
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<TestSpace>(0, 1), *this,     \
-                              errors);                                         \
-      return errors;                                                           \
-    }                                                                          \
-    KOKKOS_FUNCTION void operator()(int, int& errors) const;                   \
-  };                                                                           \
-                                                                               \
-  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>                   \
-  KOKKOS_FUNCTION void                                                         \
-  TestName<TestSpace __VA_OPT__(, ) __VA_ARGS__>::operator()(int, int& errors) \
-      const
+#define KOKKOS_DEVICE_TEST(TestName, ...)                                \
+  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>             \
+  struct [[nodiscard]] TestName {                                        \
+    KOKKOS_DEFINE_ERROR_REPORTER(2048, TestSpace);                       \
+    TestName() : KOKKOS_INIT_ERROR_REPORTER(10) {}                       \
+                                                                         \
+    [[nodiscard]] int run() const {                                      \
+      Kokkos::parallel_for(Kokkos::RangePolicy<TestSpace>(0, 1), *this); \
+                                                                         \
+      int ret;                                                           \
+      KOKKOS_RETRIEVE_ERRORS(ret);                                       \
+      return ret;                                                        \
+    }                                                                    \
+    KOKKOS_FUNCTION void operator()(int) const;                          \
+  };                                                                     \
+                                                                         \
+  template <class TestSpace __VA_OPT__(, class) __VA_ARGS__>             \
+  KOKKOS_FUNCTION void                                                   \
+  TestName<TestSpace __VA_OPT__(, ) __VA_ARGS__>::operator()(int) const
 
 }  // namespace KokkosTest
 

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -120,17 +120,17 @@ struct TestLog {
 
 template <class Space, size_t string_capacity>
 struct TestReporter {
-  using Log = KokkosTest::TestLog<string_capacity>;
+  using Log      = KokkosTest::TestLog<string_capacity>;
   using Reporter = Kokkos::Experimental::ErrorReporter<Log, Space>;
 
   TestReporter() : m_reporter(10) {}
 
   TestReporter(int size) : m_reporter(size) {}
 
-  private:
+ private:
   Reporter m_reporter;
 
-  public:
+ public:
   KOKKOS_FUNCTION Log* emplace_report() const {
     return m_reporter.emplace_report();
   }
@@ -144,198 +144,178 @@ struct TestReporter {
     }
     int ret = m_reporter.num_report_attempts();
     m_reporter.clear();
-  
+
     return ret;
   }
 };
 
 namespace Impl {
-  template <size_t capacity>
-  struct OptionalString {
-    using String = Kokkos::Impl::StaticString<capacity>;
-    String *m_ss;
+template <size_t capacity>
+struct OptionalString {
+  using String = Kokkos::Impl::StaticString<capacity>;
+  String* m_ss;
 
-    KOKKOS_FUNCTION OptionalString(String *ss = nullptr) : m_ss(ss) {}
+  KOKKOS_FUNCTION OptionalString(String* ss = nullptr) : m_ss(ss) {}
 
-    template <typename Arg>
-    KOKKOS_FUNCTION OptionalString<capacity>& operator<<(const Arg& arg) {
-      if (m_ss != nullptr) {
-        *m_ss << arg;
-      }
-      return *this;
+  template <typename Arg>
+  KOKKOS_FUNCTION OptionalString<capacity>& operator<<(const Arg& arg) {
+    if (m_ss != nullptr) {
+      *m_ss << arg;
     }
-  };
-
-  template <class Space, size_t string_capacity, class T1, class T2>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_eq(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg1,
-      const T1 arg1_val,
-      const char* arg2,
-      const T2 arg2_val) {
-    if (!((arg1_val) == (arg2_val))) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nExpected equality of these values:\n  " << arg1 << 
-        "\n    Which is: " << arg1_val << "\n  " << arg2 
-        << "\n    Which is: " << arg2_val << "\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
+    return *this;
   }
+};
 
-  template <class Space, size_t string_capacity, class T1, class T2>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_ne(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg1,
-      const T1 arg1_val,
-      const char* arg2,
-      const T2 arg2_val) {
-    if (!((arg1_val) != (arg2_val))) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nExpected: (" << arg1 << ") != ("
-        << arg2 << "), actual: " << arg1_val << " vs " << arg2_val
-        << "\n";
+template <class Space, size_t string_capacity, class T1, class T2>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_eq(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg1, const T1 arg1_val,
+    const char* arg2, const T2 arg2_val) {
+  if (!((arg1_val) == (arg2_val))) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line
+                         << ": Failure\nExpected equality of these values:\n  "
+                         << arg1 << "\n    Which is: " << arg1_val << "\n  "
+                         << arg2 << "\n    Which is: " << arg2_val << "\n";
 
-        return OptionalString<string_capacity>(&log->error_message);
-      }
+      return OptionalString<string_capacity>(&log->error_message);
     }
-    return OptionalString<string_capacity>();
   }
-
-  template <class Space, size_t string_capacity, class T>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_true(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg,
-      const T arg_val) {
-    if (!(arg_val)) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nValue of: " << arg <<
-        "\n  Actual: false\n  Expected: true\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
-  }
-
-  template <class Space, size_t string_capacity, class T>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_false(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg,
-      const T arg_val) {
-    if (!!(arg_val)) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nValue of: " << arg <<
-        "\n  Actual: true\n  Expected: false\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
-  }
-
-  template <class Space, size_t string_capacity, class Float1, class Float2>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_near_ulps(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* float1,
-      const Float1 float1_val,
-      const char* float2,
-      const Float2 float2_val,
-      int ulps) {
-    if (!KokkosTest::FloatingPointComparison::compare(float1_val, float2_val, ulps)) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) {
-        log->error_message << file << ":" << line<<
-        ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1)
-        " within " << ulps << " ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "
-        << float1_val << " vs " << float2_val << "\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
-  }
-
-  template <class Space, size_t string_capacity, class T>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_nan(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg,
-      const T arg_val) {
-    if (!Kokkos::isnan(arg_val)) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nValue of: " << arg << 
-        "\n  Actual: " << arg_val << "\nExpected: NaN\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
-  }
-
-  template <class Space, size_t string_capacity, class T>
-  KOKKOS_FUNCTION OptionalString<string_capacity> expect_inf(
-      const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
-      const char* file,
-      int line,
-      const char* arg,
-      const T arg_val) {
-    if (!Kokkos::isinf(arg_val)) {
-      auto* log = test_reporter.emplace_report();
-      if (log != nullptr) { 
-        log->error_message << file << ":" << line <<
-        ": Failure\nValue of: " << arg << 
-        "\n  Actual: " << arg_val << "\nExpected: Inf\n";
-
-        return OptionalString<string_capacity>(&log->error_message);
-      }
-    }
-    return OptionalString<string_capacity>();
-  }
+  return OptionalString<string_capacity>();
 }
+
+template <class Space, size_t string_capacity, class T1, class T2>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_ne(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg1, const T1 arg1_val,
+    const char* arg2, const T2 arg2_val) {
+  if (!((arg1_val) != (arg2_val))) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line << ": Failure\nExpected: ("
+                         << arg1 << ") != (" << arg2
+                         << "), actual: " << arg1_val << " vs " << arg2_val
+                         << "\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+
+template <class Space, size_t string_capacity, class T>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_true(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg, const T arg_val) {
+  if (!(arg_val)) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line
+                         << ": Failure\nValue of: " << arg
+                         << "\n  Actual: false\n  Expected: true\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+
+template <class Space, size_t string_capacity, class T>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_false(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg, const T arg_val) {
+  if (!!(arg_val)) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line
+                         << ": Failure\nValue of: " << arg
+                         << "\n  Actual: true\n  Expected: false\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+
+template <class Space, size_t string_capacity, class Float1, class Float2>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_near_ulps(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* float1, const Float1 float1_val,
+    const char* float2, const Float2 float2_val, int ulps) {
+  if (!KokkosTest::FloatingPointComparison::compare(float1_val, float2_val,
+                                                    ulps)) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message
+          << file << ":" << line
+          << ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1) " within "
+          << ulps << " ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "
+          << float1_val << " vs " << float2_val << "\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+
+template <class Space, size_t string_capacity, class T>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_nan(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg, const T arg_val) {
+  if (!Kokkos::isnan(arg_val)) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line
+                         << ": Failure\nValue of: " << arg
+                         << "\n  Actual: " << arg_val << "\nExpected: NaN\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+
+template <class Space, size_t string_capacity, class T>
+KOKKOS_FUNCTION OptionalString<string_capacity> expect_inf(
+    const KokkosTest::TestReporter<Space, string_capacity>& test_reporter,
+    const char* file, int line, const char* arg, const T arg_val) {
+  if (!Kokkos::isinf(arg_val)) {
+    auto* log = test_reporter.emplace_report();
+    if (log != nullptr) {
+      log->error_message << file << ":" << line
+                         << ": Failure\nValue of: " << arg
+                         << "\n  Actual: " << arg_val << "\nExpected: Inf\n";
+
+      return OptionalString<string_capacity>(&log->error_message);
+    }
+  }
+  return OptionalString<string_capacity>();
+}
+}  // namespace Impl
 
 #define KOKKOS_EXPECT_EQ(test_reporter, arg1, arg2)              \
   KokkosTest::Impl::expect_eq(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg1), arg1, KOKKOS_IMPL_STRINGIFY(arg2), arg2)
+                              KOKKOS_IMPL_STRINGIFY(arg1), arg1, \
+                              KOKKOS_IMPL_STRINGIFY(arg2), arg2)
 
 #define KOKKOS_EXPECT_NE(test_reporter, arg1, arg2)              \
   KokkosTest::Impl::expect_ne(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg1), arg1, KOKKOS_IMPL_STRINGIFY(arg2), arg2)
+                              KOKKOS_IMPL_STRINGIFY(arg1), arg1, \
+                              KOKKOS_IMPL_STRINGIFY(arg2), arg2)
 
 #define KOKKOS_EXPECT_TRUE(test_reporter, arg)                     \
   KokkosTest::Impl::expect_true(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg), arg)
+                                KOKKOS_IMPL_STRINGIFY(arg), arg)
 
 #define KOKKOS_EXPECT_FALSE(test_reporter, arg)                     \
   KokkosTest::Impl::expect_false(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg), arg)
+                                 KOKKOS_IMPL_STRINGIFY(arg), arg)
 
 #define KOKKOS_EXPECT_NEAR_ULPS(test_reporter, float1, float2, ulps)    \
-  KokkosTest::Impl::expect_near_ulps(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(float1), float1, KOKKOS_IMPL_STRINGIFY(float2), float2, ulps)
+  KokkosTest::Impl::expect_near_ulps(                                   \
+      test_reporter, __FILE__, __LINE__, KOKKOS_IMPL_STRINGIFY(float1), \
+      float1, KOKKOS_IMPL_STRINGIFY(float2), float2, ulps)
 
 #if __FINITE_MATH_ONLY__
 // Nothing to test if NaN and infinite are disabled at compilation
@@ -344,11 +324,11 @@ namespace Impl {
 #else
 #define KOKKOS_EXPECT_NAN(test_reporter, arg)                     \
   KokkosTest::Impl::expect_nan(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg), arg)
+                               KOKKOS_IMPL_STRINGIFY(arg), arg)
 
 #define KOKKOS_EXPECT_INF(test_reporter, arg)                     \
   KokkosTest::Impl::expect_inf(test_reporter, __FILE__, __LINE__, \
-      KOKKOS_IMPL_STRINGIFY(arg), arg)
+                               KOKKOS_IMPL_STRINGIFY(arg), arg)
 #endif
 
 /**
@@ -373,7 +353,5 @@ namespace Impl {
   TestName<TestSpace __VA_OPT__(, ) __VA_ARGS__>::operator()(int) const
 
 }  // namespace KokkosTest
-
-
 
 #endif

--- a/core/unit_test/KokkosTest_Utils.hpp
+++ b/core/unit_test/KokkosTest_Utils.hpp
@@ -247,11 +247,11 @@ KOKKOS_FUNCTION OptionalString<string_capacity> expect_near_ulps(
                                                     ulps)) {
     auto* log = test_reporter.emplace_report();
     if (log != nullptr) {
-      log->error_message
-          << file << ":" << line
-          << ": Failure\nExpected: " KOKKOS_IMPL_STRINGIFY(float1) " within "
-          << ulps << " ulps of " KOKKOS_IMPL_STRINGIFY(float2) ", \n  Actual: "
-          << float1_val << " vs " << float2_val << "\n";
+      log->error_message << file << ":" << line
+                         << ": Failure\nExpected: " << float1 << " within "
+                         << ulps << " ulps of " << float2
+                         << ", \n  Actual: " << float1_val << " vs "
+                         << float2_val << "\n";
 
       return OptionalString<string_capacity>(&log->error_message);
     }

--- a/core/unit_test/TestKokkosTest_Utils.hpp
+++ b/core/unit_test/TestKokkosTest_Utils.hpp
@@ -14,37 +14,36 @@ import kokkos.core;
 
 #include "KokkosTest_Utils.hpp"
 
-//KOKKOS_FUNCTION void toto() {
-//  KOKKOS_EXPECT_NE(m_test_reporter, 1,1);
-//}
+// KOKKOS_FUNCTION void toto() {
+//   KOKKOS_EXPECT_NE(m_test_reporter, 1,1);
+// }
 
-#define TEST_UNARY_EXPECT(TESTER)                                            \
-  template <typename Space, typename type>                                   \
-  struct Test_##TESTER {                                                     \
-    bool expect_pass_;                                                       \
-    type val_;                                                               \
-                                                                             \
-    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                     \
-                                                                             \
-    Test_##TESTER(bool expectation, const type& val)                         \
-        : expect_pass_(expectation),                                         \
-          val_(val) {}                                                       \
-                                                                             \
-    KOKKOS_FUNCTION void operator()(int) const {                             \
-      TESTER(m_test_reporter, val_);                                         \
-    }                                                                        \
-                                                                             \
-    void run(const char* file, int line) {                                   \
-      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);         \
-      std::stringstream os;                                                       \
-      int expected_error = (expect_pass_ ? 0 : 1);                           \
-      int nerrors        = m_test_reporter.print_errors(os);                 \
-      ASSERT_EQ(nerrors, expected_error)                                     \
-          << file << ":" << line << ":\n"                                    \
-          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors     \
-          << ", expected " << (bool)expected_error                           \
-          << "\n\tfor value: " << val_;                                      \
-    }                                                                        \
+#define TEST_UNARY_EXPECT(TESTER)                                        \
+  template <typename Space, typename type>                               \
+  struct Test_##TESTER {                                                 \
+    bool expect_pass_;                                                   \
+    type val_;                                                           \
+                                                                         \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;               \
+                                                                         \
+    Test_##TESTER(bool expectation, const type& val)                     \
+        : expect_pass_(expectation), val_(val) {}                        \
+                                                                         \
+    KOKKOS_FUNCTION void operator()(int) const {                         \
+      TESTER(m_test_reporter, val_);                                     \
+    }                                                                    \
+                                                                         \
+    void run(const char* file, int line) {                               \
+      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);     \
+      std::stringstream os;                                              \
+      int expected_error = (expect_pass_ ? 0 : 1);                       \
+      int nerrors        = m_test_reporter.print_errors(os);             \
+      ASSERT_EQ(nerrors, expected_error)                                 \
+          << file << ":" << line << ":\n"                                \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors \
+          << ", expected " << (bool)expected_error                       \
+          << "\n\tfor value: " << val_;                                  \
+    }                                                                    \
   }
 
 #define TEST_BINARY_EXPECT(TESTER)                                        \
@@ -54,12 +53,10 @@ import kokkos.core;
     type1 val1_;                                                          \
     type2 val2_;                                                          \
                                                                           \
-    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                  \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                \
                                                                           \
     Test_##TESTER(bool expectation, const type1& val1, const type2& val2) \
-        : expect_pass_(expectation),                                      \
-          val1_(val1),                                                    \
-          val2_(val2) {}                                                  \
+        : expect_pass_(expectation), val1_(val1), val2_(val2) {}          \
                                                                           \
     KOKKOS_FUNCTION void operator()(int) const {                          \
       TESTER(m_test_reporter, val1_, val2_);                              \
@@ -67,7 +64,7 @@ import kokkos.core;
                                                                           \
     void run(const char* file, int line) {                                \
       Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);      \
-      std::stringstream os;                                                    \
+      std::stringstream os;                                               \
       int expected_error = (expect_pass_ ? 0 : 1);                        \
       int nerrors        = m_test_reporter.print_errors(os);              \
       ASSERT_EQ(nerrors, expected_error)                                  \
@@ -86,14 +83,11 @@ import kokkos.core;
     type2 val2_;                                                               \
     type3 val3_;                                                               \
                                                                                \
-    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                       \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                     \
                                                                                \
     Test_##TESTER(bool expectation, const type1& val1, const type2& val2,      \
                   const type3& val3)                                           \
-        : expect_pass_(expectation),                                           \
-          val1_(val1),                                                         \
-          val2_(val2),                                                         \
-          val3_(val3) {}                                                       \
+        : expect_pass_(expectation), val1_(val1), val2_(val2), val3_(val3) {}  \
                                                                                \
     KOKKOS_FUNCTION void operator()(int) const {                               \
       TESTER(m_test_reporter, val1_, val2_, val3_);                            \
@@ -101,7 +95,7 @@ import kokkos.core;
                                                                                \
     void run(const char* file, int line) {                                     \
       Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);           \
-      std::stringstream os;                                                         \
+      std::stringstream os;                                                    \
       int expected_error = (expect_pass_ ? 0 : 1);                             \
       int nerrors        = m_test_reporter.print_errors(os);                   \
       ASSERT_EQ(nerrors, expected_error)                                       \
@@ -317,5 +311,5 @@ TEST(Test_Utils, test_expects) {
   //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
   //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFBllu), 3);
 
-  //toto();
+  // toto();
 }

--- a/core/unit_test/TestKokkosTest_Utils.hpp
+++ b/core/unit_test/TestKokkosTest_Utils.hpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 #else
@@ -13,112 +14,137 @@ import kokkos.core;
 
 #include "KokkosTest_Utils.hpp"
 
-#define TEST_UNARY_EXPECT(TESTER, TYPE)                                       \
-  template <typename Space>                                                   \
-  struct Test_##TESTER {                                                      \
-    bool expect_pass_;                                                        \
-    TYPE val_;                                                                \
-                                                                              \
-    Test_##TESTER(bool expectation, const TYPE& val)                          \
-        : expect_pass_(expectation), val_(val) {}                             \
-                                                                              \
-    KOKKOS_FUNCTION void operator()(int, int& errors) const { TESTER(val_); } \
-                                                                              \
-    void run() {                                                              \
-      int errors;                                                             \
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,        \
-                              errors);                                        \
-      int expected_error = (expect_pass_ ? 0 : 1);                            \
-      ASSERT_EQ(errors, expected_error)                                       \
-          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors       \
-          << ", expected " << (bool)expected_error                            \
-          << "\n\tfor value: " << val_;                                       \
-    }                                                                         \
+#define TEST_UNARY_EXPECT(TESTER)                                            \
+  template <typename Space, typename type>                                   \
+  struct Test_##TESTER {                                                     \
+    bool expect_pass_;                                                       \
+    type val_;                                                               \
+                                                                             \
+    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                               \
+                                                                             \
+    Test_##TESTER(bool expectation, const type& val)                         \
+        : expect_pass_(expectation),                                         \
+          val_(val),                                                         \
+          KOKKOS_INIT_ERROR_REPORTER(10) {}                                  \
+                                                                             \
+    KOKKOS_FUNCTION void operator()(int) const { TESTER(val_); }             \
+                                                                             \
+    void run(const char* file, int line) {                                   \
+      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);         \
+      int expected_error = (expect_pass_ ? 0 : 1);                           \
+      std::vector<int> reporters;                                            \
+      std::vector<Log> reports;                                              \
+      std::tie(reporters, reports) = m_error_reporter.get_reports();         \
+      int nerrors                  = m_error_reporter.num_report_attempts(); \
+      ASSERT_EQ(nerrors, expected_error)                                     \
+          << file << ":" << line << ":\n"                                    \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors     \
+          << ", expected " << (bool)expected_error                           \
+          << "\n\tfor value: " << val_;                                      \
+    }                                                                        \
   }
 
-#define TEST_BINARY_EXPECT(TESTER, TYPE1, TYPE2)                          \
-  template <typename Space>                                               \
-  struct Test_##TESTER {                                                  \
-    bool expect_pass_;                                                    \
-    TYPE1 val1_;                                                          \
-    TYPE2 val2_;                                                          \
-                                                                          \
-    Test_##TESTER(bool expectation, const TYPE1& val1, const TYPE2& val2) \
-        : expect_pass_(expectation), val1_(val1), val2_(val2) {}          \
-                                                                          \
-    KOKKOS_FUNCTION void operator()(int, int& errors) const {             \
-      TESTER(val1_, val2_);                                               \
-    }                                                                     \
-                                                                          \
-    void run() {                                                          \
-      int errors;                                                         \
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,    \
-                              errors);                                    \
-      int expected_error = (expect_pass_ ? 0 : 1);                        \
-      ASSERT_EQ(errors, expected_error)                                   \
-          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors   \
-          << ", expected " << (bool)expected_error                        \
-          << "\n\tfor values: " << val1_ << " and " << val2_;             \
-    }                                                                     \
+#define TEST_BINARY_EXPECT(TESTER)                                           \
+  template <typename Space, typename type1, typename type2>                  \
+  struct Test_##TESTER {                                                     \
+    bool expect_pass_;                                                       \
+    type1 val1_;                                                             \
+    type2 val2_;                                                             \
+                                                                             \
+    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                               \
+                                                                             \
+    Test_##TESTER(bool expectation, const type1& val1, const type2& val2)    \
+        : expect_pass_(expectation),                                         \
+          val1_(val1),                                                       \
+          val2_(val2),                                                       \
+          KOKKOS_INIT_ERROR_REPORTER(10) {}                                  \
+                                                                             \
+    KOKKOS_FUNCTION void operator()(int) const { TESTER(val1_, val2_); }     \
+                                                                             \
+    void run(const char* file, int line) {                                   \
+      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);         \
+      int expected_error = (expect_pass_ ? 0 : 1);                           \
+      std::vector<int> reporters;                                            \
+      std::vector<Log> reports;                                              \
+      std::tie(reporters, reports) = m_error_reporter.get_reports();         \
+      int nerrors                  = m_error_reporter.num_report_attempts(); \
+      ASSERT_EQ(nerrors, expected_error)                                     \
+          << file << ":" << line << ":\n"                                    \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors     \
+          << ", expected " << (bool)expected_error                           \
+          << "\n\tfor values: " << val1_ << " and " << val2_;                \
+    }                                                                        \
   }
 
-#define TEST_TERNARY_EXPECT(TESTER, TYPE1, TYPE2, TYPE3)                       \
-  template <typename Space>                                                    \
+#define TEST_TERNARY_EXPECT(TESTER)                                            \
+  template <typename Space, typename type1, typename type2, typename type3>    \
   struct Test_##TESTER {                                                       \
     bool expect_pass_;                                                         \
-    TYPE1 val1_;                                                               \
-    TYPE2 val2_;                                                               \
-    TYPE3 val3_;                                                               \
+    type1 val1_;                                                               \
+    type2 val2_;                                                               \
+    type3 val3_;                                                               \
                                                                                \
-    Test_##TESTER(bool expectation, const TYPE1& val1, const TYPE2& val2,      \
-                  const TYPE3& val3)                                           \
-        : expect_pass_(expectation), val1_(val1), val2_(val2), val3_(val3) {}  \
+    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                                 \
                                                                                \
-    KOKKOS_FUNCTION void operator()(int, int& errors) const {                  \
+    Test_##TESTER(bool expectation, const type1& val1, const type2& val2,      \
+                  const type3& val3)                                           \
+        : expect_pass_(expectation),                                           \
+          val1_(val1),                                                         \
+          val2_(val2),                                                         \
+          val3_(val3),                                                         \
+          KOKKOS_INIT_ERROR_REPORTER(10) {}                                    \
+                                                                               \
+    KOKKOS_FUNCTION void operator()(int) const {                               \
       TESTER(val1_, val2_, val3_);                                             \
     }                                                                          \
                                                                                \
-    void run() {                                                               \
-      int errors;                                                              \
-      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,         \
-                              errors);                                         \
+    void run(const char* file, int line) {                                     \
+      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);           \
       int expected_error = (expect_pass_ ? 0 : 1);                             \
-      ASSERT_EQ(errors, expected_error)                                        \
-          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors        \
+      std::vector<int> reporters;                                              \
+      std::vector<Log> reports;                                                \
+      std::tie(reporters, reports) = m_error_reporter.get_reports();           \
+      int nerrors                  = m_error_reporter.num_report_attempts();   \
+      ASSERT_EQ(nerrors, expected_error)                                       \
+          << file << ":" << line << ":\n"                                      \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors       \
           << ", expected " << (bool)expected_error                             \
           << "\n\tfor values: " << val1_ << ", " << val2_ << " and " << val3_; \
     }                                                                          \
   }
 
-TEST_UNARY_EXPECT(KOKKOS_EXPECT_TRUE, double);
-TEST_UNARY_EXPECT(KOKKOS_EXPECT_FALSE, double);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_TRUE);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_FALSE);
 #if !__FINITE_MATH_ONLY__
-TEST_UNARY_EXPECT(KOKKOS_EXPECT_NAN, double);
-TEST_UNARY_EXPECT(KOKKOS_EXPECT_INF, double);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_NAN);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_INF);
 #endif
 
-TEST_BINARY_EXPECT(KOKKOS_EXPECT_EQ, double, double);
-TEST_BINARY_EXPECT(KOKKOS_EXPECT_NE, double, double);
+TEST_BINARY_EXPECT(KOKKOS_EXPECT_EQ);
+TEST_BINARY_EXPECT(KOKKOS_EXPECT_NE);
 
-TEST_TERNARY_EXPECT(KOKKOS_EXPECT_NEAR_ULPS, double, double, int);
+TEST_TERNARY_EXPECT(KOKKOS_EXPECT_NEAR_ULPS);
 
-#define DO_UNARY_TEST(TESTER, expect_pass, val)           \
-  do {                                                    \
-    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val); \
-    test.run();                                           \
-  } while (0)
+#define DO_UNARY_TEST(TESTER, expect_pass, val)                          \
+  do {                                                                   \
+    Test_##TESTER<TEST_EXECSPACE, decltype(val)> test(expect_pass, val); \
+    test.run(__FILE__, __LINE__);                                        \
+  } while (false)
 
-#define DO_BINARY_TEST(TESTER, expect_pass, val1, val2)          \
-  do {                                                           \
-    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val1, val2); \
-    test.run();                                                  \
-  } while (0)
+#define DO_BINARY_TEST(TESTER, expect_pass, val1, val2)                 \
+  do {                                                                  \
+    Test_##TESTER<TEST_EXECSPACE, decltype(val1), decltype(val2)> test( \
+        expect_pass, val1, val2);                                       \
+    test.run(__FILE__, __LINE__);                                       \
+  } while (false)
 
-#define DO_TERNARY_TEST(TESTER, expect_pass, val1, val2, val3)         \
-  do {                                                                 \
-    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val1, val2, val3); \
-    test.run();                                                        \
-  } while (0)
+#define DO_TERNARY_TEST(TESTER, expect_pass, val1, val2, val3)    \
+  do {                                                            \
+    Test_##TESTER<TEST_EXECSPACE, decltype(val1), decltype(val2), \
+                  decltype(val3)>                                 \
+        test(expect_pass, val1, val2, val3);                      \
+    test.run(__FILE__, __LINE__);                                 \
+  } while (false)
 
 TEST(Test_Utils, test_expects) {
   DO_BINARY_TEST(KOKKOS_EXPECT_EQ, false, 5., 4.);
@@ -153,20 +179,142 @@ TEST(Test_Utils, test_expects) {
   DO_UNARY_TEST(KOKKOS_EXPECT_NAN, true, Kokkos::quiet_NaN_v<double>);
 #endif
 
-  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., 2., 1);
-  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., 1.9, 1);
+  // Expect test success
+  // Near 0
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.f, -0.f, 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.f,
+                  Kokkos::bit_cast<float>(0x1u), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.f,
+                  Kokkos::bit_cast<float>(0x2u), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.f,
+                  Kokkos::bit_cast<float>(0x4u), 4);
 
-  {
-    uint64_t u = 0x4000000000000002;
-    double d   = Kokkos::bit_cast<double>(u);
-    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., d, 1);
-    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., d, 2);
-  }
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0., -0., 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.,
+                  Kokkos::bit_cast<double>(0x1llu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.,
+                  Kokkos::bit_cast<double>(0x2llu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.,
+                  Kokkos::bit_cast<double>(0x4llu), 4);
 
-  {
-    uint64_t u = 0x3FFFFFFFFFFFFFFE;
-    double d   = Kokkos::bit_cast<double>(u);
-    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., d, 1);
-    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., d, 2);
-  }
+  // Near 1
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f,
+                  Kokkos::bit_cast<float>(0x3F7FFFFEu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f,
+                  Kokkos::bit_cast<float>(0x3F7FFFFFu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800001u), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800002u), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800004u), 4);
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.,
+                  Kokkos::bit_cast<double>(0x3FEFFFFFFFFFFFFEllu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.,
+                  Kokkos::bit_cast<double>(0x3FEFFFFFFFFFFFFFllu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000001llu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000002llu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000004llu), 4);
+
+  // Near Inf
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFEu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFDu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFBu), 4);
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFEllu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFDllu), 2);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFBllu), 4);
+
+  // Equality
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0.f, 0.f, 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1.f, 1.f, 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu), 0);
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 0., 0., 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 1., 1., 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu), 0);
+
+  // Expect test failure
+  // Near 0
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.f,
+  //                 Kokkos::bit_cast<float>(0x80000005u), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.f,
+                  Kokkos::bit_cast<float>(0x1u), 0);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.f,
+  //                 Kokkos::bit_cast<float>(0x2u), 1);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.f,
+  //                  Kokkos::bit_cast<float>(0x4u), 3);
+
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.,
+  //                 Kokkos::bit_cast<double>(0x8000000000000001llu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.,
+                  Kokkos::bit_cast<double>(0x1llu), 0);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.,
+  //                 Kokkos::bit_cast<double>(0x2llu), 1);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 0.,
+  //                 Kokkos::bit_cast<double>(0x4llu), 3);
+
+  // Near 1
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.f,
+                  Kokkos::bit_cast<float>(0x3F7FFFFE), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.f,
+                  Kokkos::bit_cast<float>(0x3F7FFFFF), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800001), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800002), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.f,
+                  Kokkos::bit_cast<float>(0x3F800004), 3);
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.,
+                  Kokkos::bit_cast<double>(0x3FEFFFFFFFFFFFFEllu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.,
+                  Kokkos::bit_cast<double>(0x3FEFFFFFFFFFFFFFllu), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000001llu), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000002llu), 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 1.,
+                  Kokkos::bit_cast<double>(0x3FF0000000000004llu), 3);
+
+  // Near Inf
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFEu), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+                  Kokkos::bit_cast<float>(0x7F7FFFFFu),
+                  Kokkos::bit_cast<float>(0x7F7FFFFDu), 1);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+  //                 Kokkos::bit_cast<float>(0x7F7FFFFFu),
+  //                 Kokkos::bit_cast<float>(0x7F7FFFFBu), 3);
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFEllu), 0);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+                  Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFDllu), 1);
+  // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
+  //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
+  //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFBllu), 3);
 }

--- a/core/unit_test/TestKokkosTest_Utils.hpp
+++ b/core/unit_test/TestKokkosTest_Utils.hpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <Kokkos_BitManipulation.hpp>
+
+#include "KokkosTest_Utils.hpp"
+
+#define TEST_UNARY_EXPECT(TESTER, TYPE)                                       \
+  template <typename Space>                                                   \
+  struct Test_##TESTER {                                                      \
+    bool expect_pass_;                                                        \
+    TYPE val_;                                                                \
+                                                                              \
+    Test_##TESTER(bool expectation, const TYPE& val)                          \
+        : expect_pass_(expectation), val_(val) {}                             \
+                                                                              \
+    KOKKOS_FUNCTION void operator()(int, int& errors) const { TESTER(val_); } \
+                                                                              \
+    void run() {                                                              \
+      int errors;                                                             \
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,        \
+                              errors);                                        \
+      int expected_error = (expect_pass_ ? 0 : 1);                            \
+      ASSERT_EQ(errors, expected_error)                                       \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors       \
+          << ", expected " << (bool)expected_error                            \
+          << "\n\tfor value: " << val_;                                       \
+    }                                                                         \
+  }
+
+#define TEST_BINARY_EXPECT(TESTER, TYPE1, TYPE2)                          \
+  template <typename Space>                                               \
+  struct Test_##TESTER {                                                  \
+    bool expect_pass_;                                                    \
+    TYPE1 val1_;                                                          \
+    TYPE2 val2_;                                                          \
+                                                                          \
+    Test_##TESTER(bool expectation, const TYPE1& val1, const TYPE2& val2) \
+        : expect_pass_(expectation), val1_(val1), val2_(val2) {}          \
+                                                                          \
+    KOKKOS_FUNCTION void operator()(int, int& errors) const {             \
+      TESTER(val1_, val2_);                                               \
+    }                                                                     \
+                                                                          \
+    void run() {                                                          \
+      int errors;                                                         \
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,    \
+                              errors);                                    \
+      int expected_error = (expect_pass_ ? 0 : 1);                        \
+      ASSERT_EQ(errors, expected_error)                                   \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors   \
+          << ", expected " << (bool)expected_error                        \
+          << "\n\tfor values: " << val1_ << " and " << val2_;             \
+    }                                                                     \
+  }
+
+#define TEST_TERNARY_EXPECT(TESTER, TYPE1, TYPE2, TYPE3)                       \
+  template <typename Space>                                                    \
+  struct Test_##TESTER {                                                       \
+    bool expect_pass_;                                                         \
+    TYPE1 val1_;                                                               \
+    TYPE2 val2_;                                                               \
+    TYPE3 val3_;                                                               \
+                                                                               \
+    Test_##TESTER(bool expectation, const TYPE1& val1, const TYPE2& val2,      \
+                  const TYPE3& val3)                                           \
+        : expect_pass_(expectation), val1_(val1), val2_(val2), val3_(val3) {}  \
+                                                                               \
+    KOKKOS_FUNCTION void operator()(int, int& errors) const {                  \
+      TESTER(val1_, val2_, val3_);                                             \
+    }                                                                          \
+                                                                               \
+    void run() {                                                               \
+      int errors;                                                              \
+      Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this,         \
+                              errors);                                         \
+      int expected_error = (expect_pass_ ? 0 : 1);                             \
+      ASSERT_EQ(errors, expected_error)                                        \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)errors        \
+          << ", expected " << (bool)expected_error                             \
+          << "\n\tfor values: " << val1_ << ", " << val2_ << " and " << val3_; \
+    }                                                                          \
+  }
+
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_TRUE, double);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_FALSE, double);
+#if !__FINITE_MATH_ONLY__
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_NAN, double);
+TEST_UNARY_EXPECT(KOKKOS_EXPECT_INF, double);
+#endif
+
+TEST_BINARY_EXPECT(KOKKOS_EXPECT_EQ, double, double);
+TEST_BINARY_EXPECT(KOKKOS_EXPECT_NE, double, double);
+
+TEST_TERNARY_EXPECT(KOKKOS_EXPECT_NEAR_ULPS, double, double, int);
+
+#define DO_UNARY_TEST(TESTER, expect_pass, val)           \
+  do {                                                    \
+    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val); \
+    test.run();                                           \
+  } while (0)
+
+#define DO_BINARY_TEST(TESTER, expect_pass, val1, val2)          \
+  do {                                                           \
+    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val1, val2); \
+    test.run();                                                  \
+  } while (0)
+
+#define DO_TERNARY_TEST(TESTER, expect_pass, val1, val2, val3)         \
+  do {                                                                 \
+    Test_##TESTER<TEST_EXECSPACE> test(expect_pass, val1, val2, val3); \
+    test.run();                                                        \
+  } while (0)
+
+TEST(Test_Utils, test_expects) {
+  DO_BINARY_TEST(KOKKOS_EXPECT_EQ, false, 5., 4.);
+  DO_BINARY_TEST(KOKKOS_EXPECT_EQ, true, 5., 5.);
+
+  DO_BINARY_TEST(KOKKOS_EXPECT_NE, false, 5., 5.);
+  DO_BINARY_TEST(KOKKOS_EXPECT_NE, true, 5., 4.);
+
+  DO_UNARY_TEST(KOKKOS_EXPECT_TRUE, false, false);
+  DO_UNARY_TEST(KOKKOS_EXPECT_TRUE, true, true);
+
+  DO_UNARY_TEST(KOKKOS_EXPECT_FALSE, true, false);
+  DO_UNARY_TEST(KOKKOS_EXPECT_FALSE, false, true);
+
+#if !__FINITE_MATH_ONLY__
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, 5.);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, 0.);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, Kokkos::finite_max_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, Kokkos::signaling_NaN_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, Kokkos::quiet_NaN_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, false, Kokkos::denorm_min_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, true, Kokkos::infinity_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_INF, true, -Kokkos::infinity_v<double>);
+
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, 5.);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, 0.);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, Kokkos::finite_max_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, Kokkos::infinity_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, -Kokkos::infinity_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, false, Kokkos::denorm_min_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, true, Kokkos::signaling_NaN_v<double>);
+  DO_UNARY_TEST(KOKKOS_EXPECT_NAN, true, Kokkos::quiet_NaN_v<double>);
+#endif
+
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., 2., 1);
+  DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., 1.9, 1);
+
+  {
+    uint64_t u = 0x4000000000000002;
+    double d   = Kokkos::bit_cast<double>(u);
+    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., d, 1);
+    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., d, 2);
+  }
+
+  {
+    uint64_t u = 0x3FFFFFFFFFFFFFFE;
+    double d   = Kokkos::bit_cast<double>(u);
+    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false, 2., d, 1);
+    DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, true, 2., d, 2);
+  }
+}

--- a/core/unit_test/TestKokkosTest_Utils.hpp
+++ b/core/unit_test/TestKokkosTest_Utils.hpp
@@ -14,28 +14,31 @@ import kokkos.core;
 
 #include "KokkosTest_Utils.hpp"
 
+//KOKKOS_FUNCTION void toto() {
+//  KOKKOS_EXPECT_NE(m_test_reporter, 1,1);
+//}
+
 #define TEST_UNARY_EXPECT(TESTER)                                            \
   template <typename Space, typename type>                                   \
   struct Test_##TESTER {                                                     \
     bool expect_pass_;                                                       \
     type val_;                                                               \
                                                                              \
-    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                               \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                     \
                                                                              \
     Test_##TESTER(bool expectation, const type& val)                         \
         : expect_pass_(expectation),                                         \
-          val_(val),                                                         \
-          KOKKOS_INIT_ERROR_REPORTER(10) {}                                  \
+          val_(val) {}                                                       \
                                                                              \
-    KOKKOS_FUNCTION void operator()(int) const { TESTER(val_); }             \
+    KOKKOS_FUNCTION void operator()(int) const {                             \
+      TESTER(m_test_reporter, val_);                                         \
+    }                                                                        \
                                                                              \
     void run(const char* file, int line) {                                   \
       Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);         \
+      std::stringstream os;                                                       \
       int expected_error = (expect_pass_ ? 0 : 1);                           \
-      std::vector<int> reporters;                                            \
-      std::vector<Log> reports;                                              \
-      std::tie(reporters, reports) = m_error_reporter.get_reports();         \
-      int nerrors                  = m_error_reporter.num_report_attempts(); \
+      int nerrors        = m_test_reporter.print_errors(os);                 \
       ASSERT_EQ(nerrors, expected_error)                                     \
           << file << ":" << line << ":\n"                                    \
           << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors     \
@@ -44,36 +47,35 @@ import kokkos.core;
     }                                                                        \
   }
 
-#define TEST_BINARY_EXPECT(TESTER)                                           \
-  template <typename Space, typename type1, typename type2>                  \
-  struct Test_##TESTER {                                                     \
-    bool expect_pass_;                                                       \
-    type1 val1_;                                                             \
-    type2 val2_;                                                             \
-                                                                             \
-    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                               \
-                                                                             \
-    Test_##TESTER(bool expectation, const type1& val1, const type2& val2)    \
-        : expect_pass_(expectation),                                         \
-          val1_(val1),                                                       \
-          val2_(val2),                                                       \
-          KOKKOS_INIT_ERROR_REPORTER(10) {}                                  \
-                                                                             \
-    KOKKOS_FUNCTION void operator()(int) const { TESTER(val1_, val2_); }     \
-                                                                             \
-    void run(const char* file, int line) {                                   \
-      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);         \
-      int expected_error = (expect_pass_ ? 0 : 1);                           \
-      std::vector<int> reporters;                                            \
-      std::vector<Log> reports;                                              \
-      std::tie(reporters, reports) = m_error_reporter.get_reports();         \
-      int nerrors                  = m_error_reporter.num_report_attempts(); \
-      ASSERT_EQ(nerrors, expected_error)                                     \
-          << file << ":" << line << ":\n"                                    \
-          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors     \
-          << ", expected " << (bool)expected_error                           \
-          << "\n\tfor values: " << val1_ << " and " << val2_;                \
-    }                                                                        \
+#define TEST_BINARY_EXPECT(TESTER)                                        \
+  template <typename Space, typename type1, typename type2>               \
+  struct Test_##TESTER {                                                  \
+    bool expect_pass_;                                                    \
+    type1 val1_;                                                          \
+    type2 val2_;                                                          \
+                                                                          \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                  \
+                                                                          \
+    Test_##TESTER(bool expectation, const type1& val1, const type2& val2) \
+        : expect_pass_(expectation),                                      \
+          val1_(val1),                                                    \
+          val2_(val2) {}                                                  \
+                                                                          \
+    KOKKOS_FUNCTION void operator()(int) const {                          \
+      TESTER(m_test_reporter, val1_, val2_);                              \
+    }                                                                     \
+                                                                          \
+    void run(const char* file, int line) {                                \
+      Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);      \
+      std::stringstream os;                                                    \
+      int expected_error = (expect_pass_ ? 0 : 1);                        \
+      int nerrors        = m_test_reporter.print_errors(os);              \
+      ASSERT_EQ(nerrors, expected_error)                                  \
+          << file << ":" << line << ":\n"                                 \
+          << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors  \
+          << ", expected " << (bool)expected_error                        \
+          << "\n\tfor values: " << val1_ << " and " << val2_;             \
+    }                                                                     \
   }
 
 #define TEST_TERNARY_EXPECT(TESTER)                                            \
@@ -84,27 +86,24 @@ import kokkos.core;
     type2 val2_;                                                               \
     type3 val3_;                                                               \
                                                                                \
-    KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);                                 \
+    KokkosTest::TestReporter<Space, 2048> m_test_reporter;                       \
                                                                                \
     Test_##TESTER(bool expectation, const type1& val1, const type2& val2,      \
                   const type3& val3)                                           \
         : expect_pass_(expectation),                                           \
           val1_(val1),                                                         \
           val2_(val2),                                                         \
-          val3_(val3),                                                         \
-          KOKKOS_INIT_ERROR_REPORTER(10) {}                                    \
+          val3_(val3) {}                                                       \
                                                                                \
     KOKKOS_FUNCTION void operator()(int) const {                               \
-      TESTER(val1_, val2_, val3_);                                             \
+      TESTER(m_test_reporter, val1_, val2_, val3_);                            \
     }                                                                          \
                                                                                \
     void run(const char* file, int line) {                                     \
       Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);           \
+      std::stringstream os;                                                         \
       int expected_error = (expect_pass_ ? 0 : 1);                             \
-      std::vector<int> reporters;                                              \
-      std::vector<Log> reports;                                                \
-      std::tie(reporters, reports) = m_error_reporter.get_reports();           \
-      int nerrors                  = m_error_reporter.num_report_attempts();   \
+      int nerrors        = m_test_reporter.print_errors(os);                   \
       ASSERT_EQ(nerrors, expected_error)                                       \
           << file << ":" << line << ":\n"                                      \
           << KOKKOS_IMPL_STRINGIFY(TESTER) " returned " << (bool)nerrors       \
@@ -317,4 +316,6 @@ TEST(Test_Utils, test_expects) {
   // DO_TERNARY_TEST(KOKKOS_EXPECT_NEAR_ULPS, false,
   //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFFllu),
   //                 Kokkos::bit_cast<double>(0xFFEFFFFFFFFFFFFBllu), 3);
+
+  //toto();
 }

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -704,7 +704,8 @@ struct TestMathUnaryFunction {
                          << type_helper<Arg>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int i) const {
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val_[i]), res_[i], Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val_[i]), res_[i],
+                            Func::ulp_factor());
   }
 };
 
@@ -810,9 +811,7 @@ struct TestMathBinaryFunction {
   Arg2 val2_;
   Ret res_;
   TestMathBinaryFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1),
-        val2_(val2),
-        res_(Func::eval_std(val1, val2)) {
+      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
@@ -824,7 +823,8 @@ struct TestMathBinaryFunction {
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_,
+                            Func::ulp_factor());
   }
 };
 
@@ -843,9 +843,7 @@ struct TestMathBinaryIntFunction {
   Arg2 val2_;
   Ret res_;
   TestMathBinaryIntFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1),
-        val2_(val2),
-        res_(Func::eval_std(val1, val2)) {
+      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
@@ -857,7 +855,8 @@ struct TestMathBinaryIntFunction {
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_,
+                            Func::ulp_factor());
   }
 };
 
@@ -877,8 +876,7 @@ struct TestMathBinaryPtrFunction {
   Ret res_int_;
   const char* m_name;
   TestMathBinaryPtrFunction(Arg val)
-      : val_(val),
-        m_name(math_function_name<Func>::name) {
+      : val_(val), m_name(math_function_name<Func>::name) {
     res_frac_ = Func::eval_std(val_, &res_int_);
     run();
   }
@@ -891,8 +889,10 @@ struct TestMathBinaryPtrFunction {
   KOKKOS_FUNCTION void operator()(int) const {
     Ret iptr;
     Ret frac = Func::eval(val_, &iptr);
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, frac, res_frac_, Func::ulp_factor());
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, iptr, res_int_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, frac, res_frac_,
+                            Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, iptr, res_int_,
+                            Func::ulp_factor());
   }
 };
 
@@ -916,9 +916,7 @@ struct TestMathBinaryPredicate {
   Arg2 val2_;
   bool res_;
   TestMathBinaryPredicate(Arg1 val1, Arg2 val2)
-      : val1_(val1),
-        val2_(val2),
-        res_(Func::eval_std(val1, val2)) {
+      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
@@ -949,8 +947,7 @@ struct TestMathBinaryIntPtrFunction {
   int res1_;
   Ret res2_;
   TestMathBinaryIntPtrFunction(Arg val)
-      : val_(val),
-        res2_(Func::eval_std(val, &res1_)) {
+      : val_(val), res2_(Func::eval_std(val, &res1_)) {
     run();
   }
   void run() {
@@ -991,9 +988,7 @@ struct TestMathTernaryIntPtrFunction {
   int val_;
   Ret res_;
   TestMathTernaryIntPtrFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1),
-        val2_(val2),
-        res_(Func::eval_std(val1, val2, &val_)) {
+      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2, &val_)) {
     run();
   }
   void run() {
@@ -1045,8 +1040,8 @@ struct TestMathTernaryFunction {
                          << type_helper<Arg3>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_, val3_), res_,
-                            Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_, val3_),
+                            res_, Func::ulp_factor());
   }
 };
 
@@ -1951,17 +1946,21 @@ KOKKOS_DEVICE_TEST(TestFloatingPointRemainderFunction) {
   KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(6.2f, 4.f), 2.2f, 1);
   KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(-6.2f, 4.f), -2.2f, 1);
 
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(2.2f), 1);
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(-2.2f), 1);
 
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(2.2f), 1);
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       fmod(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(-2.2f), 1);
 
@@ -2010,17 +2009,21 @@ KOKKOS_DEVICE_TEST(TestIEEEFloatingPointRemainderFunction) {
   KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(6.2f, 4.f), -1.8f, 2);
   KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(-6.2f, 4.f), 1.8f, 2);
 
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       remainder(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(-1.8f), 2);
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       remainder(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(1.8f), 2);
 
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       remainder(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(-1.8f), 2);
-  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
+  KOKKOS_EXPECT_NEAR_ULPS(
+      m_test_reporter,
       remainder(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(1.8f), 2);
 
@@ -2099,12 +2102,14 @@ KOKKOS_DEVICE_TEST(TestIsFinite) {
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
   KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(static_cast<KE::half_t>(2.f)));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isfinite(signaling_NaN<KE::half_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<KE::half_t>::value));
 
   KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(static_cast<KE::bhalf_t>(2.f)));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isfinite(signaling_NaN<KE::bhalf_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<KE::bhalf_t>::value));
 #endif
 
@@ -2116,7 +2121,8 @@ KOKKOS_DEVICE_TEST(TestIsFinite) {
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
   KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(3.l));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isfinite(signaling_NaN<long double>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<long double>::value));
 #endif
   // special values
@@ -2172,7 +2178,8 @@ KOKKOS_DEVICE_TEST(TestIsInf) {
 
   KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(static_cast<KE::bhalf_t>(2.f)));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isinf(signaling_NaN<KE::bhalf_t>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<KE::bhalf_t>::value));
 #endif
 
@@ -2184,7 +2191,8 @@ KOKKOS_DEVICE_TEST(TestIsInf) {
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
   KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(4.l));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isinf(signaling_NaN<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<long double>::value));
 #endif
 
@@ -2229,20 +2237,28 @@ KOKKOS_DEVICE_TEST(TestFpClassify) {
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.f), FP_ZERO);
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.f), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<float>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<float>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<float>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<float>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<float>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<float>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<float>::value),
+                   FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<float>::value),
+                   FP_SUBNORMAL);
 #endif
 
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(0.), FP_ZERO);
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.), FP_ZERO);
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<double>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<double>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<double>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<double>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<double>::value),
+                   FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<double>::value),
+                   FP_SUBNORMAL);
 #endif
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
@@ -2250,36 +2266,54 @@ KOKKOS_DEVICE_TEST(TestFpClassify) {
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.l), FP_ZERO);
   KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.l), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<long double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<long double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<long double>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<long double>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter,
+                   fpclassify(signaling_NaN<long double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<long double>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<long double>::value),
+                   FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<long double>::value),
+                   FP_SUBNORMAL);
 #endif
 #endif
 
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(-0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(1.f)), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(0.f)),
+                   FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(-0.f)),
+                   FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(1.f)),
+                   FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
   // FIXME internal compiler error for Clang+Cuda and RDC
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<KE::half_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::half_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::half_t>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::half_t>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter,
+                   fpclassify(signaling_NaN<KE::half_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::half_t>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::half_t>::value),
+                   FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::half_t>::value),
+                   FP_SUBNORMAL);
 #endif
 #endif
 
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(-0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(1.f)), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(0.f)),
+                   FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(-0.f)),
+                   FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(1.f)),
+                   FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<KE::bhalf_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::bhalf_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::bhalf_t>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::bhalf_t>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter,
+                   fpclassify(signaling_NaN<KE::bhalf_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::bhalf_t>::value),
+                   FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::bhalf_t>::value),
+                   FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::bhalf_t>::value),
+                   FP_SUBNORMAL);
 #endif
 }
 
@@ -2391,7 +2425,8 @@ KOKKOS_DEVICE_TEST(TestIsNormal) {
   // FIXME internal compiler error for Clang+Cuda and RDC
 #if !__FINITE_MATH_ONLY__
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isnormal(signaling_NaN<KE::half_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<KE::half_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<KE::half_t>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<KE::half_t>::value));
@@ -2403,9 +2438,11 @@ KOKKOS_DEVICE_TEST(TestIsNormal) {
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(static_cast<KE::bhalf_t>(-2.f)));
 #if !__FINITE_MATH_ONLY__
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isnormal(signaling_NaN<KE::bhalf_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isnormal(denorm_min<KE::bhalf_t>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<KE::bhalf_t>::value));
 #endif
 #endif
@@ -2430,9 +2467,11 @@ KOKKOS_DEVICE_TEST(TestIsNormal) {
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(-4.l));
 #if !__FINITE_MATH_ONLY__
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isnormal(signaling_NaN<long double>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<long double>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      isnormal(denorm_min<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<long double>::value));
 #endif
   KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(LDBL_MAX));
@@ -2509,19 +2548,24 @@ KOKKOS_DEVICE_TEST(TestSignbit) {
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<KE::half_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<KE::half_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      signbit(signaling_NaN<KE::half_t>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::half_t>(infinity<KE::half_t>::value)));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::half_t>(denorm_min<KE::half_t>::value)));
   // https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/mathematical-functions.html#cuda-and-ieee-754-compliance:
   // "[...] result in the sign of a NaN being updated in an
   // implementation-defined manner."
 #ifndef KOKKOS_ENABLE_CUDA
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::half_t>(quiet_NaN<KE::half_t>::value)));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::half_t>(signaling_NaN<KE::half_t>::value)));
 #endif
 #endif
@@ -2531,18 +2575,23 @@ KOKKOS_DEVICE_TEST(TestSignbit) {
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<KE::bhalf_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<KE::bhalf_t>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      signbit(signaling_NaN<KE::bhalf_t>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(static_cast<KE::bhalf_t>(-0.f)));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::bhalf_t>(infinity<KE::bhalf_t>::value)));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::bhalf_t>(denorm_min<KE::bhalf_t>::value)));
 // the bhalf test also fails for SYCL+Cuda
 #ifndef KOKKOS_IMPL_ARCH_NVIDIA_GPU
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::bhalf_t>(quiet_NaN<KE::bhalf_t>::value)));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, 
+  KOKKOS_EXPECT_TRUE(
+      m_test_reporter,
       signbit(-static_cast<KE::bhalf_t>(signaling_NaN<KE::bhalf_t>::value)));
 #endif
 #endif
@@ -2567,14 +2616,16 @@ KOKKOS_DEVICE_TEST(TestSignbit) {
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<long double>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<long double>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter,
+                      signbit(signaling_NaN<long double>::value));
   KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(0.l));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-.8l));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-infinity<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-denorm_min<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter,
+                     signbit(-signaling_NaN<long double>::value));
   KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-0.l));
 #endif
 
@@ -2716,18 +2767,22 @@ KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {
   const FP16Type neg_inf = -static_cast<FP16Type>(infinity<FP16Type>::value);
 
   // NaN Handling
-  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(quiet_NaN<FP16Type>::value, pos_one));
-  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(signaling_NaN<FP16Type>::value, pos_one));
-  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(pos_one, quiet_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(pos_one, signaling_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(m_test_reporter, 
-      nextafter(quiet_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(m_test_reporter, 
-      nextafter(quiet_NaN<FP16Type>::value, signaling_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(m_test_reporter, 
-      nextafter(signaling_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter,
+                    nextafter(quiet_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(m_test_reporter,
+                    nextafter(signaling_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(m_test_reporter,
+                    nextafter(pos_one, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter,
+                    nextafter(pos_one, signaling_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(quiet_NaN<FP16Type>::value,
+                                               quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(quiet_NaN<FP16Type>::value,
+                                               signaling_NaN<FP16Type>::value));
   KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(signaling_NaN<FP16Type>::value,
-                              signaling_NaN<FP16Type>::value));
+                                               quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(signaling_NaN<FP16Type>::value,
+                                               signaling_NaN<FP16Type>::value));
 
   // Equality (from==toward) Handling
   KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, pos_one), pos_one);
@@ -2749,9 +2804,11 @@ KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
   const FP16Type before_neg_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
-  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_smallest, pos_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_smallest, pos_zero),
+                   neg_zero);
   KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_one, pos_one), after_neg_one);
-  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_one, neg_two), before_neg_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_one, neg_two),
+                   before_neg_one);
   KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_max, neg_inf), neg_inf);
 
   // From Positive Non Zero Handling
@@ -2759,8 +2816,10 @@ KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
   const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
-  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_smallest, neg_zero), pos_zero);
-  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, neg_one), before_pos_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_smallest, neg_zero),
+                   pos_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, neg_one),
+                   before_pos_one);
   KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, pos_two), after_pos_one);
   KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_max, pos_inf), pos_inf);
 

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -686,26 +686,25 @@ DEFINE_TYPE_NAME(long double)
 template <class Space, class Func, class Arg, std::size_t N,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathUnaryFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg val_[N];
   Ret res_[N];
-  TestMathUnaryFunction(const Arg (&val)[N]) : KOKKOS_INIT_ERROR_REPORTER(10) {
+  TestMathUnaryFunction(const Arg (&val)[N]) {
     std::copy(val, val + N, val_);
     std::transform(val, val + N, res_,
                    [](auto x) { return Func::eval_std(x); });
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, N), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int i) const {
-    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val_[i]), res_[i], Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val_[i]), res_[i], Func::ulp_factor());
   }
 };
 
@@ -745,27 +744,25 @@ void do_test_half_math_unary_function(const Arg (&x)[N]) {
 
 template <class Space, class Func, class Arg, std::size_t N>
 struct TestIntMathUnaryFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg val_[N];
   int res_[N];
-  TestIntMathUnaryFunction(const Arg (&val)[N])
-      : KOKKOS_INIT_ERROR_REPORTER(10) {
+  TestIntMathUnaryFunction(const Arg (&val)[N]) {
     std::copy(val, val + N, val_);
     std::transform(val, val + N, res_,
                    [](auto x) { return Func::eval_std(x); });
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, N), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int i) const {
-    KOKKOS_EXPECT_EQ(Func::eval(val_[i]), res_[i]);
+    KOKKOS_EXPECT_EQ(m_test_reporter, Func::eval(val_[i]), res_[i]);
   }
 };
 
@@ -807,29 +804,27 @@ void do_test_int_half_math_unary_function(const Arg (&x)[N]) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
 struct TestMathBinaryFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
   TestMathBinaryFunction(Arg1 val1, Arg2 val2)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val1_(val1),
+      : val1_(val1),
         val2_(val2),
         res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_, Func::ulp_factor());
   }
 };
 
@@ -842,29 +837,27 @@ void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_unary_function_return_type_t<Arg1>>
 struct TestMathBinaryIntFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
   TestMathBinaryIntFunction(Arg1 val1, Arg2 val2)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val1_(val1),
+      : val1_(val1),
         val2_(val2),
         res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_), res_, Func::ulp_factor());
   }
 };
 
@@ -877,31 +870,29 @@ void do_test_math_binary_int_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathBinaryPtrFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg val_;
   Ret res_frac_;
   Ret res_int_;
   const char* m_name;
   TestMathBinaryPtrFunction(Arg val)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val_(val),
+      : val_(val),
         m_name(math_function_name<Func>::name) {
     res_frac_ = Func::eval_std(val_, &res_int_);
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed " << m_name << " check for "
                          << type_helper<Arg>::name();
   }
   KOKKOS_FUNCTION void operator()(int) const {
     Ret iptr;
     Ret frac = Func::eval(val_, &iptr);
-    KOKKOS_EXPECT_NEAR_ULPS(frac, res_frac_, Func::ulp_factor());
-    KOKKOS_EXPECT_NEAR_ULPS(iptr, res_int_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, frac, res_frac_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, iptr, res_int_, Func::ulp_factor());
   }
 };
 
@@ -919,29 +910,27 @@ void do_test_math_binary_ptr_function(Arg x) {
 
 template <class Space, class Func, class Arg1, class Arg2>
 struct TestMathBinaryPredicate {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg1 val1_;
   Arg2 val2_;
   bool res_;
   TestMathBinaryPredicate(Arg1 val1, Arg2 val2)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val1_(val1),
+      : val1_(val1),
         val2_(val2),
         res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_EQ(Func::eval(val1_, val2_), res_);
+    KOKKOS_EXPECT_EQ(m_test_reporter, Func::eval(val1_, val2_), res_);
   }
 };
 
@@ -954,21 +943,19 @@ void do_test_math_binary_predicate(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathBinaryIntPtrFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg val_;
   int res1_;
   Ret res2_;
   TestMathBinaryIntPtrFunction(Arg val)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val_(val),
+      : val_(val),
         res2_(Func::eval_std(val, &res1_)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
@@ -977,8 +964,8 @@ struct TestMathBinaryIntPtrFunction {
     int res1;
     Ret res2 = Func::eval(val_, &res1);
 
-    KOKKOS_EXPECT_EQ(res1, res1_);
-    KOKKOS_EXPECT_NEAR_ULPS(res2, res2_, Func::ulp_factor());
+    KOKKOS_EXPECT_EQ(m_test_reporter, res1, res1_);
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, res2, res2_, Func::ulp_factor());
   }
 };
 
@@ -997,23 +984,21 @@ void do_test_math_binary_int_ptr_function(Arg x) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
 struct TestMathTernaryIntPtrFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg1 val1_;
   Arg2 val2_;
   int val_;
   Ret res_;
   TestMathTernaryIntPtrFunction(Arg1 val1, Arg2 val2)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val1_(val1),
+      : val1_(val1),
         val2_(val2),
         res_(Func::eval_std(val1, val2, &val_)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
@@ -1022,8 +1007,8 @@ struct TestMathTernaryIntPtrFunction {
   KOKKOS_FUNCTION void operator()(int) const {
     int val;
     auto res = Func::eval(val1_, val2_, &val);
-    KOKKOS_EXPECT_NEAR_ULPS(res, res_, Func::ulp_factor());
-    KOKKOS_EXPECT_EQ(val_, val);
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, res, res_, Func::ulp_factor());
+    KOKKOS_EXPECT_EQ(m_test_reporter, val_, val);
   }
 };
 
@@ -1037,24 +1022,22 @@ void do_test_math_ternary_int_ptr_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg1, class Arg2, class Arg3,
           class Ret = math_ternary_function_return_type_t<Arg1, Arg2, Arg3>>
 struct TestMathTernaryFunction {
-  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+  KokkosTest::TestReporter<Space, 2048> m_test_reporter;
 
   Arg1 val1_;
   Arg2 val2_;
   Arg3 val3_;
   Ret res_;
   TestMathTernaryFunction(Arg1 val1, Arg2 val2, Arg3 val3)
-      : KOKKOS_INIT_ERROR_REPORTER(10),
-        val1_(val1),
+      : val1_(val1),
         val2_(val2),
         val3_(val3),
         res_(Func::eval_std(val1, val2, val3)) {
     run();
   }
   void run() {
-    int errors = 0;
     Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
-    KOKKOS_RETRIEVE_ERRORS(errors);
+    int errors = m_test_reporter.print_errors();
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
@@ -1062,7 +1045,7 @@ struct TestMathTernaryFunction {
                          << type_helper<Arg3>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int) const {
-    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_, val3_), res_,
+    KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, Func::eval(val1_, val2_, val3_), res_,
                             Func::ulp_factor());
   }
 };
@@ -1864,34 +1847,34 @@ TEST(TEST_CATEGORY,
 
 KOKKOS_DEVICE_TEST(TestAbsoluteValueFunction) {
   using Kokkos::abs;
-  KOKKOS_EXPECT_EQ(abs(1), 1);
-  KOKKOS_EXPECT_EQ(abs(-1), 1);
-  KOKKOS_EXPECT_EQ(abs(2l), 2l);
-  KOKKOS_EXPECT_EQ(abs(-2l), 2l);
-  KOKKOS_EXPECT_EQ(abs(3ll), 3ll);
-  KOKKOS_EXPECT_EQ(abs(-3ll), 3ll);
-  KOKKOS_EXPECT_EQ(abs(4.f), 4.f);
-  KOKKOS_EXPECT_EQ(abs(-4.f), 4.f);
-  KOKKOS_EXPECT_EQ(abs(static_cast<KE::half_t>(4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(1), 1);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-1), 1);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(2l), 2l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-2l), 2l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(3ll), 3ll);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-3ll), 3ll);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(4.f), 4.f);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-4.f), 4.f);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(static_cast<KE::half_t>(4.f)),
                    static_cast<KE::half_t>(4.f));
-  KOKKOS_EXPECT_EQ(abs(static_cast<KE::half_t>(-4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(static_cast<KE::half_t>(-4.f)),
                    static_cast<KE::half_t>(4.f));
-  KOKKOS_EXPECT_EQ(abs(static_cast<KE::bhalf_t>(4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(static_cast<KE::bhalf_t>(4.f)),
                    static_cast<KE::bhalf_t>(4.f));
-  KOKKOS_EXPECT_EQ(abs(static_cast<KE::bhalf_t>(-4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(static_cast<KE::bhalf_t>(-4.f)),
                    static_cast<KE::bhalf_t>(4.f));
-  KOKKOS_EXPECT_EQ(abs(5.), 5.);
-  KOKKOS_EXPECT_EQ(abs(-5.), 5.);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(5.), 5.);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-5.), 5.);
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_EQ(abs(6.l), 6.l);
-  KOKKOS_EXPECT_EQ(abs(-6.l), 6.l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(6.l), 6.l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-6.l), 6.l);
 #endif
 #if !__FINITE_MATH_ONLY__
   // special values
-  KOKKOS_EXPECT_EQ(abs(-0.), 0.);
-  KOKKOS_EXPECT_INF(abs(-INFINITY));
-  KOKKOS_EXPECT_NAN(abs(-NAN));
+  KOKKOS_EXPECT_EQ(m_test_reporter, abs(-0.), 0.);
+  KOKKOS_EXPECT_INF(m_test_reporter, abs(-INFINITY));
+  KOKKOS_EXPECT_NAN(m_test_reporter, abs(-NAN));
 #endif
 
   static_assert(std::is_same_v<decltype(abs(1)), int>);
@@ -1916,34 +1899,34 @@ TEST(TEST_CATEGORY, mathematical_functions_absolute_value) {
 KOKKOS_DEVICE_TEST(TestFloatingPointAbsoluteValueFunction) {
   using Kokkos::fabs;
 
-  KOKKOS_EXPECT_EQ(fabs(1), 1);
-  KOKKOS_EXPECT_EQ(fabs(-1), 1);
-  KOKKOS_EXPECT_EQ(fabs(2l), 2l);
-  KOKKOS_EXPECT_EQ(fabs(-2l), 2l);
-  KOKKOS_EXPECT_EQ(fabs(3ll), 3ll);
-  KOKKOS_EXPECT_EQ(fabs(-3ll), 3ll);
-  KOKKOS_EXPECT_EQ(fabs(4.f), 4.f);
-  KOKKOS_EXPECT_EQ(fabs(-4.f), 4.f);
-  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::half_t>(4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(1), 1);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-1), 1);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(2l), 2l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-2l), 2l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(3ll), 3ll);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-3ll), 3ll);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(4.f), 4.f);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-4.f), 4.f);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(static_cast<KE::half_t>(4.f)),
                    static_cast<KE::half_t>(4.f));
-  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::half_t>(-4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(static_cast<KE::half_t>(-4.f)),
                    static_cast<KE::half_t>(4.f));
-  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::bhalf_t>(4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(static_cast<KE::bhalf_t>(4.f)),
                    static_cast<KE::bhalf_t>(4.f));
-  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::bhalf_t>(-4.f)),
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(static_cast<KE::bhalf_t>(-4.f)),
                    static_cast<KE::bhalf_t>(4.f));
-  KOKKOS_EXPECT_EQ(fabs(5.), 5.);
-  KOKKOS_EXPECT_EQ(fabs(-5.), 5.);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(5.), 5.);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-5.), 5.);
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_EQ(fabs(6.l), 6.l);
-  KOKKOS_EXPECT_EQ(fabs(-6.l), 6.l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(6.l), 6.l);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-6.l), 6.l);
 #endif
 #if !__FINITE_MATH_ONLY__
   // special values
-  KOKKOS_EXPECT_EQ(fabs(-0.), 0.);
-  KOKKOS_EXPECT_INF(fabs(-INFINITY));
-  KOKKOS_EXPECT_NAN(fabs(-NAN));
+  KOKKOS_EXPECT_EQ(m_test_reporter, fabs(-0.), 0.);
+  KOKKOS_EXPECT_INF(m_test_reporter, fabs(-INFINITY));
+  KOKKOS_EXPECT_NAN(m_test_reporter, fabs(-NAN));
 #endif
 
   static_assert(
@@ -1965,30 +1948,30 @@ TEST(TEST_CATEGORY, mathematical_functions_floating_point_absolute_value) {
 KOKKOS_DEVICE_TEST(TestFloatingPointRemainderFunction) {
   using Kokkos::fmod;
 
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2f, 4.f), 2.2f, 1);
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2f, 4.f), -2.2f, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(6.2f, 4.f), 2.2f, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(-6.2f, 4.f), -2.2f, 1);
 
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(2.2f), 1);
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(-2.2f), 1);
 
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(2.2f), 1);
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       fmod(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(-2.2f), 1);
 
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2, 4.), 2.2, 1);
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2, 4.), -2.2, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(6.2, 4.), 2.2, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(-6.2, 4.), -2.2, 1);
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
   // special values
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2l, 4.l), 2.2l, 1);
-  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2l, 4.l), -2.2l, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(6.2l, 4.l), 2.2l, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, fmod(-6.2l, 4.l), -2.2l, 1);
 #endif
 
 #if !__FINITE_MATH_ONLY__
@@ -1996,11 +1979,11 @@ KOKKOS_DEVICE_TEST(TestFloatingPointRemainderFunction) {
   using Kokkos::infinity;
   using Kokkos::quiet_NaN;
 
-  KOKKOS_EXPECT_NAN(fmod(-infinity<float>::value, 1.f));
-  KOKKOS_EXPECT_EQ(fmod(5.f, -infinity<float>::value), 5.f);
-  KOKKOS_EXPECT_NAN(fmod(5.f, 0.f));
-  KOKKOS_EXPECT_NAN(fmod(-quiet_NaN<float>::value, 1.f));
-  KOKKOS_EXPECT_NAN(fmod(1.f, -quiet_NaN<float>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, fmod(-infinity<float>::value, 1.f));
+  KOKKOS_EXPECT_EQ(m_test_reporter, fmod(5.f, -infinity<float>::value), 5.f);
+  KOKKOS_EXPECT_NAN(m_test_reporter, fmod(5.f, 0.f));
+  KOKKOS_EXPECT_NAN(m_test_reporter, fmod(-quiet_NaN<float>::value, 1.f));
+  KOKKOS_EXPECT_NAN(m_test_reporter, fmod(1.f, -quiet_NaN<float>::value));
 #endif
 
   static_assert(std::is_same_v<decltype(fmod(static_cast<KE::half_t>(4.f),
@@ -2024,36 +2007,36 @@ TEST(TEST_CATEGORY, mathematical_functions_remainder_function) {
 KOKKOS_DEVICE_TEST(TestIEEEFloatingPointRemainderFunction) {
   using Kokkos::remainder;
 
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2f, 4.f), -1.8f, 2);
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2f, 4.f), 1.8f, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(6.2f, 4.f), -1.8f, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(-6.2f, 4.f), 1.8f, 2);
 
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       remainder(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(-1.8f), 2);
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       remainder(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
       static_cast<KE::half_t>(1.8f), 2);
 
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       remainder(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(-1.8f), 2);
-  KOKKOS_EXPECT_NEAR_ULPS(
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, 
       remainder(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
       static_cast<KE::bhalf_t>(1.8f), 2);
 
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2, 4.), -1.8, 2);
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2, 4.), 1.8, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(6.2, 4.), -1.8, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(-6.2, 4.), 1.8, 2);
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2l, 4.l), -1.8l, 2);
-  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2l, 4.l), 1.8l, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(6.2l, 4.l), -1.8l, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(m_test_reporter, remainder(-6.2l, 4.l), 1.8l, 2);
 #endif
 #if !__FINITE_MATH_ONLY__
   // special values
   using Kokkos::infinity;
   using Kokkos::quiet_NaN;
-  KOKKOS_EXPECT_NAN(remainder(-infinity<float>::value, 2.f));
-  KOKKOS_EXPECT_NAN(remainder(-quiet_NaN<float>::value, 2.f));
+  KOKKOS_EXPECT_NAN(m_test_reporter, remainder(-infinity<float>::value, 2.f));
+  KOKKOS_EXPECT_NAN(m_test_reporter, remainder(-quiet_NaN<float>::value, 2.f));
 #endif
 
   static_assert(
@@ -2105,40 +2088,40 @@ KOKKOS_DEVICE_TEST(TestIsFinite) {
   using Kokkos::quiet_NaN;
   using Kokkos::signaling_NaN;
 
-  KOKKOS_EXPECT_TRUE(isfinite(1));
-  KOKKOS_EXPECT_TRUE(isfinite(INT_MAX));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(1));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(INT_MAX));
 
-  KOKKOS_EXPECT_TRUE(isfinite(2.f));
-  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(infinity<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(2.f));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<float>::value));
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-  KOKKOS_EXPECT_TRUE(isfinite(static_cast<KE::half_t>(2.f)));
-  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<KE::half_t>::value));
 
-  KOKKOS_EXPECT_TRUE(isfinite(static_cast<KE::bhalf_t>(2.f)));
-  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<KE::bhalf_t>::value));
 #endif
 
-  KOKKOS_EXPECT_TRUE(isfinite(3.));
-  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(infinity<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(3.));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<double>::value));
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_TRUE(isfinite(3.l));
-  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isfinite(infinity<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isfinite(3.l));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(infinity<long double>::value));
 #endif
   // special values
-  KOKKOS_EXPECT_FALSE(isfinite(INFINITY));
-  KOKKOS_EXPECT_FALSE(isfinite(NAN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(INFINITY));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isfinite(NAN));
 
   KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
   static_assert(std::is_same_v<decltype(isfinite(1)), bool>);
@@ -2173,40 +2156,40 @@ KOKKOS_DEVICE_TEST(TestIsInf) {
 
   // We are not using KOKKOS_EXPECT_INF in this tests because it depends on
   // Kokkos::isinf internally
-  KOKKOS_EXPECT_FALSE(isinf(1));
-  KOKKOS_EXPECT_FALSE(isinf(INT_MAX));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(1));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(INT_MAX));
 
-  KOKKOS_EXPECT_FALSE(isinf(2.f));
-  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<float>::value));
-  KOKKOS_EXPECT_TRUE(isinf(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(2.f));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<float>::value));
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-  KOKKOS_EXPECT_FALSE(isinf(static_cast<KE::half_t>(2.f)));
-  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(isinf(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<KE::half_t>::value));
 
-  KOKKOS_EXPECT_FALSE(isinf(static_cast<KE::bhalf_t>(2.f)));
-  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(isinf(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<KE::bhalf_t>::value));
 #endif
 
-  KOKKOS_EXPECT_FALSE(isinf(3.));
-  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<double>::value));
-  KOKKOS_EXPECT_TRUE(isinf(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(3.));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<double>::value));
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_FALSE(isinf(4.l));
-  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_TRUE(isinf(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(4.l));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(infinity<long double>::value));
 #endif
 
-  KOKKOS_EXPECT_TRUE(isinf(INFINITY));
-  KOKKOS_EXPECT_FALSE(isinf(NAN));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isinf(INFINITY));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isinf(NAN));
 
   KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
   static_assert(std::is_same_v<decltype(isinf(1)), bool>);
@@ -2239,64 +2222,64 @@ KOKKOS_DEVICE_TEST(TestFpClassify) {
   using Kokkos::quiet_NaN;
   using Kokkos::signaling_NaN;
 
-  KOKKOS_EXPECT_EQ(fpclassify(0), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(1), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(0), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1), FP_NORMAL);
 
-  KOKKOS_EXPECT_EQ(fpclassify(0.f), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(-0.f), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(1.f), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(0.f), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.f), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.f), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<float>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<float>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(infinity<float>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<float>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<float>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<float>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<float>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<float>::value), FP_SUBNORMAL);
 #endif
 
-  KOKKOS_EXPECT_EQ(fpclassify(0.), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(-0.), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(1.), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(0.), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(infinity<double>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<double>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<double>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<double>::value), FP_SUBNORMAL);
 #endif
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_EQ(fpclassify(0.l), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(-0.l), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(1.l), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(0.l), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(-0.l), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(1.l), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<long double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<long double>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(infinity<long double>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<long double>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<long double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<long double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<long double>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<long double>::value), FP_SUBNORMAL);
 #endif
 #endif
 
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(-0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(1.f)), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(-0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::half_t>(1.f)), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
   // FIXME internal compiler error for Clang+Cuda and RDC
-  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<KE::half_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<KE::half_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(infinity<KE::half_t>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<KE::half_t>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<KE::half_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::half_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::half_t>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::half_t>::value), FP_SUBNORMAL);
 #endif
 #endif
 
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(-0.f)), FP_ZERO);
-  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(1.f)), FP_NORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(-0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(static_cast<KE::bhalf_t>(1.f)), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<KE::bhalf_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<KE::bhalf_t>::value), FP_NAN);
-  KOKKOS_EXPECT_EQ(fpclassify(infinity<KE::bhalf_t>::value), FP_INFINITE);
-  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<KE::bhalf_t>::value), FP_SUBNORMAL);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(signaling_NaN<KE::bhalf_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(quiet_NaN<KE::bhalf_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(infinity<KE::bhalf_t>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(m_test_reporter, fpclassify(denorm_min<KE::bhalf_t>::value), FP_SUBNORMAL);
 #endif
 }
 
@@ -2313,40 +2296,40 @@ KOKKOS_DEVICE_TEST(TestIsNaN) {
 
   // We are not using KOKKOS_EXPECT_NAN in this tests because it depends on
   // Kokkos::isnan internally
-  KOKKOS_EXPECT_FALSE(isnan(1));
-  KOKKOS_EXPECT_FALSE(isnan(INT_MAX));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(1));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(INT_MAX));
 
-  KOKKOS_EXPECT_FALSE(isnan(2.f));
-  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<float>::value));
-  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isnan(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(2.f));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(infinity<float>::value));
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-  KOKKOS_EXPECT_FALSE(isnan(static_cast<KE::half_t>(2.f)));
-  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isnan(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(infinity<KE::half_t>::value));
 
-  KOKKOS_EXPECT_FALSE(isnan(static_cast<KE::bhalf_t>(2.f)));
-  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isnan(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(infinity<KE::bhalf_t>::value));
 #endif
 
-  KOKKOS_EXPECT_FALSE(isnan(3.));
-  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<double>::value));
-  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isnan(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(3.));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(infinity<double>::value));
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_FALSE(isnan(4.l));
-  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isnan(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(4.l));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(infinity<long double>::value));
 #endif
   // special values
-  KOKKOS_EXPECT_FALSE(isnan(INFINITY));
-  KOKKOS_EXPECT_TRUE(isnan(NAN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnan(INFINITY));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnan(NAN));
 
   KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
   static_assert(std::is_same_v<decltype(isnan(1)), bool>);
@@ -2380,87 +2363,87 @@ KOKKOS_DEVICE_TEST(TestIsNormal) {
   using Kokkos::quiet_NaN;
   using Kokkos::signaling_NaN;
 
-  KOKKOS_EXPECT_FALSE(isnormal(0));
-  KOKKOS_EXPECT_TRUE(isnormal(1));
-  KOKKOS_EXPECT_TRUE(isnormal(INT_MAX));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(0));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(1));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(INT_MAX));
 
-  KOKKOS_EXPECT_FALSE(isnormal(0.f));
-  KOKKOS_EXPECT_TRUE(isnormal(2.f));
-  KOKKOS_EXPECT_TRUE(isnormal(-3.f));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(0.f));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(2.f));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(-3.f));
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_TRUE(isnormal(norm_min<float>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(infinity<float>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<float>::value));
 #endif
-  KOKKOS_EXPECT_TRUE(isnormal(FLT_MAX));
-  KOKKOS_EXPECT_TRUE(isnormal(FLT_MIN));
-  KOKKOS_EXPECT_FALSE(isnormal(FLT_TRUE_MIN));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(FLT_MAX));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(FLT_MIN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(FLT_TRUE_MIN));
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-  KOKKOS_EXPECT_FALSE(isnormal(static_cast<KE::half_t>(0.f)));
-  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::half_t>(2.f)));
-  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::half_t>(-2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(static_cast<KE::half_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(static_cast<KE::half_t>(-2.f)));
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
   // FIXME internal compiler error for Clang+Cuda and RDC
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(infinity<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(isnormal(norm_min<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<KE::half_t>::value));
 #endif
 #endif
 
-  KOKKOS_EXPECT_FALSE(isnormal(static_cast<KE::bhalf_t>(0.f)));
-  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::bhalf_t>(2.f)));
-  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::bhalf_t>(-2.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(static_cast<KE::bhalf_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(static_cast<KE::bhalf_t>(-2.f)));
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(infinity<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(isnormal(norm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<KE::bhalf_t>::value));
 #endif
 #endif
 
-  KOKKOS_EXPECT_FALSE(isnormal(0.));
-  KOKKOS_EXPECT_TRUE(isnormal(3.));
-  KOKKOS_EXPECT_TRUE(isnormal(-3.));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(0.));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(3.));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(-3.));
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(infinity<double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<double>::value));
-  KOKKOS_EXPECT_TRUE(isnormal(norm_min<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<double>::value));
 #endif
-  KOKKOS_EXPECT_TRUE(isnormal(DBL_MAX));
-  KOKKOS_EXPECT_TRUE(isnormal(DBL_MIN));
-  KOKKOS_EXPECT_FALSE(isnormal(DBL_TRUE_MIN));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(DBL_MAX));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(DBL_MIN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(DBL_TRUE_MIN));
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_FALSE(isnormal(0.l));
-  KOKKOS_EXPECT_TRUE(isnormal(4.l));
-  KOKKOS_EXPECT_TRUE(isnormal(-4.l));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(0.l));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(4.l));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(-4.l));
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(infinity<long double>::value));
-  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<long double>::value));
-  KOKKOS_EXPECT_TRUE(isnormal(norm_min<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(denorm_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(norm_min<long double>::value));
 #endif
-  KOKKOS_EXPECT_TRUE(isnormal(LDBL_MAX));
-  KOKKOS_EXPECT_TRUE(isnormal(LDBL_MIN));
-  KOKKOS_EXPECT_FALSE(isnormal(LDBL_TRUE_MIN));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(LDBL_MAX));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, isnormal(LDBL_MIN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(LDBL_TRUE_MIN));
 #endif
 
   // special values
 #if !__FINITE_MATH_ONLY__
-  KOKKOS_EXPECT_FALSE(isnormal(INFINITY));
-  KOKKOS_EXPECT_FALSE(isnormal(NAN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(INFINITY));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, isnormal(NAN));
 #endif
 
   KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
@@ -2494,110 +2477,110 @@ KOKKOS_DEVICE_TEST(TestSignbit) {
   using Kokkos::signaling_NaN;
   using Kokkos::signbit;
 
-  KOKKOS_EXPECT_FALSE(signbit(1));
-  KOKKOS_EXPECT_FALSE(signbit(INT_MAX));
-  KOKKOS_EXPECT_TRUE(signbit(-2));
-  KOKKOS_EXPECT_TRUE(signbit(INT_MIN));
-  KOKKOS_EXPECT_FALSE(signbit(0));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(1));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(INT_MAX));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-2));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(INT_MIN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(0));
 
-  KOKKOS_EXPECT_FALSE(signbit(3.f));
-  KOKKOS_EXPECT_FALSE(signbit(finite_max<float>::value));
-  KOKKOS_EXPECT_FALSE(signbit(infinity<float>::value));
-  KOKKOS_EXPECT_FALSE(signbit(denorm_min<float>::value));
-  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<float>::value));
-  KOKKOS_EXPECT_FALSE(signbit(0.f));
-  KOKKOS_EXPECT_TRUE(signbit(-0.4f));
-  KOKKOS_EXPECT_TRUE(signbit(finite_min<float>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-infinity<float>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<float>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<float>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<float>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-0.f));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(3.f));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(finite_max<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(0.f));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-0.4f));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-infinity<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-denorm_min<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-quiet_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-signaling_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-0.f));
 
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-  KOKKOS_EXPECT_FALSE(signbit(static_cast<KE::half_t>(0.f)));
-  KOKKOS_EXPECT_TRUE(signbit(static_cast<KE::half_t>(-0.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(static_cast<KE::half_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(static_cast<KE::half_t>(-0.f)));
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
   // FIXME internal compiler error for Clang+Cuda and RDC
-  KOKKOS_EXPECT_FALSE(signbit(finite_max<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(infinity<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(denorm_min<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(signbit(finite_min<KE::half_t>::value));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(finite_max<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::half_t>(infinity<KE::half_t>::value)));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::half_t>(denorm_min<KE::half_t>::value)));
   // https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/mathematical-functions.html#cuda-and-ieee-754-compliance:
   // "[...] result in the sign of a NaN being updated in an
   // implementation-defined manner."
 #ifndef KOKKOS_ENABLE_CUDA
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::half_t>(quiet_NaN<KE::half_t>::value)));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::half_t>(signaling_NaN<KE::half_t>::value)));
 #endif
 #endif
 
-  KOKKOS_EXPECT_FALSE(signbit(static_cast<KE::bhalf_t>(0.f)));
-  KOKKOS_EXPECT_FALSE(signbit(finite_max<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(infinity<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(denorm_min<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(signbit(static_cast<KE::bhalf_t>(-0.f)));
-  KOKKOS_EXPECT_TRUE(signbit(finite_min<KE::bhalf_t>::value));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(static_cast<KE::bhalf_t>(0.f)));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(finite_max<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(static_cast<KE::bhalf_t>(-0.f)));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::bhalf_t>(infinity<KE::bhalf_t>::value)));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::bhalf_t>(denorm_min<KE::bhalf_t>::value)));
 // the bhalf test also fails for SYCL+Cuda
 #ifndef KOKKOS_IMPL_ARCH_NVIDIA_GPU
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::bhalf_t>(quiet_NaN<KE::bhalf_t>::value)));
-  KOKKOS_EXPECT_TRUE(
+  KOKKOS_EXPECT_TRUE(m_test_reporter, 
       signbit(-static_cast<KE::bhalf_t>(signaling_NaN<KE::bhalf_t>::value)));
 #endif
 #endif
 
-  KOKKOS_EXPECT_FALSE(signbit(.5));
-  KOKKOS_EXPECT_FALSE(signbit(finite_max<double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(infinity<double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(denorm_min<double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(0.));
-  KOKKOS_EXPECT_TRUE(signbit(-6.));
-  KOKKOS_EXPECT_TRUE(signbit(finite_min<double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-infinity<double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(.5));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(finite_max<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(0.));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-6.));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-infinity<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-denorm_min<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-quiet_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-signaling_NaN<double>::value));
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-  KOKKOS_EXPECT_FALSE(signbit(7.l));
-  KOKKOS_EXPECT_FALSE(signbit(finite_max<long double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(infinity<long double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(denorm_min<long double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_FALSE(signbit(0.l));
-  KOKKOS_EXPECT_TRUE(signbit(-.8l));
-  KOKKOS_EXPECT_TRUE(signbit(finite_min<long double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-infinity<long double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<long double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<long double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<long double>::value));
-  KOKKOS_EXPECT_TRUE(signbit(-0.l));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(7.l));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(finite_max<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(denorm_min<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(0.l));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-.8l));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(finite_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-infinity<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-denorm_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(m_test_reporter, signbit(-0.l));
 #endif
 
   // special values
-  KOKKOS_EXPECT_FALSE(signbit(INFINITY));
-  KOKKOS_EXPECT_FALSE(signbit(NAN));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(INFINITY));
+  KOKKOS_EXPECT_FALSE(m_test_reporter, signbit(NAN));
 
   KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
   static_assert(std::is_same_v<decltype(signbit(1)), bool>);
@@ -2733,62 +2716,62 @@ KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {
   const FP16Type neg_inf = -static_cast<FP16Type>(infinity<FP16Type>::value);
 
   // NaN Handling
-  KOKKOS_EXPECT_NAN(nextafter(quiet_NaN<FP16Type>::value, pos_one));
-  KOKKOS_EXPECT_NAN(nextafter(signaling_NaN<FP16Type>::value, pos_one));
-  KOKKOS_EXPECT_NAN(nextafter(pos_one, quiet_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(nextafter(pos_one, signaling_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(quiet_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(signaling_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(pos_one, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(pos_one, signaling_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(m_test_reporter, 
       nextafter(quiet_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(
+  KOKKOS_EXPECT_NAN(m_test_reporter, 
       nextafter(quiet_NaN<FP16Type>::value, signaling_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(
+  KOKKOS_EXPECT_NAN(m_test_reporter, 
       nextafter(signaling_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
-  KOKKOS_EXPECT_NAN(nextafter(signaling_NaN<FP16Type>::value,
+  KOKKOS_EXPECT_NAN(m_test_reporter, nextafter(signaling_NaN<FP16Type>::value,
                               signaling_NaN<FP16Type>::value));
 
   // Equality (from==toward) Handling
-  KOKKOS_EXPECT_EQ(nextafter(pos_one, pos_one), pos_one);
-  KOKKOS_EXPECT_EQ(nextafter(pos_zero, pos_zero), pos_zero);
-  KOKKOS_EXPECT_EQ(nextafter(neg_zero, neg_zero), neg_zero);
-  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_inf), pos_inf);
-  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_inf), neg_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, pos_one), pos_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_zero, pos_zero), pos_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_zero, neg_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_inf, pos_inf), pos_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_inf, neg_inf), neg_inf);
 
   // Zero Handling
-  KOKKOS_EXPECT_EQ(nextafter(pos_zero, pos_one), pos_smallest);
-  KOKKOS_EXPECT_EQ(nextafter(pos_zero, neg_one), neg_smallest);
-  KOKKOS_EXPECT_EQ(nextafter(pos_zero, neg_zero), neg_zero);
-  KOKKOS_EXPECT_EQ(nextafter(neg_zero, pos_one), pos_smallest);
-  KOKKOS_EXPECT_EQ(nextafter(neg_zero, neg_one), neg_smallest);
-  KOKKOS_EXPECT_EQ(nextafter(neg_zero, pos_zero), pos_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_zero, pos_one), pos_smallest);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_zero, neg_one), neg_smallest);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_zero, neg_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_zero, pos_one), pos_smallest);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_zero, neg_one), neg_smallest);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_zero, pos_zero), pos_zero);
 
   // From Negative Non Zero Handling
   const FP16Type after_neg_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
   const FP16Type before_neg_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
-  KOKKOS_EXPECT_EQ(nextafter(neg_smallest, pos_zero), neg_zero);
-  KOKKOS_EXPECT_EQ(nextafter(neg_one, pos_one), after_neg_one);
-  KOKKOS_EXPECT_EQ(nextafter(neg_one, neg_two), before_neg_one);
-  KOKKOS_EXPECT_EQ(nextafter(neg_max, neg_inf), neg_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_smallest, pos_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_one, pos_one), after_neg_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_one, neg_two), before_neg_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_max, neg_inf), neg_inf);
 
   // From Positive Non Zero Handling
   const FP16Type after_pos_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
   const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
       std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
-  KOKKOS_EXPECT_EQ(nextafter(pos_smallest, neg_zero), pos_zero);
-  KOKKOS_EXPECT_EQ(nextafter(pos_one, neg_one), before_pos_one);
-  KOKKOS_EXPECT_EQ(nextafter(pos_one, pos_two), after_pos_one);
-  KOKKOS_EXPECT_EQ(nextafter(pos_max, pos_inf), pos_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_smallest, neg_zero), pos_zero);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, neg_one), before_pos_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_one, pos_two), after_pos_one);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_max, pos_inf), pos_inf);
 
   // From Inf Handling
   // Note: The behavior of nextafter with infinities is
   // implementation-defined, but in Kokkos it returns the maximum
   // finite value when moving towards a finite value.
-  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_one), pos_max);
-  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_one), neg_max);
-  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_inf), pos_inf);
-  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_inf), neg_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_inf, pos_one), pos_max);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_inf, neg_one), neg_max);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(pos_inf, pos_inf), pos_inf);
+  KOKKOS_EXPECT_EQ(m_test_reporter, nextafter(neg_inf, neg_inf), neg_inf);
 }
 
 TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -685,7 +685,7 @@ DEFINE_TYPE_NAME(long double)
 
 template <class Space, class Func, class Arg, std::size_t N,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathUnaryFunction : KokkosTest::FloatingPointComparison {
+struct TestMathUnaryFunction {
   Arg val_[N];
   Ret res_[N];
   TestMathUnaryFunction(const Arg (&val)[N]) {
@@ -702,7 +702,8 @@ struct TestMathUnaryFunction : KokkosTest::FloatingPointComparison {
                          << type_helper<Arg>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int i, int& e) const {
-    bool ar = compare(Func::eval(val_[i]), res_[i], Func::ulp_factor());
+    bool ar = KokkosTest::FloatingPointComparison::compare(
+        Func::eval(val_[i]), res_[i], Func::ulp_factor());
     if (!ar) {
       ++e;
       Kokkos::printf("value at %f which is %f was expected to be %f\n",
@@ -747,7 +748,7 @@ void do_test_half_math_unary_function(const Arg (&x)[N]) {
   do_test_half_math_unary_function<T, TEST_EXECSPACE, MathUnaryFunction_##FUNC>
 
 template <class Space, class Func, class Arg, std::size_t N>
-struct TestIntMathUnaryFunction : KokkosTest::IntegerComparison {
+struct TestIntMathUnaryFunction {
   Arg val_[N];
   int res_[N];
   TestIntMathUnaryFunction(const Arg (&val)[N]) {
@@ -764,7 +765,8 @@ struct TestIntMathUnaryFunction : KokkosTest::IntegerComparison {
                          << type_helper<Arg>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int i, int& e) const {
-    bool ar = compare(Func::eval(val_[i]), res_[i]);
+    bool ar =
+        KokkosTest::IntegerComparison::compare(Func::eval(val_[i]), res_[i]);
     if (!ar) {
       ++e;
       Kokkos::printf("value at %f which is %f was expected to be %f\n",
@@ -811,7 +813,7 @@ void do_test_int_half_math_unary_function(const Arg (&x)[N]) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
-struct TestMathBinaryFunction : KokkosTest::FloatingPointComparison {
+struct TestMathBinaryFunction {
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
@@ -828,7 +830,8 @@ struct TestMathBinaryFunction : KokkosTest::FloatingPointComparison {
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = compare(Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    bool ar = KokkosTest::FloatingPointComparison::compare(
+        Func::eval(val1_, val2_), res_, Func::ulp_factor());
     if (!ar) {
       ++e;
       Kokkos::printf("value at %f, %f which is %f was expected to be %f\n",
@@ -846,7 +849,7 @@ void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_unary_function_return_type_t<Arg1>>
-struct TestMathBinaryIntFunction : KokkosTest::FloatingPointComparison {
+struct TestMathBinaryIntFunction {
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
@@ -863,7 +866,8 @@ struct TestMathBinaryIntFunction : KokkosTest::FloatingPointComparison {
                          << type_helper<Arg2>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = compare(Func::eval(val1_, val2_), res_, Func::ulp_factor());
+    bool ar = KokkosTest::FloatingPointComparison::compare(
+        Func::eval(val1_, val2_), res_, Func::ulp_factor());
     if (!ar) {
       ++e;
       Kokkos::printf("value at %f, %f which is %f was expected to be %f\n",
@@ -881,7 +885,7 @@ void do_test_math_binary_int_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathBinaryPtrFunction : KokkosTest::FloatingPointComparison {
+struct TestMathBinaryPtrFunction {
   Arg val_;
   Ret res_frac_;
   Ret res_int_;
@@ -900,8 +904,10 @@ struct TestMathBinaryPtrFunction : KokkosTest::FloatingPointComparison {
   KOKKOS_FUNCTION void operator()(int, int& e) const {
     Ret iptr;
     Ret frac     = Func::eval(val_, &iptr);
-    bool ar_frac = compare(frac, res_frac_, Func::ulp_factor());
-    bool ar_int  = compare(iptr, res_int_, Func::ulp_factor());
+    bool ar_frac = KokkosTest::FloatingPointComparison::compare(
+        frac, res_frac_, Func::ulp_factor());
+    bool ar_int = KokkosTest::FloatingPointComparison::compare(
+        iptr, res_int_, Func::ulp_factor());
     if (!ar_frac || !ar_int) {
       ++e;
       Kokkos::printf("%s failed: Val %f -> Frac %f (exp %f), Int %f (exp %f)\n",
@@ -960,7 +966,7 @@ void do_test_math_binary_predicate(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
-struct TestMathBinaryIntPtrFunction : KokkosTest::FloatingPointComparison {
+struct TestMathBinaryIntPtrFunction {
   Arg val_;
   int res1_;
   Ret res2_;
@@ -979,7 +985,8 @@ struct TestMathBinaryIntPtrFunction : KokkosTest::FloatingPointComparison {
     int res1;
     Ret res2 = Func::eval(val_, &res1);
     bool ar1 = (res1 == res1_);
-    bool ar2 = compare(res2, res2_, Func::ulp_factor());
+    bool ar2 = KokkosTest::FloatingPointComparison::compare(res2, res2_,
+                                                            Func::ulp_factor());
     if (!(ar1 && ar2)) {
       ++e;
       Kokkos::printf(
@@ -1004,7 +1011,7 @@ void do_test_math_binary_int_ptr_function(Arg x) {
 
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
-struct TestMathTernaryIntPtrFunction : KokkosTest::FloatingPointComparison {
+struct TestMathTernaryIntPtrFunction {
   Arg1 val1_;
   Arg2 val2_;
   int val_;
@@ -1024,7 +1031,8 @@ struct TestMathTernaryIntPtrFunction : KokkosTest::FloatingPointComparison {
   KOKKOS_FUNCTION void operator()(int, int& e) const {
     int val;
     auto res  = Func::eval(val1_, val2_, &val);
-    bool ar_1 = compare(res, res_, Func::ulp_factor());
+    bool ar_1 = KokkosTest::FloatingPointComparison::compare(
+        res, res_, Func::ulp_factor());
     bool ar_2 = (val_ == val);
     if (!(ar_1 && ar_2)) {
       ++e;
@@ -1044,7 +1052,7 @@ void do_test_math_ternary_int_ptr_function(Arg1 arg1, Arg2 arg2) {
 
 template <class Space, class Func, class Arg1, class Arg2, class Arg3,
           class Ret = math_ternary_function_return_type_t<Arg1, Arg2, Arg3>>
-struct TestMathTernaryFunction : KokkosTest::FloatingPointComparison {
+struct TestMathTernaryFunction {
   Arg1 val1_;
   Arg2 val2_;
   Arg3 val3_;
@@ -1066,8 +1074,8 @@ struct TestMathTernaryFunction : KokkosTest::FloatingPointComparison {
                          << type_helper<Arg3>::name() << ")";
   }
   KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar =
-        compare(Func::eval(val1_, val2_, val3_), res_, Func::ulp_factor());
+    bool ar = KokkosTest::FloatingPointComparison::compare(
+        Func::eval(val1_, val2_, val3_), res_, Func::ulp_factor());
     if (!ar) {
       ++e;
       Kokkos::printf("value at %f, %f, %f which is %f was expected to be %f\n",
@@ -1872,296 +1880,219 @@ TEST(TEST_CATEGORY,
 #endif
 }
 
-template <class Space>
-struct TestAbsoluteValueFunction {
-  TestAbsoluteValueFunction() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::abs;
-    if (abs(1) != 1 || abs(-1) != 1) {
-      ++e;
-      Kokkos::printf("failed abs(int)\n");
-    }
-    if (abs(2l) != 2l || abs(-2l) != 2l) {
-      ++e;
-      Kokkos::printf("failed abs(long int)\n");
-    }
-    if (abs(3ll) != 3ll || abs(-3ll) != 3ll) {
-      ++e;
-      Kokkos::printf("failed abs(long long int)\n");
-    }
-    if (abs(4.f) != 4.f || abs(-4.f) != 4.f) {
-      ++e;
-      Kokkos::printf("failed abs(float)\n");
-    }
-    if (abs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
-        abs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
-      ++e;
-      Kokkos::printf("failed abs(KE::half_t)\n");
-    }
-    if (abs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
-        abs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
-      ++e;
-      Kokkos::printf("failed abs(KE::bhalf_t)\n");
-    }
-    if (abs(5.) != 5. || abs(-5.) != 5.) {
-      ++e;
-      Kokkos::printf("failed abs(double)\n");
-    }
+KOKKOS_DEVICE_TEST(TestAbsoluteValueFunction) {
+  using Kokkos::abs;
+  KOKKOS_EXPECT_EQ(abs(1), 1);
+  KOKKOS_EXPECT_EQ(abs(-1), 1);
+  KOKKOS_EXPECT_EQ(abs(2l), 2l);
+  KOKKOS_EXPECT_EQ(abs(-2l), 2l);
+  KOKKOS_EXPECT_EQ(abs(3ll), 3ll);
+  KOKKOS_EXPECT_EQ(abs(-3ll), 3ll);
+  KOKKOS_EXPECT_EQ(abs(4.f), 4.f);
+  KOKKOS_EXPECT_EQ(abs(-4.f), 4.f);
+  KOKKOS_EXPECT_EQ(abs(static_cast<KE::half_t>(4.f)),
+                   static_cast<KE::half_t>(4.f));
+  KOKKOS_EXPECT_EQ(abs(static_cast<KE::half_t>(-4.f)),
+                   static_cast<KE::half_t>(4.f));
+  KOKKOS_EXPECT_EQ(abs(static_cast<KE::bhalf_t>(4.f)),
+                   static_cast<KE::bhalf_t>(4.f));
+  KOKKOS_EXPECT_EQ(abs(static_cast<KE::bhalf_t>(-4.f)),
+                   static_cast<KE::bhalf_t>(4.f));
+  KOKKOS_EXPECT_EQ(abs(5.), 5.);
+  KOKKOS_EXPECT_EQ(abs(-5.), 5.);
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (abs(6.l) != 6.l || abs(-6.l) != 6.l) {
-      ++e;
-      Kokkos::printf("failed abs(long double)\n");
-    }
+  KOKKOS_EXPECT_EQ(abs(6.l), 6.l);
+  KOKKOS_EXPECT_EQ(abs(-6.l), 6.l);
 #endif
 #if !__FINITE_MATH_ONLY__
-    // special values
-    using Kokkos::isinf;
-    using Kokkos::isnan;
-    if (abs(-0.) != 0. || !isinf(abs(-INFINITY)) || !isnan(abs(-NAN))) {
-      ++e;
-      Kokkos::printf("failed abs(floating_point) special values\n");
-    }
+  // special values
+  KOKKOS_EXPECT_EQ(abs(-0.), 0.);
+  KOKKOS_EXPECT_INF(abs(-INFINITY));
+  KOKKOS_EXPECT_NAN(abs(-NAN));
 #endif
 
-    static_assert(std::is_same_v<decltype(abs(1)), int>);
-    static_assert(std::is_same_v<decltype(abs(2l)), long>);
-    static_assert(std::is_same_v<decltype(abs(3ll)), long long>);
-    static_assert(std::is_same_v<decltype(abs(static_cast<KE::half_t>(4.f))),
-                                 KE::half_t>);
-    static_assert(std::is_same_v<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
-                                 KE::bhalf_t>);
-    static_assert(std::is_same_v<decltype(abs(4.f)), float>);
-    static_assert(std::is_same_v<decltype(abs(5.)), double>);
+  static_assert(std::is_same_v<decltype(abs(1)), int>);
+  static_assert(std::is_same_v<decltype(abs(2l)), long>);
+  static_assert(std::is_same_v<decltype(abs(3ll)), long long>);
+  static_assert(
+      std::is_same_v<decltype(abs(static_cast<KE::half_t>(4.f))), KE::half_t>);
+  static_assert(std::is_same_v<decltype(abs(static_cast<KE::bhalf_t>(4.f))),
+                               KE::bhalf_t>);
+  static_assert(std::is_same_v<decltype(abs(4.f)), float>);
+  static_assert(std::is_same_v<decltype(abs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(abs(6.l)), long double>);
+  static_assert(std::is_same_v<decltype(abs(6.l)), long double>);
 #endif
-  }
-};
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_absolute_value) {
-  TestAbsoluteValueFunction<TEST_EXECSPACE>();
+  TestAbsoluteValueFunction<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestFloatingPointAbsoluteValueFunction {
-  TestFloatingPointAbsoluteValueFunction() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::fabs;
-    if (fabs(4.f) != 4.f || fabs(-4.f) != 4.f) {
-      ++e;
-      Kokkos::printf("failed fabs(float)\n");
-    }
-    if (fabs(static_cast<KE::half_t>(4.f)) != static_cast<KE::half_t>(4.f) ||
-        fabs(static_cast<KE::half_t>(-4.f)) != static_cast<KE::half_t>(4.f)) {
-      ++e;
-      Kokkos::printf("failed fabs(KE::half_t)\n");
-    }
-    if (fabs(static_cast<KE::bhalf_t>(4.f)) != static_cast<KE::bhalf_t>(4.f) ||
-        fabs(static_cast<KE::bhalf_t>(-4.f)) != static_cast<KE::bhalf_t>(4.f)) {
-      ++e;
-      Kokkos::printf("failed fabs(KE::bhalf_t)\n");
-    }
-    if (fabs(5.) != 5. || fabs(-5.) != 5.) {
-      ++e;
-      Kokkos::printf("failed fabs(double)\n");
-    }
+KOKKOS_DEVICE_TEST(TestFloatingPointAbsoluteValueFunction) {
+  using Kokkos::fabs;
+
+  KOKKOS_EXPECT_EQ(fabs(1), 1);
+  KOKKOS_EXPECT_EQ(fabs(-1), 1);
+  KOKKOS_EXPECT_EQ(fabs(2l), 2l);
+  KOKKOS_EXPECT_EQ(fabs(-2l), 2l);
+  KOKKOS_EXPECT_EQ(fabs(3ll), 3ll);
+  KOKKOS_EXPECT_EQ(fabs(-3ll), 3ll);
+  KOKKOS_EXPECT_EQ(fabs(4.f), 4.f);
+  KOKKOS_EXPECT_EQ(fabs(-4.f), 4.f);
+  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::half_t>(4.f)),
+                   static_cast<KE::half_t>(4.f));
+  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::half_t>(-4.f)),
+                   static_cast<KE::half_t>(4.f));
+  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::bhalf_t>(4.f)),
+                   static_cast<KE::bhalf_t>(4.f));
+  KOKKOS_EXPECT_EQ(fabs(static_cast<KE::bhalf_t>(-4.f)),
+                   static_cast<KE::bhalf_t>(4.f));
+  KOKKOS_EXPECT_EQ(fabs(5.), 5.);
+  KOKKOS_EXPECT_EQ(fabs(-5.), 5.);
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (fabs(6.l) != 6.l || fabs(-6.l) != 6.l) {
-      ++e;
-      Kokkos::printf("failed fabs(long double)\n");
-    }
+  KOKKOS_EXPECT_EQ(fabs(6.l), 6.l);
+  KOKKOS_EXPECT_EQ(fabs(-6.l), 6.l);
 #endif
 #if !__FINITE_MATH_ONLY__
-    // special values
-    using Kokkos::isinf;
-    using Kokkos::isnan;
-    if (fabs(-0.) != 0. || !isinf(fabs(-INFINITY)) || !isnan(fabs(-NAN))) {
-      ++e;
-      Kokkos::printf("failed fabs(floating_point) special values\n");
-    }
+  // special values
+  KOKKOS_EXPECT_EQ(fabs(-0.), 0.);
+  KOKKOS_EXPECT_INF(fabs(-INFINITY));
+  KOKKOS_EXPECT_NAN(fabs(-NAN));
 #endif
 
-    static_assert(std::is_same_v<decltype(fabs(static_cast<KE::half_t>(4.f))),
-                                 KE::half_t>);
-    static_assert(std::is_same_v<decltype(fabs(static_cast<KE::bhalf_t>(4.f))),
-                                 KE::bhalf_t>);
-    static_assert(std::is_same_v<decltype(fabs(4.f)), float>);
-    static_assert(std::is_same_v<decltype(fabs(5.)), double>);
+  static_assert(
+      std::is_same_v<decltype(fabs(static_cast<KE::half_t>(4.f))), KE::half_t>);
+  static_assert(std::is_same_v<decltype(fabs(static_cast<KE::bhalf_t>(4.f))),
+                               KE::bhalf_t>);
+  static_assert(std::is_same_v<decltype(fabs(4.f)), float>);
+  static_assert(std::is_same_v<decltype(fabs(5.)), double>);
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(fabs(6.l)), long double>);
+  static_assert(std::is_same_v<decltype(fabs(6.l)), long double>);
 #endif
-  }
-};
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_floating_point_absolute_value) {
-  TestFloatingPointAbsoluteValueFunction<TEST_EXECSPACE>();
+  TestFloatingPointAbsoluteValueFunction<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestFloatingPointRemainderFunction
-    : KokkosTest::FloatingPointComparison {
-  TestFloatingPointRemainderFunction() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::fmod;
-    if (!compare(fmod(6.2f, 4.f), 2.2f, 1) ||
-        !compare(fmod(-6.2f, 4.f), -2.2f, 1)) {
-      ++e;
-      Kokkos::printf("failed fmod(float)\n");
-    }
-    if (!compare(
-            fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
-            static_cast<KE::half_t>(2.2f), 1) ||
-        !compare(
-            fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
-            -static_cast<KE::half_t>(2.2f), 1)) {
-      ++e;
-      Kokkos::printf("failed fmod(KE::half_t)\n");
-    }
-    if (!compare(
-            fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
-            static_cast<KE::bhalf_t>(2.2f), 1) ||
-        !compare(fmod(static_cast<KE::bhalf_t>(-6.2f),
-                      static_cast<KE::bhalf_t>(4.f)),
-                 -static_cast<KE::bhalf_t>(2.2f), 1)) {
-      ++e;
-      Kokkos::printf("failed fmod(KE::bhalf_t)\n");
-    }
-    if (!compare(fmod(6.2, 4.), 2.2, 1) || !compare(fmod(-6.2, 4.), -2.2, 1)) {
-      ++e;
-      Kokkos::printf("failed fmod(double)\n");
-    }
+KOKKOS_DEVICE_TEST(TestFloatingPointRemainderFunction) {
+  using Kokkos::fmod;
+
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2f, 4.f), 2.2f, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2f, 4.f), -2.2f, 1);
+
+  KOKKOS_EXPECT_NEAR_ULPS(
+      fmod(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
+      static_cast<KE::half_t>(2.2f), 1);
+  KOKKOS_EXPECT_NEAR_ULPS(
+      fmod(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
+      static_cast<KE::half_t>(-2.2f), 1);
+
+  KOKKOS_EXPECT_NEAR_ULPS(
+      fmod(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
+      static_cast<KE::bhalf_t>(2.2f), 1);
+  KOKKOS_EXPECT_NEAR_ULPS(
+      fmod(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
+      static_cast<KE::bhalf_t>(-2.2f), 1);
+
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2, 4.), 2.2, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2, 4.), -2.2, 1);
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (!compare(fmod(6.2l, 4.l), 2.2l, 1) ||
-        !compare(fmod(-6.2l, 4.l), -2.2l, 1)) {
-      ++e;
-      Kokkos::printf("failed fmod(long double)\n");
-    }
-#endif
-#if !__FINITE_MATH_ONLY__
-    // special values
-    using Kokkos::infinity;
-    using Kokkos::isinf;
-    using Kokkos::isnan;
-    using Kokkos::quiet_NaN;
-    if (!isnan(fmod(-infinity<float>::value, 1.f)) ||
-        !(fmod(5.f, -infinity<float>::value) == 5.f) ||
-        !isnan(fmod(5.f, 0.f)) || !isnan(fmod(-quiet_NaN<float>::value, 1.f)) ||
-        !isnan(fmod(1.f, -quiet_NaN<float>::value))) {
-      ++e;
-      Kokkos::printf("failed fmod(floating_point) special values\n");
-    }
+  // special values
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(6.2l, 4.l), 2.2l, 1);
+  KOKKOS_EXPECT_NEAR_ULPS(fmod(-6.2l, 4.l), -2.2l, 1);
 #endif
 
-    static_assert(std::is_same_v<decltype(fmod(static_cast<KE::half_t>(4.f),
-                                               static_cast<KE::half_t>(4.f))),
-                                 KE::half_t>);
-    static_assert(std::is_same_v<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
-                                               static_cast<KE::bhalf_t>(4.f))),
-                                 KE::bhalf_t>);
-    static_assert(std::is_same_v<decltype(fmod(4.f, 4.f)), float>);
-    static_assert(std::is_same_v<decltype(fmod(5., 5.)), double>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(fmod(6.l, 6.l)), long double>);
+#if !__FINITE_MATH_ONLY__
+  // special values
+  using Kokkos::infinity;
+  using Kokkos::quiet_NaN;
+
+  KOKKOS_EXPECT_NAN(fmod(-infinity<float>::value, 1.f));
+  KOKKOS_EXPECT_EQ(fmod(5.f, -infinity<float>::value), 5.f);
+  KOKKOS_EXPECT_NAN(fmod(5.f, 0.f));
+  KOKKOS_EXPECT_NAN(fmod(-quiet_NaN<float>::value, 1.f));
+  KOKKOS_EXPECT_NAN(fmod(1.f, -quiet_NaN<float>::value));
 #endif
-  }
-};
+
+  static_assert(std::is_same_v<decltype(fmod(static_cast<KE::half_t>(4.f),
+                                             static_cast<KE::half_t>(4.f))),
+                               KE::half_t>);
+  static_assert(std::is_same_v<decltype(fmod(static_cast<KE::bhalf_t>(4.f),
+                                             static_cast<KE::bhalf_t>(4.f))),
+                               KE::bhalf_t>);
+  static_assert(std::is_same_v<decltype(fmod(4.f, 4.f)), float>);
+  static_assert(std::is_same_v<decltype(fmod(5., 5.)), double>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(fmod(6.l, 6.l)), long double>);
+#endif
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_remainder_function) {
-  TestFloatingPointRemainderFunction<TEST_EXECSPACE>();
+  TestFloatingPointRemainderFunction<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestIEEEFloatingPointRemainderFunction
-    : KokkosTest::FloatingPointComparison {
-  TestIEEEFloatingPointRemainderFunction() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::remainder;
-    if (!compare(remainder(6.2f, 4.f), -1.8f, 2) ||
-        !compare(remainder(-6.2f, 4.f), 1.8f, 2)) {
-      ++e;
-      Kokkos::printf("failed remainder(float)\n");
-    }
-    if (!compare(remainder(static_cast<KE::half_t>(6.2f),
-                           static_cast<KE::half_t>(4.f)),
-                 static_cast<KE::half_t>(-1.8f), 2) ||
-        !compare(remainder(static_cast<KE::half_t>(-6.2f),
-                           static_cast<KE::half_t>(4.f)),
-                 static_cast<KE::half_t>(1.8f), 2)) {
-      ++e;
-      Kokkos::printf("failed remainder(KE::half_t)\n");
-    }
-    if (!compare(remainder(static_cast<KE::bhalf_t>(6.2f),
-                           static_cast<KE::bhalf_t>(4.f)),
-                 static_cast<KE::bhalf_t>(-1.8f), 2) ||
-        !compare(remainder(static_cast<KE::bhalf_t>(-6.2f),
-                           static_cast<KE::bhalf_t>(4.f)),
-                 static_cast<KE::bhalf_t>(1.8f), 2)) {
-      ++e;
-      Kokkos::printf("failed remainder(KE::bhalf_t)\n");
-    }
-    if (!compare(remainder(6.2, 4.), -1.8, 2) ||
-        !compare(remainder(-6.2, 4.), 1.8, 2)) {
-      ++e;
-      Kokkos::printf("failed remainder(double)\n");
-    }
+KOKKOS_DEVICE_TEST(TestIEEEFloatingPointRemainderFunction) {
+  using Kokkos::remainder;
+
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2f, 4.f), -1.8f, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2f, 4.f), 1.8f, 2);
+
+  KOKKOS_EXPECT_NEAR_ULPS(
+      remainder(static_cast<KE::half_t>(6.2f), static_cast<KE::half_t>(4.f)),
+      static_cast<KE::half_t>(-1.8f), 2);
+  KOKKOS_EXPECT_NEAR_ULPS(
+      remainder(static_cast<KE::half_t>(-6.2f), static_cast<KE::half_t>(4.f)),
+      static_cast<KE::half_t>(1.8f), 2);
+
+  KOKKOS_EXPECT_NEAR_ULPS(
+      remainder(static_cast<KE::bhalf_t>(6.2f), static_cast<KE::bhalf_t>(4.f)),
+      static_cast<KE::bhalf_t>(-1.8f), 2);
+  KOKKOS_EXPECT_NEAR_ULPS(
+      remainder(static_cast<KE::bhalf_t>(-6.2f), static_cast<KE::bhalf_t>(4.f)),
+      static_cast<KE::bhalf_t>(1.8f), 2);
+
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2, 4.), -1.8, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2, 4.), 1.8, 2);
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (!compare(remainder(6.2l, 4.l), -1.8l, 2) ||
-        !compare(remainder(-6.2l, 4.l), 1.8l, 2)) {
-      ++e;
-      Kokkos::printf("failed remainder(long double)\n");
-    }
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(6.2l, 4.l), -1.8l, 2);
+  KOKKOS_EXPECT_NEAR_ULPS(remainder(-6.2l, 4.l), 1.8l, 2);
 #endif
 #if !__FINITE_MATH_ONLY__
-    // special values
-    using Kokkos::infinity;
-    using Kokkos::isinf;
-    using Kokkos::isnan;
-    using Kokkos::quiet_NaN;
-    if (!isnan(remainder(-infinity<float>::value, 2.f)) ||
-        !isnan(remainder(-quiet_NaN<float>::value, 2.f))) {
-      ++e;
-      Kokkos::printf("failed remainder(floating_point) special values\n");
-    }
+  // special values
+  using Kokkos::infinity;
+  using Kokkos::quiet_NaN;
+  KOKKOS_EXPECT_NAN(remainder(-infinity<float>::value, 2.f));
+  KOKKOS_EXPECT_NAN(remainder(-quiet_NaN<float>::value, 2.f));
 #endif
 
-    static_assert(
-        std::is_same_v<decltype(remainder(static_cast<KE::half_t>(4.f),
-                                          static_cast<KE::half_t>(4.f))),
-                       KE::half_t>);
-    static_assert(
-        std::is_same_v<decltype(remainder(static_cast<KE::bhalf_t>(4.f),
-                                          static_cast<KE::bhalf_t>(4.f))),
-                       KE::bhalf_t>);
-    static_assert(std::is_same_v<decltype(remainder(4.f, 4.f)), float>);
-    static_assert(std::is_same_v<decltype(remainder(5., 5.)), double>);
+  static_assert(
+      std::is_same_v<decltype(remainder(static_cast<KE::half_t>(4.f),
+                                        static_cast<KE::half_t>(4.f))),
+                     KE::half_t>);
+  static_assert(
+      std::is_same_v<decltype(remainder(static_cast<KE::bhalf_t>(4.f),
+                                        static_cast<KE::bhalf_t>(4.f))),
+                     KE::bhalf_t>);
+  static_assert(std::is_same_v<decltype(remainder(4.f, 4.f)), float>);
+  static_assert(std::is_same_v<decltype(remainder(5., 5.)), double>);
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(remainder(6.l, 6.l)), long double>);
+  static_assert(std::is_same_v<decltype(remainder(6.l, 6.l)), long double>);
 #endif
-  }
-};
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_ieee_remainder_function) {
-  TestIEEEFloatingPointRemainderFunction<TEST_EXECSPACE>();
+  TestIEEEFloatingPointRemainderFunction<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
 // TODO: TestFpClassify, see https://github.com/kokkos/kokkos/issues/6279
@@ -2186,611 +2117,528 @@ TEST(TEST_CATEGORY, mathematical_functions_ieee_remainder_function) {
 #define KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
 #endif
 
-template <class Space>
-struct TestIsFinite {
-  TestIsFinite() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::infinity;
-    using Kokkos::isfinite;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
-    if (!isfinite(1) || !isfinite(INT_MAX)) {
-      ++e;
-      Kokkos::printf("failed isfinite(integral)\n");
-    }
-    if (!isfinite(2.f) || isfinite(quiet_NaN<float>::value) ||
-        isfinite(signaling_NaN<float>::value) ||
-        isfinite(infinity<float>::value)) {
-      ++e;
-      Kokkos::printf("failed isfinite(float)\n");
-    }
+KOKKOS_DEVICE_TEST(TestIsFinite) {
+  using Kokkos::infinity;
+  using Kokkos::isfinite;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
+
+  KOKKOS_EXPECT_TRUE(isfinite(1));
+  KOKKOS_EXPECT_TRUE(isfinite(INT_MAX));
+
+  KOKKOS_EXPECT_TRUE(isfinite(2.f));
+  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(infinity<float>::value));
+
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    if (!isfinite(static_cast<KE::half_t>(2.f)) ||
-        isfinite(quiet_NaN<KE::half_t>::value) ||
-        isfinite(signaling_NaN<KE::half_t>::value) ||
-        isfinite(infinity<KE::half_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isfinite(KE::half_t)\n");
-    }
-    if (!isfinite(static_cast<KE::bhalf_t>(2.f)) ||
-        isfinite(quiet_NaN<KE::bhalf_t>::value) ||
-        isfinite(signaling_NaN<KE::bhalf_t>::value) ||
-        isfinite(infinity<KE::bhalf_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isfinite(KE::bhalf_t)\n");
-    }
-#endif
-    if (!isfinite(3.) || isfinite(quiet_NaN<double>::value) ||
-        isfinite(signaling_NaN<double>::value) ||
-        isfinite(infinity<double>::value)) {
-      ++e;
-      Kokkos::printf("failed isfinite(double)\n");
-    }
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (!isfinite(4.l) || isfinite(quiet_NaN<long double>::value) ||
-        isfinite(signaling_NaN<long double>::value) ||
-        isfinite(infinity<long double>::value)) {
-      ++e;
-      Kokkos::printf("failed isfinite(long double)\n");
-    }
-#endif
-    // special values
-    if (isfinite(INFINITY) || isfinite(NAN)) {
-      ++e;
-      Kokkos::printf("failed isfinite(floating_point) special values\n");
-    }
+  KOKKOS_EXPECT_TRUE(isfinite(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(infinity<KE::half_t>::value));
 
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
-    static_assert(std::is_same_v<decltype(isfinite(1)), bool>);
-    static_assert(std::is_same_v<decltype(isfinite(2.f)), bool>);
-    static_assert(std::is_same_v<decltype(isfinite(3.)), bool>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(isfinite(4.l)), bool>);
+  KOKKOS_EXPECT_TRUE(isfinite(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(infinity<KE::bhalf_t>::value));
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, float, bool);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, double, bool);
+  KOKKOS_EXPECT_TRUE(isfinite(3.));
+  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(infinity<double>::value));
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, long double,
-                                              bool);
+  KOKKOS_EXPECT_TRUE(isfinite(3.l));
+  KOKKOS_EXPECT_FALSE(isfinite(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isfinite(infinity<long double>::value));
 #endif
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
-  }
-};
+  // special values
+  KOKKOS_EXPECT_FALSE(isfinite(INFINITY));
+  KOKKOS_EXPECT_FALSE(isfinite(NAN));
+
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
+  static_assert(std::is_same_v<decltype(isfinite(1)), bool>);
+  static_assert(std::is_same_v<decltype(isfinite(2.f)), bool>);
+  static_assert(std::is_same_v<decltype(isfinite(3.)), bool>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(isfinite(4.l)), bool>);
+#endif
+
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, float, bool);
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, double, bool);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isfinite, long double,
+                                            bool);
+#endif
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_isfinite) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
-  TestIsFinite<TEST_EXECSPACE>();
+  TestIsFinite<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestIsInf {
-  TestIsInf() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::infinity;
-    using Kokkos::isinf;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
-    if (isinf(1) || isinf(INT_MAX)) {
-      ++e;
-      Kokkos::printf("failed isinf(integral)\n");
-    }
-    if (isinf(2.f) || isinf(quiet_NaN<float>::value) ||
-        isinf(signaling_NaN<float>::value) || !isinf(infinity<float>::value)) {
-      ++e;
-      Kokkos::printf("failed isinf(float)\n");
-    }
+KOKKOS_DEVICE_TEST(TestIsInf) {
+  using Kokkos::infinity;
+  using Kokkos::isinf;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
+
+  // We are not using KOKKOS_EXPECT_INF in this tests because it depends on
+  // Kokkos::isinf internally
+  KOKKOS_EXPECT_FALSE(isinf(1));
+  KOKKOS_EXPECT_FALSE(isinf(INT_MAX));
+
+  KOKKOS_EXPECT_FALSE(isinf(2.f));
+  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(isinf(infinity<float>::value));
+
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    if (isinf(static_cast<KE::half_t>(2.f)) ||
-        isinf(quiet_NaN<KE::half_t>::value) ||
-        isinf(signaling_NaN<KE::half_t>::value) ||
-        !isinf(infinity<KE::half_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isinf(KE::half_t)\n");
-    }
-    if (isinf(static_cast<KE::bhalf_t>(2.f)) ||
-        isinf(quiet_NaN<KE::bhalf_t>::value) ||
-        isinf(signaling_NaN<KE::bhalf_t>::value) ||
-        !isinf(infinity<KE::bhalf_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isinf(KE::bhalf_t)\n");
-    }
-#endif
-    if (isinf(3.) || isinf(quiet_NaN<double>::value) ||
-        isinf(signaling_NaN<double>::value) ||
-        !isinf(infinity<double>::value)) {
-      ++e;
-      Kokkos::printf("failed isinf(double)\n");
-    }
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (isinf(4.l) || isinf(quiet_NaN<long double>::value) ||
-        isinf(signaling_NaN<long double>::value) ||
-        !isinf(infinity<long double>::value)) {
-      ++e;
-      Kokkos::printf("failed isinf(long double)\n");
-    }
-#endif
-    // special values
-    if (!isinf(INFINITY) || isinf(NAN)) {
-      ++e;
-      Kokkos::printf("failed isinf(floating_point) special values\n");
-    }
+  KOKKOS_EXPECT_FALSE(isinf(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(isinf(infinity<KE::half_t>::value));
 
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
-    static_assert(std::is_same_v<decltype(isinf(1)), bool>);
-    static_assert(std::is_same_v<decltype(isinf(2.f)), bool>);
-    static_assert(std::is_same_v<decltype(isinf(3.)), bool>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(isinf(4.l)), bool>);
+  KOKKOS_EXPECT_FALSE(isinf(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(isinf(infinity<KE::bhalf_t>::value));
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, float, bool);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, double, bool);
+  KOKKOS_EXPECT_FALSE(isinf(3.));
+  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(isinf(infinity<double>::value));
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, long double, bool);
+  KOKKOS_EXPECT_FALSE(isinf(4.l));
+  KOKKOS_EXPECT_FALSE(isinf(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isinf(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(isinf(infinity<long double>::value));
 #endif
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
-  }
-};
+
+  KOKKOS_EXPECT_TRUE(isinf(INFINITY));
+  KOKKOS_EXPECT_FALSE(isinf(NAN));
+
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
+  static_assert(std::is_same_v<decltype(isinf(1)), bool>);
+  static_assert(std::is_same_v<decltype(isinf(2.f)), bool>);
+  static_assert(std::is_same_v<decltype(isinf(3.)), bool>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(isinf(4.l)), bool>);
+#endif
+
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, float, bool);
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, double, bool);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isinf, long double, bool);
+#endif
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_isinf) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
-  TestIsInf<TEST_EXECSPACE>();
+  TestIsInf<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestFpClassify {
-  TestFpClassify() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::denorm_min;
-    using Kokkos::fpclassify;
-    using Kokkos::infinity;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
+KOKKOS_DEVICE_TEST(TestFpClassify) {
+  using Kokkos::denorm_min;
+  using Kokkos::fpclassify;
+  using Kokkos::infinity;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
 
-    if (fpclassify(0) != FP_ZERO || fpclassify(1) != FP_NORMAL) {
-      ++e;
-      Kokkos::printf("failed fpclassify(integral)\n");
-    }
+  KOKKOS_EXPECT_EQ(fpclassify(0), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(1), FP_NORMAL);
 
-    if (fpclassify(0.f) != FP_ZERO || fpclassify(-0.f) != FP_ZERO ||
-        fpclassify(1.f) != FP_NORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(0.f), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(-0.f), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(1.f), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-        || fpclassify(signaling_NaN<float>::value) != FP_NAN ||
-        fpclassify(quiet_NaN<float>::value) != FP_NAN ||
-        fpclassify(infinity<float>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<float>::value) != FP_SUBNORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<float>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<float>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(infinity<float>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<float>::value), FP_SUBNORMAL);
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed fpclassify(float)\n");
-    }
 
-    if (fpclassify(0.) != FP_ZERO || fpclassify(-0.) != FP_ZERO ||
-        fpclassify(1.) != FP_NORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(0.), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(-0.), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(1.), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-        || fpclassify(signaling_NaN<double>::value) != FP_NAN ||
-        fpclassify(quiet_NaN<double>::value) != FP_NAN ||
-        fpclassify(infinity<double>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<double>::value) != FP_SUBNORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(infinity<double>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<double>::value), FP_SUBNORMAL);
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed fpclassify(double)\n");
-    }
 
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (fpclassify(0.l) != FP_ZERO || fpclassify(-0.l) != FP_ZERO ||
-        fpclassify(1.l) != FP_NORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(0.l), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(-0.l), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(1.l), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-        || fpclassify(signaling_NaN<long double>::value) != FP_NAN ||
-        fpclassify(quiet_NaN<long double>::value) != FP_NAN ||
-        fpclassify(infinity<long double>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<long double>::value) != FP_SUBNORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<long double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<long double>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(infinity<long double>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<long double>::value), FP_SUBNORMAL);
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed fpclassify(long double)\n");
-    }
 #endif
 
-    if (fpclassify(static_cast<KE::half_t>(0.f)) != FP_ZERO ||
-        fpclassify(static_cast<KE::half_t>(-0.f)) != FP_ZERO ||
-        fpclassify(static_cast<KE::half_t>(1.f)) != FP_NORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(-0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::half_t>(1.f)), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
-        // FIXME internal compiler error for Clang+Cuda and RDC
-        || fpclassify(signaling_NaN<KE::half_t>::value) != FP_NAN ||
-        fpclassify(quiet_NaN<KE::half_t>::value) != FP_NAN ||
-        fpclassify(infinity<KE::half_t>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<KE::half_t>::value) != FP_SUBNORMAL
+  // FIXME internal compiler error for Clang+Cuda and RDC
+  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<KE::half_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<KE::half_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(infinity<KE::half_t>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<KE::half_t>::value), FP_SUBNORMAL);
 #endif
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed fpclassify(Kokkos::Experimental::half_t)\n");
-    }
 
-    if (fpclassify(static_cast<KE::bhalf_t>(0.f)) != FP_ZERO ||
-        fpclassify(static_cast<KE::bhalf_t>(-0.f)) != FP_ZERO ||
-        fpclassify(static_cast<KE::bhalf_t>(1.f)) != FP_NORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(-0.f)), FP_ZERO);
+  KOKKOS_EXPECT_EQ(fpclassify(static_cast<KE::bhalf_t>(1.f)), FP_NORMAL);
 #if !__FINITE_MATH_ONLY__
-        || fpclassify(signaling_NaN<KE::bhalf_t>::value) != FP_NAN ||
-        fpclassify(quiet_NaN<KE::bhalf_t>::value) != FP_NAN ||
-        fpclassify(infinity<KE::bhalf_t>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<KE::bhalf_t>::value) != FP_SUBNORMAL
+  KOKKOS_EXPECT_EQ(fpclassify(signaling_NaN<KE::bhalf_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(quiet_NaN<KE::bhalf_t>::value), FP_NAN);
+  KOKKOS_EXPECT_EQ(fpclassify(infinity<KE::bhalf_t>::value), FP_INFINITE);
+  KOKKOS_EXPECT_EQ(fpclassify(denorm_min<KE::bhalf_t>::value), FP_SUBNORMAL);
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed fpclassify(Kokkos::Experimental::bhalf_t)\n");
-    }
-  }
-};
-
-TEST(TEST_CATEGORY, mathematical_functions_fpclassify) {
-  TestFpClassify<TEST_EXECSPACE>();
 }
 
-template <class Space>
-struct TestIsNaN {
-  TestIsNaN() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::infinity;
-    using Kokkos::isnan;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
-    if (isnan(1) || isnan(INT_MAX)) {
-      ++e;
-      Kokkos::printf("failed isnan(integral)\n");
-    }
-    if (isnan(2.f) || !isnan(quiet_NaN<float>::value) ||
-        !isnan(signaling_NaN<float>::value) || isnan(infinity<float>::value)) {
-      ++e;
-      Kokkos::printf("failed isnan(float)\n");
-    }
+TEST(TEST_CATEGORY, mathematical_functions_fpclassify) {
+  TestFpClassify<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
+}
+
+KOKKOS_DEVICE_TEST(TestIsNaN) {
+  using Kokkos::infinity;
+  using Kokkos::isnan;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
+
+  // We are not using KOKKOS_EXPECT_NAN in this tests because it depends on
+  // Kokkos::isnan internally
+  KOKKOS_EXPECT_FALSE(isnan(1));
+  KOKKOS_EXPECT_FALSE(isnan(INT_MAX));
+
+  KOKKOS_EXPECT_FALSE(isnan(2.f));
+  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isnan(infinity<float>::value));
+
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    if (isnan(static_cast<KE::half_t>(2.f)) ||
-        !isnan(quiet_NaN<KE::half_t>::value) ||
-        !isnan(signaling_NaN<KE::half_t>::value) ||
-        isnan(infinity<KE::half_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isnan(KE::half_t)\n");
-    }
-    if (isnan(static_cast<KE::bhalf_t>(2.f)) ||
-        !isnan(quiet_NaN<KE::bhalf_t>::value) ||
-        !isnan(signaling_NaN<KE::bhalf_t>::value) ||
-        isnan(infinity<KE::bhalf_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isnan(KE::bhalf_t)\n");
-    }
-    if (isnan(3.) || !isnan(quiet_NaN<double>::value) ||
-        !isnan(signaling_NaN<double>::value) ||
-        isnan(infinity<double>::value)) {
-      ++e;
-      Kokkos::printf("failed isnan(double)\n");
-    }
-#endif
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (isnan(4.l) || !isnan(quiet_NaN<long double>::value) ||
-        !isnan(signaling_NaN<long double>::value) ||
-        isnan(infinity<long double>::value)) {
-      ++e;
-      Kokkos::printf("failed isnan(long double)\n");
-    }
-#endif
-    // special values
-    if (isnan(INFINITY) || !isnan(NAN)) {
-      ++e;
-      Kokkos::printf("failed isnan(floating_point) special values\n");
-    }
+  KOKKOS_EXPECT_FALSE(isnan(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isnan(infinity<KE::half_t>::value));
 
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
-    static_assert(std::is_same_v<decltype(isnan(1)), bool>);
-    static_assert(std::is_same_v<decltype(isnan(2.f)), bool>);
-    static_assert(std::is_same_v<decltype(isnan(3.)), bool>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(isnan(4.l)), bool>);
+  KOKKOS_EXPECT_FALSE(isnan(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isnan(infinity<KE::bhalf_t>::value));
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, float, bool);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, double, bool);
+  KOKKOS_EXPECT_FALSE(isnan(3.));
+  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isnan(infinity<double>::value));
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, long double, bool);
+  KOKKOS_EXPECT_FALSE(isnan(4.l));
+  KOKKOS_EXPECT_TRUE(isnan(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(isnan(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isnan(infinity<long double>::value));
 #endif
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
-  }
-};
+  // special values
+  KOKKOS_EXPECT_FALSE(isnan(INFINITY));
+  KOKKOS_EXPECT_TRUE(isnan(NAN));
+
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
+  static_assert(std::is_same_v<decltype(isnan(1)), bool>);
+  static_assert(std::is_same_v<decltype(isnan(2.f)), bool>);
+  static_assert(std::is_same_v<decltype(isnan(3.)), bool>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(isnan(4.l)), bool>);
+#endif
+
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, float, bool);
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, double, bool);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnan, long double, bool);
+#endif
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_isnan) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
-  TestIsNaN<TEST_EXECSPACE>();
+  TestIsNaN<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-#define DEVICE_ASSERT(CALL)                          \
-  if (!(CALL)) {                                     \
-    printf(KOKKOS_IMPL_STRINGIFY(CALL) " failed\n"); \
-    ++e;                                             \
-  }
+KOKKOS_DEVICE_TEST(TestIsNormal) {
+  using Kokkos::denorm_min;
+  using Kokkos::infinity;
+  using Kokkos::isnormal;
+  using Kokkos::norm_min;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
 
-template <class Space>
-struct TestIsNormal {
-  TestIsNormal() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::denorm_min;
-    using Kokkos::infinity;
-    using Kokkos::isnormal;
-    using Kokkos::norm_min;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
-    if (isnormal(0) || !isnormal(1) || !isnormal(INT_MAX)) {
-      ++e;
-      Kokkos::printf("failed isnormal(integral)\n");
-    }
-    if (isnormal(0.f) || !isnormal(2.f) || !isnormal(-3.f) ||
-        isnormal(quiet_NaN<float>::value) ||
-        isnormal(signaling_NaN<float>::value) ||
-        isnormal(infinity<float>::value) ||
-        isnormal(denorm_min<float>::value) ||
-        !isnormal(norm_min<float>::value)) {
-      ++e;
-      Kokkos::printf("failed isnormal(float)\n");
-    }
+  KOKKOS_EXPECT_FALSE(isnormal(0));
+  KOKKOS_EXPECT_TRUE(isnormal(1));
+  KOKKOS_EXPECT_TRUE(isnormal(INT_MAX));
+
+  KOKKOS_EXPECT_FALSE(isnormal(0.f));
+  KOKKOS_EXPECT_TRUE(isnormal(2.f));
+  KOKKOS_EXPECT_TRUE(isnormal(-3.f));
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_TRUE(isnormal(norm_min<float>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<float>::value));
+#endif
+  KOKKOS_EXPECT_TRUE(isnormal(FLT_MAX));
+  KOKKOS_EXPECT_TRUE(isnormal(FLT_MIN));
+  KOKKOS_EXPECT_FALSE(isnormal(FLT_TRUE_MIN));
+
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    if (isnormal(static_cast<KE::half_t>(0.f)) ||
-        !isnormal(static_cast<KE::half_t>(2.f)) ||
-        !isnormal(static_cast<KE::half_t>(-2.f))
+  KOKKOS_EXPECT_FALSE(isnormal(static_cast<KE::half_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::half_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::half_t>(-2.f)));
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
-        // FIXME internal compiler error for Clang+Cuda and RDC
-        || isnormal(quiet_NaN<KE::half_t>::value) ||
-        isnormal(signaling_NaN<KE::half_t>::value) ||
-        isnormal(infinity<KE::half_t>::value) ||
-        isnormal(denorm_min<KE::half_t>::value) ||
-        !isnormal(norm_min<KE::half_t>::value)
+  // FIXME internal compiler error for Clang+Cuda and RDC
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(isnormal(norm_min<KE::half_t>::value));
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed isnormal(KE::half_t)\n");
-    }
-    if (isnormal(static_cast<KE::bhalf_t>(0.f)) ||
-        !isnormal(static_cast<KE::bhalf_t>(2.f)) ||
-        !isnormal(static_cast<KE::bhalf_t>(-2.f)) ||
-        isnormal(quiet_NaN<KE::bhalf_t>::value) ||
-        isnormal(signaling_NaN<KE::bhalf_t>::value) ||
-        isnormal(infinity<KE::bhalf_t>::value) ||
-        isnormal(denorm_min<KE::bhalf_t>::value) ||
-        !isnormal(norm_min<KE::bhalf_t>::value)) {
-      ++e;
-      Kokkos::printf("failed isnormal(KE::bhalf_t)\n");
-    }
-#endif
-    if (isnormal(0.) || !isnormal(3.) || !isnormal(-3.) ||
-        isnormal(quiet_NaN<double>::value) ||
-        isnormal(signaling_NaN<double>::value) ||
-        isnormal(infinity<double>::value) ||
-        isnormal(denorm_min<double>::value) ||
-        !isnormal(norm_min<double>::value)) {
-      ++e;
-      Kokkos::printf("failed isnormal(double)\n");
-    }
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (isnormal(0.l) || !isnormal(4.l) || !isnormal(-4.l) ||
-        isnormal(quiet_NaN<long double>::value) ||
-        isnormal(signaling_NaN<long double>::value) ||
-        isnormal(infinity<long double>::value) ||
-        isnormal(denorm_min<long double>::value) ||
-        !isnormal(norm_min<long double>::value)) {
-      ++e;
-      Kokkos::printf("failed isnormal(long double)\n");
-    }
-#endif
-    // special values
-    if (isnormal(INFINITY) || isnormal(NAN) ||
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-        !isnormal(LDBL_MAX) || !isnormal(LDBL_MIN) || isnormal(LDBL_TRUE_MIN) ||
-#endif
-        !isnormal(FLT_MAX) || !isnormal(FLT_MIN) || isnormal(FLT_TRUE_MIN) ||
-        !isnormal(DBL_MAX) || !isnormal(DBL_MIN) || isnormal(DBL_TRUE_MIN)) {
-      ++e;
-      Kokkos::printf("failed isnormal(floating_point) special values\n");
-    }
-
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
-    static_assert(std::is_same_v<decltype(isnormal(1)), bool>);
-    static_assert(std::is_same_v<decltype(isnormal(2.f)), bool>);
-    static_assert(std::is_same_v<decltype(isnormal(3.)), bool>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(isnormal(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, float, bool);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, double, bool);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, long double,
-                                              bool);
+  KOKKOS_EXPECT_FALSE(isnormal(static_cast<KE::bhalf_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::bhalf_t>(2.f)));
+  KOKKOS_EXPECT_TRUE(isnormal(static_cast<KE::bhalf_t>(-2.f)));
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(isnormal(norm_min<KE::bhalf_t>::value));
 #endif
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
-  }
-};
+#endif
+
+  KOKKOS_EXPECT_FALSE(isnormal(0.));
+  KOKKOS_EXPECT_TRUE(isnormal(3.));
+  KOKKOS_EXPECT_TRUE(isnormal(-3.));
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<double>::value));
+  KOKKOS_EXPECT_TRUE(isnormal(norm_min<double>::value));
+#endif
+  KOKKOS_EXPECT_TRUE(isnormal(DBL_MAX));
+  KOKKOS_EXPECT_TRUE(isnormal(DBL_MIN));
+  KOKKOS_EXPECT_FALSE(isnormal(DBL_TRUE_MIN));
+
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_EXPECT_FALSE(isnormal(0.l));
+  KOKKOS_EXPECT_TRUE(isnormal(4.l));
+  KOKKOS_EXPECT_TRUE(isnormal(-4.l));
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_FALSE(isnormal(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(isnormal(denorm_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(isnormal(norm_min<long double>::value));
+#endif
+  KOKKOS_EXPECT_TRUE(isnormal(LDBL_MAX));
+  KOKKOS_EXPECT_TRUE(isnormal(LDBL_MIN));
+  KOKKOS_EXPECT_FALSE(isnormal(LDBL_TRUE_MIN));
+#endif
+
+  // special values
+#if !__FINITE_MATH_ONLY__
+  KOKKOS_EXPECT_FALSE(isnormal(INFINITY));
+  KOKKOS_EXPECT_FALSE(isnormal(NAN));
+#endif
+
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
+  static_assert(std::is_same_v<decltype(isnormal(1)), bool>);
+  static_assert(std::is_same_v<decltype(isnormal(2.f)), bool>);
+  static_assert(std::is_same_v<decltype(isnormal(3.)), bool>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(isnormal(4.l)), bool>);
+#endif
+
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, float, bool);
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, double, bool);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::isnormal, long double,
+                                            bool);
+#endif
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_isnormal) {
-#if __FINITE_MATH_ONLY__
-  GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
-#endif
-  TestIsNormal<TEST_EXECSPACE>();
+  TestIsNormal<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
-template <class Space>
-struct TestSignbit {
-  TestSignbit() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::denorm_min;
-    using Kokkos::finite_max;
-    using Kokkos::finite_min;
-    using Kokkos::infinity;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
-    using Kokkos::signbit;
-    if (signbit(1) || signbit(INT_MAX) || !signbit(-2) || !signbit(INT_MIN) ||
-        signbit(0)) {
-      ++e;
-      Kokkos::printf("failed signbit(integral)\n");
-    }
-    if (signbit(3.f) || signbit(finite_max<float>::value) ||
-        signbit(infinity<float>::value) || signbit(denorm_min<float>::value) ||
-        signbit(quiet_NaN<float>::value) ||
-        signbit(signaling_NaN<float>::value) || signbit(0.f) ||
-        !signbit(-0.4f) || !signbit(finite_min<float>::value) ||
-        !signbit(-infinity<float>::value) ||
-        !signbit(-denorm_min<float>::value) ||
-        !signbit(-quiet_NaN<float>::value) ||
-        !signbit(-signaling_NaN<float>::value) || !signbit(-0.f)) {
-      ++e;
-      Kokkos::printf("failed signbit(float)\n");
-    }
+KOKKOS_DEVICE_TEST(TestSignbit) {
+  using Kokkos::denorm_min;
+  using Kokkos::finite_max;
+  using Kokkos::finite_min;
+  using Kokkos::infinity;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
+  using Kokkos::signbit;
+
+  KOKKOS_EXPECT_FALSE(signbit(1));
+  KOKKOS_EXPECT_FALSE(signbit(INT_MAX));
+  KOKKOS_EXPECT_TRUE(signbit(-2));
+  KOKKOS_EXPECT_TRUE(signbit(INT_MIN));
+  KOKKOS_EXPECT_FALSE(signbit(0));
+
+  KOKKOS_EXPECT_FALSE(signbit(3.f));
+  KOKKOS_EXPECT_FALSE(signbit(finite_max<float>::value));
+  KOKKOS_EXPECT_FALSE(signbit(infinity<float>::value));
+  KOKKOS_EXPECT_FALSE(signbit(denorm_min<float>::value));
+  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<float>::value));
+  KOKKOS_EXPECT_FALSE(signbit(0.f));
+  KOKKOS_EXPECT_TRUE(signbit(-0.4f));
+  KOKKOS_EXPECT_TRUE(signbit(finite_min<float>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-infinity<float>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<float>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<float>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-0.f));
+
 #if !(defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOS_COMPILER_MSVC))
-    if (signbit(static_cast<KE::half_t>(0.f)) ||
-        !signbit(static_cast<KE::half_t>(-0.f))
+  KOKKOS_EXPECT_FALSE(signbit(static_cast<KE::half_t>(0.f)));
+  KOKKOS_EXPECT_TRUE(signbit(static_cast<KE::half_t>(-0.f)));
 #if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
       defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
       defined(KOKKOS_COMPILER_CLANG))
-        // FIXME internal compiler error for Clang+Cuda and RDC
-        || signbit(finite_max<KE::half_t>::value) ||
-        signbit(infinity<KE::half_t>::value) ||
-        signbit(denorm_min<KE::half_t>::value) ||
-        signbit(quiet_NaN<KE::half_t>::value) ||
-        signbit(signaling_NaN<KE::half_t>::value) ||
-        !signbit(finite_min<KE::half_t>::value) ||
-        !signbit(-static_cast<KE::half_t>(infinity<KE::half_t>::value)) ||
-        !signbit(-static_cast<KE::half_t>(denorm_min<KE::half_t>::value))
-    // https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/mathematical-functions.html#cuda-and-ieee-754-compliance:
-    // "[...] result in the sign of a NaN being updated in an
-    // implementation-defined manner."
+  // FIXME internal compiler error for Clang+Cuda and RDC
+  KOKKOS_EXPECT_FALSE(signbit(finite_max<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(infinity<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(denorm_min<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(signbit(finite_min<KE::half_t>::value));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::half_t>(infinity<KE::half_t>::value)));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::half_t>(denorm_min<KE::half_t>::value)));
+  // https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/mathematical-functions.html#cuda-and-ieee-754-compliance:
+  // "[...] result in the sign of a NaN being updated in an
+  // implementation-defined manner."
 #ifndef KOKKOS_ENABLE_CUDA
-        || !signbit(-static_cast<KE::half_t>(quiet_NaN<KE::half_t>::value)) ||
-        !signbit(-static_cast<KE::half_t>(signaling_NaN<KE::half_t>::value))
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::half_t>(quiet_NaN<KE::half_t>::value)));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::half_t>(signaling_NaN<KE::half_t>::value)));
 #endif
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed signbit(KE::half_t)\n");
-    }
-    if (signbit(static_cast<KE::bhalf_t>(0.f)) ||
-        signbit(finite_max<KE::bhalf_t>::value) ||
-        signbit(infinity<KE::bhalf_t>::value) ||
-        signbit(denorm_min<KE::bhalf_t>::value) ||
-        signbit(quiet_NaN<KE::bhalf_t>::value) ||
-        signbit(signaling_NaN<KE::bhalf_t>::value) ||
-        !signbit(static_cast<KE::bhalf_t>(-0.f)) ||
-        !signbit(finite_min<KE::bhalf_t>::value) ||
-        !signbit(-static_cast<KE::bhalf_t>(infinity<KE::bhalf_t>::value)) ||
-        !signbit(-static_cast<KE::bhalf_t>(denorm_min<KE::bhalf_t>::value))
+
+  KOKKOS_EXPECT_FALSE(signbit(static_cast<KE::bhalf_t>(0.f)));
+  KOKKOS_EXPECT_FALSE(signbit(finite_max<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(infinity<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(denorm_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(signbit(static_cast<KE::bhalf_t>(-0.f)));
+  KOKKOS_EXPECT_TRUE(signbit(finite_min<KE::bhalf_t>::value));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::bhalf_t>(infinity<KE::bhalf_t>::value)));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::bhalf_t>(denorm_min<KE::bhalf_t>::value)));
 // the bhalf test also fails for SYCL+Cuda
 #ifndef KOKKOS_IMPL_ARCH_NVIDIA_GPU
-        || !signbit(-static_cast<KE::bhalf_t>(quiet_NaN<KE::bhalf_t>::value)) ||
-        !signbit(-static_cast<KE::bhalf_t>(signaling_NaN<KE::bhalf_t>::value))
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::bhalf_t>(quiet_NaN<KE::bhalf_t>::value)));
+  KOKKOS_EXPECT_TRUE(
+      signbit(-static_cast<KE::bhalf_t>(signaling_NaN<KE::bhalf_t>::value)));
 #endif
-    ) {
-      ++e;
-      Kokkos::printf("failed signbit(KE::bhalf_t)\n");
-    }
-#endif
-    if (signbit(.5) || signbit(finite_max<double>::value) ||
-        signbit(infinity<double>::value) ||
-        signbit(denorm_min<double>::value) ||
-        signbit(quiet_NaN<double>::value) ||
-        signbit(signaling_NaN<double>::value) || signbit(0.) || !signbit(-6.) ||
-        !signbit(finite_min<double>::value) ||
-        !signbit(-infinity<double>::value) ||
-        !signbit(-denorm_min<double>::value) ||
-        !signbit(-quiet_NaN<double>::value) ||
-        !signbit(-signaling_NaN<double>::value) || !signbit(-0.)) {
-      ++e;
-      Kokkos::printf("failed signbit(double)\n");
-    }
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    if (signbit(7.l) || signbit(finite_max<long double>::value) ||
-        signbit(infinity<long double>::value) ||
-        signbit(denorm_min<long double>::value) ||
-        signbit(quiet_NaN<long double>::value) ||
-        signbit(signaling_NaN<long double>::value) || signbit(0.l) ||
-        !signbit(-.8l) || !signbit(finite_min<long double>::value) ||
-        !signbit(-infinity<long double>::value) ||
-        !signbit(-denorm_min<long double>::value) ||
-        !signbit(-quiet_NaN<long double>::value) ||
-        !signbit(-signaling_NaN<long double>::value) || !signbit(-0.l)) {
-      ++e;
-      Kokkos::printf("failed signbit(long double)\n");
-    }
-#endif
-    // special values
-    if (signbit(INFINITY) || signbit(NAN)) {
-      ++e;
-      Kokkos::printf("failed signbit(floating_point) special values\n");
-    }
-
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
-    static_assert(std::is_same_v<decltype(signbit(1)), bool>);
-    static_assert(std::is_same_v<decltype(signbit(2.f)), bool>);
-    static_assert(std::is_same_v<decltype(signbit(3.)), bool>);
-#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    static_assert(std::is_same_v<decltype(signbit(4.l)), bool>);
 #endif
 
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, float, bool);
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, double, bool);
+  KOKKOS_EXPECT_FALSE(signbit(.5));
+  KOKKOS_EXPECT_FALSE(signbit(finite_max<double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(infinity<double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(denorm_min<double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(0.));
+  KOKKOS_EXPECT_TRUE(signbit(-6.));
+  KOKKOS_EXPECT_TRUE(signbit(finite_min<double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-infinity<double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<double>::value));
+
 #ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
-    KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, long double,
-                                              bool);
+  KOKKOS_EXPECT_FALSE(signbit(7.l));
+  KOKKOS_EXPECT_FALSE(signbit(finite_max<long double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(infinity<long double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(denorm_min<long double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_FALSE(signbit(0.l));
+  KOKKOS_EXPECT_TRUE(signbit(-.8l));
+  KOKKOS_EXPECT_TRUE(signbit(finite_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-infinity<long double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-denorm_min<long double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-quiet_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-signaling_NaN<long double>::value));
+  KOKKOS_EXPECT_TRUE(signbit(-0.l));
 #endif
-    KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
-  }
-};
+
+  // special values
+  KOKKOS_EXPECT_FALSE(signbit(INFINITY));
+  KOKKOS_EXPECT_FALSE(signbit(NAN));
+
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_PUSH()
+  static_assert(std::is_same_v<decltype(signbit(1)), bool>);
+  static_assert(std::is_same_v<decltype(signbit(2.f)), bool>);
+  static_assert(std::is_same_v<decltype(signbit(3.)), bool>);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  static_assert(std::is_same_v<decltype(signbit(4.l)), bool>);
+#endif
+
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, float, bool);
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, double, bool);
+#ifdef MATHEMATICAL_FUNCTIONS_HAVE_LONG_DOUBLE_OVERLOADS
+  KOKKOS_TEST_STATIC_ASSERT_UNARY_PREDICATE(Kokkos::signbit, long double, bool);
+#endif
+  KOKKOS_TEST_WORKAROUND_DEPRECATED_STD_ITERATOR_WARNINGS_POP()
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_signbit) {
 #if __FINITE_MATH_ONLY__
   GTEST_SKIP() << "skipping when compiling with -ffinite-math-only";
 #endif
-  TestSignbit<TEST_EXECSPACE>();
+  TestSignbit<TEST_EXECSPACE> test;
+  ASSERT_EQ(test.run(), 0);
 }
 
 TEST(TEST_CATEGORY, mathematical_functions_binary_predicates) {
@@ -2873,117 +2721,89 @@ TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
                         KE::bhalf_t, 1>({KE::bhalf_t(1.f)});
 }
 
-template <class Space, class FP16Type>
-struct TestNextAfterHalf {
-  TestNextAfterHalf() { run(); }
-  void run() const {
-    int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
-    ASSERT_EQ(errors, 0);
-  }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    using Kokkos::finite_max;
-    using Kokkos::finite_min;
-    using Kokkos::infinity;
-    using Kokkos::isnan;
-    using Kokkos::nextafter;
-    using Kokkos::quiet_NaN;
-    using Kokkos::signaling_NaN;
+KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {
+  using Kokkos::finite_max;
+  using Kokkos::finite_min;
+  using Kokkos::infinity;
+  using Kokkos::nextafter;
+  using Kokkos::quiet_NaN;
+  using Kokkos::signaling_NaN;
 
-    // Define useful constants
-    const std::uint16_t FP16_POS_ZERO     = 0x0000;
-    const std::uint16_t FP16_NEG_ZERO     = 0x8000;
-    const std::uint16_t FP16_SMALLEST_POS = 0x0001;
-    const std::uint16_t FP16_SMALLEST_NEG = 0x8001;
+  // Define useful constants
+  const std::uint16_t FP16_POS_ZERO     = 0x0000;
+  const std::uint16_t FP16_NEG_ZERO     = 0x8000;
+  const std::uint16_t FP16_SMALLEST_POS = 0x0001;
+  const std::uint16_t FP16_SMALLEST_NEG = 0x8001;
 
-    const FP16Type pos_one{1.0f}, pos_two{2.0f};
-    const FP16Type neg_one{-1.0f}, neg_two{-2.0f};
-    const FP16Type pos_zero     = Kokkos::bit_cast<FP16Type>(FP16_POS_ZERO);
-    const FP16Type neg_zero     = Kokkos::bit_cast<FP16Type>(FP16_NEG_ZERO);
-    const FP16Type pos_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_POS);
-    const FP16Type neg_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_NEG);
-    const FP16Type pos_max      = finite_max<FP16Type>::value;
-    const FP16Type neg_max      = finite_min<FP16Type>::value;
-    const FP16Type pos_inf      = infinity<FP16Type>::value;
-    const FP16Type neg_inf = -static_cast<FP16Type>(infinity<FP16Type>::value);
+  const FP16Type pos_one{1.0f}, pos_two{2.0f};
+  const FP16Type neg_one{-1.0f}, neg_two{-2.0f};
+  const FP16Type pos_zero     = Kokkos::bit_cast<FP16Type>(FP16_POS_ZERO);
+  const FP16Type neg_zero     = Kokkos::bit_cast<FP16Type>(FP16_NEG_ZERO);
+  const FP16Type pos_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_POS);
+  const FP16Type neg_smallest = Kokkos::bit_cast<FP16Type>(FP16_SMALLEST_NEG);
+  const FP16Type pos_max      = finite_max<FP16Type>::value;
+  const FP16Type neg_max      = finite_min<FP16Type>::value;
+  const FP16Type pos_inf      = infinity<FP16Type>::value;
+  const FP16Type neg_inf = -static_cast<FP16Type>(infinity<FP16Type>::value);
 
-    // NaN Handling
-    if (!isnan(nextafter(quiet_NaN<FP16Type>::value, pos_one)) ||
-        !isnan(nextafter(signaling_NaN<FP16Type>::value, pos_one)) ||
-        !isnan(nextafter(pos_one, quiet_NaN<FP16Type>::value)) ||
-        !isnan(nextafter(pos_one, signaling_NaN<FP16Type>::value)) ||
-        !isnan(nextafter(quiet_NaN<FP16Type>::value,
-                         quiet_NaN<FP16Type>::value)) ||
-        !isnan(nextafter(quiet_NaN<FP16Type>::value,
-                         signaling_NaN<FP16Type>::value)) ||
-        !isnan(nextafter(signaling_NaN<FP16Type>::value,
-                         quiet_NaN<FP16Type>::value)) ||
-        !isnan(nextafter(signaling_NaN<FP16Type>::value,
-                         signaling_NaN<FP16Type>::value))) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(NaN)\n");
-    }
+  // NaN Handling
+  KOKKOS_EXPECT_NAN(nextafter(quiet_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(nextafter(signaling_NaN<FP16Type>::value, pos_one));
+  KOKKOS_EXPECT_NAN(nextafter(pos_one, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(nextafter(pos_one, signaling_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(
+      nextafter(quiet_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(
+      nextafter(quiet_NaN<FP16Type>::value, signaling_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(
+      nextafter(signaling_NaN<FP16Type>::value, quiet_NaN<FP16Type>::value));
+  KOKKOS_EXPECT_NAN(nextafter(signaling_NaN<FP16Type>::value,
+                              signaling_NaN<FP16Type>::value));
 
-    // Equality (from==toward) Handling
-    if (nextafter(pos_one, pos_one) != pos_one ||
-        nextafter(pos_zero, pos_zero) != pos_zero ||
-        nextafter(neg_zero, neg_zero) != neg_zero ||
-        nextafter(pos_inf, pos_inf) != pos_inf ||
-        nextafter(neg_inf, neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(equality)\n");
-    }
+  // Equality (from==toward) Handling
+  KOKKOS_EXPECT_EQ(nextafter(pos_one, pos_one), pos_one);
+  KOKKOS_EXPECT_EQ(nextafter(pos_zero, pos_zero), pos_zero);
+  KOKKOS_EXPECT_EQ(nextafter(neg_zero, neg_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_inf), pos_inf);
+  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_inf), neg_inf);
 
-    // Zero Handling
-    if (nextafter(pos_zero, pos_one) != pos_smallest ||
-        nextafter(pos_zero, neg_one) != neg_smallest ||
-        nextafter(pos_zero, neg_zero) != neg_zero ||
-        nextafter(neg_zero, pos_one) != pos_smallest ||
-        nextafter(neg_zero, neg_one) != neg_smallest ||
-        nextafter(neg_zero, pos_zero) != pos_zero) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(zero)\n");
-    }
+  // Zero Handling
+  KOKKOS_EXPECT_EQ(nextafter(pos_zero, pos_one), pos_smallest);
+  KOKKOS_EXPECT_EQ(nextafter(pos_zero, neg_one), neg_smallest);
+  KOKKOS_EXPECT_EQ(nextafter(pos_zero, neg_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(nextafter(neg_zero, pos_one), pos_smallest);
+  KOKKOS_EXPECT_EQ(nextafter(neg_zero, neg_one), neg_smallest);
+  KOKKOS_EXPECT_EQ(nextafter(neg_zero, pos_zero), pos_zero);
 
-    // From Negative Non Zero Handling
-    const FP16Type after_neg_one = Kokkos::bit_cast<FP16Type>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
-    const FP16Type before_neg_one = Kokkos::bit_cast<FP16Type>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
-    if (nextafter(neg_smallest, pos_zero) != neg_zero ||
-        nextafter(neg_one, pos_one) != after_neg_one ||
-        nextafter(neg_one, neg_two) != before_neg_one ||
-        nextafter(neg_max, neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(negative)\n");
-    }
+  // From Negative Non Zero Handling
+  const FP16Type after_neg_one = Kokkos::bit_cast<FP16Type>(
+      std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) - 1));
+  const FP16Type before_neg_one = Kokkos::bit_cast<FP16Type>(
+      std::uint16_t(Kokkos::bit_cast<std::uint16_t>(neg_one) + 1));
+  KOKKOS_EXPECT_EQ(nextafter(neg_smallest, pos_zero), neg_zero);
+  KOKKOS_EXPECT_EQ(nextafter(neg_one, pos_one), after_neg_one);
+  KOKKOS_EXPECT_EQ(nextafter(neg_one, neg_two), before_neg_one);
+  KOKKOS_EXPECT_EQ(nextafter(neg_max, neg_inf), neg_inf);
 
-    // From Positive Non Zero Handling
-    const FP16Type after_pos_one = Kokkos::bit_cast<FP16Type>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
-    const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
-        std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
-    if (nextafter(pos_smallest, neg_zero) != pos_zero ||
-        nextafter(pos_one, neg_one) != before_pos_one ||
-        nextafter(pos_one, pos_two) != after_pos_one ||
-        nextafter(pos_max, pos_inf) != pos_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(positive)\n");
-    }
+  // From Positive Non Zero Handling
+  const FP16Type after_pos_one = Kokkos::bit_cast<FP16Type>(
+      std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) + 1));
+  const FP16Type before_pos_one = Kokkos::bit_cast<FP16Type>(
+      std::uint16_t(Kokkos::bit_cast<std::uint16_t>(pos_one) - 1));
+  KOKKOS_EXPECT_EQ(nextafter(pos_smallest, neg_zero), pos_zero);
+  KOKKOS_EXPECT_EQ(nextafter(pos_one, neg_one), before_pos_one);
+  KOKKOS_EXPECT_EQ(nextafter(pos_one, pos_two), after_pos_one);
+  KOKKOS_EXPECT_EQ(nextafter(pos_max, pos_inf), pos_inf);
 
-    // From Inf Handling
-    // Note: The behavior of nextafter with infinities is
-    // implementation-defined, but in Kokkos it returns the maximum
-    // finite value when moving towards a finite value.
-    if (nextafter(pos_inf, pos_one) != pos_max ||
-        nextafter(neg_inf, neg_one) != neg_max ||
-        nextafter(pos_inf, pos_inf) != pos_inf ||
-        nextafter(neg_inf, neg_inf) != neg_inf) {
-      ++e;
-      Kokkos::printf("failed half precision nextafter(inf)\n");
-    }
-  }
-};
+  // From Inf Handling
+  // Note: The behavior of nextafter with infinities is
+  // implementation-defined, but in Kokkos it returns the maximum
+  // finite value when moving towards a finite value.
+  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_one), pos_max);
+  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_one), neg_max);
+  KOKKOS_EXPECT_EQ(nextafter(pos_inf, pos_inf), pos_inf);
+  KOKKOS_EXPECT_EQ(nextafter(neg_inf, neg_inf), neg_inf);
+}
 
 TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
 #if defined(KOKKOS_ENABLE_CUDA) &&                         \
@@ -2998,11 +2818,13 @@ TEST(TEST_CATEGORY, mathematical_functions_nextafter_fp16) {
   bool skipped = true;
 #if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
   skipped      = false;
-  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t>();
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::half_t> test_half;
+  ASSERT_EQ(test_half.run(), 0);
 #endif
 #if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
   skipped = false;
-  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t>();
+  TestNextAfterHalf<TEST_EXECSPACE, Kokkos::Experimental::bhalf_t> test_bhalf;
+  ASSERT_EQ(test_bhalf.run(), 0);
 #endif
   if (skipped) GTEST_SKIP() << "no 16-bit floating-point precision support";
 #endif

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -686,9 +686,11 @@ DEFINE_TYPE_NAME(long double)
 template <class Space, class Func, class Arg, std::size_t N,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathUnaryFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg val_[N];
   Ret res_[N];
-  TestMathUnaryFunction(const Arg (&val)[N]) {
+  TestMathUnaryFunction(const Arg (&val)[N]) : KOKKOS_INIT_ERROR_REPORTER(10) {
     std::copy(val, val + N, val_);
     std::transform(val, val + N, res_,
                    [](auto x) { return Func::eval_std(x); });
@@ -696,20 +698,14 @@ struct TestMathUnaryFunction {
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, N), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, N), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int i, int& e) const {
-    bool ar = KokkosTest::FloatingPointComparison::compare(
-        Func::eval(val_[i]), res_[i], Func::ulp_factor());
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f which is %f was expected to be %f\n",
-                     (double)val_[i], (double)Func::eval(val_[i]),
-                     (double)res_[i]);
-    }
+  KOKKOS_FUNCTION void operator()(int i) const {
+    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val_[i]), res_[i], Func::ulp_factor());
   }
 };
 
@@ -749,9 +745,12 @@ void do_test_half_math_unary_function(const Arg (&x)[N]) {
 
 template <class Space, class Func, class Arg, std::size_t N>
 struct TestIntMathUnaryFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg val_[N];
   int res_[N];
-  TestIntMathUnaryFunction(const Arg (&val)[N]) {
+  TestIntMathUnaryFunction(const Arg (&val)[N])
+      : KOKKOS_INIT_ERROR_REPORTER(10) {
     std::copy(val, val + N, val_);
     std::transform(val, val + N, res_,
                    [](auto x) { return Func::eval_std(x); });
@@ -759,20 +758,14 @@ struct TestIntMathUnaryFunction {
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, N), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, N), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int i, int& e) const {
-    bool ar =
-        KokkosTest::IntegerComparison::compare(Func::eval(val_[i]), res_[i]);
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f which is %f was expected to be %f\n",
-                     (double)val_[i], (double)Func::eval(val_[i]),
-                     (double)res_[i]);
-    }
+  KOKKOS_FUNCTION void operator()(int i) const {
+    KOKKOS_EXPECT_EQ(Func::eval(val_[i]), res_[i]);
   }
 };
 
@@ -814,30 +807,29 @@ void do_test_int_half_math_unary_function(const Arg (&x)[N]) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
 struct TestMathBinaryFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
   TestMathBinaryFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val1_(val1),
+        val2_(val2),
+        res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = KokkosTest::FloatingPointComparison::compare(
-        Func::eval(val1_, val2_), res_, Func::ulp_factor());
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f, %f which is %f was expected to be %f\n",
-                     (double)val1_, (double)val2_,
-                     (double)Func::eval(val1_, val2_), (double)res_);
-    }
+  KOKKOS_FUNCTION void operator()(int) const {
+    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_), res_, Func::ulp_factor());
   }
 };
 
@@ -850,30 +842,29 @@ void do_test_math_binary_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_unary_function_return_type_t<Arg1>>
 struct TestMathBinaryIntFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg1 val1_;
   Arg2 val2_;
   Ret res_;
   TestMathBinaryIntFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val1_(val1),
+        val2_(val2),
+        res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = KokkosTest::FloatingPointComparison::compare(
-        Func::eval(val1_, val2_), res_, Func::ulp_factor());
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f, %f which is %f was expected to be %f\n",
-                     (double)val1_, (double)val2_,
-                     (double)Func::eval(val1_, val2_), (double)res_);
-    }
+  KOKKOS_FUNCTION void operator()(int) const {
+    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_), res_, Func::ulp_factor());
   }
 };
 
@@ -886,34 +877,31 @@ void do_test_math_binary_int_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathBinaryPtrFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg val_;
   Ret res_frac_;
   Ret res_int_;
   const char* m_name;
   TestMathBinaryPtrFunction(Arg val)
-      : val_(val), m_name(math_function_name<Func>::name) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val_(val),
+        m_name(math_function_name<Func>::name) {
     res_frac_ = Func::eval_std(val_, &res_int_);
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed " << m_name << " check for "
                          << type_helper<Arg>::name();
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
+  KOKKOS_FUNCTION void operator()(int) const {
     Ret iptr;
-    Ret frac     = Func::eval(val_, &iptr);
-    bool ar_frac = KokkosTest::FloatingPointComparison::compare(
-        frac, res_frac_, Func::ulp_factor());
-    bool ar_int = KokkosTest::FloatingPointComparison::compare(
-        iptr, res_int_, Func::ulp_factor());
-    if (!ar_frac || !ar_int) {
-      ++e;
-      Kokkos::printf("%s failed: Val %f -> Frac %f (exp %f), Int %f (exp %f)\n",
-                     m_name, (double)val_, (double)frac, (double)res_frac_,
-                     (double)iptr, (double)res_int_);
-    }
+    Ret frac = Func::eval(val_, &iptr);
+    KOKKOS_EXPECT_NEAR_ULPS(frac, res_frac_, Func::ulp_factor());
+    KOKKOS_EXPECT_NEAR_ULPS(iptr, res_int_, Func::ulp_factor());
   }
 };
 
@@ -931,30 +919,29 @@ void do_test_math_binary_ptr_function(Arg x) {
 
 template <class Space, class Func, class Arg1, class Arg2>
 struct TestMathBinaryPredicate {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg1 val1_;
   Arg2 val2_;
   bool res_;
   TestMathBinaryPredicate(Arg1 val1, Arg2 val2)
-      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2)) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val1_(val1),
+        val2_(val2),
+        res_(Func::eval_std(val1, val2)) {
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = Func::eval(val1_, val2_) == res_;
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f, %f which is %s was expected to be %s\n",
-                     (double)val1_, (double)val2_,
-                     Func::eval(val1_, val2_) ? "true" : "false",
-                     res_ ? "true" : "false");
-    }
+  KOKKOS_FUNCTION void operator()(int) const {
+    KOKKOS_EXPECT_EQ(Func::eval(val1_, val2_), res_);
   }
 };
 
@@ -967,33 +954,31 @@ void do_test_math_binary_predicate(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg,
           class Ret = math_unary_function_return_type_t<Arg>>
 struct TestMathBinaryIntPtrFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg val_;
   int res1_;
   Ret res2_;
   TestMathBinaryIntPtrFunction(Arg val)
-      : val_(val), res2_(Func::eval_std(val, &res1_)) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val_(val),
+        res2_(Func::eval_std(val, &res1_)) {
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
+  KOKKOS_FUNCTION void operator()(int) const {
     int res1;
     Ret res2 = Func::eval(val_, &res1);
-    bool ar1 = (res1 == res1_);
-    bool ar2 = KokkosTest::FloatingPointComparison::compare(res2, res2_,
-                                                            Func::ulp_factor());
-    if (!(ar1 && ar2)) {
-      ++e;
-      Kokkos::printf(
-          "values at %f which are %f, %f were expected to be %f, %f\n",
-          (double)val_, (double)res1, (double)res2, (double)res1_,
-          (double)res2_);
-    }
+
+    KOKKOS_EXPECT_EQ(res1, res1_);
+    KOKKOS_EXPECT_NEAR_ULPS(res2, res2_, Func::ulp_factor());
   }
 };
 
@@ -1012,34 +997,33 @@ void do_test_math_binary_int_ptr_function(Arg x) {
 template <class Space, class Func, class Arg1, class Arg2,
           class Ret = math_binary_function_return_type_t<Arg1, Arg2>>
 struct TestMathTernaryIntPtrFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg1 val1_;
   Arg2 val2_;
   int val_;
   Ret res_;
   TestMathTernaryIntPtrFunction(Arg1 val1, Arg2 val2)
-      : val1_(val1), val2_(val2), res_(Func::eval_std(val1, val2, &val_)) {
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val1_(val1),
+        val2_(val2),
+        res_(Func::eval_std(val1, val2, &val_)) {
     run();
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
+  KOKKOS_FUNCTION void operator()(int) const {
     int val;
-    auto res  = Func::eval(val1_, val2_, &val);
-    bool ar_1 = KokkosTest::FloatingPointComparison::compare(
-        res, res_, Func::ulp_factor());
-    bool ar_2 = (val_ == val);
-    if (!(ar_1 && ar_2)) {
-      ++e;
-      Kokkos::printf(
-          "value at %f, %f which is %f and %i was expected to be %f and %i\n",
-          (double)val1_, (double)val2_, (double)res, val, (double)res_, val_);
-    }
+    auto res = Func::eval(val1_, val2_, &val);
+    KOKKOS_EXPECT_NEAR_ULPS(res, res_, Func::ulp_factor());
+    KOKKOS_EXPECT_EQ(val_, val);
   }
 };
 
@@ -1053,12 +1037,15 @@ void do_test_math_ternary_int_ptr_function(Arg1 arg1, Arg2 arg2) {
 template <class Space, class Func, class Arg1, class Arg2, class Arg3,
           class Ret = math_ternary_function_return_type_t<Arg1, Arg2, Arg3>>
 struct TestMathTernaryFunction {
+  KOKKOS_DEFINE_ERROR_REPORTER(2048, Space);
+
   Arg1 val1_;
   Arg2 val2_;
   Arg3 val3_;
   Ret res_;
   TestMathTernaryFunction(Arg1 val1, Arg2 val2, Arg3 val3)
-      : val1_(val1),
+      : KOKKOS_INIT_ERROR_REPORTER(10),
+        val1_(val1),
         val2_(val2),
         val3_(val3),
         res_(Func::eval_std(val1, val2, val3)) {
@@ -1066,22 +1053,17 @@ struct TestMathTernaryFunction {
   }
   void run() {
     int errors = 0;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Space>(0, 1), *this, errors);
+    Kokkos::parallel_for(Kokkos::RangePolicy<Space>(0, 1), *this);
+    KOKKOS_RETRIEVE_ERRORS(errors);
     ASSERT_EQ(errors, 0) << "Failed check no error for "
                          << math_function_name<Func>::name << "("
                          << type_helper<Arg1>::name() << ", "
                          << type_helper<Arg2>::name() << ", "
                          << type_helper<Arg3>::name() << ")";
   }
-  KOKKOS_FUNCTION void operator()(int, int& e) const {
-    bool ar = KokkosTest::FloatingPointComparison::compare(
-        Func::eval(val1_, val2_, val3_), res_, Func::ulp_factor());
-    if (!ar) {
-      ++e;
-      Kokkos::printf("value at %f, %f, %f which is %f was expected to be %f\n",
-                     (double)val1_, (double)val2_, (double)val3_,
-                     (double)Func::eval(val1_, val2_, val3_), (double)res_);
-    }
+  KOKKOS_FUNCTION void operator()(int) const {
+    KOKKOS_EXPECT_NEAR_ULPS(Func::eval(val1_, val2_, val3_), res_,
+                            Func::ulp_factor());
   }
 };
 
@@ -2716,9 +2698,13 @@ DEFINE_UNARY_FUNCTION_EVAL_CUSTOM(test_fallback_bhalf, 0,
 
 TEST(TEST_CATEGORY, mathematical_functions_impl_half_fallback) {
   TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_half,
-                        KE::half_t, 1>({KE::half_t(1.f)});
+                        KE::half_t, 1>
+      test_half({KE::half_t(1.f)});
+  (void)test_half;
   TestMathUnaryFunction<TEST_EXECSPACE, MathUnaryFunction_test_fallback_bhalf,
-                        KE::bhalf_t, 1>({KE::bhalf_t(1.f)});
+                        KE::bhalf_t, 1>
+      test_bhalf({KE::bhalf_t(1.f)});
+  (void)test_bhalf;
 }
 
 KOKKOS_DEVICE_TEST(TestNextAfterHalf, FP16Type) {

--- a/core/unit_test/TestStringManipulationRuntime.hpp
+++ b/core/unit_test/TestStringManipulationRuntime.hpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+namespace {
+
+struct TestStaticString {
+  TestStaticString() { EXPECT_EQ(run(), 0); }
+
+  int run() const {
+    int nerrors;
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), *this,
+                            nerrors);
+    return nerrors;
+  }
+
+  template <std::size_t capacity>
+  KOKKOS_FUNCTION int check(const Kokkos::Impl::StaticString<capacity>& ss,
+                            const char* ref) const {
+    if (Kokkos::Impl::strncmp(ss.c_str(), ref, ss.size() + 1) != 0) {
+      Kokkos::printf("Error: %s != %s\n", ss.c_str(), ref);
+      return 1;
+    }
+    return 0;
+  }
+
+  KOKKOS_FUNCTION void operator()(int, int& errors) const {
+    {
+      // Empty constructor should return an empty valid cstring
+      Kokkos::Impl::StaticString<10> ss;
+      const char* ref = "";
+      errors += check(ss, ref);
+    }
+    {
+      // Constructor taking a cstring
+      Kokkos::Impl::StaticString<10> ss("test");
+      const char* ref = "test";
+      errors += check(ss, ref);
+    }
+    {
+      // Append cstring
+      Kokkos::Impl::StaticString<10> ss("test");
+      ss << "test";
+      const char* ref = "testtest";
+      errors += check(ss, ref);
+    }
+    {
+      // Exceed string capacity in constructor
+      Kokkos::Impl::StaticString<10> ss("testtesttest");
+      const char* ref = "testte...";
+      errors += check(ss, ref);
+    }
+    {
+      // Append int
+      Kokkos::Impl::StaticString<10> ss("test");
+      ss << 5;
+      const char* ref = "test5";
+      errors += check(ss, ref);
+    }
+    {
+      // Completely fill the string without exceeding the capacity
+      Kokkos::Impl::StaticString<10> ss("testtest");
+      ss << 5;
+      const char* ref = "testtest5";
+      errors += check(ss, ref);
+    }
+    {
+      // Fill the string and try to append an int
+      Kokkos::Impl::StaticString<10> ss("testtestt");
+      ss << 5;
+      const char* ref = "testte...";
+      errors += check(ss, ref);
+    }
+    {
+      // Fill the string and try to append a cstring
+      Kokkos::Impl::StaticString<10> ss("testtestt");
+      ss << "test";
+      const char* ref = "testte...";
+      errors += check(ss, ref);
+    }
+    {
+      // Try to write an int to big for the capacity, before appending a string
+      Kokkos::Impl::StaticString<10> ss;
+      ss << 1'000'000'000 << "test";
+      const char* ref = "...";
+      errors += check(ss, ref);
+    }
+    {
+      // Multiple append
+      Kokkos::Impl::StaticString<250> ss;
+      ss << "test" << 5 << "test" << 5 << "test";
+      const char* ref = "test5test5test";
+      errors += check(ss, ref);
+    }
+    {
+      // Append Booleans
+      Kokkos::Impl::StaticString<10> ss;
+      ss << true << false;
+      const char* ref = "TrueFalse";
+      errors += check(ss, ref);
+    }
+    {
+      // Append Booleans without enough capacity
+      Kokkos::Impl::StaticString<10> ss;
+      ss << "test" << true << false;
+      const char* ref = "testTr...";
+      errors += check(ss, ref);
+    }
+    {
+      // Append Float
+      Kokkos::Impl::StaticString<15> ss;
+      ss << 1.5f;
+      const char* ref = "1";
+      errors += check(ss, ref);
+    }
+    {
+      // Append Double
+      Kokkos::Impl::StaticString<15> ss;
+      ss << 1.5;
+      const char* ref = "1";
+      errors += check(ss, ref);
+    }
+#if defined(KOKKOS_HALF_T_IS_FLOAT) && !KOKKOS_HALF_T_IS_FLOAT
+    {
+      // Append half_t
+      Kokkos::Impl::StaticString<20> ss;
+      ss << Kokkos::Experimental::half_t(1.5f);
+      const char* ref = "1";
+      errors += check(ss, ref);
+    }
+#endif
+#if defined(KOKKOS_BHALF_T_IS_FLOAT) && !KOKKOS_BHALF_T_IS_FLOAT
+    {
+      // Append half_t
+      Kokkos::Impl::StaticString<20> ss;
+      ss << Kokkos::Experimental::bhalf_t(1.5f);
+      const char* ref = "1";
+      errors += check(ss, ref);
+    }
+#endif
+  }
+};
+
+TEST(TEST_CATEGORY, TestStaticString) { TestStaticString(); }
+
+}  // namespace


### PR DESCRIPTION
The goal of this PR is to make error messages clearer for the mathematical function tests and make writing the tests themself easier and more consistent with hosts tests.

For instance, I introduced an error in `nextafter` to compare the result of the display:
The old test code was:
```
    if (nextafter(pos_smallest, neg_zero) != pos_zero ||
        nextafter(pos_one, neg_one) != before_pos_one ||
        nextafter(pos_one, pos_two) != after_pos_one ||
        nextafter(pos_max, pos_inf) != pos_inf) {
      ++e;
      Kokkos::printf("failed half precision nextafter(positive)\n");
    }
```
Which outputs:
```
failed half precision nextafter(positive)
/gpfs/users/gannayp/kokkos_dev/core/unit_test/TestMathematicalFunctions.hpp:2076: Failure
Expected equality of these values:
  errors
    Which is: 1
  0
```

The new code is:
```
DEXPECT_EQ(nextafter(m_test_reporter, pos_one, neg_one), before_pos_one);
```
Which outputs:
```
/gpfs/users/gannayp/kokkos_dev/core/unit_test/TestMathematicalFunctions.hpp:2108: Failure
Expected equality of these values:
  nextafter(pos_one, neg_one)
    Which is: 1.007812
  before_pos_one
    Which is: 0.996094
/gpfs/users/gannayp/kokkos_dev/core/unit_test/TestMathematicalFunctions.hpp:2035: Failure
Expected equality of these values:
  errors
    Which is: 1
  0
```

I tried to stay as close as possible to the syntax gtest uses to display error.

### Related issues / PRs
 - https://github.com/kokkos/kokkos/pull/9244 is needed before this can be merged
 - this PR is based on and is an improvement of the changes proposed here: https://github.com/kokkos/kokkos/pull/8768

### Changelog Entry
Not sure a changelog entry is needed since it only change the way Kokkos test are written.
