### PR TITLE
Fix NextSilicon CI

### DIFF
--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.cpp
@@ -50,11 +50,11 @@ std::byte *NextSiliconInternal::resize_functor_buffer(size_t requested) {
   return functorBuffer_.ensure("functor heap buffer", requested);
 }
 
-std::lock_guard<std::mutex>
+std::lock_guard<std::recursive_mutex>
 Kokkos::Experimental::Impl::NextSiliconInternal::lock_device() {
   KOKKOS_IF_ON_DEVICE(
       (KOKKOS_ASSERT(false && "lock_device should never be called on device");))
-  return std::lock_guard<std::mutex>(this->device_mutex_);
+  return std::lock_guard<std::recursive_mutex>(this->device_mutex_);
 }
 
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
@@ -54,7 +54,7 @@ class NextSiliconInternal {
 
   uint32_t instance_id() const noexcept;
 
-  [[nodiscard]] std::lock_guard<std::mutex> lock_device();
+  [[nodiscard]] std::lock_guard<std::recursive_mutex> lock_device();
 };
 
 }  // namespace Kokkos::Experimental::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_ParallelFor_Range.hpp
@@ -34,7 +34,7 @@ class Kokkos::Impl::ParallelFor<Functor, Kokkos::RangePolicy<Traits...>,
 
   void execute() const {
     // Acquire the device for potential handoff before kernel execution begins
-    const std::lock_guard<std::mutex> device_lock =
+    const std::lock_guard<std::recursive_mutex> device_lock =
         this->m_policy.space().impl_internal_space_instance()->lock_device();
 
     // Clone the driver to prevent the stack from getting migrated to device.


### PR DESCRIPTION
Fixing
```
/home/runner/_work/kokkos/kokkos/kokkos/core/src/NextSilicon/Kokkos_NextSilicon_Instance.cpp:57:10: error: no matching conversion for functional-style cast from '::Kokkos::Impl::PageAlignedData<std::recursive_mutex, ::Kokkos::Impl::PageLocation::Device>' to 'std::lock_guard<std::mutex>'
   57 |   return std::lock_guard<std::mutex>(this->device_mutex_);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/nextsilicon/sysroot/usr/include/c++/v1/__mutex/lock_guard.h:30:52: note: candidate constructor not viable: no known conversion from '::Kokkos::Impl::PageAlignedData<std::recursive_mutex, ::Kokkos::Impl::PageLocation::Device>' to 'mutex_type &' (aka 'std::mutex &') for 1st argument
   30 |   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI explicit lock_guard(mutex_type& __m) _LIBCPP_ACQUIRE_CAPABILITY(__m)
      |                                                    ^          ~~~~~~~~~~~~~~~
/opt/nextsilicon/sysroot/usr/include/c++/v1/__mutex/lock_guard.h:39:3: note: candidate constructor not viable: no known conversion from '::Kokkos::Impl::PageAlignedData<std::recursive_mutex, ::Kokkos::Impl::PageLocation::Device>' to 'const lock_guard<std::mutex>' for 1st argument
   39 |   lock_guard(lock_guard const&)            = delete;
      |   ^          ~~~~~~~~~~~~~~~~~
/opt/nextsilicon/sysroot/usr/include/c++/v1/__mutex/lock_guard.h:35:43: note: candidate constructor not viable: requires 2 arguments, but 1 was provided
   35 |   [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI lock_guard(mutex_type& __m, adopt_lock_t) _LIBCPP_REQUIRES_CAPABILITY(__m)
      |                                           ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```