### PR TITLE
Fix warning on deduction guides with HIP Clang 22.1

### DIFF
--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -43,7 +43,14 @@
 #define KOKKOS_LAMBDA [=] __host__ __device__
 #define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
 
+// Starting from Clang 22.1, CUDA target attributes on deduction guides are
+// deprecated and will be rejected in a future Clang release
+#if defined(__clang__) && \
+    (__clang_major__ > 22 || (__clang_major__ == 22 && __clang_minor__ >= 1))
+#define KOKKOS_DEDUCTION_GUIDE
+#else
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
+#endif
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__

--- a/core/src/setup/Kokkos_Setup_HIP.hpp
+++ b/core/src/setup/Kokkos_Setup_HIP.hpp
@@ -20,7 +20,14 @@ static_assert(false,
 #define KOKKOS_LAMBDA [=] __host__ __device__
 #define KOKKOS_CLASS_LAMBDA [ =, *this ] __host__ __device__
 
+// Starting from Clang 22.1, HIP target attributes on deduction guides are
+// deprecated and will be rejected in a future Clang release
+#if defined(__clang__) && \
+    (__clang_major__ > 22 || (__clang_major__ == 22 && __clang_minor__ >= 1))
+#define KOKKOS_DEDUCTION_GUIDE
+#else
 #define KOKKOS_DEDUCTION_GUIDE __host__ __device__
+#endif
 
 #define KOKKOS_IMPL_FORCEINLINE_FUNCTION __device__ __host__ __forceinline__
 #define KOKKOS_IMPL_FORCEINLINE_ATTRIBUTE __forceinline__


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
Starting from Clang 22.1, CUDA/HIP target attributes `__host__ __device__` on deduction guides are deprecated and will be rejected in a future Clang release.

https://releases.llvm.org/22.1.0/tools/clang/docs/HIPSupport.html#deduction-guides

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
  - Not required

