### PR TITLE
Remove deadlocking interface from SFC RNG

### DIFF
--- a/algorithms/src/Kokkos_Random.hpp
+++ b/algorithms/src/Kokkos_Random.hpp
@@ -1673,22 +1673,6 @@ class Random_SFC64_Pool {
     return Random_SFC64<DeviceType>(state_, state_idx);
   }
 
-  // NOTE: state_idx MUST be less than num_states
-  KOKKOS_INLINE_FUNCTION
-  Random_SFC64<DeviceType> get_state_safely(const uint64_t state_idx) const {
-    int delay           = 1;
-    const int max_delay = 1024;  // Arbitrary value to avoid infinite wait
-    while (Kokkos::atomic_compare_exchange(&locks_(state_idx, 0), 0, 1)) {
-      // Exponential backoff spinlock pattern
-      for (int tick = 0; tick < delay; ++tick) {
-        Kokkos::load_fence();
-      }
-
-      if (delay < max_delay) delay *= 2;
-    }
-    return Random_SFC64<DeviceType>(state_, state_idx);
-  }
-
   KOKKOS_INLINE_FUNCTION
   void free_state(const Random_SFC64<DeviceType>& state) const {
     for (int i = 0; i < 4; i++) state_(state.state_idx_, i) = state.state_[i];


### PR DESCRIPTION
remove `get_state_safely` function that does not work on architectures without forward progress guarantee.
If one thread in a warp exits the while loop and another thread is waiting for the same lock, it will just deadlock on archs without forward progress guarantee (e.g. AMD)



<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

  - Related to #https://github.com/kokkos/kokkos/issues/9231
<!-- Link any related issues or PRs. -->

### Changelog Entry

  - Not required

