### PR TITLE
Refactor ErrorReporter so that it is a specialization of a more generic Logger struct

### DIFF
--- a/containers/src/Kokkos_ErrorReporter.cppm
+++ b/containers/src/Kokkos_ErrorReporter.cppm
@@ -10,9 +10,9 @@ export module kokkos.error_reporter;
 export {
   namespace Kokkos {
   namespace Experimental {
-  using ::Kokkos::Experimental::Logger;
   using ::Kokkos::Experimental::ErrorReport;
   using ::Kokkos::Experimental::ErrorReporter;
-  }
+  using ::Kokkos::Experimental::Logger;
+  }  // namespace Experimental
   }  // namespace Kokkos
 }

--- a/containers/src/Kokkos_ErrorReporter.cppm
+++ b/containers/src/Kokkos_ErrorReporter.cppm
@@ -10,6 +10,8 @@ export module kokkos.error_reporter;
 export {
   namespace Kokkos {
   namespace Experimental {
+  using ::Kokkos::Experimental::Logger;
+  using ::Kokkos::Experimental::ErrorReport;
   using ::Kokkos::Experimental::ErrorReporter;
   }
   }  // namespace Kokkos

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -22,91 +22,95 @@ import kokkos.core;
 
 namespace Kokkos {
 namespace Experimental {
-template <typename ReportType,
+template <typename LogType,
           typename DeviceType = typename DefaultExecutionSpace::device_type>
-class ErrorReporter {
+class Logger {
  public:
-  using report_type     = ReportType;
+  using log_type        = LogType;
   using device_type     = DeviceType;
   using execution_space = typename device_type::execution_space;
 
-  ErrorReporter(const std::string &label, int max_results)
-      : m_numReportsAttempted(label + "::m_numReportsAttempted"),
-        m_reports(label + "::m_reports", max_results),
-        m_reporters(label + "::m_reporters", max_results) {
+  Logger(const std::string& label, int max_results)
+      : m_insertionAttempted(label + "::m_insertionAttempted"),
+        m_logs(label + "::m_logs", max_results) {
     clear();
   }
 
-  ErrorReporter(int max_results)
-      : ErrorReporter("ErrorReporter", max_results) {}
+  Logger(int max_results) : Logger("Logger", max_results) {}
 
-  int capacity() const { return m_reports.extent(0); }
+  int capacity() const { return m_logs.extent(0); }
 
-  int num_reports() const {
-    return std::clamp(num_report_attempts(), 0, capacity());
-  }
+  int size() const { return std::clamp(insertion_attempts(), 0, capacity()); }
 
-  int num_report_attempts() const {
+  int insertion_attempts() const {
     int value;
-    Kokkos::deep_copy(value, m_numReportsAttempted);
+    Kokkos::deep_copy(value, m_insertionAttempted);
     return value;
   }
 
-  auto get_reports() const {
-    int num_reps = num_reports();
-    std::vector<int> reporters_out(num_reps);
-    std::vector<report_type> reports_out(num_reps);
+  std::vector<log_type> get() const {
+    int num_elements = size();
+    std::vector<log_type> res(num_elements);
 
-    if (num_reps > 0) {
-      Kokkos::View<int *, Kokkos::HostSpace> h_reporters(reporters_out.data(),
-                                                         num_reps);
-      Kokkos::View<report_type *, Kokkos::HostSpace> h_reports(
-          reports_out.data(), num_reps);
+    if (num_elements > 0) {
+      Kokkos::View<log_type*, Kokkos::HostSpace> h_logs(res.data(),
+                                                        num_elements);
 
-      Kokkos::deep_copy(
-          h_reporters, Kokkos::subview(m_reporters, Kokkos::pair{0, num_reps}));
-      Kokkos::deep_copy(h_reports,
-                        Kokkos::subview(m_reports, Kokkos::pair{0, num_reps}));
+      Kokkos::deep_copy(h_logs,
+                        Kokkos::subview(m_logs, Kokkos::pair{0, num_elements}));
     }
-    return std::pair{std::move(reporters_out), std::move(reports_out)};
+    return std::move(res);
   }
 
-  bool full() const { return (num_report_attempts() >= capacity()); }
+  bool full() const { return (insertion_attempts() >= capacity()); }
 
-  void clear() const { Kokkos::deep_copy(m_numReportsAttempted, 0); }
+  void clear() const { Kokkos::deep_copy(m_insertionAttempted, 0); }
 
-  // This function keeps reports up to new_size alive
-  // It may lose the information on attempted reports
+  // This function keeps logs up to new_size alive
+  // It may lose the information on attempted logs
   void resize(const size_t new_size) {
-    // We have to reset the attempts so we don't accidently
-    // report more stored reports than there actually are
+    // We have to reset the attempts so we don't accidentally
+    // report more stored logs than there actually are
     // after growing capacity.
-    int num_reps = num_report_attempts();
-    if (new_size > static_cast<size_t>(capacity()) && num_reps > capacity())
-      Kokkos::deep_copy(m_numReportsAttempted, num_reports());
+    int attempts = insertion_attempts();
+    if (new_size > static_cast<size_t>(capacity()) && attempts > capacity())
+      Kokkos::deep_copy(m_insertionAttempted, size());
 
-    Kokkos::resize(m_reports, new_size);
-    Kokkos::resize(m_reporters, new_size);
+    Kokkos::resize(m_logs, new_size);
   }
 
-  KOKKOS_INLINE_FUNCTION
-  bool add_report(int reporter_id, report_type report) const {
-    int idx = Kokkos::atomic_fetch_inc(&m_numReportsAttempted());
+  KOKKOS_INLINE_FUNCTION bool try_push(const LogType&& log) const {
+    return try_emplace(log) != nullptr;
+  }
 
-    if (idx >= 0 && (idx < m_reports.extent_int(0))) {
-      m_reporters(idx) = reporter_id;
-      m_reports(idx)   = report;
-      return true;
+  template <class... Args>
+  KOKKOS_INLINE_FUNCTION log_type* try_emplace(Args&&... args) const {
+    int idx = Kokkos::atomic_fetch_inc(&m_insertionAttempted());
+
+    if (idx >= 0 && (idx < m_logs.extent_int(0))) {
+      log_type* mem = &m_logs(idx);
+      mem->~LogType();
+      return new (mem) LogType(args...);
     } else {
-      return false;
+      return nullptr;
     }
   }
 
  private:
-  Kokkos::View<int, device_type> m_numReportsAttempted;
-  Kokkos::View<report_type *, device_type> m_reports;
-  Kokkos::View<int *, device_type> m_reporters;
+  Kokkos::View<int, device_type> m_insertionAttempted;
+  Kokkos::View<log_type*, device_type> m_logs;
 };
+
+template <typename ErrorType,
+          typename DeviceType = typename DefaultExecutionSpace::device_type>
+struct ErrorReport {
+  int m_reporter_id;
+  ErrorType m_error;
+};
+
+template <typename ErrorType,
+          typename DeviceType = typename DefaultExecutionSpace::device_type>
+using ErrorReporter = Logger<ErrorReport<ErrorType>, DeviceType>;
 
 }  // namespace Experimental
 }  // namespace Kokkos

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -90,7 +90,7 @@ class Logger {
     if (idx >= 0 && (idx < m_logs.extent_int(0))) {
       log_type* mem = &m_logs(idx);
       mem->~LogType();
-      return new (mem) LogType(args...);
+      return new (mem) LogType{args...};
     } else {
       return nullptr;
     }

--- a/containers/src/Kokkos_ErrorReporter.hpp
+++ b/containers/src/Kokkos_ErrorReporter.hpp
@@ -59,7 +59,7 @@ class Logger {
       Kokkos::deep_copy(h_logs,
                         Kokkos::subview(m_logs, Kokkos::pair{0, num_elements}));
     }
-    return std::move(res);
+    return res;
   }
 
   bool full() const { return (insertion_attempts() >= capacity()); }
@@ -104,8 +104,8 @@ class Logger {
 template <typename ErrorType,
           typename DeviceType = typename DefaultExecutionSpace::device_type>
 struct ErrorReport {
-  int m_reporter_id;
-  ErrorType m_error;
+  int reporter_id;
+  ErrorType error;
 };
 
 template <typename ErrorType,

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -205,7 +205,7 @@ void ErrorReporter_test_resize() {
   Kokkos::Experimental::ErrorReporter<int, TEST_EXECSPACE> logger("Reporter",
                                                                   10);
 
-  // produce more errors when we can store
+  // produce more errors that we can store
   Kokkos::parallel_for(
       "TestErrorReporter_resize", Kokkos::RangePolicy<TEST_EXECSPACE>(0, 20),
       KOKKOS_LAMBDA(int i) { logger.try_emplace(i, 0); });

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -35,11 +35,11 @@ std::ostream &operator<<(
 }
 
 template <typename ReportType>
-void checkReportersAndReportsAgree(const std::vector<int> &reporters,
-                                   const std::vector<ReportType> &reports) {
+void checkReportersAndReportsAgree(
+    const std::vector<Kokkos::Experimental::ErrorReport<ReportType>> &reports) {
   for (size_t i = 0; i < reports.size(); ++i) {
-    EXPECT_EQ(1, reporters[i] % 2);
-    EXPECT_EQ(reporters[i], reports[i].m_data1);
+    EXPECT_EQ(1, reports[i].m_reporter_id % 2);
+    EXPECT_EQ(reports[i].m_reporter_id, reports[i].m_error.m_data1);
   }
 }
 
@@ -60,11 +60,11 @@ struct ErrorReporterDriverBase {
 
   void check_expectations(int reporter_capacity, int test_size) {
     using namespace std;
-    int num_reported = m_errorReporter.num_reports();
-    int num_attempts = m_errorReporter.num_report_attempts();
+    int num_reported = m_errorReporter.size();
+    int num_attempts = m_errorReporter.insertion_attempts();
 
-    int expected_num_reports = min(reporter_capacity, test_size / 2);
-    EXPECT_EQ(expected_num_reports, num_reported);
+    int expected_size = min(reporter_capacity, test_size / 2);
+    EXPECT_EQ(expected_size, num_reported);
     EXPECT_EQ(test_size / 2, num_attempts);
 
     bool expect_full   = (reporter_capacity <= (test_size / 2));
@@ -77,17 +77,13 @@ template <typename ErrorReporterDriverType>
 void TestErrorReporter() {
   using tester_type = ErrorReporterDriverType;
 
-  std::vector<int> reporters;
-  std::vector<typename tester_type::report_type> reports;
-
   tester_type test1(100, 10);
-
-  std::tie(reporters, reports) = test1.m_errorReporter.get_reports();
-  checkReportersAndReportsAgree(reporters, reports);
+  auto reports1 = test1.m_errorReporter.get();
+  checkReportersAndReportsAgree(reports1);
 
   tester_type test2(10, 100);
-  auto [reporters2, reports2] = test2.m_errorReporter.get_reports();
-  checkReportersAndReportsAgree(reporters2, reports2);
+  auto reports2 = test2.m_errorReporter.get();
+  checkReportersAndReportsAgree(reports2);
 }
 
 template <typename DeviceType>
@@ -99,8 +95,8 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
   ErrorReporterDriver(int reporter_capacity, int test_size)
       : driver_base(reporter_capacity, test_size) {
     EXPECT_EQ(driver_base::m_errorReporter.capacity(), reporter_capacity);
-    EXPECT_EQ(driver_base::m_errorReporter.num_reports(), 0);
-    EXPECT_EQ(driver_base::m_errorReporter.num_report_attempts(), 0);
+    EXPECT_EQ(driver_base::m_errorReporter.size(), 0);
+    EXPECT_EQ(driver_base::m_errorReporter.insertion_attempts(), 0);
 
     execute(reporter_capacity, test_size);
 
@@ -108,13 +104,13 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
     if (reporter_capacity < test_size) {
       driver_base::m_errorReporter.clear();
       EXPECT_EQ(driver_base::m_errorReporter.capacity(), reporter_capacity);
-      EXPECT_EQ(driver_base::m_errorReporter.num_reports(), 0);
-      EXPECT_EQ(driver_base::m_errorReporter.num_report_attempts(), 0);
+      EXPECT_EQ(driver_base::m_errorReporter.size(), 0);
+      EXPECT_EQ(driver_base::m_errorReporter.insertion_attempts(), 0);
 
       driver_base::m_errorReporter.resize(test_size);
       EXPECT_EQ(driver_base::m_errorReporter.capacity(), test_size);
-      EXPECT_EQ(driver_base::m_errorReporter.num_reports(), 0);
-      EXPECT_EQ(driver_base::m_errorReporter.num_report_attempts(), 0);
+      EXPECT_EQ(driver_base::m_errorReporter.size(), 0);
+      EXPECT_EQ(driver_base::m_errorReporter.insertion_attempts(), 0);
       execute(test_size, test_size);
     }
   }
@@ -131,7 +127,7 @@ struct ErrorReporterDriver : public ErrorReporterDriverBase<DeviceType> {
     if (driver_base::error_condition(work_idx)) {
       double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
       typename driver_base::report_type report = {work_idx, -2 * work_idx, val};
-      driver_base::m_errorReporter.add_report(work_idx, report);
+      driver_base::m_errorReporter.try_emplace(work_idx, report);
     }
   }
 };
@@ -157,7 +153,7 @@ struct ErrorReporterDriverUseLambda
             double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
             typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                         val};
-            driver_base::m_errorReporter.add_report(work_idx, report);
+            driver_base::m_errorReporter.try_emplace(work_idx, report);
           }
         });
     Kokkos::fence();
@@ -180,7 +176,7 @@ struct ErrorReporterDriverNativeOpenMP
         double val = Kokkos::numbers::pi * static_cast<double>(work_idx);
         typename driver_base::report_type report = {work_idx, -2 * work_idx,
                                                     val};
-        driver_base::m_errorReporter.add_report(work_idx, report);
+        driver_base::m_errorReporter.try_emplace(work_idx, report);
       }
     };
     driver_base::check_expectations(reporter_capacity, test_size);
@@ -212,21 +208,21 @@ void ErrorReporter_test_resize() {
   // produce more errors when we can store
   Kokkos::parallel_for(
       "TestErrorReporter_resize", Kokkos::RangePolicy<TEST_EXECSPACE>(0, 20),
-      KOKKOS_LAMBDA(int i) { logger.add_report(i, 0); });
+      KOKKOS_LAMBDA(int i) { logger.try_emplace(i, 0); });
 
-  ASSERT_EQ(logger.num_reports(), 10);
-  ASSERT_EQ(logger.num_report_attempts(), 20);
+  ASSERT_EQ(logger.size(), 10);
+  ASSERT_EQ(logger.insertion_attempts(), 20);
 
   logger.resize(15);
-  ASSERT_EQ(logger.num_reports(), 10);
-  ASSERT_EQ(logger.num_report_attempts(), 10);
+  ASSERT_EQ(logger.size(), 10);
+  ASSERT_EQ(logger.insertion_attempts(), 10);
 
   logger.resize(5);
-  ASSERT_EQ(logger.num_reports(), 5);
-  ASSERT_EQ(logger.num_report_attempts(), 10);
+  ASSERT_EQ(logger.size(), 5);
+  ASSERT_EQ(logger.insertion_attempts(), 10);
 }
 
 TEST(TEST_CATEGORY, ErrorReporter_resize) { ErrorReporter_test_resize(); }
 
 }  // namespace Test
-#endif  // #ifndef KOKKOS_TEST_ERROR_REPORTING_HPP
+#endif  // #ifndef KOKKOS_TEST_EXPERIMENTAL_ERROR_REPORTER_HPP

--- a/containers/unit_tests/TestErrorReporter.hpp
+++ b/containers/unit_tests/TestErrorReporter.hpp
@@ -38,8 +38,8 @@ template <typename ReportType>
 void checkReportersAndReportsAgree(
     const std::vector<Kokkos::Experimental::ErrorReport<ReportType>> &reports) {
   for (size_t i = 0; i < reports.size(); ++i) {
-    EXPECT_EQ(1, reports[i].m_reporter_id % 2);
-    EXPECT_EQ(reports[i].m_reporter_id, reports[i].m_error.m_data1);
+    EXPECT_EQ(1, reports[i].reporter_id % 2);
+    EXPECT_EQ(reports[i].reporter_id, reports[i].error.m_data1);
   }
 }
 

--- a/example/tutorial/Debugging/01_ErrorReporter/error_reporter.cpp
+++ b/example/tutorial/Debugging/01_ErrorReporter/error_reporter.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
             // add_report takes an id and a payload
             // Note that we don't have to check how many reports were already
             // submitted
-            errors.add_report(i, pos);
+            errors.try_emplace(i, pos);
           } else if (pos < 50.)
             count_lower++;
           else
@@ -59,12 +59,12 @@ int main(int argc, char* argv[]) {
     printf(
         "There were %i particles outside of the valid domain (0 - 100). Here "
         "are the first %i:\n",
-        errors.num_report_attempts(), errors.num_reports());
+        errors.insertion_attempts(), errors.size());
 
     // Using structured bindings to get the reporter ids and reports
-    auto [reporter_ids, reports] = errors.get_reports();
-    for (int e = 0; e < errors.num_reports(); e++)
-      printf("%i %lf\n", reporter_ids[e], reports[e]);
+    auto reports = errors.get();
+    for (int e = 0; e < errors.size(); e++)
+      printf("%i %lf\n", reports[e].reporter_id, reports[e].error);
   }
   Kokkos::finalize();
 }


### PR DESCRIPTION
Refactor the `ErrorReporter` container to remove the mandatory `reporter` attribute, allowing users of the class (now called `Logger`), to log whatever they want without being forced to find a value for `reporter` even when it doesn't make sense for their usage.

We then redefine `ErrorReporter` from this base `Logger` class.

In addition, I'm proposing new name for both classes methods:
 - `add_report` becomes `try_push` and `try_emplace`, to get closer to std containers names
 - `num_reports` becomes `size` for the same reason
 - `num_report_attempts` become `insertion_attempts`, to get rid of the `report`, and because I don't think the `num` part is necessary
 - `get_reports` becomes `get` to get rid of `report`

### Related issues / PRs

This came from a discussion that started here: https://github.com/kokkos/kokkos/pull/9252#discussion_r3436532374
Basically, I need a container akin to `ErrorReporter` but don't have usage for the `reporter` part of it, so rather than creating a daughter class were `reporter` is ignored, I though it would make more sense to redefine `ErrorReporter` from a simpler class without `reporter`.

### Changelog Entry

This will need an entry in the changelog. 
