### PR TITLE
Workaround nvc++ compiler issue

### DIFF
--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
@@ -23,7 +23,8 @@ constexpr bool test_create_mirror_types() {
       Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace,
                                  MemSpace>::accessible;
 
-  constexpr bool const_T = std::is_const_v<T>;
+  // explicitly not using is_const_v to work around nvc++ compiler issue
+  constexpr bool const_T = std::is_const<T>::value;
 
   using host_mirror_space_t =
       std::conditional_t<host_accessible, MemSpace, Kokkos::HostSpace>;

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
@@ -23,8 +23,7 @@ constexpr bool test_create_mirror_types() {
       Kokkos::SpaceAccessibility<Kokkos::DefaultHostExecutionSpace,
                                  MemSpace>::accessible;
 
-  // explicitly not using is_const_v to work around nvc++ compiler issue
-  constexpr bool const_T = std::is_const<T>::value;
+  constexpr bool const_T = std::is_const_v<T>;
 
   using host_mirror_space_t =
       std::conditional_t<host_accessible, MemSpace, Kokkos::HostSpace>;
@@ -147,7 +146,10 @@ static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, 
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
 static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, SD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
 
+// FIXME_OPENACC, FIXME_NVHPC This particular case causes internal compiler errors with NVHPC 23.7
+#ifndef KOKKOS_ENABLE_OPENACC
 static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SH, Kokkos::MemoryTraits<>>());
+#endif
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
 static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SH, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());


### PR DESCRIPTION
Popped up in our CI for both OpenACC and CUDA with nvc++ as host compiler. Couldn't reproduce standalone even with same versions.

This was the observed issue:

```
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] "/var/jenkins/workspace/Kokkos_PR-9295/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp", line 26: internal error: assertion failed at: "lower_init.cpp", line 9766 in copy_non_static_data_member_initializers_if_necessary
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER]   constexpr bool const_T = std::is_const_v< T> ; 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER]                  ^
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 1 catastrophic error detected in the compilation of "/tmp/tmpxft_0000238b_00000000-
```

This tries now avoiding one level of indirection by not going through the template alias value. 