### PR TITLE
Add missing header in Kokkos_Clamp.hpp

### DIFF
--- a/core/src/Kokkos_Clamp.hpp
+++ b/core/src/Kokkos_Clamp.hpp
@@ -4,6 +4,7 @@
 #ifndef KOKKOS_CLAMP_HPP
 #define KOKKOS_CLAMP_HPP
 
+#include <Kokkos_Assert.hpp>
 #include <Kokkos_Macros.hpp>
 
 namespace Kokkos {


### PR DESCRIPTION
Kokkos_Clamp.hpp is using `KOKKOS_EXPECTS` which is defined in `Kokkos_Assert.hpp` which was not included.

### Related issues / PRs

n/a

### Changelog Entry

Unsure