### PR TITLE
`volatile_load` fall back to old cas-based store avoiding the comparison for non-lock-free types on SYCL

### DIFF
--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -87,11 +87,11 @@ KOKKOS_FORCEINLINE_FUNCTION void store_workaround(T *const ref, T value) {
   KOKKOS_IF_ON_HOST(
       (desul::Impl::host_atomic_fetch_oper(
            desul::Impl::_store_fetch_operator<T, const T>(), ref, value,
-           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);));
+           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());));
   KOKKOS_IF_ON_DEVICE(
       (desul::Impl::device_atomic_fetch_oper(
            desul::Impl::_store_fetch_operator<T, const T>(), ref, value,
-           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
+           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
 }
 
 }  // namespace Impl

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -85,12 +85,12 @@ auto allocate_with_sequential_host_init_if_possible(
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION void store_workaround(T *const ref, T value) {
   KOKKOS_IF_ON_HOST(
-      (desul::host_atomic_fetch_oper(desul::_store_fetch_operator<T, const T>(),
-                                     ref, value, desul::MemoryOrderRelaxed(),
-                                     KOKKOS_DESUL_MEM_SCOPE);));
+      (desul::Impl::host_atomic_fetch_oper(
+           desul::Impl::_store_fetch_operator<T, const T>(), ref, value,
+           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);));
   KOKKOS_IF_ON_DEVICE(
-      (desul::device_atomic_fetch_oper(
-           desul::_store_fetch_operator<T, const T>(), ref, value,
+      (desul::Impl::device_atomic_fetch_oper(
+           desul::Impl::_store_fetch_operator<T, const T>(), ref, value,
            desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
 }
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -82,6 +82,7 @@ auto allocate_with_sequential_host_init_if_possible(
 
 // FIXME_SYCL This forces compare and swap to be used for the store as a simple
 // store is not visible to other threads with SYCL
+#ifdef KOKKOS_ENABLE_SYCL
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION void store_workaround(T *const ref, T value) {
   KOKKOS_IF_ON_HOST(
@@ -93,6 +94,7 @@ KOKKOS_FORCEINLINE_FUNCTION void store_workaround(T *const ref, T value) {
            desul::Impl::_store_fetch_operator<T, const T>(), ref, value,
            desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
 }
+#endif
 
 }  // namespace Impl
 

--- a/containers/src/Kokkos_UnorderedMap.hpp
+++ b/containers/src/Kokkos_UnorderedMap.hpp
@@ -80,16 +80,20 @@ auto allocate_with_sequential_host_init_if_possible(
         std::forward<Args>(args)...);
 }
 
+// FIXME_SYCL This forces compare and swap to be used for the store as a simple
+// store is not visible to other threads with SYCL
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION void store_workaround(T *const ref, T value) {
-  T old = *ref;
-  T assumed;
-  do {
-    assumed = old;
-    old     = Kokkos::atomic_compare_exchange(ref, assumed, value);
-
-  } while (assumed != old);
+  KOKKOS_IF_ON_HOST(
+      (desul::host_atomic_fetch_oper(desul::_store_fetch_operator<T, const T>(),
+                                     ref, value, desul::MemoryOrderRelaxed(),
+                                     KOKKOS_DESUL_MEM_SCOPE);));
+  KOKKOS_IF_ON_DEVICE(
+      (desul::device_atomic_fetch_oper(
+           desul::_store_fetch_operator<T, const T>(), ref, value,
+           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
 }
+
 }  // namespace Impl
 
 enum : unsigned { UnorderedMapInvalidIndex = ~0u };

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -600,9 +600,6 @@ TEST(TEST_CATEGORY, UnorderedMap_View_as_value) {
   ASSERT_TRUE(map_copy.is_allocated());
 }
 
-// FIXME_SYCL
-//////////////////////////Tests for UnorderedMap with at type as value type that
-/// does not provide comparison operators
 struct NonComparableType {
   bool operator==(NonComparableType const &) = delete;
   bool operator!=(NonComparableType const &) = delete;

--- a/containers/unit_tests/TestUnorderedMap.hpp
+++ b/containers/unit_tests/TestUnorderedMap.hpp
@@ -599,6 +599,52 @@ TEST(TEST_CATEGORY, UnorderedMap_View_as_value) {
   ASSERT_GE(map_copy.capacity(), 200u);
   ASSERT_TRUE(map_copy.is_allocated());
 }
+
+// FIXME_SYCL
+//////////////////////////Tests for UnorderedMap with at type as value type that
+/// does not provide comparison operators
+struct NonComparableType {
+  bool operator==(NonComparableType const &) = delete;
+  bool operator!=(NonComparableType const &) = delete;
+  double dummy[3];  //>8bytes to force triggering the lock-table based atomics
+};
+
+/**
+ * @test This test ensures that an @ref UnorderedMap can be used with a
+ * value_type that does not provide comparison. This is relevant since we need a
+ * SYCL workaround for volatile_load and store to make the map work.
+ */
+TEST(TEST_CATEGORY, UnorderedMap_non_comparable_type_as_value) {
+  using value_type = NonComparableType;
+  using map_type   = Kokkos::UnorderedMap<int, value_type, Kokkos::HostSpace>;
+  map_type map(Kokkos::view_alloc("test NonComparableType umap"), 150);
+  // creation
+  ASSERT_EQ(map.size(), 0u);
+  ASSERT_GE(map.capacity(), 150u);
+  ASSERT_TRUE(map.is_allocated());
+
+  // insert
+  ASSERT_TRUE(map.insert(1, NonComparableType{}).success());
+  ASSERT_TRUE(map.insert(2, NonComparableType{}).success());
+  ASSERT_EQ(map.size(), 2u);
+
+  // copy
+  map_type map_copy(map);
+  ASSERT_EQ(map_copy.size(), 2u);
+  ASSERT_GE(map_copy.capacity(), 150u);
+  ASSERT_TRUE(map_copy.is_allocated());
+
+  // rehash
+  ASSERT_TRUE(map.rehash(200u));
+  ASSERT_GE(map.capacity(), 200u);
+  ASSERT_TRUE(map.is_allocated());
+
+  // assign
+  map_copy = map;
+  ASSERT_EQ(map_copy.size(), 2u);
+  ASSERT_GE(map_copy.capacity(), 200u);
+  ASSERT_TRUE(map_copy.is_allocated());
+}
 }  // namespace Test
 
 #endif  // KOKKOS_TEST_UNORDERED_MAP_HPP

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -30,13 +30,13 @@ namespace Kokkos {
     KOKKOS_COMPILER_INTEL_LLVM < 20260000
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
-  KOKKOS_IF_ON_HOST((desul::device_atomic_fetch_oper(
-                         desul::_load_fetch_operator<T, const T>(),
+  KOKKOS_IF_ON_HOST((desul::Impl::device_atomic_fetch_oper(
+                         desul::Impl::_load_fetch_operator<T, const T>(),
                          const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
                          desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
   KOKKOS_IF_ON_DEVICE(
-      (desul::device_atomic_fetch_oper(
-           desul::_load_fetch_operator<T, const T>(),
+      (desul::Impl::device_atomic_fetch_oper(
+           desul::Impl::_load_fetch_operator<T, const T>(),
            const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
            desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
 }

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -30,15 +30,16 @@ namespace Kokkos {
     KOKKOS_COMPILER_INTEL_LLVM < 20260000
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
-  KOKKOS_IF_ON_HOST((desul::Impl::device_atomic_fetch_oper(
-                         desul::Impl::_load_fetch_operator<T, const T>(),
-                         const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
-                         desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
+  KOKKOS_IF_ON_HOST(
+      (desul::Impl::device_atomic_fetch_oper(
+           desul::Impl::_load_fetch_operator<T, const T>(),
+           const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
+           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
   KOKKOS_IF_ON_DEVICE(
       (desul::Impl::device_atomic_fetch_oper(
            desul::Impl::_load_fetch_operator<T, const T>(),
            const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
-           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
+           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
 }
 #else
 template <typename T>

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -24,21 +24,21 @@ namespace Kokkos {
 
 //----------------------------------------------------------------------------
 
-// FIXME_SYCL
+// FIXME_SYCL use old compare and swap way of storing value as we saw that
+// otherwise the volatile load will not be honored correctly
 #if defined KOKKOS_ENABLE_SYCL && defined(KOKKOS_COMPILER_INTEL_LLVM) && \
     KOKKOS_COMPILER_INTEL_LLVM < 20260000
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
-  T old = const_cast<const T&>(*src_ptr);
-  T assumed;
-  do {
-    assumed = old;
-    old     = desul::atomic_compare_exchange(
-        const_cast<std::remove_volatile_t<T>*>(src_ptr), assumed, assumed,
-        desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());
-
-  } while (assumed != old);
-  return old;
+  KOKKOS_IF_ON_HOST((desul::device_atomic_fetch_oper(
+                         desul::_load_fetch_operator<T, const T>(),
+                         const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
+                         desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
+  KOKKOS_IF_ON_DEVICE(
+      (desul::device_atomic_fetch_oper(
+           desul::_load_fetch_operator<T, const T>(),
+           const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
+           desul::MemoryOrderRelaxed(), KOKKOS_DESUL_MEM_SCOPE);))
 }
 #else
 template <typename T>

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -31,15 +31,15 @@ namespace Kokkos {
 template <typename T>
 KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
   KOKKOS_IF_ON_HOST(
-      (desul::Impl::device_atomic_fetch_oper(
-           desul::Impl::_load_fetch_operator<T, const T>(),
-           const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
-           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
+      (return desul::Impl::device_atomic_fetch_oper(
+                  desul::Impl::_load_fetch_operator<T, const T>(),
+                  const_cast<std::remove_volatile_t<T>*>(src_ptr), *src_ptr,
+                  desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
   KOKKOS_IF_ON_DEVICE(
-      (desul::Impl::device_atomic_fetch_oper(
-           desul::Impl::_load_fetch_operator<T, const T>(),
-           const_cast<std::remove_volatile_t<T>*>(src_ptr), value,
-           desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
+      (return desul::Impl::device_atomic_fetch_oper(
+                  desul::Impl::_load_fetch_operator<T, const T>(),
+                  const_cast<std::remove_volatile_t<T>*>(src_ptr), *src_ptr,
+                  desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
 }
 #else
 template <typename T>

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -24,7 +24,6 @@ namespace Kokkos {
 
 //----------------------------------------------------------------------------
 
-
 // FIXME_SYCL use old compare and swap way of storing value as we saw that
 // otherwise the volatile load will not be honored correctly
 #if defined KOKKOS_ENABLE_SYCL

--- a/core/src/impl/Kokkos_Volatile_Load.hpp
+++ b/core/src/impl/Kokkos_Volatile_Load.hpp
@@ -33,13 +33,13 @@ KOKKOS_FORCEINLINE_FUNCTION T volatile_load(T const volatile* const src_ptr) {
   KOKKOS_IF_ON_HOST(
       (return desul::Impl::device_atomic_fetch_oper(
                   desul::Impl::_load_fetch_operator<T, const T>(),
-                  const_cast<std::remove_volatile_t<T>*>(src_ptr), *src_ptr,
-                  desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
+                  const_cast<T*>(src_ptr), T(), desul::MemoryOrderRelaxed(),
+                  desul::MemoryScopeDevice());))
   KOKKOS_IF_ON_DEVICE(
       (return desul::Impl::device_atomic_fetch_oper(
                   desul::Impl::_load_fetch_operator<T, const T>(),
-                  const_cast<std::remove_volatile_t<T>*>(src_ptr), *src_ptr,
-                  desul::MemoryOrderRelaxed(), desul::MemoryScopeDevice());))
+                  const_cast<T*>(src_ptr), T(), desul::MemoryOrderRelaxed(),
+                  desul::MemoryScopeDevice());))
 }
 #else
 template <typename T>


### PR DESCRIPTION
Tries to address https://github.com/kokkos/kokkos/pull/9219#issuecomment-4868128784 @ndellingwood 
The problem seems to be that with the previous cas-loop we needed a comparison `!=` to be implemented
Not sure if this is trying to be too smart ... but if I understand things correctly, we could get around needing a comparison operator for non-lock-free types by letting desul decide if it wants to use the lock tables or the cas intrinsic (instead of us doing the while loop externally). The lock-tables based one should not require `!=`

Alternatives:
As described by @dalg24 in the comments preceding https://github.com/kokkos/kokkos/pull/9219#issuecomment-4869530325

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

https://github.com/kokkos/kokkos/pull/9305
https://github.com/kokkos/kokkos/issues/9304

<!-- Link any related issues or PRs. -->

### Changelog Entry

  - Not required
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:

  - Unsure
-->
