### PR TITLE
Propagate mdspan-style View template args to nested typedefs

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -3057,6 +3057,7 @@ namespace Kokkos {
 namespace Impl {
 
 // Deduce Mirror Types
+// Variant for classic View template argument style
 template <class Space, class T, class... P>
 struct MirrorViewType {
   // The incoming view_type
@@ -3068,11 +3069,39 @@ struct MirrorViewType {
       std::is_same_v<memory_space, typename src_view_type::memory_space>;
   // The array_layout
   using array_layout = typename src_view_type::array_layout;
-  // The data type (we probably want it non-const since otherwise we can't even
+  // The data type (we want it non-const since otherwise we can't even
   // deep_copy to it.
   using data_type = typename src_view_type::non_const_data_type;
   // The destination view type if it is not the same memory space
   using dest_view_type = Kokkos::View<data_type, array_layout, Space>;
+  // If it is the same memory_space return the existsing view_type
+  // This will also keep the unmanaged trait if necessary
+  using view_type =
+      std::conditional_t<is_same_memspace, src_view_type, dest_view_type>;
+};
+
+// Specialization for Views with mdspan style template arguments
+template <class Space, class T, class IndexType, size_t... Extents, class... P>
+struct MirrorViewType<Space, T, Kokkos::extents<IndexType, Extents...>, P...> {
+  using extents_type = Kokkos::extents<IndexType, Extents...>;
+  // The incoming view_type
+  using src_view_type = typename Kokkos::View<T, extents_type, P...>;
+  // The memory space for the mirror view
+  using memory_space = typename Space::memory_space;
+  // Check whether it is the same memory space
+  static constexpr bool is_same_memspace =
+      std::is_same_v<memory_space, typename src_view_type::memory_space>;
+  // The array_layout
+  using layout_type = typename src_view_type::layout_type;
+  // The element type (we want it non-const since otherwise we can't even
+  // deep_copy to it.
+  using element_type =
+      std::remove_const_t<typename src_view_type::element_type>;
+  // The destination view type if it is not the same memory space
+  using dest_view_type =
+      Kokkos::View<element_type, extents_type, layout_type,
+                   Kokkos::Experimental::Accessor<element_type, memory_space,
+                                                  Kokkos::MemoryTraits<>>>;
   // If it is the same memory_space return the existsing view_type
   // This will also keep the unmanaged trait if necessary
   using view_type =

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -215,6 +215,109 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_extents_impl(
     const LView& lhs, const RView& rhs, std::index_sequence<I...>) {
   return ((lhs.extent(I) == rhs.extent(I)) && ...);
 }
+
+// Helper to define the nested View types inside the View class
+// These differ based on whether a hooks policy is used, and whether
+// legacy style template arguments or mdspan-style template arguments
+// are used.
+template <class ViewType, bool HasHooksPolicy, bool MDSpanStyleArgs>
+struct ViewTypeDefs;
+
+// Hooks Policy + Legacy Style Arguments
+template <class ViewType>
+struct ViewTypeDefs<ViewType, true, false> {
+  using traits        = typename ViewType::traits;
+  using array_layout  = typename traits::array_layout;
+  using device_type   = typename traits::device_type;
+  using hooks_policy  = typename traits::hooks_policy;
+  using memory_traits = typename traits::memory_traits;
+
+  //----------------------------------------
+  // Compatible view of a data type
+  using type = View<typename traits::data_type, array_layout, device_type,
+                    hooks_policy, memory_traits>;
+
+  // Compatible view of const data type
+  using const_type = View<typename traits::const_data_type, array_layout,
+                          device_type, hooks_policy, memory_traits>;
+
+  // Compatible view of non-const data type
+  using non_const_type =
+      View<typename traits::non_const_data_type, array_layout, device_type,
+           hooks_policy, memory_traits>;
+
+  // Compatible host mirror view
+  using host_mirror_type =
+      View<typename traits::non_const_data_type, array_layout,
+           Device<DefaultHostExecutionSpace,
+                  typename traits::host_mirror_space::memory_space>,
+           hooks_policy>;
+};
+
+// No Hooks Policy + Legacy Style Arguments
+template <class ViewType>
+struct ViewTypeDefs<ViewType, false, false> {
+  using traits        = typename ViewType::traits;
+  using array_layout  = typename traits::array_layout;
+  using device_type   = typename traits::device_type;
+  using memory_traits = typename traits::memory_traits;
+
+  //----------------------------------------
+  // Compatible view of a data type
+  using type = View<typename traits::data_type, array_layout, device_type,
+                    memory_traits>;
+
+  // Compatible view of const data type
+  using const_type = View<typename traits::const_data_type, array_layout,
+                          device_type, memory_traits>;
+
+  // Compatible view of non-const data type
+  using non_const_type = View<typename traits::non_const_data_type,
+                              array_layout, device_type, memory_traits>;
+
+  // Compatible host mirror view
+  using host_mirror_type =
+      View<typename traits::non_const_data_type, array_layout,
+           Device<DefaultHostExecutionSpace,
+                  typename traits::host_mirror_space::memory_space> >;
+};
+
+// MDspan Style Arguments - hooks policy would be encoded in accessor
+// so this is independent of that parameter value
+template <class ViewType, bool HasHooksPolicy>
+struct ViewTypeDefs<ViewType, HasHooksPolicy, true> {
+  using element_type    = typename ViewType::element_type;
+  using nc_element_type = std::remove_const_t<element_type>;
+  using extents_type    = typename ViewType::extents_type;
+  using layout_type     = typename ViewType::layout_type;
+
+  //----------------------------------------
+  // Compatible view of a data type
+  using type = View<element_type, extents_type, layout_type,
+                    typename ViewType::accessor_type>;
+
+  // Compatible view of const data type
+  using const_type =
+      View<const element_type, extents_type, layout_type,
+           Kokkos::Experimental::Accessor<const element_type,
+                                          typename ViewType::memory_space,
+                                          typename ViewType::memory_traits> >;
+
+  // Compatible view of non-const data type
+  using non_const_type =
+      View<nc_element_type, extents_type, layout_type,
+           Kokkos::Experimental::Accessor<nc_element_type,
+                                          typename ViewType::memory_space,
+                                          typename ViewType::memory_traits> >;
+
+  // Compatible host mirror view
+  using host_mirror_type =
+      View<nc_element_type, extents_type, layout_type,
+           Kokkos::Experimental::Accessor<
+               nc_element_type,
+               typename ViewType::host_mirror_space::memory_space> >;
+};
+
 }  // namespace Impl
 
 // FIXME spurious warnings like
@@ -299,50 +402,22 @@ class View
   using reference_type = typename base_t::reference;
   using typename base_t::data_handle_type;
 
-  //----------------------------------------
-  // Compatible view of a data type
-  using type = std::conditional_t<
-      has_hooks_policy,
-      View<typename traits::data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>,
-      View<typename traits::data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::memory_traits> >;
+ private:
+  using view_types =
+      Impl::ViewTypeDefs<View, has_hooks_policy,
+                         basic_view_from_traits::mdspan_style_args>;
+
+ public:
+  using type             = typename view_types::type;
+  using const_type       = typename view_types::const_type;
+  using non_const_type   = typename view_types::non_const_type;
+  using host_mirror_type = typename view_types::host_mirror_type;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
   //----------------------------------------
   // Compatible view of array of scalar types
   using array_type KOKKOS_DEPRECATED_WITH_COMMENT("Use type instead.") = type;
 #endif
-
-  // Compatible view of const data type
-  using const_type = std::conditional_t<
-      has_hooks_policy,
-      View<typename traits::const_data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>,
-      View<typename traits::const_data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::memory_traits> >;
-
-  // Compatible view of non-const data type
-  using non_const_type = std::conditional_t<
-      has_hooks_policy,
-      View<typename traits::non_const_data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::hooks_policy,
-           typename traits::memory_traits>,
-      View<typename traits::non_const_data_type, typename traits::array_layout,
-           typename traits::device_type, typename traits::memory_traits> >;
-
-  // Compatible host mirror view
-  using host_mirror_type = std::conditional_t<
-      has_hooks_policy,
-      View<typename traits::non_const_data_type, typename traits::array_layout,
-           Device<DefaultHostExecutionSpace,
-                  typename traits::host_mirror_space::memory_space>,
-           typename traits::hooks_policy>,
-      View<typename traits::non_const_data_type, typename traits::array_layout,
-           Device<DefaultHostExecutionSpace,
-                  typename traits::host_mirror_space::memory_space> > >;
 
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_4
   /** \brief  Compatible HostMirror view */

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -286,10 +286,10 @@ struct ViewTypeDefs<ViewType, false, false> {
 // so this is independent of that parameter value
 template <class ViewType, bool HasHooksPolicy>
 struct ViewTypeDefs<ViewType, HasHooksPolicy, true> {
-  using element_type    = typename ViewType::element_type;
-  using nc_element_type = std::remove_const_t<element_type>;
-  using extents_type    = typename ViewType::extents_type;
-  using layout_type     = typename ViewType::layout_type;
+  using element_type           = typename ViewType::element_type;
+  using non_const_element_type = std::remove_const_t<element_type>;
+  using extents_type           = typename ViewType::extents_type;
+  using layout_type            = typename ViewType::layout_type;
 
   //----------------------------------------
   // Compatible view of a data type
@@ -305,16 +305,16 @@ struct ViewTypeDefs<ViewType, HasHooksPolicy, true> {
 
   // Compatible view of non-const data type
   using non_const_type =
-      View<nc_element_type, extents_type, layout_type,
-           Kokkos::Experimental::Accessor<nc_element_type,
+      View<non_const_element_type, extents_type, layout_type,
+           Kokkos::Experimental::Accessor<non_const_element_type,
                                           typename ViewType::memory_space,
                                           typename ViewType::memory_traits> >;
 
   // Compatible host mirror view
   using host_mirror_type =
-      View<nc_element_type, extents_type, layout_type,
+      View<non_const_element_type, extents_type, layout_type,
            Kokkos::Experimental::Accessor<
-               nc_element_type,
+               non_const_element_type,
                typename ViewType::host_mirror_space::memory_space> >;
 };
 

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(COMPILE_ONLY_SOURCES
     view/TestConversionFromPointer.cpp
     view/TestMemoryTraitTypes.cpp
     view/TestViewMDSpanTemplateArgumentEquivalence.cpp
+    view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
 )
 
 # FIXME_NEXTSILICON: whitelisted tests
@@ -79,6 +80,7 @@ if(NOT Kokkos_ENABLE_IMPL_MDSPAN OR Kokkos_ENABLE_IMPL_VIEW_LEGACY)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestAccessorFromMemoryTraits.cpp)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewCustomization.cpp)
   list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewMDSpanTemplateArgumentEquivalence.cpp)
+  list(REMOVE_ITEM COMPILE_ONLY_SOURCES view/TestViewMDSpanTemplateArgumentTypeDefs.cpp)
 endif()
 
 #testing if windows.h and Kokkos_Core.hpp can be included

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -31,6 +31,17 @@ struct ViewTestHarness {
   using accessor_type = typename Kokkos::View<ElementType>::accessor_type;
   using new_view_t = Kokkos::View<ElementType, Exts, LayoutType, accessor_type>;
 
+  // check that the index_type (and thus the template argument style) propagates
+  static_assert(std::is_same_v<typename new_view_t::type::index_type,
+                               typename new_view_t::index_type>);
+  static_assert(std::is_same_v<typename new_view_t::const_type::index_type,
+                               typename new_view_t::index_type>);
+  static_assert(std::is_same_v<typename new_view_t::non_const_type::index_type,
+                               typename new_view_t::index_type>);
+  static_assert(
+      std::is_same_v<typename new_view_t::host_mirror_type::index_type,
+                     typename new_view_t::index_type>);
+
   using old_view_t = Kokkos::View<
       typename new_view_t::data_type, typename new_view_t::array_layout,
       typename new_view_t::device_type, typename new_view_t::memory_traits>;
@@ -148,9 +159,6 @@ struct ViewTestHarness {
   template <class... Extents>
   static void create_mirror(Extents... extents) {
     new_view_t a("A", extents...);
-    static_assert(
-        std::is_same_v<typename new_view_t::host_mirror_type::index_type,
-                       size_t>);
     {
       auto h_a = Kokkos::create_mirror(a);
       static_assert(
@@ -160,8 +168,6 @@ struct ViewTestHarness {
     {
       auto h_a     = Kokkos::create_mirror(Kokkos::HostSpace(), a);
       using h_type = decltype(h_a);
-      // since create_mirror still uses old-style template args
-      // the extents type isn't necessarily the same index_type
       static_assert(
           std::is_same_v<typename h_type::memory_space, Kokkos::HostSpace>);
       static_assert(std::is_same_v<typename h_type::element_type,
@@ -170,7 +176,26 @@ struct ViewTestHarness {
       ASSERT_EQ(a.extents(), h_a.extents());
     }
     {
-      auto h_a = Kokkos::create_mirror_view(a);
+      typename new_view_t::const_type ac = a;
+      static_assert(
+          std::is_same_v<typename new_view_t::const_type::element_type,
+                         typename new_view_t::element_type const>);
+
+      auto h_ac    = Kokkos::create_mirror(Kokkos::HostSpace(), ac);
+      using h_type = decltype(h_ac);
+      static_assert(
+          std::is_same_v<typename h_type::memory_space, Kokkos::HostSpace>);
+      static_assert(std::is_same_v<typename h_type::element_type,
+                                   typename new_view_t::element_type>);
+
+      ASSERT_EQ(a.extents(), h_ac.extents());
+    }
+    {
+      auto h_a     = Kokkos::create_mirror_view(a);
+      using h_type = decltype(h_a);
+      static_assert(std::is_same_v<typename h_type::element_type,
+                                   typename new_view_t::element_type>);
+
       ASSERT_EQ(a.extents(), h_a.extents());
     }
     {

--- a/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
+++ b/core/unit_test/view/TestMinimalViewMDSpanTemplateArgumentViability.hpp
@@ -28,10 +28,13 @@ template <class ElementType, class Exts,
           class LayoutType = typename Kokkos::View<int>::layout_type>
 struct ViewTestHarness {
   // using the default accessor type
-  using accessor_type = typename Kokkos::View<ElementType>::accessor_type;
+  using accessor_type =
+      typename Kokkos::View<ElementType, TEST_EXECSPACE>::accessor_type;
   using new_view_t = Kokkos::View<ElementType, Exts, LayoutType, accessor_type>;
 
   // check that the index_type (and thus the template argument style) propagates
+  // this is just a sanity check, the real check is in
+  // TestViewMDSpanTemplateArgumentTypeDefs.cpp
   static_assert(std::is_same_v<typename new_view_t::type::index_type,
                                typename new_view_t::index_type>);
   static_assert(std::is_same_v<typename new_view_t::const_type::index_type,
@@ -156,47 +159,84 @@ struct ViewTestHarness {
     }
   }
 
+  // This checks that create_mirror works
+  // correct return types are checked in
+  // TestViewMDSpanTemplateArgumentTypeDefs.cpp
   template <class... Extents>
   static void create_mirror(Extents... extents) {
     new_view_t a("A", extents...);
+
+    // Note: only for APU builds - i.e. making default GPU memory space
+    // host accessible the two bools below are not the same in this test.
+    constexpr bool is_host_space =
+        std::is_same_v<typename new_view_t::memory_space, Kokkos::HostSpace>;
+    constexpr bool host_accessible = Kokkos::SpaceAccessibility<
+        Kokkos::DefaultHostExecutionSpace,
+        typename new_view_t::memory_space>::accessible;
+
     {
       auto h_a = Kokkos::create_mirror(a);
-      static_assert(
-          std::is_same_v<decltype(h_a), typename new_view_t::host_mirror_type>);
       ASSERT_EQ(a.extents(), h_a.extents());
-    }
-    {
-      auto h_a     = Kokkos::create_mirror(Kokkos::HostSpace(), a);
-      using h_type = decltype(h_a);
-      static_assert(
-          std::is_same_v<typename h_type::memory_space, Kokkos::HostSpace>);
-      static_assert(std::is_same_v<typename h_type::element_type,
-                                   typename new_view_t::element_type>);
-
-      ASSERT_EQ(a.extents(), h_a.extents());
+      ASSERT_EQ(a.data() == h_a.data(), false);
     }
     {
       typename new_view_t::const_type ac = a;
-      static_assert(
-          std::is_same_v<typename new_view_t::const_type::element_type,
-                         typename new_view_t::element_type const>);
-
-      auto h_ac    = Kokkos::create_mirror(Kokkos::HostSpace(), ac);
-      using h_type = decltype(h_ac);
-      static_assert(
-          std::is_same_v<typename h_type::memory_space, Kokkos::HostSpace>);
-      static_assert(std::is_same_v<typename h_type::element_type,
-                                   typename new_view_t::element_type>);
-
+      auto h_ac                          = Kokkos::create_mirror(ac);
       ASSERT_EQ(a.extents(), h_ac.extents());
+      ASSERT_EQ(a.data() == h_ac.data(), false);
     }
     {
-      auto h_a     = Kokkos::create_mirror_view(a);
-      using h_type = decltype(h_a);
-      static_assert(std::is_same_v<typename h_type::element_type,
-                                   typename new_view_t::element_type>);
-
+      auto h_a = Kokkos::create_mirror(Kokkos::HostSpace(), a);
       ASSERT_EQ(a.extents(), h_a.extents());
+      ASSERT_EQ(a.data() == h_a.data(), false);
+    }
+    {
+      typename new_view_t::const_type ac = a;
+      auto h_ac = Kokkos::create_mirror(Kokkos::HostSpace(), ac);
+      ASSERT_EQ(a.extents(), h_ac.extents());
+      ASSERT_EQ(a.data() == h_ac.data(), false);
+    }
+    {
+      auto h_a = Kokkos::create_mirror_view(a);
+      ASSERT_EQ(a.extents(), h_a.extents());
+      ASSERT_EQ(a.data() == h_a.data(), host_accessible);
+    }
+    // There is an inconsistency here where for constant element type
+    // create_mirror_view without space arg always returns a new allocation
+    // while if you give a space arg it doesn't.
+    {
+      typename new_view_t::const_type ac = a;
+      auto h_ac                          = Kokkos::create_mirror_view(ac);
+      ASSERT_EQ(a.extents(), h_ac.extents());
+      ASSERT_EQ(a.data() == h_ac.data(), false);
+    }
+    {
+      auto h_a = Kokkos::create_mirror_view(Kokkos::HostSpace(), a);
+      ASSERT_EQ(a.extents(), h_a.extents());
+      ASSERT_EQ(a.data() == h_a.data(), is_host_space);
+    }
+    {
+      typename new_view_t::const_type ac = a;
+      auto h_ac = Kokkos::create_mirror_view(Kokkos::HostSpace(), ac);
+      ASSERT_EQ(a.extents(), h_ac.extents());
+      ASSERT_EQ(a.data() == h_ac.data(), is_host_space);
+    }
+    {
+      init_view(a, 1, extents...);
+      auto h_a = Kokkos::create_mirror_view_and_copy(a);
+      ASSERT_EQ(a.extents(), h_a.extents());
+      size_t errors = check_view(h_a, 1, extents...);
+      ASSERT_EQ(errors, 0lu);
+      ASSERT_EQ(a.data() == h_a.data(), host_accessible);
+    }
+    {
+      init_view(a, 1, extents...);
+      typename new_view_t::const_type ac = a;
+      auto h_ac = Kokkos::create_mirror_view_and_copy(ac);
+      ASSERT_EQ(a.extents(), h_ac.extents());
+      size_t errors = check_view(h_ac, 1, extents...);
+      ASSERT_EQ(errors, 0lu);
+      ASSERT_EQ(a.data() == h_ac.data(), host_accessible);
     }
     {
       init_view(a, 1, extents...);
@@ -204,6 +244,47 @@ struct ViewTestHarness {
       ASSERT_EQ(a.extents(), h_a.extents());
       size_t errors = check_view(h_a, 1, extents...);
       ASSERT_EQ(errors, 0lu);
+      ASSERT_EQ(a.data() == h_a.data(), is_host_space);
+    }
+    {
+      init_view(a, 1, extents...);
+      typename new_view_t::const_type ac = a;
+      auto h_ac = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), ac);
+      ASSERT_EQ(a.extents(), h_ac.extents());
+      size_t errors = check_view(h_ac, 1, extents...);
+      ASSERT_EQ(errors, 0lu);
+      ASSERT_EQ(a.data() == h_ac.data(), is_host_space);
+    }
+    // Sanity check that the classical View args show
+    // the same inconsistency in the return value for create_mirror_view
+    // with respect to constant element types.
+    {
+      Kokkos::View<int, Kokkos::HostSpace> b("A");
+      Kokkos::View<const int, Kokkos::HostSpace> bc(b);
+      {
+        auto h_b  = create_mirror_view(b);
+        auto h_bc = create_mirror_view(bc);
+        ASSERT_EQ(b.data(), h_b.data());
+        ASSERT_NE(b.data(), h_bc.data());
+      }
+      {
+        auto h_b  = create_mirror_view(Kokkos::HostSpace(), b);
+        auto h_bc = create_mirror_view(Kokkos::HostSpace(), bc);
+        ASSERT_EQ(b.data(), h_b.data());
+        ASSERT_EQ(b.data(), h_bc.data());
+      }
+      {
+        auto h_b  = create_mirror_view_and_copy(b);
+        auto h_bc = create_mirror_view_and_copy(bc);
+        ASSERT_EQ(b.data(), h_b.data());
+        ASSERT_EQ(b.data(), h_bc.data());
+      }
+      {
+        auto h_b  = create_mirror_view_and_copy(Kokkos::HostSpace(), b);
+        auto h_bc = create_mirror_view_and_copy(Kokkos::HostSpace(), bc);
+        ASSERT_EQ(b.data(), h_b.data());
+        ASSERT_EQ(b.data(), h_bc.data());
+      }
     }
   }
 };

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <cstdlib>
+#include <type_traits>
+
+namespace {
+
+template <class T, class Extents, class Layout, class MemSpace, class MemTraits>
+constexpr bool test_create_mirror_types() {
+  using view_t =
+      Kokkos::View<T, Extents, Layout,
+                   Kokkos::Experimental::Accessor<T, MemSpace, MemTraits>>;
+  constexpr bool host_accessible =
+      Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace,
+                                 MemSpace>::accessible;
+
+  constexpr bool const_T = std::is_const_v<T>;
+
+  using host_mirror_space_t =
+      std::conditional_t<host_accessible, MemSpace, Kokkos::HostSpace>;
+
+  using create_mirror_t = std::conditional_t<
+      host_accessible && !const_T, view_t,
+      Kokkos::View<std::remove_const_t<T>, Extents, Layout,
+                   Kokkos::Experimental::Accessor<std::remove_const_t<T>,
+                                                  host_mirror_space_t,
+                                                  Kokkos::MemoryTraits<>>>>;
+
+  using create_mirror_view_t = std::conditional_t<
+      host_accessible, view_t,
+      Kokkos::View<std::remove_const_t<T>, Extents, Layout,
+                   Kokkos::Experimental::Accessor<std::remove_const_t<T>,
+                                                  host_mirror_space_t,
+                                                  Kokkos::MemoryTraits<>>>>;
+
+  static_assert(std::is_same_v<create_mirror_t, decltype(Kokkos::create_mirror(
+                                                    std::declval<view_t>()))>);
+  static_assert(
+      std::is_same_v<create_mirror_t, decltype(Kokkos::create_mirror_view(
+                                          std::declval<view_t>()))>);
+  static_assert(std::is_same_v<create_mirror_view_t,
+                               decltype(Kokkos::create_mirror_view_and_copy(
+                                   std::declval<view_t>()))>);
+
+  using host_create_mirror_t = Kokkos::View<
+      std::remove_const_t<T>, Extents, Layout,
+      Kokkos::Experimental::Accessor<std::remove_const_t<T>, Kokkos::HostSpace,
+                                     Kokkos::MemoryTraits<>>>;
+  static_assert(std::is_same_v<host_create_mirror_t,
+                               decltype(Kokkos::create_mirror(
+                                   Kokkos::HostSpace(), view_t()))>);
+  using host_create_mirror_view_t = std::conditional_t<
+      std::is_same_v<Kokkos::HostSpace, MemSpace>, view_t,
+      Kokkos::View<std::remove_const_t<T>, Extents, Layout,
+                   Kokkos::Experimental::Accessor<std::remove_const_t<T>,
+                                                  Kokkos::HostSpace,
+                                                  Kokkos::MemoryTraits<>>>>;
+  static_assert(std::is_same_v<host_create_mirror_view_t,
+                               decltype(Kokkos::create_mirror_view(
+                                   Kokkos::HostSpace(), view_t()))>);
+  static_assert(std::is_same_v<host_create_mirror_view_t,
+                               decltype(Kokkos::create_mirror_view_and_copy(
+                                   Kokkos::HostSpace(), view_t()))>);
+
+#ifdef KOKKOS_HAS_SHARED_SPACE
+  using shared_create_mirror_t = Kokkos::View<
+      std::remove_const_t<T>, Extents, Layout,
+      Kokkos::Experimental::Accessor<
+          std::remove_const_t<T>, Kokkos::SharedSpace, Kokkos::MemoryTraits<>>>;
+  using shared_create_mirror_view_t = std::conditional_t<
+      std::is_same_v<MemSpace, Kokkos::SharedSpace>, view_t,
+      Kokkos::View<std::remove_const_t<T>, Extents, Layout,
+                   Kokkos::Experimental::Accessor<std::remove_const_t<T>,
+                                                  Kokkos::SharedSpace,
+                                                  Kokkos::MemoryTraits<>>>>;
+  static_assert(std::is_same_v<shared_create_mirror_t,
+                               decltype(Kokkos::create_mirror(
+                                   Kokkos::SharedSpace(), view_t()))>);
+  static_assert(std::is_same_v<shared_create_mirror_view_t,
+                               decltype(Kokkos::create_mirror_view(
+                                   Kokkos::SharedSpace(), view_t()))>);
+  static_assert(std::is_same_v<shared_create_mirror_view_t,
+                               decltype(Kokkos::create_mirror_view_and_copy(
+                                   Kokkos::SharedSpace(), view_t()))>);
+#endif
+  return true;
+}
+
+template <class T, class Extents, class Layout, class MemSpace, class MemTraits>
+constexpr bool test_typedefs() {
+  using view_t =
+      Kokkos::View<T, Extents, Layout,
+                   Kokkos::Experimental::Accessor<T, MemSpace, MemTraits>>;
+  static_assert(std::is_same_v<view_t, typename view_t::type>);
+
+  using const_view_t = Kokkos::View<
+      const T, Extents, Layout,
+      Kokkos::Experimental::Accessor<const T, MemSpace, MemTraits>>;
+  static_assert(std::is_same_v<const_view_t, typename view_t::const_type>);
+
+  using non_const_view_t =
+      Kokkos::View<std::remove_const_t<T>, Extents, Layout,
+                   Kokkos::Experimental::Accessor<std::remove_const_t<T>,
+                                                  MemSpace, MemTraits>>;
+  static_assert(
+      std::is_same_v<non_const_view_t, typename view_t::non_const_type>);
+
+  return true;
+}
+
+template <class T, class Extents, class Layout, class MemSpace, class MemTraits>
+constexpr bool test_derived_types() {
+  constexpr bool typedef_result =
+      test_typedefs<T, Extents, Layout, MemSpace, MemTraits>();
+
+  if constexpr (MemTraits::is_atomic) {
+    return typedef_result;
+  } else {
+    return typedef_result &&
+           test_create_mirror_types<T, Extents, Layout, MemSpace, MemTraits>();
+  }
+}
+
+using LL           = Kokkos::layout_left;
+using LR           = Kokkos::layout_right;
+using SH           = Kokkos::HostSpace;
+using SD           = typename Kokkos::DefaultExecutionSpace::memory_space;
+using f            = float;
+using cf           = const float;
+constexpr size_t d = Kokkos::dynamic_extent;
+
+// clang-format off
+
+static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SD, Kokkos::MemoryTraits<>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SD, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, SD, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, SD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+
+static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SH, Kokkos::MemoryTraits<>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SH, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, SH, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+
+#ifdef KOKKOS_HAS_SHARED_SPACE
+using SS = Kokkos::SharedSpace;
+
+static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SS, Kokkos::MemoryTraits<>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SS, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, SS, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
+static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SS, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
+static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, SS, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+#endif
+
+// clang-format on
+
+}  // namespace


### PR DESCRIPTION
This makes sure that View::[type/const_type/non_const_type/host_mirror_type] are using mdspan-style args if the primary template used mdspan-style args.

I am leaving Uniform type alone - because there is an argument that they should all map to the same. Though we may want to reconsider which style they should use.