### PR TITLE
TestTeamPolicyConstructors.hpp: ask and respect what max supported team size is

### DIFF
--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -29,13 +29,9 @@ template <typename Policy>
 void test_run_time_parameters() {
   int league_size = 131;
 
-  using ExecutionSpace = typename Policy::execution_space;
-  using ParallelTag    = Kokkos::ParallelForTag;
-  int team_size =
-      4 < ExecutionSpace().concurrency() ? 4 : ExecutionSpace().concurrency();
-#ifdef KOKKOS_ENABLE_HPX
-  team_size = 1;
-#endif
+  using ParallelTag      = Kokkos::ParallelForTag;
+  int max_team_size      = Policy{}.team_size_max(FunctorFor{}, ParallelTag{});
+  const int team_size    = std::min(max_team_size, 4);
   int chunk_size         = 4;
   int per_team_scratch   = 1024;
   int per_thread_scratch = 16;


### PR DESCRIPTION
Rather than special-case it for HPX

```
cmake -S . -B build  -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_COMPILER_WARNINGS=ON -DKokkos_ENABLE_TESTS=ON

# Kokkos_CoreUnitTest_<Backend>2
cmake --build build --target Kokkos_CoreUnitTest_Serial2

build/core/unit_test/Kokkos_CoreUnitTest_Serial2 --gtest_filter='*team_policy_runtime_parameters*'
```