### PR TITLE
Fix typos, Bash quoting, and variable initialization in compiler scripts

### DIFF
--- a/bin/kokkos_launch_compiler
+++ b/bin/kokkos_launch_compiler
@@ -39,7 +39,7 @@ done
 # if Kokkos compiler is not passed, someone is probably trying to invoke it directly
 if [ -z "${1}" ]; then
     echo -e "\n${BASH_SOURCE[0]} was invoked without the Kokkos compiler as the first argument."
-    echo "This script is not indended to be directly invoked by any mechanism other"
+    echo "This script is not intended to be directly invoked by any mechanism other"
     echo -e "than through a RULE_LAUNCH_COMPILE or RULE_LAUNCH_LINK property set in CMake.\n"
     exit 1
 fi

--- a/bin/nvcc_wrapper
+++ b/bin/nvcc_wrapper
@@ -286,11 +286,11 @@ do
   # -Werror=kind,... will be split into two parts, those kinds that belong to nvcc (see above) go there, while all others go towards the host compiler
   -Werror=*)
     kinds_str="${1:8}" # strip -Werror=
-    IFS="," read -r -a kinds <<< ${kinds_str}
+    IFS="," read -r -a kinds <<< "${kinds_str}"
     first_werror_cuda=1
     first_werror_host=1
     xcompiler_args_werror=
-    # loop over all kinds that are sparated via ','
+    # loop over all kinds that are separated via ','
     for kind in "${kinds[@]}"
     do
       case ${kind} in
@@ -368,13 +368,13 @@ do
   -A)
     ;;
 
-  #strip of -std=c++98 due to nvcc warnings and Tribits will place both -std=c++11 and -std=c++98
+  #strip off -std=c++98 due to nvcc warnings and Tribits will place both -std=c++11 and -std=c++98
   -std=c++98|--std=c++98)
     ;;
-  #strip of pedantic because it produces endless warnings about #LINE added by the preprocessor
+  #strip off pedantic because it produces endless warnings about #LINE added by the preprocessor
   -pedantic|-pedantic-errors|-Wpedantic|-ansi)
     ;;
-  #strip of -Woverloaded-virtual to avoid "cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C"
+  #strip off -Woverloaded-virtual to avoid "cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C"
   -Woverloaded-virtual)
     ;;
   #strip -Xcompiler because we add it
@@ -448,7 +448,7 @@ do
     fi
     ;;
   #Handle -code argument (if its not set use a default) this is the version with = sign
-  -code*)
+  -code=*)
     cuda_args="$cuda_args $1"
     ;;
   #Handle -code argument (if its not set use a default) this is the version without = sign
@@ -528,6 +528,7 @@ fi
 
 #Remove duplicate object files
 if [ $remove_duplicate_link_files -eq 1 ]; then
+object_files_reverse=""
 for obj in $object_files
 do
   object_files_reverse="$obj $object_files_reverse"


### PR DESCRIPTION

In this PR, typos in `kokkos_nvcc_wrapper` and `kokkos_launch_compiler` were fixed typos, quoting around `"@{kinds_str}"` to prevent word-splitting and converting from code* to code=*
https://github.com/kokkos/kokkos/blob/601d7acbd1e0af501259ffee6c44df70a3d4081f/bin/nvcc_wrapper#L450
, to correctly align with the behavior described in the inline comment.
### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Unsure
-->
Not sure