### PR TITLE
Add missing TeamPolicy.team/thread_scratch_size() for some backends

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -792,6 +792,14 @@ class TeamPolicyInternal<Kokkos::Experimental::HPX, Properties...>
            team_size_ * m_thread_scratch_size[level];
   }
 
+  size_t team_scratch_size(int level) const {
+    return m_team_scratch_size[level];
+  }
+
+  size_t thread_scratch_size(int level) const {
+    return m_thread_scratch_size[level];
+  }
+
   inline static int scratch_size_max(int level) {
     return (level == 0 ? 1024 * 32 :  // Roughly L1 size
                 20 * 1024 * 1024);    // Limit to keep compatibility with CUDA

--- a/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Team.hpp
@@ -229,6 +229,12 @@ class TeamPolicyInternal<Kokkos::Experimental::OpenACC, Properties...>
     return m_team_scratch_size[level] +
            team_size_ * m_thread_scratch_size[level];
   }
+  size_t team_scratch_size(int level) const {
+    return m_team_scratch_size[level];
+  }
+  size_t thread_scratch_size(int level) const {
+    return m_thread_scratch_size[level];
+  }
 
   Kokkos::Experimental::OpenACC space() const { return m_space; }
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Team.hpp
@@ -158,6 +158,12 @@ class TeamPolicyInternal<Kokkos::OpenMP, Properties...>
     return m_team_scratch_size[level] +
            team_size_ * m_thread_scratch_size[level];
   }
+  inline size_t team_scratch_size(int level) const {
+    return m_team_scratch_size[level];
+  }
+  inline size_t thread_scratch_size(int level) const {
+    return m_thread_scratch_size[level];
+  }
 
   /** \brief  Specify league size, request team size */
   TeamPolicyInternal(const typename traits::execution_space& space,

--- a/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
+++ b/core/src/Serial/Kokkos_Serial_Parallel_Team.hpp
@@ -92,6 +92,12 @@ class TeamPolicyInternal<Kokkos::Serial, Properties...>
   inline size_t scratch_size(const int& level, int = 0) const {
     return m_team_scratch_size[level] + m_thread_scratch_size[level];
   }
+  inline size_t team_scratch_size(int level) const {
+    return m_team_scratch_size[level];
+  }
+  inline size_t thread_scratch_size(int level) const {
+    return m_thread_scratch_size[level];
+  }
 
   inline int impl_vector_length() const { return 1; }
   inline static int vector_length_max() {

--- a/core/src/Threads/Kokkos_Threads_Team.hpp
+++ b/core/src/Threads/Kokkos_Threads_Team.hpp
@@ -662,6 +662,12 @@ class TeamPolicyInternal<Kokkos::Threads, Properties...>
     return m_team_scratch_size[level] +
            team_size_ * m_thread_scratch_size[level];
   }
+  inline size_t team_scratch_size(int level) const {
+    return m_team_scratch_size[level];
+  }
+  inline size_t thread_scratch_size(int level) const {
+    return m_thread_scratch_size[level];
+  }
 
   inline int team_iter() const { return m_team_iter; }
 

--- a/core/unit_test/TestTeamScratch.hpp
+++ b/core/unit_test/TestTeamScratch.hpp
@@ -52,5 +52,23 @@ TEST(TEST_CATEGORY, team_scratch_memory_index_parallel_for) {
   Kokkos::parallel_for("kernel", policy, DummyTeamParallelForFunctor());
 }
 
+TEST(TEST_CATEGORY, scratch_size_query) {
+  const int thread_scratch[] = {4, 32};
+  const int team_scratch[]   = {64, 256};
+  const int league_size      = 10;
+  const int team_size        = 1;
+
+  Kokkos::TeamPolicy<TEST_EXECSPACE> policy(league_size, team_size);
+  policy.set_scratch_size(0, Kokkos::PerTeam(team_scratch[0]),
+                          Kokkos::PerThread(thread_scratch[0]));
+  policy.set_scratch_size(1, Kokkos::PerTeam(team_scratch[1]),
+                          Kokkos::PerThread(thread_scratch[1]));
+
+  ASSERT_EQ(policy.team_scratch_size(0), team_scratch[0]);
+  ASSERT_EQ(policy.team_scratch_size(1), team_scratch[1]);
+  ASSERT_EQ(policy.thread_scratch_size(0), thread_scratch[0]);
+  ASSERT_EQ(policy.thread_scratch_size(1), thread_scratch[1]);
+}
+
 }  // namespace Test
 #endif


### PR DESCRIPTION
`team_scratch_size(int)` and `thread_scratch_size(int)` are currently only implemented for the CUDA, HIP and SYCL backends, this PR adds the function for the remaining backends (host backends and OpenACC) and adds a test for these two functions.

### Related issues / PRs

### Changelog Entry

Add support for querying the team and thread level scratch size on all backends
