### PR TITLE
Introduce Experimental::BadAlloc exception type to throw on allocation failures

### DIFF
--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -246,6 +246,9 @@ export {
   using ::Kokkos::real;
   using ::Kokkos::tie;
   using ::Kokkos::to_array;
+  namespace Experimental {
+  using ::Kokkos::Experimental::BadAllocation;
+  }  // namespace Experimental
 
   // reducers
   using ::Kokkos::BAnd;

--- a/core/src/Kokkos_Core.cppm
+++ b/core/src/Kokkos_Core.cppm
@@ -247,7 +247,7 @@ export {
   using ::Kokkos::tie;
   using ::Kokkos::to_array;
   namespace Experimental {
-  using ::Kokkos::Experimental::BadAllocation;
+  using ::Kokkos::Experimental::BadAlloc;
   }  // namespace Experimental
 
   // reducers

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -19,7 +19,7 @@ void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
 
 void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
                                    std::size_t size, std::string_view label) {
-  throw Kokkos::Experimental::BadAllocation(memory_space_name, size, label);
+  throw Kokkos::Experimental::BadAlloc(memory_space_name, size, label);
 }
 
 void Kokkos::Impl::log_warning(const std::string &msg) {

--- a/core/src/impl/Kokkos_Error.cpp
+++ b/core/src/impl/Kokkos_Error.cpp
@@ -19,11 +19,7 @@ void Kokkos::Impl::throw_runtime_exception(const std::string &msg) {
 
 void Kokkos::Impl::throw_bad_alloc(std::string_view memory_space_name,
                                    std::size_t size, std::string_view label) {
-  std::stringstream ss;
-  ss << "Kokkos ERROR: " << memory_space_name
-     << " memory space failed to allocate " << human_memory_size(size)
-     << " (label=\"" << label << "\").";
-  throw std::runtime_error(ss.str());
+  throw Kokkos::Experimental::BadAllocation(memory_space_name, size, label);
 }
 
 void Kokkos::Impl::log_warning(const std::string &msg) {

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -5,6 +5,9 @@
 #define KOKKOS_IMPL_ERROR_HPP
 
 #include <string>
+#include <string_view>
+#include <stdexcept>
+#include <sstream>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Abort.hpp>
 #include <Kokkos_Assert.hpp>
@@ -19,5 +22,45 @@ void log_warning(const std::string &msg);
 std::string human_memory_size(size_t bytes);
 
 }  // namespace Kokkos::Impl
+
+namespace Kokkos::Experimental {
+
+/// Exception thrown when a Kokkos memory allocation fails.
+///
+/// Inherits from std::runtime_error for backward compatibility — existing
+/// catch blocks that catch std::runtime_error still work.  Provides structured
+/// access to the memory space, requested allocation size, and label of the
+/// allocation that failed.
+class BadAllocation : public std::runtime_error {
+  std::string m_memory_space_name;
+  std::size_t m_allocation_size;
+  std::string m_label;
+
+  static std::string make_message(std::string_view memory_space_name,
+                                  std::size_t size, std::string_view label) {
+    std::stringstream ss;
+    ss << "Kokkos ERROR: " << memory_space_name
+       << " memory space failed to allocate "
+       << Kokkos::Impl::human_memory_size(size) << " (label=\"" << label
+       << "\").";
+    return ss.str();
+  }
+
+ public:
+  BadAllocation(std::string_view memory_space_name, std::size_t size,
+                std::string_view label)
+      : std::runtime_error(make_message(memory_space_name, size, label)),
+        m_memory_space_name(memory_space_name),
+        m_allocation_size(size),
+        m_label(label) {}
+
+  const std::string& memory_space_name() const noexcept {
+    return m_memory_space_name;
+  }
+  std::size_t allocation_size() const noexcept { return m_allocation_size; }
+  const std::string& label() const noexcept { return m_label; }
+};
+
+}  // namespace Kokkos::Experimental
 
 #endif

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -31,7 +31,7 @@ namespace Kokkos::Experimental {
 /// catch blocks that catch std::runtime_error still work.  Provides structured
 /// access to the memory space, requested allocation size, and label of the
 /// allocation that failed.
-class BadAllocation : public std::runtime_error {
+class BadAlloc : public std::runtime_error {
   std::string m_memory_space_name;
   std::size_t m_allocation_size;
   std::string m_label;
@@ -47,8 +47,8 @@ class BadAllocation : public std::runtime_error {
   }
 
  public:
-  BadAllocation(std::string_view memory_space_name, std::size_t size,
-                std::string_view label)
+  BadAlloc(std::string_view memory_space_name, std::size_t size,
+           std::string_view label)
       : std::runtime_error(make_message(memory_space_name, size, label)),
         m_memory_space_name(memory_space_name),
         m_allocation_size(size),

--- a/core/src/impl/Kokkos_Error.hpp
+++ b/core/src/impl/Kokkos_Error.hpp
@@ -14,10 +14,10 @@
 
 namespace Kokkos::Impl {
 
-[[noreturn]] void throw_runtime_exception(const std::string &msg);
+[[noreturn]] void throw_runtime_exception(const std::string& msg);
 [[noreturn]] void throw_bad_alloc(std::string_view memory_space_name,
                                   std::size_t size, std::string_view label);
-void log_warning(const std::string &msg);
+void log_warning(const std::string& msg);
 
 std::string human_memory_size(size_t bytes);
 

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -43,7 +43,7 @@ void test_view_bad_alloc_typed_catch() {
     auto should_always_fail =
         Kokkos::View<double *, MemorySpace>(label, too_large);
     FAIL() << "It should have thrown.";
-  } catch (Kokkos::Experimental::BadAllocation const &error) {
+  } catch (Kokkos::Experimental::BadAlloc const &error) {
     ASSERT_EQ(error.memory_space_name(), MemorySpace::name());
     ASSERT_GE(error.allocation_size(), too_large * sizeof(double));
     ASSERT_EQ(error.label(), label);

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -35,6 +35,29 @@ void test_view_bad_alloc() {
   }
 }
 
+template <class MemorySpace>
+void test_view_bad_alloc_typed_catch() {
+  auto too_large    = std::numeric_limits<size_t>::max() - 42;
+  std::string label = "my_label";
+  try {
+    auto should_always_fail =
+        Kokkos::View<double *, MemorySpace>(label, too_large);
+    FAIL() << "It should have thrown.";
+  } catch (Kokkos::Experimental::BadAllocation const &error) {
+    ASSERT_EQ(error.memory_space_name(), MemorySpace::name());
+    ASSERT_GE(error.allocation_size(), too_large * sizeof(double));
+    ASSERT_EQ(error.label(), label);
+    // what() preserves the formatted message for backward compat
+    ASSERT_PRED_FORMAT2(
+        ::testing::IsSubstring,
+        std::string(MemorySpace::name()) + " memory space failed to allocate",
+        std::string(error.what()));
+    ASSERT_PRED_FORMAT2(::testing::IsSubstring,
+                        std::string("(label=\"") + label + "\")",
+                        std::string(error.what()));
+  }
+}
+
 TEST(TEST_CATEGORY, view_bad_alloc) {
   using ExecutionSpace = TEST_EXECSPACE;
   using MemorySpace    = ExecutionSpace::memory_space;
@@ -62,7 +85,10 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
   listen_tool_events(Config::DisableAll(), Config::EnableAllocs());
 
   ASSERT_TRUE(validate_absence(
-      [] { test_view_bad_alloc<MemorySpace>(); },
+      [] {
+        test_view_bad_alloc<MemorySpace>();
+        test_view_bad_alloc_typed_catch<MemorySpace>();
+      },
       [](AllocateDataEvent) { return MatchDiagnostic{true}; }));
 
   listen_tool_events(Config::DisableAll());
@@ -75,9 +101,11 @@ TEST(TEST_CATEGORY, view_bad_alloc) {
   if constexpr (execution_space_is_device) {
 #ifdef KOKKOS_HAS_SHARED_SPACE
     test_view_bad_alloc<Kokkos::SharedSpace>();
+    test_view_bad_alloc_typed_catch<Kokkos::SharedSpace>();
 #endif
 #ifdef KOKKOS_HAS_SHARED_HOST_PINNED_SPACE
     test_view_bad_alloc<Kokkos::SharedHostPinnedSpace>();
+    test_view_bad_alloc_typed_catch<Kokkos::SharedHostPinnedSpace>();
 #endif
   }
 }

--- a/core/unit_test/TestViewBadAlloc.hpp
+++ b/core/unit_test/TestViewBadAlloc.hpp
@@ -16,7 +16,7 @@ namespace {
 
 template <class MemorySpace>
 void test_view_bad_alloc() {
-  auto too_large    = std::numeric_limits<size_t>::max() - 42;
+  auto too_large    = std::numeric_limits<size_t>::max() / sizeof(double) - 42;
   std::string label = "my_label";
   try {
     auto should_always_fail =
@@ -37,7 +37,7 @@ void test_view_bad_alloc() {
 
 template <class MemorySpace>
 void test_view_bad_alloc_typed_catch() {
-  auto too_large    = std::numeric_limits<size_t>::max() - 42;
+  auto too_large    = std::numeric_limits<size_t>::max() / sizeof(double) - 42;
   std::string label = "my_label";
   try {
     auto should_always_fail =


### PR DESCRIPTION
Added `Kokkos::Experimental::BadAllocation` as a typed exception thrown when memory allocation fails. Inherits from `std::runtime_error` for backwards compatibility. Makes programmatic OOM handling easier.

A corresponding typed-catch test is added to `TestViewBadAlloc`.