### PR TITLE
Revert "Recursive templates based nested loops for parallel_for (#9209)"

### DIFF
--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -21,13 +21,285 @@
 namespace Kokkos {
 namespace Impl {
 
-// FIXME: Implement generation of nested for loops for parallel_reduce
-// using recursive templates (like it is done for parallel_for)
+// New Loop Macros...
+// parallel_for, non-tagged
+#define KOKKOS_IMPL_APPLY(func, ...) func(__VA_ARGS__);
 
-// Loop Macros for parallel_reduce
+// LayoutRight
+// d = 0 to start
+#define KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d, ...)   \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
+    KOKKOS_IMPL_APPLY(func, __VA_ARGS__, i0 + m_offset[d])           \
+  }
 
-// non-tagged
+#define KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d, ...)         \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {       \
+    KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i1 + m_offset[d])                                 \
+  }
 
+#define KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d, ...)         \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {       \
+    KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i2 + m_offset[d])                                 \
+  }
+
+#define KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d, ...)         \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {       \
+    KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i3 + m_offset[d])                                 \
+  }
+
+#define KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d, ...)         \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {       \
+    KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i4 + m_offset[d])                                 \
+  }
+
+#define KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d, ...)         \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {       \
+    KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i5 + m_offset[d])                                 \
+  }
+
+#define KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d, ...)         \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {       \
+    KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i6 + m_offset[d])                                 \
+  }
+
+#define KOKKOS_IMPL_LOOP_R_8(func, type, m_offset, extent, d, ...)         \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {       \
+    KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
+                         i7 + m_offset[d])                                 \
+  }
+
+// LayoutLeft
+// d = rank-1 to start
+#define KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d, ...)   \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
+    KOKKOS_IMPL_APPLY(func, i0 + m_offset[d], __VA_ARGS__)           \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d, ...)   \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) { \
+    KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d - 1,        \
+                         i1 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d, ...)   \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) { \
+    KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d - 1,        \
+                         i2 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d, ...)   \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) { \
+    KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d - 1,        \
+                         i3 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d, ...)   \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) { \
+    KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d - 1,        \
+                         i4 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d, ...)   \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) { \
+    KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d - 1,        \
+                         i5 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d, ...)   \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) { \
+    KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d - 1,        \
+                         i6 + m_offset[d], __VA_ARGS__)              \
+  }
+
+#define KOKKOS_IMPL_LOOP_L_8(func, type, m_offset, extent, d, ...)   \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) { \
+    KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d - 1,        \
+                         i7 + m_offset[d], __VA_ARGS__)              \
+  }
+
+// Left vs Right
+// TODO: rank not necessary to pass through, can hardcode the values
+#define KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent, rank) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {           \
+    KOKKOS_IMPL_APPLY(func, i0 + m_offset[0])                                  \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
+      KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, rank - 2,             \
+                           i1 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
+      KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, 1, i1 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
+      KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, rank - 2,             \
+                           i2 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
+      KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, 1, i2 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
+      KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, rank - 2,             \
+                           i3 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
+      KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, 1, i3 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
+      KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, rank - 2,             \
+                           i4 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
+      KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, 1, i4 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
+      KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, rank - 2,             \
+                           i5 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
+      KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, 1, i5 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
+      KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, rank - 2,             \
+                           i6 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
+      KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, 1, i6 + m_offset[0])  \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent, rank) \
+  if (is_left) {                                                               \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
+      KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, rank - 2,             \
+                           i7 + m_offset[rank - 1])                            \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
+      KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, 1, i7 + m_offset[0])  \
+    }                                                                          \
+  }
+
+// Partial vs Full Tile
+#define KOKKOS_IMPL_TILE_LOOP_1(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_2(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_3(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_4(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_5(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_6(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_7(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+#define KOKKOS_IMPL_TILE_LOOP_8(func, type, is_left, cond, m_offset,         \
+                                extent_full, extent_partial, rank)           \
+  if (cond) {                                                                \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_full,    \
+                              rank)                                          \
+  } else {                                                                   \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_partial, \
+                              rank)                                          \
+  }
+
+// parallel_reduce, non-tagged
+// Reduction version
 #define KOKKOS_IMPL_APPLY_REDUX(val, func, ...) func(__VA_ARGS__, val);
 
 // LayoutRight
@@ -324,10 +596,309 @@ namespace Impl {
     KOKKOS_IMPL_LOOP_LAYOUT_8_REDUX(val, func, type, is_left, m_offset,      \
                                     extent_partial, rank)                    \
   }
-// end untagged macros
+// end New Loop Macros
 
-// tagged
+// tagged macros
+#define KOKKOS_IMPL_TAGGED_APPLY(tag, func, ...) func(tag, __VA_ARGS__);
 
+// LayoutRight
+// d = 0 to start
+#define KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
+    KOKKOS_IMPL_TAGGED_APPLY(tag, func, __VA_ARGS__, i0 + m_offset[d])         \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i1 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i2 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i3 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i4 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i5 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i6 + m_offset[d])                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_R_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d + 1,      \
+                                __VA_ARGS__, i7 + m_offset[d])                 \
+  }
+
+// LayoutLeft
+// d = rank-1 to start
+#define KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
+    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[d], __VA_ARGS__)         \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d - 1,      \
+                                i1 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d - 1,      \
+                                i2 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d - 1,      \
+                                i3 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d - 1,      \
+                                i4 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d - 1,      \
+                                i5 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d - 1,      \
+                                i6 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_L_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
+    KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d - 1,      \
+                                i7 + m_offset[d], __VA_ARGS__)                 \
+  }
+
+// Left vs Right
+// TODO: rank not necessary to pass through, can hardcode the values
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, \
+                                         extent, rank)                       \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {         \
+    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[0])                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, rank - 2, \
+                                  i1 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, 1,        \
+                                  i1 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, rank - 2, \
+                                  i2 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, 1,        \
+                                  i2 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, rank - 2, \
+                                  i3 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, 1,        \
+                                  i3 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, rank - 2, \
+                                  i4 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, 1,        \
+                                  i4 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, rank - 2, \
+                                  i5 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, 1,        \
+                                  i5 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, rank - 2, \
+                                  i6 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, 1,        \
+                                  i6 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,   \
+                                         extent, rank)                         \
+  if (is_left) {                                                               \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
+      KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, rank - 2, \
+                                  i7 + m_offset[rank - 1])                     \
+    }                                                                          \
+  } else {                                                                     \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
+      KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, 1,        \
+                                  i7 + m_offset[0])                            \
+    }                                                                          \
+  }
+
+// Partial vs Full Tile
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_1(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_2(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_3(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_4(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_5(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_6(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_7(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+#define KOKKOS_IMPL_TAGGED_TILE_LOOP_8(tag, func, type, is_left, cond,        \
+                                       m_offset, extent_full, extent_partial, \
+                                       rank)                                  \
+  if (cond) {                                                                 \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
+                                     extent_full, rank)                       \
+  } else {                                                                    \
+    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
+                                     extent_partial, rank)                    \
+  }
+
+// parallel_reduce, tagged
+// Reduction version
 #define KOKKOS_IMPL_TAGGED_APPLY_REDUX(val, tag, func, ...) \
   func(tag, __VA_ARGS__, val);
 
@@ -653,16 +1224,19 @@ namespace Impl {
 
 // end tagged macros
 
-// Structs for calling loops to compute the reductions
-
+// Structs for calling loops
 template <int Rank, bool IsLeft, typename IType, typename Tagged,
           typename Enable = void>
 struct Tile_Loop_Type;
 
-// non-tagged versions
-
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<1, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_1(func, IType, IsLeft, cond, offset, a, b, 1);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -674,6 +1248,12 @@ struct Tile_Loop_Type<1, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<2, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_2(func, IType, IsLeft, cond, offset, a, b, 2);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -685,6 +1265,12 @@ struct Tile_Loop_Type<2, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<3, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_3(func, IType, IsLeft, cond, offset, a, b, 3);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -696,6 +1282,12 @@ struct Tile_Loop_Type<3, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<4, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_4(func, IType, IsLeft, cond, offset, a, b, 4);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -707,6 +1299,12 @@ struct Tile_Loop_Type<4, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<5, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_5(func, IType, IsLeft, cond, offset, a, b, 5);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -718,6 +1316,12 @@ struct Tile_Loop_Type<5, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<6, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_6(func, IType, IsLeft, cond, offset, a, b, 6);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -729,6 +1333,12 @@ struct Tile_Loop_Type<6, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<7, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_7(func, IType, IsLeft, cond, offset, a, b, 7);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -740,6 +1350,12 @@ struct Tile_Loop_Type<7, IsLeft, IType, void, void> {
 
 template <bool IsLeft, typename IType>
 struct Tile_Loop_Type<8, IsLeft, IType, void, void> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_8(func, IType, IsLeft, cond, offset, a, b, 8);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -754,6 +1370,13 @@ struct Tile_Loop_Type<8, IsLeft, IType, void, void> {
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_1(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 1);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -766,6 +1389,13 @@ struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_2(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 2);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -778,6 +1408,13 @@ struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_3(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 3);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -790,6 +1427,13 @@ struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_4(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 4);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -802,6 +1446,13 @@ struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_5(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 5);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -814,6 +1465,13 @@ struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_6(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 6);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -826,6 +1484,13 @@ struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_7(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 7);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -838,6 +1503,13 @@ struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
 template <bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type<8, IsLeft, IType, Tagged,
                       std::enable_if_t<!std::is_void_v<Tagged>>> {
+  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
+  static void apply(Func const& func, bool cond, Offset const& offset,
+                    ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TAGGED_TILE_LOOP_8(Tagged(), func, IType, IsLeft, cond, offset,
+                                   a, b, 8);
+  }
+
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
   static void apply(ValType& value, Func const& func, bool cond,
@@ -846,8 +1518,7 @@ struct Tile_Loop_Type<8, IsLeft, IType, Tagged,
                                          cond, offset, a, b, 8);
   }
 };
-
-// end structs for calling loops for reduction
+// end Structs for calling loops
 
 template <typename RP, typename Functor, typename Tag = void,
           typename ValueType = void, typename Enable = void>
@@ -865,17 +1536,22 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
   inline HostIterateTile(RP const& rp, Functor const& func)
       : m_rp(rp), m_func(func) {}
 
-  inline void check_iteration_bounds(point_type& actual_tile,
+  inline bool check_iteration_bounds(point_type& partial_tile,
                                      const point_type& offset) const {
+    bool is_full_tile = true;
+
     for (int i = 0; i < RP::rank; ++i) {
       if ((offset[i] + m_rp.m_tile[i]) <= m_rp.m_upper[i]) {
-        actual_tile[i] = m_rp.m_tile[i];
+        partial_tile[i] = m_rp.m_tile[i];
       } else {
-        actual_tile[i] =
+        is_full_tile = false;
+        partial_tile[i] =
             m_rp.m_upper[i] - offset[i];  // remaining elements in dimension i
       }
     }
-  }  // end check_iteration_bounds
+
+    return is_full_tile;
+  }  // end check bounds
 
   template <int Rank>
   struct RankTag {
@@ -883,106 +1559,44 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
     enum { value = (int)Rank };
   };
 
-  // functor encapsulating the inner-most loop
-  template <typename TileOffset, typename TileDims, typename... Idxs>
-  void func_innermost_loop(TileOffset const& offset, TileDims const& tiledims,
-                           Idxs&&... idxs) const {
-    if constexpr (RP::inner_direction == Iterate::Left) {
-      KOKKOS_ENABLE_IVDEP_MDRANGE
-      for (index_type i = offset[0]; i < offset[0] + tiledims[0]; ++i) {
-        if constexpr (std::is_void_v<Tag>) {
-          m_func(i, (Idxs&&)idxs...);
-        } else {
-          m_func(Tag{}, i, (Idxs&&)idxs...);
-        }
-      }
-    } else {
-      KOKKOS_ENABLE_IVDEP_MDRANGE
-      for (index_type i = offset[RP::rank - 1];
-           i < offset[RP::rank - 1] + tiledims[RP::rank - 1]; ++i) {
-        if constexpr (std::is_void_v<Tag>) {
-          m_func((Idxs&&)idxs..., i);
-        } else {
-          m_func(Tag{}, (Idxs&&)idxs..., i);
-        }
-      }
-    }
-  }
-
-  // ----------------------------------------------------------------------- //
-  // \brief Nested loops with recursive template instantiation
-  //
-  // Nested for loop order depends on the iteration order:
-  //  Iterate::Left:
-  //    Outermost loop corresponds to right-most index.
-  //  Iterate::Right:
-  //    Outermost loop corresponds to left-most index.
-  // The fastest changing index is always in innermost loop.
-  //
-  // Indices accumulated in parameter pack Idxs...
-  //
-  // Loop indices passed according to iteration order:
-  //  Iterate::Left:
-  //    functor(i_{inner_most}, ..., i_{outer_most})
-  //  Iterate::Right:
-  //    functor(i_{outer_most}, ..., i_{inner_most})
-  //
-  //  \tparam IterLevel iteration level of the nested loops
-  //  \tparam Idxs... index pack
-  template <unsigned IterLevel, typename TileOffset, typename TileDims,
-            typename... Idxs>
-  inline void iterate(std::integral_constant<unsigned, IterLevel>,
-                      TileOffset const& offset, TileDims const& tiledims,
-                      Idxs... idxs) const {
-    const index_type start = (RP::inner_direction == Iterate::Left)
-                                 ? offset[RP::rank - 1 - IterLevel]
-                                 : offset[IterLevel];
-    const index_type end   = (RP::inner_direction == Iterate::Left)
-                                 ? offset[RP::rank - 1 - IterLevel] +
-                                     tiledims[RP::rank - 1 - IterLevel]
-                                 : offset[IterLevel] + tiledims[IterLevel];
-
-    for (index_type idx = start; idx < end; ++idx) {
-      if constexpr (RP::inner_direction == Iterate::Left) {
-        iterate(std::integral_constant<unsigned, IterLevel + 1>(), offset,
-                tiledims, idx, idxs...);
-      } else {
-        iterate(std::integral_constant<unsigned, IterLevel + 1>(), offset,
-                tiledims, idxs..., idx);
-      }
-    }
-  }
-
-  template <typename TileOffset, typename TileDims, typename... Idxs>
-  inline void iterate(std::integral_constant<unsigned, RP::rank - 1>,
-                      TileOffset const& offset, TileDims const& tiledims,
-                      Idxs... idxs) const {
-    func_innermost_loop(offset, tiledims, idxs...);
-  }
-
   template <typename IType>
   inline void operator()(IType tile_idx) const {
-    point_type offset;
-    point_type tiledims;
+    point_type m_offset;
+    point_type m_tiledims;
 
     if constexpr (RP::outer_direction == Iterate::Left) {
       for (int i = 0; i < RP::rank; ++i) {
-        offset[i] =
+        m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
         tile_idx /= m_rp.m_tile_end[i];
       }
     } else {
       for (int i = RP::rank - 1; i >= 0; --i) {
-        offset[i] =
+        m_offset[i] =
             (tile_idx % m_rp.m_tile_end[i]) * m_rp.m_tile[i] + m_rp.m_lower[i];
         tile_idx /= m_rp.m_tile_end[i];
       }
     }
 
-    // Check if offset+tiledim in bounds - return actual tile dims in tiledims
-    check_iteration_bounds(tiledims, offset);
+    // Check if offset+tiledim in bounds - if not, replace tile dims with the
+    // partial tile dims
+    const bool full_tile = check_iteration_bounds(m_tiledims, m_offset);
 
-    iterate(std::integral_constant<unsigned, 0u>(), offset, tiledims);
+    Tile_Loop_Type<RP::rank, (RP::inner_direction == Iterate::Left), index_type,
+                   Tag>::apply(m_func, full_tile, m_offset, m_rp.m_tile,
+                               m_tiledims);
+  }
+
+  template <typename... Args>
+  std::enable_if_t<(sizeof...(Args) == RP::rank && std::is_void_v<Tag>), void>
+  apply(Args&&... args) const {
+    m_func(args...);
+  }
+
+  template <typename... Args>
+  std::enable_if_t<(sizeof...(Args) == RP::rank && !std::is_void_v<Tag>), void>
+  apply(Args&&... args) const {
+    m_func(m_tag, args...);
   }
 
   RP const m_rp;
@@ -1146,6 +1760,39 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 
 // ------------------------------------------------------------------ //
 
+#undef KOKKOS_IMPL_APPLY
+#undef KOKKOS_IMPL_LOOP_R_1
+#undef KOKKOS_IMPL_LOOP_R_2
+#undef KOKKOS_IMPL_LOOP_R_3
+#undef KOKKOS_IMPL_LOOP_R_4
+#undef KOKKOS_IMPL_LOOP_R_5
+#undef KOKKOS_IMPL_LOOP_R_6
+#undef KOKKOS_IMPL_LOOP_R_7
+#undef KOKKOS_IMPL_LOOP_R_8
+#undef KOKKOS_IMPL_LOOP_L_1
+#undef KOKKOS_IMPL_LOOP_L_2
+#undef KOKKOS_IMPL_LOOP_L_3
+#undef KOKKOS_IMPL_LOOP_L_4
+#undef KOKKOS_IMPL_LOOP_L_5
+#undef KOKKOS_IMPL_LOOP_L_6
+#undef KOKKOS_IMPL_LOOP_L_7
+#undef KOKKOS_IMPL_LOOP_L_8
+#undef KOKKOS_IMPL_LOOP_LAYOUT_1
+#undef KOKKOS_IMPL_LOOP_LAYOUT_2
+#undef KOKKOS_IMPL_LOOP_LAYOUT_3
+#undef KOKKOS_IMPL_LOOP_LAYOUT_4
+#undef KOKKOS_IMPL_LOOP_LAYOUT_5
+#undef KOKKOS_IMPL_LOOP_LAYOUT_6
+#undef KOKKOS_IMPL_LOOP_LAYOUT_7
+#undef KOKKOS_IMPL_LOOP_LAYOUT_8
+#undef KOKKOS_IMPL_TILE_LOOP_1
+#undef KOKKOS_IMPL_TILE_LOOP_2
+#undef KOKKOS_IMPL_TILE_LOOP_3
+#undef KOKKOS_IMPL_TILE_LOOP_4
+#undef KOKKOS_IMPL_TILE_LOOP_5
+#undef KOKKOS_IMPL_TILE_LOOP_6
+#undef KOKKOS_IMPL_TILE_LOOP_7
+#undef KOKKOS_IMPL_TILE_LOOP_8
 #undef KOKKOS_IMPL_APPLY_REDUX
 #undef KOKKOS_IMPL_LOOP_R_1_REDUX
 #undef KOKKOS_IMPL_LOOP_R_2_REDUX
@@ -1179,6 +1826,39 @@ struct HostIterateTile<RP, Functor, Tag, ValueType,
 #undef KOKKOS_IMPL_TILE_LOOP_6_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_7_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_8_REDUX
+#undef KOKKOS_IMPL_TAGGED_APPLY
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_1
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_2
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_3
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_4
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_5
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_6
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_7
+#undef KOKKOS_IMPL_TAGGED_LOOP_R_8
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_1
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_2
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_3
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_4
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_5
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_6
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_7
+#undef KOKKOS_IMPL_TAGGED_LOOP_L_8
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7
+#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_1
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_2
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_3
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_4
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_5
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_6
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_7
+#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_8
 #undef KOKKOS_IMPL_TAGGED_APPLY_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_1_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_2_REDUX


### PR DESCRIPTION
This PR was causing ~20% slowdown for intrepid2 performance test in trilinos. Will need to revert if no solution is found for 5.2 release.

Timings from Eclipse for the `Intrepid2_SierraGradProjection` benchmark with various Kokkos versions:
```
Kokkos develop:                    17.1s
Kokkos develop with 9209 reverted: 14.5s
Kokkos 5.1.1:                      14.2s
```

