### PR TITLE
Also test conversions between half/bhalf and bool

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Half_Conversion.hpp
@@ -27,6 +27,8 @@ half_t cast_to_half(short val) { return __short2half_rn(val); }
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned short val) { return __ushort2half_rn(val); }
 KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(bool val) { return cast_to_half(static_cast<float>(val)); }
+KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(int val) { return __int2half_rn(val); }
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(unsigned int val) { return __uint2half_rn(val); }
@@ -52,6 +54,11 @@ template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
 cast_from_half(half_t val) {
   return static_cast<double>(__half2float(__half(val)));
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, bool>, T>
+cast_from_half(half_t val) {
+  return static_cast<T>(cast_from_half<float>(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, short>, T>
@@ -234,6 +241,10 @@ bhalf_t cast_to_bhalf(float val) { return __float2bfloat16(val); }
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(double val) { return __double2bfloat16(val); }
 KOKKOS_INLINE_FUNCTION
+bhalf_t cast_to_bhalf(bool val) {
+  return cast_to_bhalf(static_cast<float>(val));
+}
+KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(short val) { return __short2bfloat16_rn(val); }
 KOKKOS_INLINE_FUNCTION
 bhalf_t cast_to_bhalf(unsigned short val) { return __ushort2bfloat16_rn(val); }
@@ -263,6 +274,11 @@ template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
 cast_from_bhalf(bhalf_t val) {
   return static_cast<double>(__bfloat162float(__nv_bfloat16(val)));
+}
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, bool>, T>
+cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(cast_from_bhalf<float>(val));
 }
 template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, short>, T>

--- a/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
+++ b/core/src/HIP/Kokkos_HIP_Half_Conversion.hpp
@@ -18,12 +18,12 @@ KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(float val) { return half_t(__float2half(val)); }
 
 KOKKOS_INLINE_FUNCTION
-half_t cast_to_half(bool val) { return cast_to_half(static_cast<float>(val)); }
-
-KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(double val) {
   return half_t(__float2half(static_cast<float>(val)));
 }
+
+KOKKOS_INLINE_FUNCTION
+half_t cast_to_half(bool val) { return cast_to_half(static_cast<float>(val)); }
 
 KOKKOS_INLINE_FUNCTION
 half_t cast_to_half(short val) {
@@ -96,15 +96,15 @@ cast_from_half(half_t val) {
 }
 
 template <class T>
-KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, bool>, T>
-cast_from_half(half_t val) {
-  return static_cast<T>(cast_from_half<float>(val));
-}
-
-template <class T>
 KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, double>, T>
 cast_from_half(half_t val) {
   return static_cast<T>(__half2float(half_t::impl_type(val)));
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION std::enable_if_t<std::is_same_v<T, bool>, T>
+cast_from_half(half_t val) {
+  return static_cast<T>(cast_from_half<float>(val));
 }
 
 template <class T>

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -91,9 +91,7 @@ inline bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
 inline bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
 inline bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
-inline bhalf_t cast_to_bhalf(bool val) {
-  return cast_to_bhalf(static_cast<float>(val));
-}
+inline bhalf_t cast_to_bhalf(bool val) { return bhalf_t::impl_type(val); }
 inline bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
 inline bhalf_t cast_to_bhalf(unsigned short val) {
   return bhalf_t::impl_type(val);

--- a/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Half_Conversion.hpp
@@ -20,6 +20,7 @@ inline half_t cast_to_half(short val) { return half_t::impl_type(val); }
 inline half_t cast_to_half(unsigned short val) {
   return half_t::impl_type(val);
 }
+inline half_t cast_to_half(bool val) { return half_t::impl_type(val); }
 inline half_t cast_to_half(int val) { return half_t::impl_type(val); }
 inline half_t cast_to_half(unsigned int val) { return half_t::impl_type(val); }
 inline half_t cast_to_half(long long val) { return half_t::impl_type(val); }
@@ -35,6 +36,10 @@ std::enable_if_t<std::is_same_v<T, float>, T> cast_from_half(half_t val) {
 }
 template <class T>
 std::enable_if_t<std::is_same_v<T, double>, T> cast_from_half(half_t val) {
+  return static_cast<T>(half_t::impl_type(val));
+}
+template <class T>
+std::enable_if_t<std::is_same_v<T, bool>, T> cast_from_half(half_t val) {
   return static_cast<T>(half_t::impl_type(val));
 }
 template <class T>
@@ -86,6 +91,9 @@ inline bhalf_t cast_to_bhalf(bhalf_t val) { return val; }
 
 inline bhalf_t cast_to_bhalf(float val) { return bhalf_t::impl_type(val); }
 inline bhalf_t cast_to_bhalf(double val) { return bhalf_t::impl_type(val); }
+inline bhalf_t cast_to_bhalf(bool val) {
+  return cast_to_bhalf(static_cast<float>(val));
+}
 inline bhalf_t cast_to_bhalf(short val) { return bhalf_t::impl_type(val); }
 inline bhalf_t cast_to_bhalf(unsigned short val) {
   return bhalf_t::impl_type(val);
@@ -109,6 +117,10 @@ std::enable_if_t<std::is_same_v<T, float>, T> cast_from_bhalf(bhalf_t val) {
 }
 template <class T>
 std::enable_if_t<std::is_same_v<T, double>, T> cast_from_bhalf(bhalf_t val) {
+  return static_cast<T>(bhalf_t::impl_type(val));
+}
+template <class T>
+std::enable_if_t<std::is_same_v<T, bool>, T> cast_from_bhalf(bhalf_t val) {
   return static_cast<T>(bhalf_t::impl_type(val));
 }
 template <class T>

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -23,7 +23,8 @@ void test_half_conversion_type() {
 
   auto test_values_device = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace::memory_space{},
-      Kokkos::View<T*>(test_values.data(), test_values.size()));
+      Kokkos::View<T*, Kokkos::HostSpace>(test_values.data(),
+                                          test_values.size()));
   Kokkos::View<T*> b_v("b_v", test_values.size());
   Kokkos::parallel_for(
       "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {
@@ -52,7 +53,8 @@ void test_bhalf_conversion_type() {
 
   auto test_values_device = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace::memory_space{},
-      Kokkos::View<T*>(test_values.data(), test_values.size()));
+      Kokkos::View<T*, Kokkos::HostSpace>(test_values.data(),
+                                          test_values.size()));
   Kokkos::View<T*> b_v("b_v", test_values.size());
   Kokkos::parallel_for(
       "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -12,44 +12,58 @@ template <class T>
 void test_half_conversion_type() {
   // When truncating mantissa to 10bits (like f16), 3.3 becomes 3.298828125
   // 3.3 - 3.298828125 < 1.1719e-3, so conversion error should be smaller
-  double epsilon                 = KOKKOS_HALF_T_IS_FLOAT ? 3e-7 : 1.1719e-3;
-  T base                         = static_cast<T>(3.3);
-  Kokkos::Experimental::half_t a = Kokkos::Experimental::cast_to_half(base);
-  T b                            = Kokkos::Experimental::cast_from_half<T>(a);
-  ASSERT_NEAR(b, base, epsilon);
+  double epsilon = KOKKOS_HALF_T_IS_FLOAT ? 3e-7 : 1.1719e-3;
+  Kokkos::Array<T, 5> test_values({T(-3.3), T(-.1), T(0), T(.1), T(3.3)});
+  for (T test_value : test_values) {
+    Kokkos::Experimental::half_t a =
+        Kokkos::Experimental::cast_to_half(test_value);
+    T b = Kokkos::Experimental::cast_from_half<T>(a);
+    ASSERT_NEAR(b, test_value, epsilon);
+  }
 
-  Kokkos::View<T> b_v("b_v");
+  auto test_values_device = Kokkos::create_mirror_view_and_copy(
+      Kokkos::DefaultExecutionSpace::memory_space{},
+      Kokkos::View<T*>(test_values.data(), test_values.size()));
+  Kokkos::View<T*> b_v("b_v", 5);
   Kokkos::parallel_for(
-      "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
+      "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {
         Kokkos::Experimental::half_t d_a =
-            Kokkos::Experimental::cast_to_half(base);
-        b_v() = Kokkos::Experimental::cast_from_half<T>(d_a);
+            Kokkos::Experimental::cast_to_half(test_values_device(i));
+        b_v(i) = Kokkos::Experimental::cast_from_half<T>(d_a);
       });
 
-  Kokkos::deep_copy(b, b_v);
-  ASSERT_NEAR(b, base, epsilon);
+  auto results_host = Kokkos::create_mirror_view_and_copy(b_v);
+  for (unsigned int i = 0; i < test_values.size(); ++i)
+    ASSERT_NEAR(results_host(i), test_values[i], epsilon);
 }
 
 template <class T>
 void test_bhalf_conversion_type() {
   // When truncating mantissa to 7bits (like b16), 3.3 becomes 3.296875
   // 3.3 - 3.296875 < 3.125e-3, so conversion error should be smaller
-  double epsilon                  = KOKKOS_BHALF_T_IS_FLOAT ? 3e-7 : 3.125e-3;
-  T base                          = static_cast<T>(3.3);
-  Kokkos::Experimental::bhalf_t a = Kokkos::Experimental::cast_to_bhalf(base);
-  T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
-  ASSERT_NEAR(b, base, epsilon);
+  double epsilon = KOKKOS_BHALF_T_IS_FLOAT ? 3e-7 : 3.125e-3;
+  Kokkos::Array<T, 5> test_values({T(-3.3), T(-.1), T(0), T(.1), T(3.3)});
+  for (T test_value : test_values) {
+    Kokkos::Experimental::bhalf_t a =
+        Kokkos::Experimental::cast_to_bhalf(test_value);
+    T b = Kokkos::Experimental::cast_from_bhalf<T>(a);
+    ASSERT_NEAR(b, test_value, epsilon);
+  }
 
-  Kokkos::View<T> b_v("b_v");
+  auto test_values_device = Kokkos::create_mirror_view_and_copy(
+      Kokkos::DefaultExecutionSpace::memory_space{},
+      Kokkos::View<T*>(test_values.data(), test_values.size()));
+  Kokkos::View<T*> b_v("b_v", 5);
   Kokkos::parallel_for(
-      "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
+      "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {
         Kokkos::Experimental::bhalf_t d_a =
-            Kokkos::Experimental::cast_to_bhalf(base);
-        b_v() = Kokkos::Experimental::cast_from_bhalf<T>(d_a);
+            Kokkos::Experimental::cast_to_bhalf(test_values_device(i));
+        b_v(i) = Kokkos::Experimental::cast_from_bhalf<T>(d_a);
       });
 
-  Kokkos::deep_copy(b, b_v);
-  ASSERT_NEAR(b, base, epsilon);
+  auto results_host = Kokkos::create_mirror_view_and_copy(b_v);
+  for (unsigned int i = 0; i < test_values.size(); ++i)
+    ASSERT_NEAR(results_host(i), test_values[i], epsilon);
 }
 
 void test_half_conversion() {

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -56,6 +56,7 @@ void test_half_conversion() {
   test_half_conversion_type<float>();
   test_half_conversion_type<double>();
   test_half_conversion_type<short>();
+  test_half_conversion_type<bool>();
   test_half_conversion_type<int>();
   test_half_conversion_type<long>();
   test_half_conversion_type<long long>();
@@ -69,6 +70,7 @@ void test_bhalf_conversion() {
   test_bhalf_conversion_type<float>();
   test_bhalf_conversion_type<double>();
   test_bhalf_conversion_type<short>();
+  test_bhalf_conversion_type<bool>();
   test_bhalf_conversion_type<int>();
   test_bhalf_conversion_type<long>();
   test_bhalf_conversion_type<long long>();

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -13,7 +13,7 @@ void test_half_conversion_type() {
   // When truncating mantissa to 10bits (like f16), 3.3 becomes 3.298828125
   // 3.3 - 3.298828125 < 1.1719e-3, so conversion error should be smaller
   double epsilon = KOKKOS_HALF_T_IS_FLOAT ? 3e-7 : 1.1719e-3;
-  Kokkos::Array<T, 5> test_values({T(-3.3), T(-.1), T(0), T(.1), T(3.3)});
+  Kokkos::Array<T, 5> test_values({T(0), T(.1), T(3.3)});
   for (T test_value : test_values) {
     Kokkos::Experimental::half_t a =
         Kokkos::Experimental::cast_to_half(test_value);
@@ -24,7 +24,7 @@ void test_half_conversion_type() {
   auto test_values_device = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace::memory_space{},
       Kokkos::View<T*>(test_values.data(), test_values.size()));
-  Kokkos::View<T*> b_v("b_v", 5);
+  Kokkos::View<T*> b_v("b_v", test_values.size());
   Kokkos::parallel_for(
       "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {
         Kokkos::Experimental::half_t d_a =
@@ -42,7 +42,7 @@ void test_bhalf_conversion_type() {
   // When truncating mantissa to 7bits (like b16), 3.3 becomes 3.296875
   // 3.3 - 3.296875 < 3.125e-3, so conversion error should be smaller
   double epsilon = KOKKOS_BHALF_T_IS_FLOAT ? 3e-7 : 3.125e-3;
-  Kokkos::Array<T, 5> test_values({T(-3.3), T(-.1), T(0), T(.1), T(3.3)});
+  Kokkos::Array<T, 5> test_values({T(0), T(.1), T(3.3)});
   for (T test_value : test_values) {
     Kokkos::Experimental::bhalf_t a =
         Kokkos::Experimental::cast_to_bhalf(test_value);
@@ -53,7 +53,7 @@ void test_bhalf_conversion_type() {
   auto test_values_device = Kokkos::create_mirror_view_and_copy(
       Kokkos::DefaultExecutionSpace::memory_space{},
       Kokkos::View<T*>(test_values.data(), test_values.size()));
-  Kokkos::View<T*> b_v("b_v", 5);
+  Kokkos::View<T*> b_v("b_v", test_values.size());
   Kokkos::parallel_for(
       "TestHalfConversion", test_values.size(), KOKKOS_LAMBDA(int i) {
         Kokkos::Experimental::bhalf_t d_a =


### PR DESCRIPTION
Apparently, the conversion from and to `bool` weren't implemented for all backends providing native implementatiions.