### PR TITLE
parallel_scan: test with empty work range

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -967,80 +967,79 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
   }
 
   inline void execute() {
-    const auto nwork = m_policy.end() - m_policy.begin();
-    if (nwork) {
-      enum { GridMaxComputeCapability_2x = 0x0ffff };
+    // Use at least one work item for calculating launch parameters to handle
+    // empty ranges correctly.
+    const auto nwork = std::max(1, m_policy.end() - m_policy.begin());
+    enum { GridMaxComputeCapability_2x = 0x0ffff };
 
-      const int block_size = local_block_size(m_functor_reducer.get_functor());
-      KOKKOS_ASSERT(block_size > 0);
+    const int block_size = local_block_size(m_functor_reducer.get_functor());
+    KOKKOS_ASSERT(block_size > 0);
 
-      const int grid_max =
-          (block_size * block_size) < GridMaxComputeCapability_2x
-              ? (block_size * block_size)
-              : GridMaxComputeCapability_2x;
+    const int grid_max = (block_size * block_size) < GridMaxComputeCapability_2x
+                             ? (block_size * block_size)
+                             : GridMaxComputeCapability_2x;
 
-      // At most 'max_grid' blocks:
-      const int max_grid =
-          std::min(int(grid_max), int((nwork + block_size - 1) / block_size));
+    // At most 'max_grid' blocks:
+    const int max_grid =
+        std::min(int(grid_max), int((nwork + block_size - 1) / block_size));
 
-      // How much work per block:
-      const int work_per_block = (nwork + max_grid - 1) / max_grid;
+    // How much work per block:
+    const int work_per_block = (nwork + max_grid - 1) / max_grid;
 
-      // How many block are really needed for this much work:
-      const int grid_x = (nwork + work_per_block - 1) / work_per_block;
+    // How many block are really needed for this much work:
+    const int grid_x = (nwork + work_per_block - 1) / work_per_block;
 
-      const typename Analysis::Reducer& final_reducer =
-          m_functor_reducer.get_reducer();
+    const typename Analysis::Reducer& final_reducer =
+        m_functor_reducer.get_reducer();
 
-      // Only let one instance at a time resize the instance's scratch memory
-      // allocations.
-      std::scoped_lock<std::mutex> scratch_buffers_lock(
-          m_policy.space().impl_internal_space_instance()->m_mutexScratchSpace);
+    // Only let one instance at a time resize the instance's scratch memory
+    // allocations.
+    std::scoped_lock<std::mutex> scratch_buffers_lock(
+        m_policy.space().impl_internal_space_instance()->m_mutexScratchSpace);
 
-      m_scratch_space =
-          reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
-              m_policy.space(), final_reducer.value_size() * grid_x));
-      m_scratch_flags =
-          cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type) * 1);
+    m_scratch_space =
+        reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
+            m_policy.space(), final_reducer.value_size() * grid_x));
+    m_scratch_flags =
+        cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type) * 1);
 
-      dim3 grid(grid_x, 1, 1);
-      dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
-      const int shmem = final_reducer.value_size() * (block_size + 2);
+    dim3 grid(grid_x, 1, 1);
+    dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
+    const int shmem = final_reducer.value_size() * (block_size + 2);
 
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
-      if (m_run_serial) {
-        block = dim3(1, 1, 1);
-        grid  = dim3(1, 1, 1);
-      } else
+    if (m_run_serial) {
+      block = dim3(1, 1, 1);
+      grid  = dim3(1, 1, 1);
+    } else
 #endif
-      {
-        m_final = false;
-        CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
-            *this, grid, block, shmem,
-            m_policy.space()
-                .impl_internal_space_instance());  // copy to device and execute
-      }
-      m_final = true;
+    {
+      m_final = false;
       CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
           *this, grid, block, shmem,
           m_policy.space()
               .impl_internal_space_instance());  // copy to device and execute
+    }
+    m_final = true;
+    CudaParallelLaunch<ParallelScanWithTotal, LaunchBounds>(
+        *this, grid, block, shmem,
+        m_policy.space()
+            .impl_internal_space_instance());  // copy to device and execute
 
-      const int size = final_reducer.value_size();
+    const int size = final_reducer.value_size();
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
-      if (m_run_serial)
-        DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), &m_returnvalue,
-                                             m_scratch_space, size);
-      else
+    if (m_run_serial)
+      DeepCopy<HostSpace, CudaSpace, Cuda>(m_policy.space(), &m_returnvalue,
+                                           m_scratch_space, size);
+    else
 #endif
-      {
-        if (!m_result_ptr_device_accessible)
-          DeepCopy<HostSpace, CudaSpace, Cuda>(
-              m_policy.space(), m_result_ptr,
-              m_scratch_space + (static_cast<ptrdiff_t>(grid_x) - 1) * size /
-                                    sizeof(word_size_type),
-              size);
-      }
+    {
+      if (!m_result_ptr_device_accessible)
+        DeepCopy<HostSpace, CudaSpace, Cuda>(
+            m_policy.space(), m_result_ptr,
+            m_scratch_space + (static_cast<ptrdiff_t>(grid_x) - 1) * size /
+                                  sizeof(word_size_type),
+            size);
     }
   }
 

--- a/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelScan_Range.hpp
@@ -228,52 +228,53 @@ class ParallelScanHIPBase {
   }
 
   inline void impl_execute(int block_size) {
-    const index_type nwork = m_policy.end() - m_policy.begin();
-    if (nwork) {
-      // FIXME_HIP we cannot choose it larger for large work sizes to work
-      // correctly, the unit tests fail with wrong results
-      const int gridMaxComputeCapability_2x = 0x01fff;
+    // Use at least one work item for calculating launch parameters to handle
+    // empty ranges correctly.
+    const auto nwork =
+        std::max<index_type>(1, m_policy.end() - m_policy.begin());
+    // FIXME_HIP we cannot choose it larger for large work sizes to work
+    // correctly, the unit tests fail with wrong results
+    const int gridMaxComputeCapability_2x = 0x01fff;
 
-      const int grid_max =
-          std::min(block_size * block_size, gridMaxComputeCapability_2x);
+    const int grid_max =
+        std::min(block_size * block_size, gridMaxComputeCapability_2x);
 
-      // At most 'max_grid' blocks:
-      const int max_grid =
-          std::min<int>(grid_max, (nwork + block_size - 1) / block_size);
+    // At most 'max_grid' blocks:
+    const int max_grid =
+        std::min<int>(grid_max, (nwork + block_size - 1) / block_size);
 
-      // How much work per block:
-      const int work_per_block = (nwork + max_grid - 1) / max_grid;
+    // How much work per block:
+    const int work_per_block = (nwork + max_grid - 1) / max_grid;
 
-      // How many block are really needed for this much work:
-      m_grid_x = (nwork + work_per_block - 1) / work_per_block;
+    // How many block are really needed for this much work:
+    m_grid_x = (nwork + work_per_block - 1) / work_per_block;
 
-      const typename Analysis::Reducer& final_reducer =
-          m_functor_reducer.get_reducer();
+    const typename Analysis::Reducer& final_reducer =
+        m_functor_reducer.get_reducer();
 
-      m_scratch_space =
-          reinterpret_cast<word_size_type*>(Impl::hip_internal_scratch_space(
-              m_policy.space(), final_reducer.value_size() * m_grid_x));
-      m_scratch_flags = Impl::hip_internal_scratch_flags(m_policy.space(),
-                                                         sizeof(size_type) * 1);
+    m_scratch_space =
+        reinterpret_cast<word_size_type*>(Impl::hip_internal_scratch_space(
+            m_policy.space(), final_reducer.value_size() * m_grid_x));
+    m_scratch_flags = Impl::hip_internal_scratch_flags(m_policy.space(),
+                                                       sizeof(size_type) * 1);
 
-      dim3 grid(m_grid_x, 1, 1);
-      dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
-      const int shmem = final_reducer.value_size() * (block_size + 2);
+    dim3 grid(m_grid_x, 1, 1);
+    dim3 block(1, block_size, 1);  // REQUIRED DIMENSIONS ( 1 , N , 1 )
+    const int shmem = final_reducer.value_size() * (block_size + 2);
 
-      m_final = false;
-      // these ones are OK to be just the base because the specializations
-      // do not modify the kernel at all
-      Impl::hip_parallel_launch<ParallelScanHIPBase, LaunchBounds>(
-          *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
+    m_final = false;
+    // these ones are OK to be just the base because the specializations
+    // do not modify the kernel at all
+    Impl::hip_parallel_launch<ParallelScanHIPBase, LaunchBounds>(
+        *this, grid, block, shmem,
+        m_policy.space().impl_internal_space_instance(),
+        false);  // copy to device and execute
 
-      m_final = true;
-      Impl::hip_parallel_launch<ParallelScanHIPBase, LaunchBounds>(
-          *this, grid, block, shmem,
-          m_policy.space().impl_internal_space_instance(),
-          false);  // copy to device and execute
-    }
+    m_final = true;
+    Impl::hip_parallel_launch<ParallelScanHIPBase, LaunchBounds>(
+        *this, grid, block, shmem,
+        m_policy.space().impl_internal_space_instance(),
+        false);  // copy to device and execute
   }
 
   ParallelScanHIPBase(const FunctorType& arg_functor, const Policy& arg_policy,
@@ -359,8 +360,7 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
     Base::impl_execute(block_size);
 
-    const auto nwork = Base::m_policy.end() - Base::m_policy.begin();
-    if (nwork && !Base::m_result_ptr_device_accessible) {
+    if (!Base::m_result_ptr_device_accessible) {
       const int size =
           Base::Analysis::value_size(Base::m_functor_reducer.get_functor());
       DeepCopy<HostSpace, HIPSpace, HIP>(

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -434,7 +434,6 @@ class Kokkos::Impl::ParallelScanWithTotal<
             ->m_mutexScratchSpace);
 
     Base::impl_execute([&]() {
-      const long long nwork = Base::m_policy.end() - Base::m_policy.begin();
       if (!Base::m_result_ptr_device_accessible) {
         // Using DeepCopy instead of fence+memcpy turned out to be up to 2x
         // slower.

--- a/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelScan_Range.hpp
@@ -153,7 +153,27 @@ class ParallelScanSYCLBase {
         *space.impl_internal_space_instance();
     sycl::queue& q = space.sycl_queue();
 
+    if (!m_result_ptr_device_accessible)
+      m_scratch_host = static_cast<sycl::global_ptr<value_type>>(
+          instance.scratch_host(sizeof(value_type)));
+    pointer_type result_ptr = m_result_ptr_device_accessible
+                                  ? m_result_ptr
+                                  : static_cast<pointer_type>(m_scratch_host);
+
     const auto size = m_policy.end() - m_policy.begin();
+
+    if (size == 0) {
+      auto single_event = q.submit([&](sycl::handler& cgh) {
+        cgh.single_task([=]() {
+          const CombinedFunctorReducer<FunctorType, typename Analysis::Reducer>&
+              functor_reducer = functor_wrapper.get_functor();
+          const typename Analysis::Reducer& reducer =
+              functor_reducer.get_reducer();
+          reducer.init(result_ptr);
+        });
+      });
+      return single_event;
+    }
 
     auto scratch_flags = static_cast<sycl::global_ptr<unsigned int>>(
         instance.scratch_flags(sizeof(unsigned int)));
@@ -280,8 +300,6 @@ class ParallelScanSYCLBase {
       global_mem =
           static_cast<sycl::global_ptr<value_type>>(instance.scratch_space(
               n_wgroups * (wgroup_size + 1) * sizeof(value_type)));
-      m_scratch_host = static_cast<sycl::global_ptr<value_type>>(
-          instance.scratch_host(sizeof(value_type)));
 
       group_results = global_mem + n_wgroups * wgroup_size;
 
@@ -309,12 +327,6 @@ class ParallelScanSYCLBase {
 
     // Write results to global memory
     auto update_global_results = q.submit([&](sycl::handler& cgh) {
-      // The compiler failed with CL_INVALID_ARG_VALUE if using m_result_ptr
-      // directly.
-      pointer_type result_ptr = m_result_ptr_device_accessible
-                                    ? m_result_ptr
-                                    : static_cast<pointer_type>(m_scratch_host);
-
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
       cgh.depends_on(perform_work_group_scans);
 #endif
@@ -354,8 +366,6 @@ class ParallelScanSYCLBase {
  public:
   template <typename PostFunctor>
   void impl_execute(const PostFunctor& post_functor) {
-    if (m_policy.begin() == m_policy.end()) return;
-
     auto& instance = *m_policy.space().impl_internal_space_instance();
 
     Kokkos::Impl::SYCLInternal::IndirectKernelMem& indirectKernelMem =
@@ -425,7 +435,7 @@ class Kokkos::Impl::ParallelScanWithTotal<
 
     Base::impl_execute([&]() {
       const long long nwork = Base::m_policy.end() - Base::m_policy.begin();
-      if (nwork > 0 && !Base::m_result_ptr_device_accessible) {
+      if (!Base::m_result_ptr_device_accessible) {
         // Using DeepCopy instead of fence+memcpy turned out to be up to 2x
         // slower.
         m_exec.fence(

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -122,7 +122,7 @@ struct TestParallelScanRangePolicy {
       // Input: label, work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = 0;
+        ValueType return_val = -1;
         Kokkos::parallel_scan("TestWithStrArg2", work_size, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -133,7 +133,7 @@ struct TestParallelScanRangePolicy {
       // Input: work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = 0;
+        ValueType return_val = -1;
         Kokkos::parallel_scan(work_size, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -167,7 +167,7 @@ struct TestParallelScanRangePolicy {
       {
         // Input: label, work_count, functor
         // Input/Output: return_value
-        ValueType return_val = 0;
+        ValueType return_val = -1;
         Kokkos::parallel_scan("TestWithStrArg4", policy, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -178,7 +178,7 @@ struct TestParallelScanRangePolicy {
       // Input: work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = 0;
+        ValueType return_val = -1;
         Kokkos::parallel_scan(policy, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -210,7 +210,7 @@ struct TestParallelScanRangePolicy {
 
         // Input: work_count, functor
         // Input/Output: return_value
-        ValueType return_val = 0;
+        ValueType return_val = -1;
         Kokkos::parallel_scan(policy_with_require, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -234,7 +234,7 @@ struct TestParallelScanRangePolicy {
         {
           // Input: label, work_count, functor
           // Input/Output: return_value
-          ValueType return_val = 0;
+          ValueType return_val = -1;
           Kokkos::parallel_scan("TestWithStrArg6", policy2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(
@@ -246,7 +246,7 @@ struct TestParallelScanRangePolicy {
         // Input: work_count, functor
         // Input/Output: return_value
         {
-          ValueType return_val = 0;
+          ValueType return_val = -1;
           Kokkos::parallel_scan(policy2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(
@@ -280,7 +280,7 @@ struct TestParallelScanRangePolicy {
 
           // Input: work_count, functor
           // Input/Output: return_value
-          ValueType return_val = 0;
+          ValueType return_val = -1;
           Kokkos::parallel_scan(policy_with_require2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(
@@ -305,7 +305,7 @@ TEST(TEST_CATEGORY, parallel_scan_range_policy) {
   {
     TestParallelScanRangePolicy<char> f;
 
-    std::vector<size_t> work_sizes{5, 10};
+    std::vector<size_t> work_sizes{0, 5, 10};
     f.test_scan<>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Static>>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>>(work_sizes);

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -122,7 +122,7 @@ struct TestParallelScanRangePolicy {
       // Input: label, work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = -1;
+        ValueType return_val = static_cast<ValueType>(-1);
         Kokkos::parallel_scan("TestWithStrArg2", work_size, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -133,7 +133,7 @@ struct TestParallelScanRangePolicy {
       // Input: work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = -1;
+        ValueType return_val = static_cast<ValueType>(-1);
         Kokkos::parallel_scan(work_size, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -167,7 +167,7 @@ struct TestParallelScanRangePolicy {
       {
         // Input: label, work_count, functor
         // Input/Output: return_value
-        ValueType return_val = -1;
+        ValueType return_val = static_cast<ValueType>(-1);
         Kokkos::parallel_scan("TestWithStrArg4", policy, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -178,7 +178,7 @@ struct TestParallelScanRangePolicy {
       // Input: work_count, functor
       // Input/Output: return_value
       {
-        ValueType return_val = -1;
+        ValueType return_val = static_cast<ValueType>(-1);
         Kokkos::parallel_scan(policy, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -210,7 +210,7 @@ struct TestParallelScanRangePolicy {
 
         // Input: work_count, functor
         // Input/Output: return_value
-        ValueType return_val = -1;
+        ValueType return_val = static_cast<ValueType>(-1);
         Kokkos::parallel_scan(policy_with_require, *this, return_val);
         check_scan_results();
         ASSERT_EQ(static_cast<ValueType>(static_cast<ValueType>(work_size) *
@@ -234,7 +234,7 @@ struct TestParallelScanRangePolicy {
         {
           // Input: label, work_count, functor
           // Input/Output: return_value
-          ValueType return_val = -1;
+          ValueType return_val = static_cast<ValueType>(-1);
           Kokkos::parallel_scan("TestWithStrArg6", policy2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(
@@ -246,7 +246,7 @@ struct TestParallelScanRangePolicy {
         // Input: work_count, functor
         // Input/Output: return_value
         {
-          ValueType return_val = -1;
+          ValueType return_val = static_cast<ValueType>(-1);
           Kokkos::parallel_scan(policy2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(
@@ -280,7 +280,7 @@ struct TestParallelScanRangePolicy {
 
           // Input: work_count, functor
           // Input/Output: return_value
-          ValueType return_val = -1;
+          ValueType return_val = static_cast<ValueType>(-1);
           Kokkos::parallel_scan(policy_with_require2, *this, return_val);
           check_scan_results_start2();
           ASSERT_EQ(


### PR DESCRIPTION
We noticed in #9300 that `parallel_scan` with empty ranges (and result argument) are no-ops whereas we expect the neutral element to be returned in the result argument.