### PR TITLE
Make View::static_extent conforming with mdspan::static_extent

### DIFF
--- a/algorithms/src/sorting/Kokkos_SortByKeyPublicAPI.hpp
+++ b/algorithms/src/sorting/Kokkos_SortByKeyPublicAPI.hpp
@@ -41,8 +41,8 @@ void sort_by_key(
       "Kokkos::sort: execution space instance is not able to access "
       "the memory space of the values View argument!");
 
-  static_assert(KeysType::static_extent(0) == 0 ||
-                ValuesType::static_extent(0) == 0 ||
+  static_assert(KeysType::rank_dynamic() == 1 ||
+                ValuesType::rank_dynamic() == 1 ||
                 KeysType::static_extent(0) == ValuesType::static_extent(0));
   if (values.size() != keys.size())
     Kokkos::abort((std::string("values and keys extents must be the same. The "
@@ -87,8 +87,8 @@ void sort_by_key(
       "Kokkos::sort: execution space instance is not able to access "
       "the memory space of the values View argument!");
 
-  static_assert(KeysType::static_extent(0) == 0 ||
-                ValuesType::static_extent(0) == 0 ||
+  static_assert(KeysType::rank_dynamic() == 1 ||
+                ValuesType::rank_dynamic() == 1 ||
                 KeysType::static_extent(0) == ValuesType::static_extent(0));
   if (values.size() != keys.size())
     Kokkos::abort((std::string("values and keys extents must be the same. The "

--- a/algorithms/unit_tests/TestSortByKey.hpp
+++ b/algorithms/unit_tests/TestSortByKey.hpp
@@ -209,6 +209,9 @@ TEST(TEST_CATEGORY, SortByKeyStaticExtents) {
   Kokkos::View<int *, ExecutionSpace> values_dynamic("values_dynamic", 10);
   // checking that it does not throw
   Kokkos::Experimental::sort_by_key(space, keys, values_dynamic);
+
+  Kokkos::Experimental::sort_by_key(space, keys, values_dynamic,
+                                    SortImpl::Less{});
 }
 
 template <typename ExecutionSpace, typename Keys, typename Values>

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -520,7 +520,7 @@ class View
       ((res = indices[rank() - 1 - I] +
               static_cast<idx_type>((rank() - 1 - I) == 0u /* extent_to_pad */
                                         ? m_map.stride(1)
-                                        : extent(rank() - 1 - I)) *
+                                        : base_t::extent(rank() - 1 - I)) *
                   res),
        ...);
       return res;
@@ -531,7 +531,7 @@ class View
       idx_type res = 0;
       ((res = static_cast<idx_type>(index_offsets) +
               static_cast<idx_type>(I == rank() - 1 ? m_map.stride(rank() - 2)
-                                                    : extent(I)) *
+                                                    : base_t::extent(I)) *
                   res),
        ...);
       return res;
@@ -1473,29 +1473,6 @@ class View
     } else {
       return this->data_handle().use_count();
     }
-  }
-
-  KOKKOS_FUNCTION
-  constexpr typename base_t::index_type extent(size_t r) const noexcept {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    // casting to int to avoid warning for pointless comparison of unsigned
-    // with 0
-    if (static_cast<int>(r) >= static_cast<int>(base_t::extents_type::rank()))
-      return 1;
-#endif
-    return base_t::extent(r);
-  }
-
-  KOKKOS_FUNCTION
-  static constexpr size_t static_extent(size_t r) noexcept {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    // casting to int to avoid warning for pointless comparison of unsigned
-    // with 0
-    if (static_cast<int>(r) >= static_cast<int>(base_t::extents_type::rank()))
-      return 1;
-#endif
-    size_t value = base_t::extents_type::static_extent(r);
-    return value == Kokkos::dynamic_extent ? 0 : value;
   }
 };
 

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -1474,6 +1474,27 @@ class View
       return this->data_handle().use_count();
     }
   }
+
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+  KOKKOS_FUNCTION
+  constexpr typename base_t::index_type extent(size_t r) const noexcept {
+    // casting to int to avoid warning for pointless comparison of unsigned
+    // with 0
+    if (static_cast<int>(r) >= static_cast<int>(base_t::extents_type::rank()))
+      return 1;
+    return base_t::extent(r);
+  }
+
+  KOKKOS_FUNCTION
+  static constexpr size_t static_extent(size_t r) noexcept {
+    // casting to int to avoid warning for pointless comparison of unsigned
+    // with 0
+    if (static_cast<int>(r) >= static_cast<int>(base_t::extents_type::rank()))
+      return 1;
+    size_t value = base_t::extents_type::static_extent(r);
+    return value == Kokkos::dynamic_extent ? 0 : value;
+  }
+#endif
 };
 
 #if defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU >= 1500

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -155,35 +155,19 @@ class BasicView {
     return extents_type::rank_dynamic();
   }
   KOKKOS_FUNCTION static constexpr size_t static_extent(rank_type r) noexcept {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    // casting to int to avoid warning for pointless comparison of unsigned
-    // with 0
-    if (static_cast<int>(r) >= static_cast<int>(extents_type::rank())) return 1;
-#else
 // FIXME_CUDA is_constant_evaluated only available in host code
 #ifndef KOKKOS_ENABLE_CUDA
+    // we can't call Kokkos::abort in a constexpr context
     if (!std::is_constant_evaluated()) {
       // Need to cast in order to avoid warning for rank zero about pointless
       // comparison to zero
       KOKKOS_ASSERT(static_cast<int>(r) < static_cast<int>(rank()));
     }
 #endif
-#endif
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    size_t value = extents_type::static_extent(r);
-    return value == Kokkos::dynamic_extent ? 0 : value;
-#else
     return extents_type::static_extent(r);
-#endif
   }
   KOKKOS_FUNCTION constexpr index_type extent(rank_type r) const noexcept {
-    // Need to cast in order to avoid warning for rank zero about pointless
-    // comparison to zero
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    if (static_cast<int>(r) >= static_cast<int>(rank())) return 1;
-#else
     KOKKOS_ASSERT(static_cast<int>(r) < static_cast<int>(rank()));
-#endif
     return m_map.extents().extent(r);
   }
 

--- a/core/src/View/Kokkos_BasicView.hpp
+++ b/core/src/View/Kokkos_BasicView.hpp
@@ -155,17 +155,33 @@ class BasicView {
     return extents_type::rank_dynamic();
   }
   KOKKOS_FUNCTION static constexpr size_t static_extent(rank_type r) noexcept {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
-    // Need to cast in order to avoid warning for rank zero about pointless
-    // comparison to zero
-    KOKKOS_ASSERT(static_cast<int>(r) < static_cast<int>(rank()));
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    // casting to int to avoid warning for pointless comparison of unsigned
+    // with 0
+    if (static_cast<int>(r) >= static_cast<int>(extents_type::rank())) return 1;
+#else
+// FIXME_CUDA is_constant_evaluated only available in host code
+#ifndef KOKKOS_ENABLE_CUDA
+    if (!std::is_constant_evaluated()) {
+      // Need to cast in order to avoid warning for rank zero about pointless
+      // comparison to zero
+      KOKKOS_ASSERT(static_cast<int>(r) < static_cast<int>(rank()));
+    }
 #endif
+#endif
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    size_t value = extents_type::static_extent(r);
+    return value == Kokkos::dynamic_extent ? 0 : value;
+#else
     return extents_type::static_extent(r);
+#endif
   }
   KOKKOS_FUNCTION constexpr index_type extent(rank_type r) const noexcept {
-#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
     // Need to cast in order to avoid warning for rank zero about pointless
     // comparison to zero
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    if (static_cast<int>(r) >= static_cast<int>(rank())) return 1;
+#else
     KOKKOS_ASSERT(static_cast<int>(r) < static_cast<int>(rank()));
 #endif
     return m_map.extents().extent(r);

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -217,6 +217,7 @@ void test_view_extent_precondition_violation(V v) {
     for (size_t r = 0; r < V::rank(); ++r) {
       (void)v.extent(r);
       (void)v.extent_int(r);
+      (void)v.static_extent(r);
     }
   }
 
@@ -224,11 +225,21 @@ void test_view_extent_precondition_violation(V v) {
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
     ASSERT_EQ(v.extent(r), 1u);
     ASSERT_EQ(v.extent_int(r), 1);
+    ASSERT_EQ(v.static_extent(r), 1);
 #else
     std::string const poor_msg =
         "static_cast<int>\\(r\\) < static_cast<int>\\(rank\\(\\)\\)";
     ASSERT_DEATH({ (void)v.extent(r); }, poor_msg);
     ASSERT_DEATH({ (void)v.extent_int(r); }, poor_msg);
+    ASSERT_DEATH({ (void)v.static_extent(r); }, poor_msg);
+#endif
+  }
+
+  for (size_t r = 0; r < V::rank_dynamic(); ++r) {
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE_5
+    ASSERT_EQ(v.static_extent(r), 0);
+#else
+    ASSERT_EQ(v.static_extent(r), Kokkos::dynamic_extent);
 #endif
   }
 }
@@ -256,6 +267,14 @@ TEST(TEST_CATEGORY_DEATH, view_extent_precondition_violation) {
       Kokkos::View<int***, TEST_EXECSPACE>("v3", 3, 7, 13));
   test_view_extent_precondition_violation(
       Kokkos::View<int********, TEST_EXECSPACE>("v8", 1, 2, 3, 4, 5, 6, 7, 8));
+  test_view_extent_precondition_violation(
+      Kokkos::View<double[1], TEST_EXECSPACE>("v0"));
+  test_view_extent_precondition_violation(
+      Kokkos::View<float* [2], TEST_EXECSPACE>("v1", 5));
+  test_view_extent_precondition_violation(
+      Kokkos::View<int* [3][7], TEST_EXECSPACE>("v3", 13));
+  test_view_extent_precondition_violation(
+      Kokkos::View<int***** [1][2][3], TEST_EXECSPACE>("v8", 4, 5, 6, 7, 8));
 }
 
 inline void test_anonymous_space() {


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/9076 addressing https://github.com/kokkos/kokkos/pull/9076#pullrequestreview-4548166107.
Not sure if we should consider this a bug fix or if we rather want to guard it with `KOKKOS_ENABLE_DEPRECATED_CODE_5` even though it's not backward-compatible.