### PR TITLE
Fix comment containing #cmakedefine in KokkosCore_config.h.in

### DIFF
--- a/cmake/KokkosCore_config.h.in
+++ b/cmake/KokkosCore_config.h.in
@@ -10,7 +10,7 @@
 // KOKKOS_VERSION / 100 % 100 is the minor version
 // KOKKOS_VERSION / 10000 is the major version
 #cmakedefine KOKKOS_VERSION @KOKKOS_VERSION@
-// Not using #cmakedefine below because a "0" FOO version number
+// Not using cmakedefine below because a "0" FOO version number
 // yields /* undef KOKKOS_VERSION_FOO */
 #define KOKKOS_VERSION_MAJOR @KOKKOS_VERSION_MAJOR@
 #define KOKKOS_VERSION_MINOR @KOKKOS_VERSION_MINOR@


### PR DESCRIPTION
Using `#cmakedefine` inside a comment in `KokkosCore_config.h.in` produced a weird comment in the resulting `KokkosCore_config.h`:
```
/* #undef below */
```

### Changelog Entry

Not required