### PR TITLE
Fix KOKKOS_FORCEINLINE[_CLASS]_LAMBDA with nvcc

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -331,11 +331,12 @@
 #define KOKKOS_CLASS_LAMBDA [ =, *this ]
 #endif
 
-#if !defined(KOKKOS_ENABLE_CXX20) && \
-    !defined(KOKKOS_COMPILER_CLANG)  // since C++23
+// since C++23
+#if !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_COMPILER_CLANG) && \
+    !defined(KOKKOS_COMPILER_NVCC)
 
-// FIXME_CLANG Clang does not accept GNU __attribute__((...)) in
-// the lambda front-attr position
+// FIXME_CLANG FIXME_NVCC Clang and nvcc don't accept GNU __attribute__((...))
+// in the lambda front-attr position
 
 #if !defined(KOKKOS_FORCEINLINE_LAMBDA)
 #define KOKKOS_FORCEINLINE_LAMBDA \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -332,7 +332,7 @@
 #endif
 
 // since C++23
-#if !defined(KOKKOS_ENABLE_CXX20) && !defined(KOKKOS_COMPILER_CLANG) && \
+#if !defined(KOKKOS_ENABLE_CXX20) && !defined(__clang__) && \
     !defined(KOKKOS_COMPILER_NVCC)
 
 // FIXME_CLANG FIXME_NVCC Clang and nvcc don't accept GNU __attribute__((...))


### PR DESCRIPTION
Fixes https://gitlab.spack.io/kokkos/kokkos/-/jobs/23075887:
```
/builds/kokkos/kokkos/core/unit_test/TestFunctionAnnotationMacros.hpp(119): error: expected a "{" introducing a lambda body
      auto lambda = [ =, *this ] __attribute__((host)) __attribute__((device)) __inline__ __attribute__((always_inline))(int y) {
                                                                               ^
/builds/kokkos/kokkos/core/unit_test/TestFunctionAnnotationMacros.hpp(119): error: expected a ";"
      auto lambda = [ =, *this ] __attribute__((host)) __attribute__((device)) __inline__ __attribute__((always_inline))(int y) {
                                                                               ^
/builds/kokkos/kokkos/core/unit_test/TestFunctionAnnotationMacros.hpp(141): error: expected a "{" introducing a lambda body
    auto lambda = [=] __attribute__((host)) __attribute__((device)) __inline__ __attribute__((always_inline))(int y) { return y << 6; };
                                                                    ^
/builds/kokkos/kokkos/core/unit_test/TestFunctionAnnotationMacros.hpp(141): error: expected a ";"
    auto lambda = [=] __attribute__((host)) __attribute__((device)) __inline__ __attribute__((always_inline))(int y) { return y << 6; };
                                                                    ^
```