### PR TITLE
nextsilicon: `recursive_mutex` -> `mutex`, disable ToolIndependence, ProfilingTestErrorNoCallbacks, CTestDevice

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -469,5 +469,6 @@ jobs:
           # FIXME_NEXTSILICON: death tests require fork, not supported by runtime
           GTEST_FILTER: -*DeathTest*
           XDG_CACHE_HOME: $HOME/optimizer-cache
+        # FIXME_NEXTSILICON: exclusions are CS-737, OOM in main() teardown, observed in 1.3.0-395
         run: |
-          ctest -V --timeout 3600
+          ctest -V --timeout 3600 -E "ToolIndependence|ProfilingTestErrorNoCallbacks|CTestDevice"

--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
@@ -20,7 +20,7 @@ namespace Kokkos::Experimental::Impl {
 
 class NextSiliconInternal {
   Impl::NextSiliconHeapBuffer functorBuffer_;
-  ::Kokkos::Impl::PageAlignedData<std::recursive_mutex,
+  ::Kokkos::Impl::PageAlignedData<std::mutex,
                                   ::Kokkos::Impl::PageLocation::Device>
       device_mutex_;
 


### PR DESCRIPTION
`recursive_mutex` slipped in while NextSilicon CI was down

@kc9jud 