### PR TITLE
Add missing exposure of impl function in modules for testing

### DIFF
--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -62,6 +62,7 @@ export {
   using ::Kokkos::Impl::SpaceAwareAccessor;
   using ::Kokkos::Impl::SubviewExtents;
   using ::Kokkos::Impl::SubviewLegalArgsCompileTime;
+  using ::Kokkos::Impl::transform_kokkos_slice_to_mdspan_slice;
   using ::Kokkos::Impl::ViewArguments;
   using ::Kokkos::Impl::ViewArrayAnalysis;
   using ::Kokkos::Impl::ViewCopy;


### PR DESCRIPTION
This is used core/unit_test/view/TestViewMDSpanTemplateArgumentSubview.hpp:71