### PR TITLE
Test with oneAPI 2026.0.0 in HPSF CI

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -133,9 +133,9 @@ NVIDIA-P100:
 INTEL-DATA-CENTER-MAX-1100:
   extends: .common-setup
   tags: [intel-data-center-max-1100]
-  image: intel/oneapi-basekit:2024.2.1-0-devel-ubuntu22.04
+  image: intel/oneapi:2026.0.0-devel-ubuntu24.04
   script:
-    - apt-get update && apt-get install -y git
+    - apt-get update && apt-get install -y git intel-ocloc
     - sycl-ls
     - export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
     - export CLANG_TIDY_EXE=$(dirname $(which icpx))/compiler/clang-tidy

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -247,10 +247,12 @@ KOKKOS_FUNCTION constexpr auto to_array(T (&&a)[N]) {
 
 //<editor-fold desc="Support for structured binding">
 template <class T, std::size_t N>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_size<Kokkos::Array<T, N>>
     : std::integral_constant<std::size_t, N> {};
 
 template <std::size_t I, class T, std::size_t N>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_element<I, Kokkos::Array<T, N>> {
   static_assert(I < N);
   using type = T;

--- a/core/src/Kokkos_Complex.hpp
+++ b/core/src/Kokkos_Complex.hpp
@@ -251,10 +251,12 @@ class
 // the C++26 working draft on 2023-11)
 
 template <typename RealType>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_size<Kokkos::complex<RealType>>
     : std::integral_constant<size_t, 2> {};
 
 template <size_t I, typename RealType>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::tuple_element<I, Kokkos::complex<RealType>> {
   static_assert(I < 2);
   using type = RealType;

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -711,6 +711,7 @@ void view_copy(const DstType& dst, const SrcType& src) {
   // Figure out iteration order in case we need it
   Kokkos::Iterate iterate = get_iteration_order(dst);
 
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if ((dst.span() >= size_t(std::numeric_limits<int>::max())) ||
       (src.span() >= size_t(std::numeric_limits<int>::max()))) {
     if (iterate == Kokkos::Iterate::Right)
@@ -1032,6 +1033,7 @@ inline void deep_copy(
       std::conditional_t<ViewType::rank == 0,
                          typename ViewType::uniform_runtime_type,
                          typename ViewType::uniform_runtime_nomemspace_type>;
+  // NOLINTNEXTLINE(bugprone-branch-clone)
   if (dst.span() > static_cast<size_t>(std::numeric_limits<int>::max())) {
     if (iterate == Kokkos::Iterate::Right)
       Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight,
@@ -2232,6 +2234,7 @@ inline void deep_copy(
         std::conditional_t<ViewType::rank == 0,
                            typename ViewType::uniform_runtime_type,
                            typename ViewType::uniform_runtime_nomemspace_type>;
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if (dst.span() > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
       if (iterate == Kokkos::Iterate::Right)
         Kokkos::Impl::ViewFill<ViewTypeUniform, Kokkos::LayoutRight, ExecSpace,

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_MDRange.hpp
@@ -156,6 +156,7 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::MDRangePolicy<Traits...>,
 
     bool need_grid_stride = true;
 
+    // NOLINTNEXTLINE(bugprone-branch-clone)
     if constexpr (Policy::rank == 1) {
       if ((m_max_grid_size[0] * local_range[0]) >=
           static_cast<std::size_t>(m_extent[0])) {

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -200,6 +200,7 @@ KOKKOS_INLINE_FUNCTION auto mapping_from_array_layout_impl(
           }))
 #endif
 
+      // NOLINTNEXTLINE(bugprone-branch-clone)
       if (layout.stride == KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
         return MappingType{extents_type{
             dextents<index_type, MappingType::extents_type::rank()>{

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -25,8 +25,7 @@ namespace Kokkos {
 //----------------------------------------------------------------------------
 
 // FIXME_SYCL
-#if defined KOKKOS_ENABLE_SYCL && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM < 20260000
+#if defined KOKKOS_ENABLE_SYCL
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
   T old = *src_ptr;

--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -182,6 +182,7 @@ TEST(TEST_CATEGORY, interact_with_sycl_node) {
   try {
     auto sycl_graph_exec = graph.sycl_graph_exec();
     ASSERT_TRUE(sycl_graph_exec.has_value());
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     sycl_graph_exec->update(sycl_node);
     FAIL();
   } catch (const std::exception& err) {


### PR DESCRIPTION
We are currently testing with 2024.2.1 in both HPSF SYCL builds which isn't great for coverage. Since we don't have any build covering the 2026.0.0 release, switching one of them seems to be a good idea.