### PR TITLE
[5.2.0][Windows][View] Fixed C3520: parameter pack must be expanded in this context

### DIFF
--- a/core/src/View/Kokkos_ViewCtor.hpp
+++ b/core/src/View/Kokkos_ViewCtor.hpp
@@ -262,7 +262,7 @@ struct ViewCtorProp : public ViewCtorProp<void, P>... {
 
   /* Copy from a matching property subset */
   KOKKOS_FUNCTION ViewCtorProp(pointer_type arg0)
-      : ViewCtorProp<void, pointer_type>(arg0) {}
+      : view_ctor_prop_base<pointer_type>(arg0) {}
 
   // If we use `ViewCtorProp<Args...>` and `ViewCtorProp<void, Args>...` here
   // directly, MSVC 16.5.5+CUDA 10.2 appears to think that `ViewCtorProp` refers


### PR DESCRIPTION
Cherry picking view constructor properties fix for MSVC #9340 into the 5.2 release candidate branch

Changelog entry: could fold this under medley MSVC fixes to avoid getting into details