### PR TITLE
Expand guard for dynView test to allow compilation with `ROCm 7.2.4`

### DIFF
--- a/containers/unit_tests/TestDynViewAPI.hpp
+++ b/containers/unit_tests/TestDynViewAPI.hpp
@@ -697,7 +697,7 @@ class TestDynViewAPI {
   static void run_operator_test_rank67() {
     // FIXME_CLANG 22 The test triggers an internal compiler error in clang 22.
 #if !defined(KOKKOS_COMPILER_CLANG) || (KOKKOS_COMPILER_CLANG < 2200) || \
-    (KOKKOS_COMPILER_CLANG > 2210)
+    (KOKKOS_COMPILER_CLANG > 2300)
     TestViewOperator_LeftAndRight<int, device, 7>::testit(2, 3, 4, 2, 3, 4, 2);
 #endif
     TestViewOperator_LeftAndRight<int, device, 6>::testit(2, 3, 4, 2, 3, 4);


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
Although I can not reproduce, @khuck-AMD said he also had problems with this test on the newest ROCm version.
According to https://github.com/kokkos/kokkos/issues/9316#issuecomment-4907278745 it is fixed in clang 23

### Related issues / PRs
 fixes #9316
<!-- Link any related issues or PRs. -->

### Changelog Entry
- Not required
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  
  - Unsure
-->
