### PR TITLE
Make the flag argument in simd load/store optional

### DIFF
--- a/simd/src/Kokkos_SIMD_AVX2.hpp
+++ b/simd/src/Kokkos_SIMD_AVX2.hpp
@@ -1090,11 +1090,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_pd(ptr, static_cast<__m256d>(simd));
   } else {
@@ -1102,20 +1102,20 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
                       static_cast<__m256d>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<double, simd_abi::avx2_fixed_size<4>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_pd(ptr, _mm256_castpd_si256(static_cast<__m256d>(mask)),
                       static_cast<__m256d>(simd));
 }
@@ -1444,11 +1444,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm_store_ps(ptr, static_cast<__m128>(simd));
   } else {
@@ -1456,20 +1456,20 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx2_fixed_size<4>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm_maskstore_ps(ptr, _mm_castps_si128(static_cast<__m128>(mask)),
                    static_cast<__m128>(simd));
 }
@@ -1774,7 +1774,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
 
 template <typename SimdType, typename... Flags>
   requires std::same_as<typename SimdType::abi_type,
-                        simd_abi::avx2_fixed_size<4>>
+                        simd_abi::avx2_fixed_size<8>>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
     basic_simd<float, simd_abi::avx2_fixed_size<8>>
     simd_unchecked_load(
@@ -1806,11 +1806,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx2_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_ps(ptr, static_cast<__m256>(simd));
   } else {
@@ -1818,20 +1818,20 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
                       static_cast<__m256>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx2_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_ps(ptr, _mm256_castps_si256(static_cast<__m256>(mask)),
                       static_cast<__m256>(simd));
 }
@@ -2140,11 +2140,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm_store_si128(reinterpret_cast<__m128i*>(ptr),
                     static_cast<__m128i>(simd));
@@ -2154,22 +2154,22 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm_maskstore_epi32(ptr, static_cast<__m128i>(mask),
                       static_cast<__m128i>(simd));
 }
@@ -2480,11 +2480,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
                        static_cast<__m256i>(simd));
@@ -2494,22 +2494,22 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::avx2_fixed_size<8>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx2_fixed_size<8>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi32(ptr, static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
@@ -2837,11 +2837,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::int64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
                        static_cast<__m256i>(simd));
@@ -2851,23 +2851,23 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
@@ -3192,11 +3192,11 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
-    std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::uint64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_si256(reinterpret_cast<__m256i*>(ptr),
                        static_cast<__m256i>(simd));
@@ -3206,23 +3206,23 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx2_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   _mm256_maskstore_epi64(reinterpret_cast<long long int*>(ptr),
                          static_cast<__m256i>(mask),
                          static_cast<__m256i>(simd));

--- a/simd/src/Kokkos_SIMD_AVX512.hpp
+++ b/simd/src/Kokkos_SIMD_AVX512.hpp
@@ -640,11 +640,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_pd(ptr, static_cast<__m512d>(simd));
   } else {
@@ -652,12 +652,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
                          static_cast<__m512d>(simd));
@@ -667,12 +667,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<double, simd_abi::avx512_fixed_size<8>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_pd(ptr, static_cast<__mmask8>(mask),
                          static_cast<__m512d>(simd));
@@ -1020,11 +1020,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<8>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_store_ps(ptr, static_cast<__m256>(simd));
   } else {
@@ -1032,12 +1032,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                          static_cast<__m256>(simd));
@@ -1047,12 +1047,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx512_fixed_size<8>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_ps(ptr, static_cast<__mmask8>(mask),
                          static_cast<__m256>(simd));
@@ -1402,11 +1402,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::avx512_fixed_size<16>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_ps(ptr, static_cast<__m512>(simd));
   } else {
@@ -1414,12 +1414,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
                          static_cast<__m512>(simd));
@@ -1429,12 +1429,12 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::avx512_fixed_size<16>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_ps(ptr, static_cast<__mmask16>(mask),
                          static_cast<__m512>(simd));
@@ -1772,13 +1772,13 @@ simd_partial_load(
                                                                   flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   using mask_type =
       basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>>;
-  if constexpr (std::is_same_v<FlagType,
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
                             static_cast<__m256i>(simd));
@@ -1788,13 +1788,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m256i>(simd));
@@ -1804,13 +1804,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m256i>(simd));
@@ -2149,11 +2149,11 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
   } else {
@@ -2164,13 +2164,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
                             static_cast<__m512i>(simd));
@@ -2180,13 +2180,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
                             static_cast<__m512i>(simd));
@@ -2519,13 +2519,13 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
-    std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   using mask_type =
       basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>>;
-  if constexpr (std::is_same_v<FlagType,
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask_type(true)),
                             static_cast<__m256i>(simd));
@@ -2535,13 +2535,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m256i>(simd));
@@ -2551,13 +2551,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm256_mask_store_epi32(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m256i>(simd));
@@ -2892,11 +2892,11 @@ simd_partial_load(
                                                                     flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
-    std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
-  if constexpr (std::is_same_v<FlagType,
+    std::uint32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_store_epi32(ptr, static_cast<__m512i>(simd));
   } else {
@@ -2907,13 +2907,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
                             static_cast<__m512i>(simd));
@@ -2923,13 +2923,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::avx512_fixed_size<16>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi32(ptr, static_cast<__mmask16>(mask),
                             static_cast<__m512i>(simd));
@@ -3262,13 +3262,13 @@ simd_partial_load(
                                                                   flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
-    std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   using mask_type =
       basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>>;
-  if constexpr (std::is_same_v<FlagType,
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
                             static_cast<__m512i>(simd));
@@ -3278,13 +3278,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m512i>(simd));
@@ -3294,13 +3294,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m512i>(simd));
@@ -3625,13 +3625,13 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
-    std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   using mask_type =
       basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>>;
-  if constexpr (std::is_same_v<FlagType,
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask_type(true)),
                             static_cast<__m512i>(simd));
@@ -3641,13 +3641,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m512i>(simd));
@@ -3657,13 +3657,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
   }
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::avx512_fixed_size<8>> const& mask,
-    FlagType) {
-  if constexpr (std::is_same_v<FlagType,
+    simd_flags<Flags...> = simd_flag_default) {
+  if constexpr (std::is_same_v<simd_flags<Flags...>,
                                simd_flags<simd_alignment_vector_aligned>>) {
     _mm512_mask_store_epi64(ptr, static_cast<__mmask8>(mask),
                             static_cast<__m512i>(simd));

--- a/simd/src/Kokkos_SIMD_Common.hpp
+++ b/simd/src/Kokkos_SIMD_Common.hpp
@@ -40,6 +40,7 @@ class basic_simd_mask;
 class simd_alignment_vector_aligned {};
 
 template <typename... Flags>
+  requires(std::same_as<Flags, simd_alignment_vector_aligned> && ...)
 struct simd_flags {};
 
 inline constexpr simd_flags<> simd_flag_default{};

--- a/simd/src/Kokkos_SIMD_NEON.hpp
+++ b/simd/src/Kokkos_SIMD_NEON.hpp
@@ -686,27 +686,27 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<double, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
+    simd_flags<Flags...> = simd_flag_default) {
   vst1q_f64(ptr, static_cast<float64x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<double, simd_abi::neon_fixed_size<2>> const& simd, double* ptr,
     basic_simd_mask<double, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
@@ -1041,27 +1041,27 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<2>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
+    simd_flags<Flags...> = simd_flag_default) {
   vst1_f32(ptr, static_cast<float32x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::neon_fixed_size<2>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
@@ -1400,29 +1400,29 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
   return basic_simd<float, simd_abi::neon_fixed_size<4>>(ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
-    [[maybe_unused]] FlagType flag = simd_flag_default) {
+    simd_flags<Flags...> = simd_flag_default) {
   vst1q_f32(ptr, static_cast<float32x4_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::neon_fixed_size<4>> const& simd, float* ptr,
     basic_simd_mask<float, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
@@ -1769,29 +1769,29 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1_s32(ptr, static_cast<int32x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
@@ -2134,31 +2134,31 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1q_s32(ptr, static_cast<int32x4_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
@@ -2501,29 +2501,29 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& simd,
-    std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1_u32(ptr, static_cast<uint32x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
@@ -2862,31 +2862,31 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& simd,
-    std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1q_u32(ptr, static_cast<uint32x4_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
   if (mask[3]) ptr[3] = simd[3];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint32_t, simd_abi::neon_fixed_size<4>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t, simd_abi::neon_fixed_size<4>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
   if (mask[2]) ptr[2] = simd[2];
@@ -3234,29 +3234,29 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                 flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
-    std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1q_s64(ptr, static_cast<int64x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::int64_t* ptr,
     basic_simd_mask<std::int64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
@@ -3593,29 +3593,29 @@ simd_partial_load(
                                                                  flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
-    std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   vst1q_u64(ptr, static_cast<uint64x2_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint64_t, simd_abi::neon_fixed_size<2>> const& simd,
     std::uint64_t* ptr,
     basic_simd_mask<std::uint64_t, simd_abi::neon_fixed_size<2>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   if (mask[0]) ptr[0] = simd[0];
   if (mask[1]) ptr[1] = simd[1];
 }

--- a/simd/src/Kokkos_SIMD_SVE.hpp
+++ b/simd/src/Kokkos_SIMD_SVE.hpp
@@ -767,33 +767,33 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
       ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
-    double* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    double* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b64(), ptr, static_cast<vls_float64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
     double* ptr,
     basic_simd_mask<
         double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         simd,
     double* ptr,
     basic_simd_mask<
         double, simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float64_t>(simd));
 }
 
@@ -1203,33 +1203,33 @@ simd_partial_load(
       ptr, mask, flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         simd,
-    float* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    float* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_float32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         simd,
     float* ptr,
     basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         simd,
     float* ptr,
     basic_simd_mask<float, simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_float32_t>(simd));
 }
 
@@ -1698,33 +1698,33 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_int32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t,
                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::int32_t* ptr,
     basic_simd_mask<std::int32_t,
                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int32_t>(simd));
 }
 
@@ -2185,33 +2185,33 @@ simd_partial_load(
                                                                    flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
-    std::uint32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint32_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_uint32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t,
                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint32_t,
                simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& simd,
     std::uint32_t* ptr,
     basic_simd_mask<std::uint32_t,
                     simd_abi::sve_fixed_size<SVE_WORDS_IN_VECTOR>> const& mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint32_t>(simd));
 }
 
@@ -2664,15 +2664,15 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
-    std::int64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_int64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -2680,11 +2680,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd_mask<std::int64_t,
                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -2692,7 +2692,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd_mask<std::int64_t,
                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_int64_t>(simd));
 }
 
@@ -3145,15 +3145,15 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
-    std::uint64_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::uint64_t* ptr, simd_flags<Flags...> = simd_flag_default) {
   svst1(svptrue_b32(), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::uint64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -3161,11 +3161,11 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd_mask<std::uint64_t,
                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::uint64_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -3173,7 +3173,7 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd_mask<std::uint64_t,
                     simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> = simd_flag_default) {
   svst1(static_cast<vls_bool_t>(mask), ptr, static_cast<vls_uint64_t>(simd));
 }
 
@@ -3499,18 +3499,18 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION
                                                                      flag);
 }
 
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
-    std::int32_t* ptr, [[maybe_unused]] FlagType flag = simd_flag_default) {
+    std::int32_t* ptr, simd_flags<Flags...> flag = simd_flag_default) {
   simd_unchecked_store<std::int32_t,
                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
       simd, ptr, flag);
 }
 
 // FIXME should be converted to use sve mask
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -3518,17 +3518,17 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_unchecked_store(
     basic_simd_mask<std::int32_t,
                     simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> flag = simd_flag_default) {
   basic_simd_mask<std::int32_t,
                   simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](Impl::simd_size_t i) { return mask[i]; });
   simd_unchecked_store<std::int32_t,
                        simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
-      simd, ptr, nmask, FlagType{});
+      simd, ptr, nmask, flag);
 }
 
 // FIXME should be converted to use sve mask
-template <typename FlagType>
+template <typename... Flags>
 KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd<std::int32_t,
                simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>> const& simd,
@@ -3536,13 +3536,13 @@ KOKKOS_IMPL_HOST_FORCEINLINE_FUNCTION void simd_partial_store(
     basic_simd_mask<std::int32_t,
                     simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>> const&
         mask,
-    FlagType) {
+    simd_flags<Flags...> flag = simd_flag_default) {
   basic_simd_mask<std::int32_t,
                   simd_abi::neon_fixed_size<SVE_DOUBLES_IN_VECTOR>>
       nmask([=](Impl::simd_size_t i) { return mask[i]; });
   simd_partial_store<std::int32_t,
                      simd_abi::sve_fixed_size<SVE_DOUBLES_IN_VECTOR>>(
-      simd, ptr, nmask, FlagType{});
+      simd, ptr, nmask, flag);
 }
 
 // FIXME should be converted to use sve mask

--- a/simd/unit_tests/include/TestSIMD_LoadStore.hpp
+++ b/simd/unit_tests/include/TestSIMD_LoadStore.hpp
@@ -136,7 +136,7 @@ inline void host_test_simd_loadstore() {
     return (i % 2 == 0) ? (i + 1) * 12 : DataType();
   });
 
-  // unchecked_load
+  // unchecked_store
   host_test_simd_store<false>(expected, expected);
   host_test_simd_unaligned_store<false>(expected, expected);
   host_test_simd_store<false>(expected, expected,
@@ -155,7 +155,7 @@ inline void host_test_simd_loadstore() {
   host_test_simd_store<false>(expected, expected_masked, mask,
                               Kokkos::Experimental::simd_flag_aligned);
 
-  // partial_load
+  // partial_store
   host_test_simd_store<true>(expected, expected_masked, mask);
   host_test_simd_unaligned_store<true>(expected, expected_masked, mask);
   host_test_simd_store<true>(expected, expected_masked, mask,
@@ -165,7 +165,7 @@ inline void host_test_simd_loadstore() {
   host_test_simd_store<true>(expected, expected_masked, mask,
                              Kokkos::Experimental::simd_flag_aligned);
 
-  // unchecked_store
+  // unchecked_load
   host_test_simd_load<false>(expected, expected);
   host_test_simd_unaligned_load<false>(expected, expected);
   host_test_simd_load<false>(expected, expected,
@@ -184,7 +184,7 @@ inline void host_test_simd_loadstore() {
   host_test_simd_load<false>(expected, expected_masked, mask,
                              Kokkos::Experimental::simd_flag_aligned);
 
-  // partial_store
+  // partial_load
   host_test_simd_load<true>(expected, expected_masked, mask);
   host_test_simd_unaligned_load<true>(expected, expected_masked, mask);
   host_test_simd_load<true>(expected, expected_masked, mask,
@@ -331,7 +331,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   simd_type expected_masked(
       [=](std::size_t i) { return (mask[i]) ? (i + 1) * 12 : DataType(); });
 
-  // unchecked_load
+  // unchecked_store
   device_test_simd_store<false>(expected, expected);
   device_test_simd_unaligned_store<false>(expected, expected);
   device_test_simd_store<false>(expected, expected,
@@ -350,7 +350,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   device_test_simd_store<false>(expected, expected_masked, mask,
                                 Kokkos::Experimental::simd_flag_aligned);
 
-  // partial_load
+  // partial_store
   device_test_simd_store<true>(expected, expected_masked, mask);
   device_test_simd_unaligned_store<true>(expected, expected_masked, mask);
   device_test_simd_store<true>(expected, expected_masked, mask,
@@ -360,7 +360,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   device_test_simd_store<true>(expected, expected_masked, mask,
                                Kokkos::Experimental::simd_flag_aligned);
 
-  // unchecked_store
+  // unchecked_load
   device_test_simd_load<false>(expected, expected);
   device_test_simd_unaligned_load<false>(expected, expected);
   device_test_simd_load<false>(expected, expected,
@@ -379,7 +379,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   device_test_simd_load<false>(expected, expected_masked, mask,
                                Kokkos::Experimental::simd_flag_aligned);
 
-  // partial_store
+  // partial_load
   device_test_simd_load<true>(expected, expected_masked, mask);
   device_test_simd_unaligned_load<true>(expected, expected_masked, mask);
   device_test_simd_load<true>(expected, expected_masked, mask,

--- a/simd/unit_tests/include/TestSIMD_LoadStore.hpp
+++ b/simd/unit_tests/include/TestSIMD_LoadStore.hpp
@@ -13,7 +13,7 @@ import kokkos.simd_impl;
 #endif
 #include <SIMDTesting_Utilities.hpp>
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 inline void host_test_simd_load(SimdType const& init, SimdType const& expected,
                                 Args... args) {
   using data_type = typename SimdType::value_type;
@@ -27,7 +27,7 @@ inline void host_test_simd_load(SimdType const& init, SimdType const& expected,
 
   SimdType result;
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     result = simd_partial_load(arr, args...);
   } else {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -47,7 +47,7 @@ inline void host_test_simd_load(SimdType const& init, SimdType const& expected,
   }
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 inline void host_test_simd_unaligned_load(SimdType const& init,
                                           SimdType const& expected,
                                           Args... args) {
@@ -63,7 +63,7 @@ inline void host_test_simd_unaligned_load(SimdType const& init,
 
   SimdType result;
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     result = simd_partial_load(arr + 1, args...);
   } else {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -83,7 +83,7 @@ inline void host_test_simd_unaligned_load(SimdType const& init,
   }
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
                                  Args... args) {
   constexpr size_t alignment =
@@ -91,7 +91,7 @@ inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
 
   alignas(alignment) typename SimdType::value_type arr[SimdType::size()] = {0};
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     simd_partial_store(init, arr, args...);
   } else {
     simd_unchecked_store(init, arr, args...);
@@ -103,7 +103,7 @@ inline void host_test_simd_store(SimdType const& init, SimdType const& expected,
   }
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 inline void host_test_simd_unaligned_store(SimdType const& init,
                                            SimdType const& expected,
                                            Args... args) {
@@ -113,7 +113,7 @@ inline void host_test_simd_unaligned_store(SimdType const& init,
   alignas(alignment)
       typename SimdType::value_type arr[SimdType::size() + 1] = {0};
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     simd_partial_store(init, arr + 1, args...);
   } else {
     simd_unchecked_store(init, arr + 1, args...);
@@ -136,31 +136,63 @@ inline void host_test_simd_loadstore() {
     return (i % 2 == 0) ? (i + 1) * 12 : DataType();
   });
 
-  host_test_simd_store(expected, expected,
-                       Kokkos::Experimental::simd_flag_default);
-  host_test_simd_unaligned_store(expected, expected,
-                                 Kokkos::Experimental::simd_flag_default);
-  host_test_simd_store(expected, expected,
-                       Kokkos::Experimental::simd_flag_aligned);
-  host_test_simd_store(expected, expected_masked, mask,
-                       Kokkos::Experimental::simd_flag_default);
-  host_test_simd_unaligned_store(expected, expected_masked, mask,
-                                 Kokkos::Experimental::simd_flag_default);
-  host_test_simd_store(expected, expected_masked, mask,
-                       Kokkos::Experimental::simd_flag_aligned);
+  // unchecked_load
+  host_test_simd_store<false>(expected, expected);
+  host_test_simd_unaligned_store<false>(expected, expected);
+  host_test_simd_store<false>(expected, expected,
+                              Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_store<false>(
+      expected, expected, Kokkos::Experimental::simd_flag_default);
+  host_test_simd_store<false>(expected, expected,
+                              Kokkos::Experimental::simd_flag_aligned);
 
-  host_test_simd_load(expected, expected,
-                      Kokkos::Experimental::simd_flag_default);
-  host_test_simd_unaligned_load(expected, expected,
-                                Kokkos::Experimental::simd_flag_default);
-  host_test_simd_load(expected, expected,
-                      Kokkos::Experimental::simd_flag_aligned);
-  host_test_simd_load(expected, expected_masked, mask,
-                      Kokkos::Experimental::simd_flag_default);
-  host_test_simd_unaligned_load(expected, expected_masked, mask,
-                                Kokkos::Experimental::simd_flag_default);
-  host_test_simd_load(expected, expected_masked, mask,
-                      Kokkos::Experimental::simd_flag_aligned);
+  host_test_simd_store<false>(expected, expected_masked, mask);
+  host_test_simd_unaligned_store<false>(expected, expected_masked, mask);
+  host_test_simd_store<false>(expected, expected_masked, mask,
+                              Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_store<false>(
+      expected, expected_masked, mask, Kokkos::Experimental::simd_flag_default);
+  host_test_simd_store<false>(expected, expected_masked, mask,
+                              Kokkos::Experimental::simd_flag_aligned);
+
+  // partial_load
+  host_test_simd_store<true>(expected, expected_masked, mask);
+  host_test_simd_unaligned_store<true>(expected, expected_masked, mask);
+  host_test_simd_store<true>(expected, expected_masked, mask,
+                             Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_store<true>(expected, expected_masked, mask,
+                                       Kokkos::Experimental::simd_flag_default);
+  host_test_simd_store<true>(expected, expected_masked, mask,
+                             Kokkos::Experimental::simd_flag_aligned);
+
+  // unchecked_store
+  host_test_simd_load<false>(expected, expected);
+  host_test_simd_unaligned_load<false>(expected, expected);
+  host_test_simd_load<false>(expected, expected,
+                             Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_load<false>(expected, expected,
+                                       Kokkos::Experimental::simd_flag_default);
+  host_test_simd_load<false>(expected, expected,
+                             Kokkos::Experimental::simd_flag_aligned);
+
+  host_test_simd_load<false>(expected, expected_masked, mask);
+  host_test_simd_unaligned_load<false>(expected, expected_masked, mask);
+  host_test_simd_load<false>(expected, expected_masked, mask,
+                             Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_load<false>(expected, expected_masked, mask,
+                                       Kokkos::Experimental::simd_flag_default);
+  host_test_simd_load<false>(expected, expected_masked, mask,
+                             Kokkos::Experimental::simd_flag_aligned);
+
+  // partial_store
+  host_test_simd_load<true>(expected, expected_masked, mask);
+  host_test_simd_unaligned_load<true>(expected, expected_masked, mask);
+  host_test_simd_load<true>(expected, expected_masked, mask,
+                            Kokkos::Experimental::simd_flag_default);
+  host_test_simd_unaligned_load<true>(expected, expected_masked, mask,
+                                      Kokkos::Experimental::simd_flag_default);
+  host_test_simd_load<true>(expected, expected_masked, mask,
+                            Kokkos::Experimental::simd_flag_aligned);
 }
 
 template <typename Abi, typename DataType>
@@ -183,7 +215,7 @@ inline void host_check_loadstore_all_abis(
   (host_check_loadstore_all_types<Abis>(DataTypes()), ...);
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 KOKKOS_INLINE_FUNCTION void device_test_simd_load(SimdType const& init,
                                                   SimdType const& expected,
                                                   Args... args) {
@@ -198,7 +230,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_load(SimdType const& init,
 
   SimdType result;
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     result = simd_partial_load(arr, args...);
   } else {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -214,7 +246,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_load(SimdType const& init,
   device_check_equality(result, expected, SimdType::size());
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_load(
     SimdType const& init, SimdType const& expected, Args... args) {
   using data_type = typename SimdType::value_type;
@@ -229,7 +261,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_load(
 
   SimdType result;
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     result = simd_partial_load(arr + 1, args...);
   } else {
     if constexpr (std::is_same_v<Kokkos::Experimental::simd_abi::Impl::
@@ -245,7 +277,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_load(
   device_check_equality(result, expected, SimdType::size());
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
                                                    SimdType const& expected,
                                                    Args... args) {
@@ -254,7 +286,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
 
   alignas(alignment) typename SimdType::value_type arr[SimdType::size()] = {0};
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     simd_partial_store(init, arr, args...);
   } else {
     simd_unchecked_store(init, arr, args...);
@@ -267,7 +299,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_store(SimdType const& init,
   }
 }
 
-template <typename SimdType, typename... Args>
+template <bool UsePartialLoad, typename SimdType, typename... Args>
 KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_store(
     SimdType const& init, SimdType const& expected, Args... args) {
   constexpr size_t alignment =
@@ -276,7 +308,7 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_unaligned_store(
   alignas(alignment)
       typename SimdType::value_type arr[SimdType::size() + 1] = {0};
 
-  if constexpr (sizeof...(args) > 1) {
+  if constexpr (UsePartialLoad) {
     simd_partial_store(init, arr + 1, args...);
   } else {
     simd_unchecked_store(init, arr + 1, args...);
@@ -299,31 +331,63 @@ KOKKOS_INLINE_FUNCTION void device_test_simd_loadstore() {
   simd_type expected_masked(
       [=](std::size_t i) { return (mask[i]) ? (i + 1) * 12 : DataType(); });
 
-  device_test_simd_store(expected, expected,
-                         Kokkos::Experimental::simd_flag_default);
-  device_test_simd_unaligned_store(expected, expected,
-                                   Kokkos::Experimental::simd_flag_default);
-  device_test_simd_store(expected, expected,
-                         Kokkos::Experimental::simd_flag_aligned);
-  device_test_simd_store(expected, expected_masked, mask,
-                         Kokkos::Experimental::simd_flag_default);
-  device_test_simd_unaligned_store(expected, expected_masked, mask,
-                                   Kokkos::Experimental::simd_flag_default);
-  device_test_simd_store(expected, expected_masked, mask,
-                         Kokkos::Experimental::simd_flag_aligned);
+  // unchecked_load
+  device_test_simd_store<false>(expected, expected);
+  device_test_simd_unaligned_store<false>(expected, expected);
+  device_test_simd_store<false>(expected, expected,
+                                Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_store<false>(
+      expected, expected, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_store<false>(expected, expected,
+                                Kokkos::Experimental::simd_flag_aligned);
 
-  device_test_simd_load(expected, expected,
-                        Kokkos::Experimental::simd_flag_default);
-  device_test_simd_unaligned_load(expected, expected,
-                                  Kokkos::Experimental::simd_flag_default);
-  device_test_simd_load(expected, expected,
-                        Kokkos::Experimental::simd_flag_aligned);
-  device_test_simd_load(expected, expected_masked, mask,
-                        Kokkos::Experimental::simd_flag_default);
-  device_test_simd_unaligned_load(expected, expected_masked, mask,
-                                  Kokkos::Experimental::simd_flag_default);
-  device_test_simd_load(expected, expected_masked, mask,
-                        Kokkos::Experimental::simd_flag_aligned);
+  device_test_simd_store<false>(expected, expected_masked, mask);
+  device_test_simd_unaligned_store<false>(expected, expected_masked, mask);
+  device_test_simd_store<false>(expected, expected_masked, mask,
+                                Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_store<false>(
+      expected, expected_masked, mask, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_store<false>(expected, expected_masked, mask,
+                                Kokkos::Experimental::simd_flag_aligned);
+
+  // partial_load
+  device_test_simd_store<true>(expected, expected_masked, mask);
+  device_test_simd_unaligned_store<true>(expected, expected_masked, mask);
+  device_test_simd_store<true>(expected, expected_masked, mask,
+                               Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_store<true>(
+      expected, expected_masked, mask, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_store<true>(expected, expected_masked, mask,
+                               Kokkos::Experimental::simd_flag_aligned);
+
+  // unchecked_store
+  device_test_simd_load<false>(expected, expected);
+  device_test_simd_unaligned_load<false>(expected, expected);
+  device_test_simd_load<false>(expected, expected,
+                               Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_load<false>(
+      expected, expected, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_load<false>(expected, expected,
+                               Kokkos::Experimental::simd_flag_aligned);
+
+  device_test_simd_load<false>(expected, expected_masked, mask);
+  device_test_simd_unaligned_load<false>(expected, expected_masked, mask);
+  device_test_simd_load<false>(expected, expected_masked, mask,
+                               Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_load<false>(
+      expected, expected_masked, mask, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_load<false>(expected, expected_masked, mask,
+                               Kokkos::Experimental::simd_flag_aligned);
+
+  // partial_store
+  device_test_simd_load<true>(expected, expected_masked, mask);
+  device_test_simd_unaligned_load<true>(expected, expected_masked, mask);
+  device_test_simd_load<true>(expected, expected_masked, mask,
+                              Kokkos::Experimental::simd_flag_default);
+  device_test_simd_unaligned_load<true>(
+      expected, expected_masked, mask, Kokkos::Experimental::simd_flag_default);
+  device_test_simd_load<true>(expected, expected_masked, mask,
+                              Kokkos::Experimental::simd_flag_aligned);
 }
 
 template <typename Abi, typename DataType>


### PR DESCRIPTION
Follow up to #9211, makes the flag argument for the `simd_[unchecked|partial]_[load|store]` functions optional, in accordance with the c++26 standard (https://eel.is/c++draft/simd.loadstore)

### Related issues / PRs

#9211

### Changelog Entry

Make the flag argument in simd load/store functions optional aligning with C++26