### PR TITLE
TeamPolicy copy-ctor by reference rather than value

### DIFF
--- a/core/src/Kokkos_ExecPolicy.hpp
+++ b/core/src/Kokkos_ExecPolicy.hpp
@@ -691,7 +691,7 @@ class TeamPolicy
                         validate_team_size_argument(team_size), Kokkos::AUTO) {}
 
   template <class... OtherProperties>
-  TeamPolicy(const TeamPolicy<OtherProperties...> p) : internal_policy(p) {
+  TeamPolicy(const TeamPolicy<OtherProperties...>& p) : internal_policy(p) {
     // Cannot call converting constructor in the member initializer list because
     // it is not a direct base.
     internal_policy::traits::operator=(p);

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -54,6 +54,7 @@ set(COMPILE_ONLY_SOURCES
     TestTypeList.cpp
     TestMDRangePolicyCTAD.cpp
     TestTeamPolicyCTAD.cpp
+    TestTeamPolicyCompileOnly.cpp
     TestTeamMDRangePolicyCTAD.cpp
     TestNestedReducerCTAD.cpp
     view/TestAccessorFromMemoryTraits.cpp

--- a/core/unit_test/TestTeamPolicyCompileOnly.cpp
+++ b/core/unit_test/TestTeamPolicyCompileOnly.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+// For research/prototyping it can be convenient to derive from TeamPolicy
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+namespace {
+
+struct DerivedPolicy : Kokkos::TeamPolicy<> {
+  using base = Kokkos::TeamPolicy<>;
+
+  using base::base;
+
+  explicit DerivedPolicy(const base& policy) : base(policy) {}
+};
+
+[[maybe_unused]] DerivedPolicy make_derived_policy(
+    const Kokkos::TeamPolicy<>& policy) {
+  return DerivedPolicy(policy);
+}
+
+}  // namespace

--- a/core/unit_test/TestTeamPolicyCompileOnly.cpp
+++ b/core/unit_test/TestTeamPolicyCompileOnly.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
-// For research/prototyping it can be convenient to derive from TeamPolicy
-
 #include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
@@ -12,6 +10,8 @@ import kokkos.core;
 
 namespace {
 
+// In a research prototype where we derived from TeamPolicy we saw
+// an issue with copy construction that this test reproduces.
 struct DerivedPolicy : Kokkos::TeamPolicy<> {
   using base = Kokkos::TeamPolicy<>;
 


### PR DESCRIPTION
When `OtherProperties...` is `<>`, nvcc saw it as `TeamPolicy(const TeamPolicy<> p)`, which is not a valid copy-ctor. For some reason my Serial build was happy with that, but `nvcc` was not.

