### PR TITLE
Fix: Address FIXMEs in DynRankView required_allocation_size and add unit tests

### DIFF
--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1046,9 +1046,10 @@ class DynRankView : private View<DataType*******, Properties...> {
       const size_t arg_N3 = 1, const size_t arg_N4 = 1, const size_t arg_N5 = 1,
       const size_t arg_N6                  = 1,
       [[maybe_unused]] const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
+#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_5)
     KOKKOS_ASSERT(arg_N7 == KOKKOS_INVALID_INDEX &&
                   "DynRankView: Cannot allocate 8 dimensions!");
-
+#endif
     return view_type::required_allocation_size(arg_N0, arg_N1, arg_N2, arg_N3,
                                                arg_N4, arg_N5, arg_N6);
   }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1041,13 +1041,16 @@ class DynRankView : private View<DataType*******, Properties...> {
 
   //----------------------------------------
   // Memory span required to wrap these dimensions.
-  // FIXME: this function needs to be tested
   static constexpr size_t required_allocation_size(
       const size_t arg_N0 = 1, const size_t arg_N1 = 1, const size_t arg_N2 = 1,
       const size_t arg_N3 = 1, const size_t arg_N4 = 1, const size_t arg_N5 = 1,
       const size_t arg_N6                  = 1,
       [[maybe_unused]] const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
-    // FIXME: check that arg_N7 is not set by user (in debug mode)
+#ifdef KOKKOS_ENABLE_DEBUG
+    KOKKOS_ASSERT(arg_N7 == KOKKOS_INVALID_INDEX &&
+                  "DynRankView: Cannot allocate 8 dimensions!");
+#endif
+
     return view_type::required_allocation_size(arg_N0, arg_N1, arg_N2, arg_N3,
                                                arg_N4, arg_N5, arg_N6);
   }

--- a/containers/src/Kokkos_DynRankView.hpp
+++ b/containers/src/Kokkos_DynRankView.hpp
@@ -1046,10 +1046,8 @@ class DynRankView : private View<DataType*******, Properties...> {
       const size_t arg_N3 = 1, const size_t arg_N4 = 1, const size_t arg_N5 = 1,
       const size_t arg_N6                  = 1,
       [[maybe_unused]] const size_t arg_N7 = KOKKOS_INVALID_INDEX) {
-#ifdef KOKKOS_ENABLE_DEBUG
     KOKKOS_ASSERT(arg_N7 == KOKKOS_INVALID_INDEX &&
                   "DynRankView: Cannot allocate 8 dimensions!");
-#endif
 
     return view_type::required_allocation_size(arg_N0, arg_N1, arg_N2, arg_N3,
                                                arg_N4, arg_N5, arg_N6);

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -59,7 +59,11 @@ static void test_required_allocation_size() {
 
 template <class DataType, class ExecSpace, class LayOut>
 static void test_required_allocation_size_death() {
-#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_5) && defined(KOKKOS_ENABLE_DEBUG)
+#ifndef KOKKOS_ENABLE_DEPRECATED_CODE_5
+#ifndef KOKKOS_ENABLE_DEBUG
+  GTEST_SKIP() << "only enforced when debug checks are enabled";
+  KOKKOS_IMPL_UNREACHABLE();
+#endif
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   using DynRankType = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   ASSERT_DEATH(DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9),

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -45,14 +45,14 @@ static void test_required_allocation_size() {
   using DynRankType  = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   const size_t bytes = sizeof(DataType);
   auto size_length_1 = DynRankType::required_allocation_size(10);
-  ASSERT_EQ(size_length_1, 10 * bytes);
+  ASSERT_EQ(size_length_1, bytes * 10);
   auto size_length_2 = DynRankType::required_allocation_size(10, 20);
-  ASSERT_EQ(size_length_2, 10 * 20 * bytes);
+  ASSERT_EQ(size_length_2, bytes * 10 * 20);
   auto size_length_3 = DynRankType::required_allocation_size(10, 20, 3);
-  ASSERT_EQ(size_length_3, 10 * 20 * 3 * bytes);
+  ASSERT_EQ(size_length_3, bytes * 10 * 20 * 3);
   auto size_length_7 =
       DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8);
-  ASSERT_EQ(size_length_7, 2 * 3 * 4 * 5 * 6 * 7 * 8 * bytes);
+  ASSERT_EQ(size_length_7, bytes * 2 * 3 * 4 * 5 * 6 * 7 * 8);
 #ifdef KOKKOS_ENABLE_DEBUG
   ASSERT_DEATH(DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9),
                "Cannot allocate 8 dimensions");

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -45,15 +45,18 @@ static void test_required_allocation_size() {
   using DynRankType  = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   const size_t bytes = sizeof(DataType);
   auto size_length_1 = DynRankType::required_allocation_size(10);
-  DynRankType rank_1("Initiate", 10);
   ASSERT_EQ(size_length_1, 10 * bytes);
   auto size_length_2 = DynRankType::required_allocation_size(10, 20);
   ASSERT_EQ(size_length_2, 10 * 20 * bytes);
   auto size_length_3 = DynRankType::required_allocation_size(10, 20, 3);
   ASSERT_EQ(size_length_3, 10 * 20 * 3 * bytes);
-  auto size_length_8 =
-      DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9);
-  ASSERT_NE(size_length_8, 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * bytes);
+  auto size_length_7 =
+      DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8);
+  ASSERT_EQ(size_length_7, 2 * 3 * 4 * 5 * 6 * 7 * 8 * bytes);
+#ifdef KOKKOS_ENABLE_DEBUG
+  ASSERT_DEATH(DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9),
+               "Cannot allocate 8 dimensions");
+#endif
 }
 
 TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -42,6 +42,8 @@ void test_dyn_rank_view_ctor_from_members() {
 }
 template <class DataType, class ExecSpace, class LayOut>
 static void test_required_allocation_size() {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
   using DynRankType  = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   const size_t bytes = sizeof(DataType);
   auto size_length_1 = DynRankType::required_allocation_size(10);
@@ -53,16 +55,30 @@ static void test_required_allocation_size() {
   auto size_length_7 =
       DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8);
   ASSERT_EQ(size_length_7, bytes * 2 * 3 * 4 * 5 * 6 * 7 * 8);
-#ifdef KOKKOS_ENABLE_DEBUG
+}
+
+template <class DataType, class ExecSpace, class LayOut>
+static void test_required_allocation_size_death() {
+#if !defined(KOKKOS_ENABLE_DEPRECATED_CODE_5) && defined(KOKKOS_ENABLE_DEBUG)
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  using DynRankType = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   ASSERT_DEATH(DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9),
                "Cannot allocate 8 dimensions");
 #endif
 }
 
-TEST(TEST_CATEGORY_DEATH, dyn_rank_view_ctor_from_members) {
+TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {
   test_dyn_rank_view_ctor_from_members();
+}
+
+TEST(TEST_CATEGORY, dyn_rank_view_required_allocation_size) {
   test_required_allocation_size<double, TEST_EXECSPACE, Kokkos::LayoutRight>();
   test_required_allocation_size<int, TEST_EXECSPACE, Kokkos::LayoutRight>();
+}
+
+TEST(TEST_CATEGORY_DEATH, dyn_rank_view_required_allocation_size_death) {
+  test_required_allocation_size_death<double, TEST_EXECSPACE,
+                                      Kokkos::LayoutRight>();
 }
 
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -59,7 +59,7 @@ static void test_required_allocation_size() {
 #endif
 }
 
-TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {
+TEST(TEST_CATEGORY_DEATH, dyn_rank_view_ctor_from_members) {
   test_dyn_rank_view_ctor_from_members();
   test_required_allocation_size<double, TEST_EXECSPACE, Kokkos::LayoutRight>();
   test_required_allocation_size<int, TEST_EXECSPACE, Kokkos::LayoutRight>();

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -40,9 +40,26 @@ void test_dyn_rank_view_ctor_from_members() {
     ASSERT_EQ(data.data(), drv.data());
   }
 }
+template <class DataType, class ExecSpace, class LayOut>
+static void test_required_allocation_size() {
+  using DynRankType  = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
+  const size_t bytes = sizeof(DataType);
+  auto size_length_1 = DynRankType::required_allocation_size(10);
+  DynRankType rank_1("Initiate", 10);
+  ASSERT_EQ(size_length_1, 10 * bytes);
+  auto size_length_2 = DynRankType::required_allocation_size(10, 20);
+  ASSERT_EQ(size_length_2, 10 * 20 * bytes);
+  auto size_length_3 = DynRankType::required_allocation_size(10, 20, 3);
+  ASSERT_EQ(size_length_3, 10 * 20 * 3 * bytes);
+  auto size_length_8 =
+      DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9);
+  ASSERT_NE(size_length_8, 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * bytes);
+}
 
 TEST(TEST_CATEGORY, dyn_rank_view_ctor_from_members) {
   test_dyn_rank_view_ctor_from_members();
+  test_required_allocation_size<double, TEST_EXECSPACE, Kokkos::LayoutRight>();
+  test_required_allocation_size<int, TEST_EXECSPACE, Kokkos::LayoutRight>();
 }
 
 #ifndef KOKKOS_ENABLE_IMPL_VIEW_LEGACY


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
This PR resolves two  FIXME comments in `containers/src/Kokkos_DynRankView.hpp` related to the `required_allocation_size` memory calculation.
Added a `KOKKOS_ASSERT` guard to ensure `arg_N7 == KOKKOS_INVALID_INDEX` in debug mode. As stated in the DynRankView API documentation, the rank has an upper bound of 7 dimensions. This assertion prevents silent memory allocation errors if a user attempts to pass an 8th dimension
https://github.com/kokkos/kokkos/blob/13453f60b323707b2a1d0a2acdb66743422c8964/containers/src/Kokkos_DynRankView.hpp#L1041-L1053
Implemented `test_required_allocation_size` to verify correct mathematical memory mapping for standard dynamic arrays (tested 1D, 2D, and 3D allocations).
Added a  `ASSERT_DEATH` test under `#ifdef KOKKOS_ENABLE_DEBUG` to prove the newly added assertion successfully catches and aborts 8-dimensional inputs.

Successfully built and passed on the following backends:

```bash
    Kokkos_ContainersUnitTest_Cuda ([ OK ] 2250 ms)

    Kokkos_ContainersUnitTest_OpenMP ([ OK ] 2254 ms)
```
### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
