### PR TITLE
Fix subview test warning with Cuda 13.3

### DIFF
--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -36,6 +36,7 @@ export {
   using ::Kokkos::Impl::CheckedRelaxedAtomicAccessor;
   using ::Kokkos::Impl::choose_create_mirror;
   using ::Kokkos::Impl::CommonSubview;
+  using ::Kokkos::Impl::convert_to_kokkos_pair_if_std_pair;
   using ::Kokkos::Impl::DataTypeFromExtents;
   using ::Kokkos::Impl::DeepCopy;
   using ::Kokkos::Impl::ExtentsFromDataType;

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentSubview.hpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentSubview.hpp
@@ -68,7 +68,8 @@ void compare_subview(V v, Slices... slices) {
 
   using mdspan_sub_t = decltype(Kokkos::submdspan(
       std::declval<typename V::mdspan_type>(),
-      Kokkos::Impl::transform_kokkos_slice_to_mdspan_slice(slices)...));
+      Kokkos::Impl::transform_kokkos_slice_to_mdspan_slice(
+          Kokkos::Impl::convert_to_kokkos_pair_if_std_pair(slices))...));
   static_assert(std::is_same_v<mdspan_sub_t, typename new_sub_t::mdspan_type>);
 
   static_assert(


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/9333. The issue is that https://github.com/kokkos/mdspan/blob/cae4a4e4f3e399b3edc7066596b0b6b7b063423f/include/experimental/__p2630_bits/submdspan.hpp#L23-L29 doesn't convert `std::pair` to `Kokkos::pair` like we do since https://github.com/kokkos/kokkos/pull/9264.