### PR TITLE
Allow kernels requiring a block size smaller than warp size

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_BlockSize_Deduction.hpp
@@ -126,7 +126,7 @@ inline int cuda_deduce_block_size(bool early_termination,
   int opt_threads_per_sm = 0;
 
   for (int block_size = max_threads_per_block; block_size > 0;
-       block_size -= 32) {
+       block_size <= 32 ? block_size /= 2 : (block_size -= 32)) {
     size_t const dynamic_shmem = block_size_to_dynamic_shmem(block_size);
 
     int blocks_per_sm = cuda_max_active_blocks_per_sm(

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -619,20 +619,32 @@ class ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // blockDim.y must be power of two = 128 (4 warps) or 256 (8 warps) or 512
-    // (16 warps) gridDim.x <= blockDim.y * blockDim.y
-    //
     // 4 warps was 10% faster than 8 warps and 20% faster than 16 warps in unit
     // testing
 
+    unsigned n = CudaTraits::WarpSize * 4;
     const int maxShmemPerBlock =
         m_policy.space().cuda_device_prop().sharedMemPerBlock;
-    unsigned n = CudaTraits::WarpSize * 4;
-    while (n &&
-           unsigned(maxShmemPerBlock) <
-               cuda_single_inter_block_reduce_scan_shmem<true, WorkTag,
-                                                         value_type>(f, n)) {
+    int shmem_size =
+        cuda_single_inter_block_reduce_scan_shmem<true, WorkTag, value_type>(f,
+                                                                             n);
+    using closure_type =
+        Impl::ParallelScan<FunctorType, Kokkos::RangePolicy<Traits...>,
+                           Kokkos::Cuda>;
+    cudaFuncAttributes attr = CudaParallelLaunch<closure_type, LaunchBounds>::
+        get_cuda_func_attributes(
+            m_policy.space().impl_internal_space_instance());
+    while (
+        (n && (maxShmemPerBlock < shmem_size)) ||
+        (n >
+         static_cast<unsigned>(
+             Kokkos::Impl::cuda_get_max_block_size<FunctorType, LaunchBounds>(
+                 m_policy.space().impl_internal_space_instance(), attr, f, 1,
+                 shmem_size, 0)))) {
       n >>= 1;
+      shmem_size =
+          cuda_single_inter_block_reduce_scan_shmem<true, WorkTag, value_type>(
+              f, n);
     }
     return n;
   }
@@ -948,20 +960,32 @@ class ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
 
   // Determine block size constrained by shared memory:
   inline unsigned local_block_size(const FunctorType& f) {
-    // blockDim.y must be power of two = 128 (4 warps) or 256 (8 warps) or 512
-    // (16 warps) gridDim.x <= blockDim.y * blockDim.y
-    //
     // 4 warps was 10% faster than 8 warps and 20% faster than 16 warps in unit
     // testing
 
+    unsigned n = CudaTraits::WarpSize * 4;
     const int maxShmemPerBlock =
         m_policy.space().cuda_device_prop().sharedMemPerBlock;
-    unsigned n = CudaTraits::WarpSize * 4;
-    while (n &&
-           unsigned(maxShmemPerBlock) <
-               cuda_single_inter_block_reduce_scan_shmem<true, WorkTag,
-                                                         value_type>(f, n)) {
+    int shmem_size =
+        cuda_single_inter_block_reduce_scan_shmem<true, WorkTag, value_type>(f,
+                                                                             n);
+    using closure_type =
+        Impl::ParallelScanWithTotal<FunctorType, Kokkos::RangePolicy<Traits...>,
+                                    ReturnType, Kokkos::Cuda>;
+    cudaFuncAttributes attr = CudaParallelLaunch<closure_type, LaunchBounds>::
+        get_cuda_func_attributes(
+            m_policy.space().impl_internal_space_instance());
+    while (
+        (n && (maxShmemPerBlock < shmem_size)) ||
+        (n >
+         static_cast<unsigned>(
+             Kokkos::Impl::cuda_get_max_block_size<FunctorType, LaunchBounds>(
+                 m_policy.space().impl_internal_space_instance(), attr, f, 1,
+                 shmem_size, 0)))) {
       n >>= 1;
+      shmem_size =
+          cuda_single_inter_block_reduce_scan_shmem<true, WorkTag, value_type>(
+              f, n);
     }
     return n;
   }

--- a/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
+++ b/core/src/HIP/Kokkos_HIP_BlockSize_Deduction.hpp
@@ -132,7 +132,7 @@ unsigned hip_internal_get_block_size(const HIPInternal *hip_instance,
       }
     }
     block_size >>= 1;
-  } while (block_size >= HIPTraits::WarpSize);
+  } while (block_size >= 1);
 
   return min_block_size;
 }

--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -439,13 +439,8 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
             "valid execution configuration.");
     }
 
-    // Must be a power of two greater than two, get the one not bigger than the
-    // requested one.
-    if ((m_team_size & m_team_size - 1) || m_team_size < 2) {
-      int temp_team_size = 2;
-      while ((temp_team_size << 1) < m_team_size) temp_team_size <<= 1;
-      m_team_size = temp_team_size;
-    }
+    // Must be a power of two get the one not bigger than the requested one.
+    m_team_size = Kokkos::bit_floor<unsigned int>(m_team_size);
 
     m_shmem_begin     = (sizeof(double) * (m_team_size + 2));
     m_shmem_size      = (m_policy.scratch_size(0, m_team_size) +

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -325,11 +325,6 @@ TEST(TEST_CATEGORY, parallel_scan_range_policy) {
     f.test_scan<>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Static>>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>>(work_sizes);
-    f.test_scan<Kokkos::LaunchBounds<16>>(work_sizes);
-    f.test_scan<Kokkos::Schedule<Kokkos::Static>, Kokkos::LaunchBounds<16>>(
-        work_sizes);
-    f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>, Kokkos::LaunchBounds<16>>(
-        work_sizes);
   }
   {
     TestParallelScanRangePolicy<long int> f;
@@ -354,6 +349,17 @@ TEST(TEST_CATEGORY, parallel_scan_range_policy) {
     f.test_scan<>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Static>>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>>(work_sizes);
+  }
+  {
+    TestParallelScanRangePolicy<int> f;
+
+    std::vector<size_t> work_sizes{0, 1, 2, 1000, 1001};
+    f.test_scan<Kokkos::LaunchBounds<1>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<2>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<4>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<8>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<16>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<32>>(work_sizes);
   }
 }
 }  // namespace

--- a/core/unit_test/TestParallelScanRangePolicy.hpp
+++ b/core/unit_test/TestParallelScanRangePolicy.hpp
@@ -325,6 +325,11 @@ TEST(TEST_CATEGORY, parallel_scan_range_policy) {
     f.test_scan<>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Static>>(work_sizes);
     f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>>(work_sizes);
+    f.test_scan<Kokkos::LaunchBounds<16>>(work_sizes);
+    f.test_scan<Kokkos::Schedule<Kokkos::Static>, Kokkos::LaunchBounds<16>>(
+        work_sizes);
+    f.test_scan<Kokkos::Schedule<Kokkos::Dynamic>, Kokkos::LaunchBounds<16>>(
+        work_sizes);
   }
   {
     TestParallelScanRangePolicy<long int> f;

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -208,11 +208,15 @@ void test_team_policy_launch_with_maximum_scratch_size(int level) {
 
     int team_size_max =
         policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
-    if (level == 0) EXPECT_EQ(team_size_max, 1);
+    if (level == 0) {
+      EXPECT_EQ(team_size_max, 1);
+    }
 
     int team_size_recommended =
         policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
-    if (level == 0) EXPECT_EQ(team_size_recommended, 1);
+    if (level == 0) {
+      EXPECT_EQ(team_size_recommended, 1);
+    }
 
     Kokkos::parallel_for(policy, dummy_functor);
   }
@@ -221,11 +225,15 @@ void test_team_policy_launch_with_maximum_scratch_size(int level) {
 
     int team_size_max =
         policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
-    if (level == 0) EXPECT_EQ(team_size_max, 1);
+    if (level == 0) {
+      EXPECT_EQ(team_size_max, 1);
+    }
 
     int team_size_recommended =
         policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
-    if (level == 0) EXPECT_EQ(team_size_recommended, 1);
+    if (level == 0) {
+      EXPECT_EQ(team_size_recommended, 1);
+    }
 
     int dummy;
     Kokkos::parallel_reduce(policy, dummy_functor, dummy);

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -208,6 +208,9 @@ void test_team_policy_launch_with_maximum_scratch_size(int level) {
 #ifdef KOKKOS_ENABLE_OPENMP
   // OpenMP's team size isn't limited by the max scratch size
   check_team_size &= !std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>;
+#elif defined KOKKOS_ENABLE_THREADS
+  // OpenMP's team size isn't limited by the max scratch size
+  check_team_size &= !std::is_same_v<TEST_EXECSPACE, Kokkos::Threads>;
 #endif
 
   {

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -197,4 +197,45 @@ TEST(TEST_CATEGORY, team_policy_minmax_scalar_without_plus_equal_k) {
   ASSERT_EQ(val.max_val, num_teams - 1);
 }
 
+void test_team_policy_launch_with_maximum_scratch_size(int level) {
+  // Ensure that we can launch a kernel where 1 thread consumes all scratch
+  // memory
+  policy_type policy(1, 1);
+  policy.set_scratch_size(
+      level, Kokkos::PerThread(policy_type::scratch_size_max(level)));
+  {
+    auto dummy_functor = KOKKOS_LAMBDA(const policy_type::member_type&){};
+
+    int team_size_max =
+        policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
+    if (level == 0) EXPECT_EQ(team_size_max, 1);
+
+    int team_size_recommended =
+        policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
+    if (level == 0) EXPECT_EQ(team_size_recommended, 1);
+
+    Kokkos::parallel_for(policy, dummy_functor);
+  }
+  {
+    auto dummy_functor = KOKKOS_LAMBDA(const policy_type::member_type&, int&){};
+
+    int team_size_max =
+        policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
+    if (level == 0) EXPECT_EQ(team_size_max, 1);
+
+    int team_size_recommended =
+        policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
+    if (level == 0) EXPECT_EQ(team_size_recommended, 1);
+
+    int dummy;
+    Kokkos::parallel_reduce(policy, dummy_functor, dummy);
+    EXPECT_EQ(dummy, 0) << " level: " << level;
+  }
+}
+
+TEST(TEST_CATEGORY, team_policy_launch_with_maximum_scratch_size) {
+  test_team_policy_launch_with_maximum_scratch_size(0);
+  test_team_policy_launch_with_maximum_scratch_size(1);
+}
+
 }  // namespace Test

--- a/core/unit_test/TestTeamTeamSize.hpp
+++ b/core/unit_test/TestTeamTeamSize.hpp
@@ -203,18 +203,25 @@ void test_team_policy_launch_with_maximum_scratch_size(int level) {
   policy_type policy(1, 1);
   policy.set_scratch_size(
       level, Kokkos::PerThread(policy_type::scratch_size_max(level)));
+
+  bool check_team_size = level == 0;
+#ifdef KOKKOS_ENABLE_OPENMP
+  // OpenMP's team size isn't limited by the max scratch size
+  check_team_size &= !std::is_same_v<TEST_EXECSPACE, Kokkos::OpenMP>;
+#endif
+
   {
     auto dummy_functor = KOKKOS_LAMBDA(const policy_type::member_type&){};
 
     int team_size_max =
         policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
-    if (level == 0) {
+    if (check_team_size) {
       EXPECT_EQ(team_size_max, 1);
     }
 
     int team_size_recommended =
         policy.team_size_max(dummy_functor, Kokkos::ParallelForTag());
-    if (level == 0) {
+    if (check_team_size) {
       EXPECT_EQ(team_size_recommended, 1);
     }
 
@@ -225,13 +232,13 @@ void test_team_policy_launch_with_maximum_scratch_size(int level) {
 
     int team_size_max =
         policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
-    if (level == 0) {
+    if (check_team_size) {
       EXPECT_EQ(team_size_max, 1);
     }
 
     int team_size_recommended =
         policy.team_size_max(dummy_functor, Kokkos::ParallelReduceTag());
-    if (level == 0) {
+    if (check_team_size) {
       EXPECT_EQ(team_size_recommended, 1);
     }
 


### PR DESCRIPTION
Fixes https://github.com/arborx/ArborX/blob/898299b91d069fe25bbc4dfa88650b6ec5f12c76/test/tstInterpDetailsMLSCoefficients.cpp#L45-L57, https://github.com/arborx/ArborX/blob/898299b91d069fe25bbc4dfa88650b6ec5f12c76/test/tstInterpDetailsMLSCoefficients.cpp#L134-L147, and https://github.com/arborx/ArborX/blob/898299b91d069fe25bbc4dfa88650b6ec5f12c76/test/tstInterpMovingLeastSquares.cpp#L26-L36, and https://github.com/arborx/ArborX/blob/898299b91d069fe25bbc4dfa88650b6ec5f12c76/test/tstInterpMovingLeastSquares.cpp#L111-L124.

With this change we drop down to a minimum of 32 in those tests on Frontier.