### PR TITLE
TeamMember overload for deep_copy.

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -1361,8 +1361,50 @@ inline void deep_copy(
   }
 }
 
-//----------------------------------------------------------------------------
-//----------------------------------------------------------------------------
+// A deep copy between views of non-zero rank and contiguous memory, called
+// within a team-parallel region.
+template <class TeamType, class DT, class... DP, class ST, class... SP>
+void KOKKOS_INLINE_FUNCTION deep_copy_contiguous(const TeamType& team,
+                                                 const View<DT, DP...>& dst,
+                                                 const View<ST, SP...>& src) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, src.span()),
+                       [&](const int& i) { dst.data()[i] = src.data()[i]; });
+}
+
+// A deep copy between views with non-zero rank and contiguous memory, called by
+// a thread.
+template <class DT, class... DP, class ST, class... SP>
+void KOKKOS_INLINE_FUNCTION deep_copy_contiguous(const View<DT, DP...>& dst,
+                                                 const View<ST, SP...>& src) {
+  for (size_t i = 0; i < src.span(); ++i) {
+    dst.data()[i] = src.data()[i];
+  }
+}
+
+// Deep copy a value into a view, contiguous memory, called within a
+// team-parallel region
+template <class TeamType, class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION deep_copy_contiguous(
+    const TeamType& team, const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, dst.span()),
+                       [&](const int& i) { dst.data()[i] = value; });
+}
+
+// Deep copy a value into a view, contiguous memory, called by a thread
+template <class DT, class... DP>
+void KOKKOS_INLINE_FUNCTION deep_copy_contiguous(
+    const View<DT, DP...>& dst,
+    typename ViewTraits<DT, DP...>::const_value_type& value,
+    std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
+                                    void>>* = nullptr) {
+  for (size_t i = 0; i < dst.span(); ++i) {
+    dst.data()[i] = value;
+  }
+}
+
 namespace Experimental {
 /** \brief  A local deep copy between views of the default specialization,
  * compatible type, same non-zero rank.
@@ -1371,16 +1413,13 @@ template <class TeamType, class DT, class... DP, class ST, class... SP>
 void KOKKOS_INLINE_FUNCTION
 local_deep_copy_contiguous(const TeamType& team, const View<DT, DP...>& dst,
                            const View<ST, SP...>& src) {
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, src.span()),
-                       [&](const int& i) { dst.data()[i] = src.data()[i]; });
+  Kokkos::deep_copy_contiguous(team, dst, src);
 }
 //----------------------------------------------------------------------------
 template <class DT, class... DP, class ST, class... SP>
 void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
     const View<DT, DP...>& dst, const View<ST, SP...>& src) {
-  for (size_t i = 0; i < src.span(); ++i) {
-    dst.data()[i] = src.data()[i];
-  }
+  Kokkos::deep_copy_contiguous(dst, src);
 }
 //----------------------------------------------------------------------------
 template <class TeamType, class DT, class... DP, class ST, class... SP>
@@ -1745,8 +1784,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
     typename ViewTraits<DT, DP...>::const_value_type& value,
     std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
                                     void>>* = nullptr) {
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, dst.span()),
-                       [&](const int& i) { dst.data()[i] = value; });
+  Kokkos::deep_copy_contiguous(team, dst, value);
 }
 //----------------------------------------------------------------------------
 template <class DT, class... DP>
@@ -1755,9 +1793,7 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy_contiguous(
     typename ViewTraits<DT, DP...>::const_value_type& value,
     std::enable_if_t<std::is_same_v<typename ViewTraits<DT, DP...>::specialize,
                                     void>>* = nullptr) {
-  for (size_t i = 0; i < dst.span(); ++i) {
-    dst.data()[i] = value;
-  }
+  Kokkos::deep_copy_contiguous(dst, value);
 }
 //----------------------------------------------------------------------------
 template <class TeamType, class DT, class... DP>
@@ -2165,6 +2201,224 @@ void KOKKOS_INLINE_FUNCTION local_deep_copy(
                 dst(i0, i1, i2, i3, i4, i5, i6) = value;
 }
 } /* namespace Experimental */
+
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 1 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 1),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0);
+
+  team.team_barrier();
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N),
+                       [&](const int& i) { dst(i) = src(i); });
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 2 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 2),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0) * dst.extent(1);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0      = i % dst.extent(0);
+      int i1      = i / dst.extent(0);
+      dst(i0, i1) = src(i0, i1);
+    });
+  }
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 3 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 3),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0          = i % dst.extent(0);
+      int itmp        = i / dst.extent(0);
+      int i1          = itmp % dst.extent(1);
+      int i2          = itmp / dst.extent(1);
+      dst(i0, i1, i2) = src(i0, i1, i2);
+    });
+  }
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 4 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 4),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N =
+      dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0              = i % dst.extent(0);
+      int itmp            = i / dst.extent(0);
+      int i1              = itmp % dst.extent(1);
+      itmp                = itmp / dst.extent(1);
+      int i2              = itmp % dst.extent(2);
+      int i3              = itmp / dst.extent(2);
+      dst(i0, i1, i2, i3) = src(i0, i1, i2, i3);
+    });
+  }
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 5 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 5),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0                  = i % dst.extent(0);
+      int itmp                = i / dst.extent(0);
+      int i1                  = itmp % dst.extent(1);
+      itmp                    = itmp / dst.extent(1);
+      int i2                  = itmp % dst.extent(2);
+      itmp                    = itmp / dst.extent(2);
+      int i3                  = itmp % dst.extent(3);
+      int i4                  = itmp / dst.extent(3);
+      dst(i0, i1, i2, i3, i4) = src(i0, i1, i2, i3, i4);
+    });
+  }
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 6 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 6),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4) * dst.extent(5);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0                      = i % dst.extent(0);
+      int itmp                    = i / dst.extent(0);
+      int i1                      = itmp % dst.extent(1);
+      itmp                        = itmp / dst.extent(1);
+      int i2                      = itmp % dst.extent(2);
+      itmp                        = itmp / dst.extent(2);
+      int i3                      = itmp % dst.extent(3);
+      itmp                        = itmp / dst.extent(3);
+      int i4                      = itmp % dst.extent(4);
+      int i5                      = itmp / dst.extent(4);
+      dst(i0, i1, i2, i3, i4, i5) = src(i0, i1, i2, i3, i4, i5);
+    });
+  }
+  team.team_barrier();
+}
+//----------------------------------------------------------------------------
+template <class TeamMember, class DT, class... DP, class ST, class... SP,
+          std::enable_if_t<(Kokkos::is_team_handle<TeamMember>::value &&
+                            unsigned(ViewTraits<DT, DP...>::rank) == 7 &&
+                            unsigned(ViewTraits<ST, SP...>::rank) == 7),
+                           int> = 0>
+KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
+                                      const View<DT, DP...>& dst,
+                                      const View<ST, SP...>& src) {
+  if (dst.data() == nullptr) {
+    return;
+  }
+
+  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
+                   dst.extent(3) * dst.extent(4) * dst.extent(5) *
+                   dst.extent(6);
+
+  team.team_barrier();
+  if (dst.span_is_contiguous() && src.span_is_contiguous()) {
+    deep_copy_contiguous(team, dst, src);
+  } else {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
+      int i0                          = i % dst.extent(0);
+      int itmp                        = i / dst.extent(0);
+      int i1                          = itmp % dst.extent(1);
+      itmp                            = itmp / dst.extent(1);
+      int i2                          = itmp % dst.extent(2);
+      itmp                            = itmp / dst.extent(2);
+      int i3                          = itmp % dst.extent(3);
+      itmp                            = itmp / dst.extent(3);
+      int i4                          = itmp % dst.extent(4);
+      itmp                            = itmp / dst.extent(4);
+      int i5                          = itmp % dst.extent(5);
+      int i6                          = itmp / dst.extent(5);
+      dst(i0, i1, i2, i3, i4, i5, i6) = src(i0, i1, i2, i3, i4, i5, i6);
+    });
+  }
+  team.team_barrier();
+}
+
 } /* namespace Kokkos */
 
 //----------------------------------------------------------------------------

--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -2234,17 +2234,14 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N = dst.extent(0) * dst.extent(1);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0      = i % dst.extent(0);
-      int i1      = i / dst.extent(0);
-      dst(i0, i1) = src(i0, i1);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<2>, TeamMember>(
+            team, dst.extent(0), dst.extent(1)),
+        [&](const int i0, const int i1) { dst(i0, i1) = src(i0, i1); });
   }
   team.team_barrier();
 }
@@ -2261,19 +2258,16 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0          = i % dst.extent(0);
-      int itmp        = i / dst.extent(0);
-      int i1          = itmp % dst.extent(1);
-      int i2          = itmp / dst.extent(1);
-      dst(i0, i1, i2) = src(i0, i1, i2);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<3>, TeamMember>(
+            team, dst.extent(0), dst.extent(1), dst.extent(2)),
+        [&](const int i0, const int i1, const int i2) {
+          dst(i0, i1, i2) = src(i0, i1, i2);
+        });
   }
   team.team_barrier();
 }
@@ -2290,22 +2284,16 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N =
-      dst.extent(0) * dst.extent(1) * dst.extent(2) * dst.extent(3);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0              = i % dst.extent(0);
-      int itmp            = i / dst.extent(0);
-      int i1              = itmp % dst.extent(1);
-      itmp                = itmp / dst.extent(1);
-      int i2              = itmp % dst.extent(2);
-      int i3              = itmp / dst.extent(2);
-      dst(i0, i1, i2, i3) = src(i0, i1, i2, i3);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<4>, TeamMember>(
+            team, dst.extent(0), dst.extent(1), dst.extent(2), dst.extent(3)),
+        [&](const int i0, const int i1, const int i2, const int i3) {
+          dst(i0, i1, i2, i3) = src(i0, i1, i2, i3);
+        });
   }
   team.team_barrier();
 }
@@ -2322,24 +2310,18 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                  = i % dst.extent(0);
-      int itmp                = i / dst.extent(0);
-      int i1                  = itmp % dst.extent(1);
-      itmp                    = itmp / dst.extent(1);
-      int i2                  = itmp % dst.extent(2);
-      itmp                    = itmp / dst.extent(2);
-      int i3                  = itmp % dst.extent(3);
-      int i4                  = itmp / dst.extent(3);
-      dst(i0, i1, i2, i3, i4) = src(i0, i1, i2, i3, i4);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<5>, TeamMember>(
+            team, dst.extent(0), dst.extent(1), dst.extent(2), dst.extent(3),
+            dst.extent(4)),
+        [&](const int i0, const int i1, const int i2, const int i3,
+            const int i4) {
+          dst(i0, i1, i2, i3, i4) = src(i0, i1, i2, i3, i4);
+        });
   }
   team.team_barrier();
 }
@@ -2356,26 +2338,18 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                      = i % dst.extent(0);
-      int itmp                    = i / dst.extent(0);
-      int i1                      = itmp % dst.extent(1);
-      itmp                        = itmp / dst.extent(1);
-      int i2                      = itmp % dst.extent(2);
-      itmp                        = itmp / dst.extent(2);
-      int i3                      = itmp % dst.extent(3);
-      itmp                        = itmp / dst.extent(3);
-      int i4                      = itmp % dst.extent(4);
-      int i5                      = itmp / dst.extent(4);
-      dst(i0, i1, i2, i3, i4, i5) = src(i0, i1, i2, i3, i4, i5);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<6>, TeamMember>(
+            team, dst.extent(0), dst.extent(1), dst.extent(2), dst.extent(3),
+            dst.extent(4), dst.extent(5)),
+        [&](const int i0, const int i1, const int i2, const int i3,
+            const int i4, const int i5) {
+          dst(i0, i1, i2, i3, i4, i5) = src(i0, i1, i2, i3, i4, i5);
+        });
   }
   team.team_barrier();
 }
@@ -2392,29 +2366,18 @@ KOKKOS_INLINE_FUNCTION void deep_copy(const TeamMember& team,
     return;
   }
 
-  const size_t N = dst.extent(0) * dst.extent(1) * dst.extent(2) *
-                   dst.extent(3) * dst.extent(4) * dst.extent(5) *
-                   dst.extent(6);
-
   team.team_barrier();
   if (dst.span_is_contiguous() && src.span_is_contiguous()) {
     deep_copy_contiguous(team, dst, src);
   } else {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, N), [&](const int& i) {
-      int i0                          = i % dst.extent(0);
-      int itmp                        = i / dst.extent(0);
-      int i1                          = itmp % dst.extent(1);
-      itmp                            = itmp / dst.extent(1);
-      int i2                          = itmp % dst.extent(2);
-      itmp                            = itmp / dst.extent(2);
-      int i3                          = itmp % dst.extent(3);
-      itmp                            = itmp / dst.extent(3);
-      int i4                          = itmp % dst.extent(4);
-      itmp                            = itmp / dst.extent(4);
-      int i5                          = itmp % dst.extent(5);
-      int i6                          = itmp / dst.extent(5);
-      dst(i0, i1, i2, i3, i4, i5, i6) = src(i0, i1, i2, i3, i4, i5, i6);
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorMDRange<Kokkos::Rank<7>, TeamMember>(
+            team, dst.extent(0), dst.extent(1), dst.extent(2), dst.extent(3),
+            dst.extent(4), dst.extent(5), dst.extent(6)),
+        [&](const int i0, const int i1, const int i2, const int i3,
+            const int i4, const int i5, const int i6) {
+          dst(i0, i1, i2, i3, i4, i5, i6) = src(i0, i1, i2, i3, i4, i5, i6);
+        });
   }
   team.team_barrier();
 }


### PR DESCRIPTION
The PR does the following

As per some discussions on slack with @crtrott and @weinbe2 , the first small step to introduce newer updates to CUDA backend is to make `local_deep_copy` an overload of `deep_copy` so that `local_deep_copy` signature can be used to do fast TMA copies. Look at #9293 and #9302 for detailed discussions 

The current PR is the first pre-requisite step and a review if this is the right way to do these updates.

1. Four new `Kokkos::deep_copy_contiguous` overloads (view-to-view team/no-team, fill-value team/no-team)  when both views are contiguous.
2. Corresponding  four`local_deep_copy_contiguous` are now a one-line forwards to the matching `deep_copy_contiguous`.
3. `Kokkos::deep_copy(team, dst, src)` overloads (ranks 1–7), mirroring `local_deep_copy(team, dst, src)`  calling the new deep_copy_contiguous for the contiguous path.
