### PR TITLE
Fix NVCC/GCC 12.5 but with use of constexpr in Kokkos_SharedAlloc.hpp 

### DIFF
--- a/core/src/impl/Kokkos_SharedAlloc.hpp
+++ b/core/src/impl/Kokkos_SharedAlloc.hpp
@@ -618,12 +618,12 @@ union SharedAllocationTracker {
 
   KOKKOS_FORCEINLINE_FUNCTION
 #if defined(KOKKOS_COMPILER_NVCC) || !defined(KOKKOS_COMPILER_GNU) || \
-    (KOKKOS_COMPILER_GNU < 1220) || (KOKKOS_COMPILER_GNU > 1240)
-      // FIXME_GCC: The ViewSupport test fails with gcc 12.2, 12.3 and 12.4
+    (KOKKOS_COMPILER_GNU < 1220) || (KOKKOS_COMPILER_GNU > 1250)
+      // FIXME_GCC: The ViewSupport test fails with gcc 12.2-12.5
       // because this constructor is optimized out, which leads to a nullptr
       // dereference. Removing the constexpr fixes the issue but nvcc complains,
       // so we keep the constexpr but only when using anything other than those
-      // three faulty gcc versions.
+      // four faulty gcc versions.
       constexpr
 #endif
       SharedAllocationTracker()


### PR DESCRIPTION
I get segfaults in my application since moving to Kokkos 5.1.1 with a nullptr derefence. It only happens with GCC 12.5.0 for me. Copilot found this and I think I would agree.

I will confirm if this fixes my issue, but I happen to make the PR first.

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

- Fixed nullptr dereference possibility with GCC 12.5.0.
