### PR TITLE
Fix OpenACC CI

### DIFF
--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -196,6 +196,11 @@ void from_nullptr_and_0() {
 }
 
 TEST(TEST_CATEGORY, view_ctor_ptr_convertible) {
+  // FIXME_OPENACC
+#ifdef KOKKOS_ENABLE_OPENACC
+  GTEST_SKIP() << "Known to fail with OpenACC" << std::endl;
+  KOKKOS_IMPL_UNREACHABLE();
+#endif
   from_array_like();
   from_carray();
   from_custom_ptr();

--- a/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
+++ b/core/unit_test/view/TestViewCtorConvertibleToPtr.hpp
@@ -198,7 +198,7 @@ void from_nullptr_and_0() {
 TEST(TEST_CATEGORY, view_ctor_ptr_convertible) {
   // FIXME_OPENACC
 #ifdef KOKKOS_ENABLE_OPENACC
-  GTEST_SKIP() << "Known to fail with OpenACC" << std::endl;
+  GTEST_SKIP() << "Known to fail with OpenACC";
   KOKKOS_IMPL_UNREACHABLE();
 #endif
   from_array_like();


### PR DESCRIPTION
Fixes test failures on `develop`. Follow-up to https://github.com/kokkos/kokkos/pull/9165.