### PR TITLE
core(graph): node properties enhancements with `get_properties_or`

### DIFF
--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -235,13 +235,13 @@ class GraphNodeRef {
                                         std::remove_cvref_t<Functor>>;
     auto graph_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_ptr))
-    auto full_props = Kokkos::Impl::with_properties_if_unset(
-        std::forward<Props>(props), graph_ptr->get_device_handle(),
-        "[unlabeled]");
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_ptr->get_device_handle(),
+            "[unlabeled]");
     return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        std::forward<Policy>(policy), std::forward<Functor>(functor)});
+        std::move(label), device_handle.m_exec, std::forward<Policy>(policy),
+        std::forward<Functor>(functor)});
   }
 
   template <typename Props, typename Functor>
@@ -410,15 +410,16 @@ class GraphNodeRef {
 
     auto graph_ptr = m_graph_impl.lock();
     KOKKOS_EXPECTS(bool(graph_ptr))
-    auto full_props =
-        with_properties_if_unset(std::forward<Props>(props),
-                                 graph_ptr->get_device_handle(), "[unlabeled]");
+
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_ptr->get_device_handle(),
+            "[unlabeled]");
 
     using policy_type = std::remove_cvref_t<Policy>;
     auto policy       = Experimental::require(
-        policy_type(
-            Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
-            Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        policy_type(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+                          device_handle.m_exec),
         Kokkos::Impl::KernelInGraphProperty{});
 
     using next_policy_t = decltype(policy);
@@ -426,10 +427,9 @@ class GraphNodeRef {
         Kokkos::Impl::GraphNodeKernelImpl<ExecutionSpace, next_policy_t,
                                           std::decay_t<Functor>,
                                           Kokkos::ParallelForTag>;
-    return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        (Functor&&)functor, std::move(policy)});
+    return this->_then_kernel(
+        next_kernel_t{std::move(label), device_handle.m_exec,
+                      (Functor&&)functor, std::move(policy)});
   }
 
   template <class Policy, class Functor>
@@ -498,10 +498,6 @@ class GraphNodeRef {
     // needs static assertion of constraint:
     //   DataParallelReductionFunctor<Functor, ReturnType>
 
-    auto full_props = with_properties_if_unset(
-        std::forward<Props>(props), graph_impl_ptr->get_device_handle(),
-        "[unlabeled]");
-
     // This is also just an expectation, but it's one that we expect the user
     // to interact with (even in release mode), so we should throw an exception
     // with an explanation rather than just doing a contract assertion.
@@ -556,11 +552,15 @@ class GraphNodeRef {
     // End of Kokkos reducer disaster
     //----------------------------------------
 
+    auto [device_handle, label] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::forward<Props>(props), graph_impl_ptr->get_device_handle(),
+            "[unlabeled]");
+
     using policy_type = std::remove_cvref_t<Policy>;
     auto policy       = Experimental::require(
-        policy_type(
-            Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
-            Kokkos::Impl::get_property<device_handle_t>(full_props).m_exec),
+        policy_type(Kokkos::Impl::PolicyUpdate{}, (Policy&&)arg_policy,
+                          device_handle.m_exec),
         Kokkos::Impl::KernelInGraphProperty{});
 
     using passed_reducer_type = typename return_value_adapter::reducer_type;
@@ -587,12 +587,11 @@ class GraphNodeRef {
                                           decltype(functor_reducer),
                                           Kokkos::ParallelReduceTag>;
 
-    return this->_then_kernel(next_kernel_t{
-        Kokkos::Impl::extract_property<std::string>(full_props),
-        Kokkos::Impl::extract_property<device_handle_t>(full_props).m_exec,
-        std::move(functor_reducer), std::move(policy),
-        return_value_adapter::return_value(return_value,
-                                           std::forward<Functor>(functor))});
+    return this->_then_kernel(
+        next_kernel_t{std::move(label), device_handle.m_exec,
+                      std::move(functor_reducer), std::move(policy),
+                      return_value_adapter::return_value(
+                          return_value, std::forward<Functor>(functor))});
   }
 
   template <class Policy, class Functor, class ReturnType>

--- a/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
+++ b/core/src/impl/Kokkos_GraphNodeCtorProps.hpp
@@ -5,7 +5,10 @@
 #define KOKKOS_IMPL_KOKKOS_GRAPHNODECTORPROPS_HPP
 
 #include "impl/Kokkos_DeviceHandle.hpp"
+#include "impl/Kokkos_Utilities.hpp"
 #include "View/Kokkos_ViewCtor.hpp"
+
+#include <tuple>
 
 namespace Kokkos::Impl {
 
@@ -76,60 +79,38 @@ constexpr bool is_node_props_v = is_node_props<T>::value;
 template <typename T>
 concept NodeProperties = is_node_props_v<T>;
 
-template <typename Prop, NodeProperties Props>
-  requires Props::template
-has<Prop> [[nodiscard]] constexpr decltype(auto) get_property(
-    const Props& props) {
-  return static_cast<const NodeCtorProp<Prop>&>(props).m_value;
+template <ValidNodeProperty Prop, typename PropsContainer>
+  requires(NodeProperties<std::remove_cvref_t<PropsContainer>> &&
+           std::remove_cvref_t<PropsContainer>::template has<Prop>)
+[[nodiscard]] constexpr decltype(auto) get_property(PropsContainer&& props) {
+  using base_t = std::conditional_t<
+      std::is_const_v<std::remove_reference_t<PropsContainer>>,
+      const NodeCtorProp<Prop>, NodeCtorProp<Prop>>;
+  return Kokkos::Impl::forward_like<PropsContainer>(
+      static_cast<base_t&>(props).m_value);
 }
 
-template <typename Prop, NodeProperties Props>
-  requires Props::template
-has<Prop> [[nodiscard]] constexpr decltype(auto) extract_property(
-    Props& props) {
-  return std::move(static_cast<NodeCtorProp<Prop>&>(props).m_value);
-}
-
-struct WithProperty {
-  template <typename... Props, typename Property>
-    requires(sizeof...(Props) > 0)
-  [[nodiscard]] static constexpr decltype(auto) set(
-      NodeCtorProps<Props...> props, Property&& property) {
-    using NewNodeCtorProps =
-        typename NodeCtorProps<Props...,
-                               std::remove_cvref_t<Property>>::uniform_type;
-    return NewNodeCtorProps{extract_property<Props>(props)...,
-                            std::forward<Property>(property)};
-  }
-
-  template <typename Property>
-  [[nodiscard]] static constexpr decltype(auto) set(NodeCtorProps<>,
-                                                    Property&& prop) {
-    return typename NodeCtorProps<std::remove_cvref_t<Property>>::uniform_type{
-        std::forward<Property>(prop)};
-  }
-};
-
-template <NodeProperties Props>
-[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
-    Props node_props) noexcept {
-  return node_props;
-}
-
-template <NodeProperties Props, typename Property, typename... Properties>
-[[nodiscard]] constexpr decltype(auto) with_properties_if_unset(
-    Props node_props, [[maybe_unused]] Property&& property,
-    Properties&&... properties) {
-  if constexpr (!Props::template has<typename Kokkos::Impl::NodeCtorProp<
-                    std::remove_cvref_t<Property>>::value_type>) {
-    return with_properties_if_unset(
-        WithProperty::set(std::move(node_props),
-                          std::forward<Property>(property)),
-        std::forward<Properties>(properties)...);
-  } else {
-    return with_properties_if_unset(std::move(node_props),
-                                    std::forward<Properties>(properties)...);
-  }
+template <ValidNodeProperty... Props, typename PropsContainer,
+          typename... Defaults>
+  requires(NodeProperties<std::remove_cvref_t<PropsContainer>> &&
+           (std::convertible_to<Defaults, Props> && ...))
+[[nodiscard]] constexpr auto get_properties_or(PropsContainer&& props,
+                                               Defaults&&... defaults)
+    -> std::tuple<Props...> {
+  using props_container_t = std::remove_cvref_t<PropsContainer>;
+  constexpr bool is_base_const =
+      std::is_const_v<std::remove_reference_t<PropsContainer>>;
+  return {[&]() -> decltype(auto) {
+    if constexpr (props_container_t::template has<Props>) {
+      using base_t =
+          std::conditional_t<is_base_const, const NodeCtorProp<Props>,
+                             NodeCtorProp<Props>>;
+      return Kokkos::Impl::forward_like<PropsContainer>(
+          static_cast<base_t&>(props).m_value);
+    } else {
+      return std::forward<Defaults>(defaults);
+    }
+  }()...};
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -50,6 +50,30 @@ KOKKOS_FUNCTION constexpr std::underlying_type_t<E> to_underlying(
   return static_cast<std::underlying_type_t<E>>(e);
 }
 
+#if defined(__cpp_lib_forward_like)
+// since C++23
+using std::forward_like;
+#else
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2445r0.pdf
+template <typename T, typename U>
+using override_ref_t = std::conditional_t<std::is_rvalue_reference_v<T>,
+                                          std::remove_reference_t<U> &&, U &>;
+
+template <typename T, typename U>
+using copy_const_t =
+    std::conditional_t<std::is_const_v<std::remove_reference_t<T>>, U const, U>;
+
+template <typename T, typename U>
+using forward_like_t =
+    override_ref_t<T &&, copy_const_t<T, std::remove_reference_t<U>>>;
+
+template <typename T>
+[[nodiscard]] constexpr auto forward_like(auto &&x) noexcept
+    -> forward_like_t<T, decltype(x)> {
+  return static_cast<forward_like_t<T, decltype(x)>>(x);
+}
+#endif
+
 #if defined(__cpp_lib_is_scoped_enum)
 // since C++23
 using std::is_scoped_enum;

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -1650,4 +1650,20 @@ TEST_F(TEST_CATEGORY_FIXTURE(graph), team_launch_bounds_in_graph) {
   }
 }
 
+// Ensure that node properties can be passed by const lvalue.
+TEST_F(TEST_CATEGORY_FIXTURE(graph), property_by_const_lvalue) {
+  Kokkos::Experimental::Graph<TEST_EXECSPACE> graph{};
+
+  const auto node_props = Kokkos::Experimental::node_props(
+      "property by const lvalue",
+      Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+
+  const auto node_then = graph.root_node().then(node_props, NoOp{});
+  const auto node_pfor = node_then.then_parallel_for(
+      node_props, Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), NoOp{});
+  [[maybe_unused]] const auto node_pred = node_pfor.then_parallel_reduce(
+      node_props, Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
+      NoOpReduceFunctor<TEST_EXECSPACE, int>{}, count);
+}
+
 }  // end namespace Test

--- a/core/unit_test/TestGraphNodeCtorProps.hpp
+++ b/core/unit_test/TestGraphNodeCtorProps.hpp
@@ -117,69 +117,97 @@ TEST(TEST_CATEGORY, node_props_label_device_handle) {
       Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
 }
 
-TEST(TEST_CATEGORY, node_props_with_properties_if_unset) {
-  {
-    const auto props_label_device_handle_old = Kokkos::Experimental::node_props(
-        "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
-    const auto props_label_device_handle_new =
-        Kokkos::Impl::with_properties_if_unset(props_label_device_handle_old,
-                                               "another label");
+TEST(TEST_CATEGORY, node_props_get_properties_or) {
+  const auto [exec_A, exec_B] =
+      Kokkos::Experimental::partition_space(TEST_EXECSPACE{}, 1, 1);
 
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle_old),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle_new),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+  using device_handle_t = Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>;
 
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle_old),
-        "label");
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle_new),
-        "label");
-  }
+  const device_handle_t device_handle_A =
+      Kokkos::Experimental::get_device_handle(exec_A);
+  const device_handle_t device_handle_B =
+      Kokkos::Experimental::get_device_handle(exec_B);
 
   {
-    const auto props_empty = Kokkos::Experimental::node_props();
-    const auto props_label_device_handle =
-        Kokkos::Impl::with_properties_if_unset(
-            props_empty, "label", Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+    auto empty = Kokkos::Experimental::node_props();
 
-    static_assert(
-        std::same_as<
-            decltype(props_label_device_handle),
-            const Kokkos::Impl::NodeCtorProps<
-                std::string, Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>>);
+    const auto [d_h_const_lvalue, label_const_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::as_const(empty), device_handle_B, "[unlabeled]");
+    const auto [d_h_lvalue, label_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            empty, device_handle_B, "[unlabeled]");
+    const auto [d_h_rvalue, label_rvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(empty), device_handle_B, "[unlabeled]");
 
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<std::string>(props_label_device_handle),
-        "label");
-    ASSERT_EQ(
-        Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
-            props_label_device_handle),
-        Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+    ASSERT_EQ(d_h_const_lvalue, device_handle_B);
+    ASSERT_EQ(d_h_lvalue, device_handle_B);
+    ASSERT_EQ(d_h_rvalue, device_handle_B);
+    ASSERT_EQ(label_const_lvalue, "[unlabeled]");
+    ASSERT_EQ(label_lvalue, "[unlabeled]");
+    ASSERT_EQ(label_rvalue, "[unlabeled]");
   }
-}
+  {
+    auto prop_label = Kokkos::Experimental::node_props("label");
 
-TEST(TEST_CATEGORY, node_props_get_property) {
-  auto props = Kokkos::Experimental::node_props(
-      "label", Kokkos::Experimental::get_device_handle(TEST_EXECSPACE{}));
+    const auto [d_h_const_lvalue, label_const_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::as_const(prop_label), device_handle_B, "[unlabeled]");
+    const auto [d_h_lvalue, label_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            prop_label, device_handle_B, "[unlabeled]");
+    const auto [d_h_rvalue, label_rvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(prop_label), device_handle_B, "[unlabeled]");
 
-  ASSERT_EQ(Kokkos::Impl::get_property<std::string>(props), "label");
-  ASSERT_EQ(
-      Kokkos::Impl::get_property<Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>>(
-          props),
-      Kokkos::Impl::DeviceHandle<TEST_EXECSPACE>{});
+    ASSERT_EQ(d_h_const_lvalue, device_handle_B);
+    ASSERT_EQ(d_h_lvalue, device_handle_B);
+    ASSERT_EQ(d_h_rvalue, device_handle_B);
+    ASSERT_EQ(label_const_lvalue, "label");
+    ASSERT_EQ(label_lvalue, "label");
+    ASSERT_EQ(label_rvalue, "label");
+  }
+  {
+    auto prop_device_handle = Kokkos::Experimental::node_props(device_handle_A);
 
-  const auto label = Kokkos::Impl::extract_property<std::string>(props);
+    const auto [d_h_const_lvalue, label_const_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::as_const(prop_device_handle), device_handle_B, "[unlabeled]");
+    const auto [d_h_lvalue, label_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            prop_device_handle, device_handle_B, "[unlabeled]");
+    const auto [d_h_rvalue, label_rvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(prop_device_handle), device_handle_B, "[unlabeled]");
 
-  ASSERT_EQ(label, "label");
-  ASSERT_TRUE(Kokkos::Impl::get_property<std::string>(props).empty());
+    ASSERT_EQ(d_h_const_lvalue, device_handle_A);
+    ASSERT_EQ(d_h_lvalue, device_handle_A);
+    ASSERT_EQ(d_h_rvalue, device_handle_A);
+    ASSERT_EQ(label_const_lvalue, "[unlabeled]");
+    ASSERT_EQ(label_lvalue, "[unlabeled]");
+    ASSERT_EQ(label_rvalue, "[unlabeled]");
+  }
+  {
+    auto props = Kokkos::Experimental::node_props("label", device_handle_A);
+
+    const auto [d_h_const_lvalue, label_const_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::as_const(props), device_handle_B, "[unlabeled]");
+    const auto [d_h_lvalue, label_lvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            props, device_handle_B, "[unlabeled]");
+    const auto [d_h_rvalue, label_rvalue] =
+        Kokkos::Impl::get_properties_or<device_handle_t, std::string>(
+            std::move(props), device_handle_B, "[unlabeled]");
+
+    ASSERT_EQ(d_h_const_lvalue, device_handle_A);
+    ASSERT_EQ(d_h_lvalue, device_handle_A);
+    ASSERT_EQ(d_h_rvalue, device_handle_A);
+    ASSERT_EQ(label_const_lvalue, "label");
+    ASSERT_EQ(label_lvalue, "label");
+    ASSERT_EQ(label_rvalue, "label");
+  }
 }
 
 }  // end namespace


### PR DESCRIPTION
This PR tries to simplify the use of node properties internally.

It removes old helpers and introduces `get_properties_or`, that allows to get all properties (or a default value) with proper value category semantics.

It returns a `std::tuple` to facilitate structured binding.

Extracted from:
- #9137 