### PR TITLE
[Windows][View] Fixed C3520: parameter pack must be expanded in this context

### DIFF
--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -262,7 +262,7 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
 
   /* Copy from a matching property subset */
   KOKKOS_FUNCTION ViewCtorProp(pointer_type arg0)
-      : ViewCtorProp<void, pointer_type>(arg0) {}
+      : view_ctor_prop_base<pointer_type>(arg0) {}
 
   // If we use `ViewCtorProp<Args...>` and `ViewCtorProp<void, Args>...` here
   // directly, MSVC 16.5.5+CUDA 10.2 appears to think that `ViewCtorProp` refers


### PR DESCRIPTION
Found this issue when recompiling the kokkos-kernels, which firstly requires to build kokkos with the same properties.

| Item       | Value                                            |
| ---------- | ------------------------------------------------ |
| OS         | Windows 11 Pro x64, Build 26100                  |
| CPU        | Intel Core i9-12900H (20 logical cores)          |
| CMake      | 4.3.2                                           |
| MSVC       | 19.51.36246 (VS 2026 Community)                  |
| Ninja      | 1.12.1                                           |
| Build type | RelWithDebInfo, shared libs, C++20               |
|CUDA|13.2; driver: 595.95|

As we can see in this snippet above the changed code:

```cpp
  // If we use `ViewCtorProp<void, Args>...` here MSVC gets confused
  // error C3528: 'args': the number of elements in this pack expansion
  // does not match the number of elements in 'P'
  // Using the alias view_ctor_prop_base here as below fixes the issue.
  // Encountered with MSVC 17 and CUDA 12.6
  template <typename... Args>
  KOKKOS_FUNCTION ViewCtorProp(pointer_type arg0, Args const &...args)
      : view_ctor_prop_base<pointer_type>(arg0),
        view_ctor_prop_base<typename view_ctor_prop_base<Args>::type>(args)... {
  }
```

This file already encountered with such kind of a problem, but for now I catch it on MSVC 19.51 + CUDA 13.2.

### Related issues / PRs

[Kokkos-Kernels PR-3174](https://github.com/kokkos/kokkos-kernels/pull/3174)

### Changelog Entry

Replacing direct invoke of `ViewCtorProp<void, pointer_type>(arg0)` to base class `view_ctor_prop_base` like did it above.

### Additional Information

It looks like a MSVC frontend bug, I'll investigate it.
