### PR TITLE
Allow non-RDC desul atomics to be used in RDC code

### DIFF
--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -453,6 +453,17 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       list(REMOVE_ITEM ${Tag}_SOURCES_SMOKE ${dir}/Test${Tag}_Reductions.cpp)
     endif()
     kokkos_add_executable_and_test(CoreUnitTest_${Tag}_SmokeTest SOURCES UnitTestMainInit.cpp ${${Tag}_SOURCES_SMOKE})
+
+    if(Kokkos_ENABLE_HIP OR Kokkos_ENABLE_CUDA)
+      kokkos_add_executable_and_test(CoreUnitTest_AtomicsRDC SOURCES UnitTestMain.cpp ${dir}/Test${Tag}_Atomics.cpp)
+
+      if(Kokkos_ENABLE_CUDA)
+        set_property(TARGET Kokkos_CoreUnitTest_AtomicsRDC PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+      elseif(Kokkos_ENABLE_HIP)
+        target_compile_options(Kokkos_CoreUnitTest_AtomicsRDC PRIVATE -fgpu-rdc)
+        target_link_options(Kokkos_CoreUnitTest_AtomicsRDC PRIVATE --hip-link)
+      endif()
+    endif()
   endif()
 endforeach()
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_CUDA.hpp
@@ -61,11 +61,15 @@ void finalize_lock_arrays_cuda();
 /// That is the purpose of the ensure_cuda_lock_arrays_on_device function.
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_DEVICE;
 
 #ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* CUDA_SPACE_ATOMIC_LOCKS_NODE;
 

--- a/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
+++ b/tpls/desul/include/desul/atomics/Lock_Array_HIP.hpp
@@ -65,11 +65,15 @@ void finalize_lock_arrays_hip();
  */
 #ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_DEVICE;
 
 #ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
 extern
+#else
+static
 #endif
     __device__ __constant__ int32_t* HIP_SPACE_ATOMIC_LOCKS_NODE;
 

--- a/tpls/desul/include/desul/atomics/Macros.hpp
+++ b/tpls/desul/include/desul/atomics/Macros.hpp
@@ -19,9 +19,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #endif
 
 #if (defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) &&  \
-     !defined(DESUL_IMPL_CUDA_RDC)) ||                            \
-    (!defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) && \
-     defined(DESUL_IMPL_CUDA_RDC))
+     !defined(DESUL_IMPL_CUDA_RDC))
 #error Relocatable device code mode incompatible with desul atomics configuration
 #endif
 

--- a/tpls/desul/include/desul/atomics/Macros.hpp
+++ b/tpls/desul/include/desul/atomics/Macros.hpp
@@ -18,7 +18,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #define DESUL_IMPL_CUDA_RDC
 #endif
 
-#if (defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) &&  \
+#if (defined(DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION) && \
      !defined(DESUL_IMPL_CUDA_RDC))
 #error Relocatable device code mode incompatible with desul atomics configuration
 #endif
@@ -29,10 +29,7 @@ SPDX-License-Identifier: (BSD-3-Clause)
 #endif
 
 #ifdef DESUL_ATOMICS_ENABLE_HIP
-#if (defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) &&  \
-     !defined(__CLANG_RDC__)) ||                                 \
-    (!defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) && \
-     defined(__CLANG_RDC__))
+#if (defined(DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION) && !defined(__CLANG_RDC__))
 #error Relocatable device code mode incompatible with desul atomics configuration
 #endif
 #endif

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -24,11 +24,12 @@ namespace desul {
 
 namespace {
 
-__global__ void init_lock_arrays_cuda_kernel() {
+__global__ void init_lock_arrays_cuda_kernel(int32_t* device_locks,
+                                             int32_t* node_locks) {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < CUDA_SPACE_ATOMIC_MASK + 1) {
-    Impl::CUDA_SPACE_ATOMIC_LOCKS_DEVICE[i] = 0;
-    Impl::CUDA_SPACE_ATOMIC_LOCKS_NODE[i] = 0;
+    device_locks[i] = 0;
+    node_locks[i] = 0;
   }
 }
 
@@ -68,12 +69,13 @@ void init_lock_arrays_cuda() {
   check_error_and_throw_cuda(error_malloc2,
                              "init_lock_arrays_cuda: cudaMalloc host locks");
 
-  auto error_sync1 = cudaDeviceSynchronize();
+#ifdef DESUL_ATOMICS_ENABLE_CUDA_SEPARABLE_COMPILATION
   copy_cuda_lock_arrays_to_device();
-  check_error_and_throw_cuda(error_sync1, "init_lock_arrays_cuda: post mallocs");
-  init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
-  auto error_sync2 = cudaDeviceSynchronize();
-  check_error_and_throw_cuda(error_sync2, "init_lock_arrays_cuda: post init kernel");
+#endif
+  init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>(
+      CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h, CUDA_SPACE_ATOMIC_LOCKS_NODE_h);
+  auto error_sync = cudaDeviceSynchronize();
+  check_error_and_throw_cuda(error_sync, "init_lock_arrays_cuda: post init kernel");
 }
 
 template <typename T>

--- a/tpls/desul/src/Lock_Array_CUDA.cpp
+++ b/tpls/desul/src/Lock_Array_CUDA.cpp
@@ -74,6 +74,7 @@ void init_lock_arrays_cuda() {
 #endif
   init_lock_arrays_cuda_kernel<<<(CUDA_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>(
       CUDA_SPACE_ATOMIC_LOCKS_DEVICE_h, CUDA_SPACE_ATOMIC_LOCKS_NODE_h);
+
   auto error_sync = cudaDeviceSynchronize();
   check_error_and_throw_cuda(error_sync, "init_lock_arrays_cuda: post init kernel");
 }

--- a/tpls/desul/src/Lock_Array_HIP.cpp
+++ b/tpls/desul/src/Lock_Array_HIP.cpp
@@ -24,11 +24,11 @@ namespace desul {
 
 namespace {
 
-__global__ void init_lock_arrays_hip_kernel() {
+__global__ void init_lock_arrays_hip_kernel(int32_t* device_locks, int32_t node_locks) {
   unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < HIP_SPACE_ATOMIC_MASK + 1) {
-    Impl::HIP_SPACE_ATOMIC_LOCKS_DEVICE[i] = 0;
-    Impl::HIP_SPACE_ATOMIC_LOCKS_NODE[i] = 0;
+    device_locks[i] = 0;
+    node_locks[i] = 0;
   }
 }
 
@@ -68,13 +68,14 @@ void init_lock_arrays_hip() {
   check_error_and_throw_hip(error_malloc2,
                             "init_lock_arrays_hip: hipMallocHost host locks");
 
-  auto error_sync1 = hipDeviceSynchronize();
+#ifdef DESUL_ATOMICS_ENABLE_HIP_SEPARABLE_COMPILATION
   copy_hip_lock_arrays_to_device();
-  check_error_and_throw_hip(error_sync1, "init_lock_arrays_hip: post malloc");
+#endif
 
-  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>();
+  init_lock_arrays_hip_kernel<<<(HIP_SPACE_ATOMIC_MASK + 1 + 255) / 256, 256>>>(
+      HIP_SPACE_ATOMIC_LOCKS_DEVICE_h, HIP_SPACE_ATOMIC_LOCKS_NODE_h);
 
-  auto error_sync2 = hipDeviceSynchronize();
+  auto error_sync = hipDeviceSynchronize();
   check_error_and_throw_hip(error_sync2, "init_lock_arrays_hip: post init");
 }
 


### PR DESCRIPTION
This PR allows non-RDC desul atomics to be used in RDC code. It is currently required to set the RDC option (either on or off) consistently across all the downstream packages. If an application that wants to use RDC acquires Kokkos through one of its upstream packages, and if the package has its own Kokkos codes not using RDC, meeting this requirement becomes really painful.

I'm an application developer and not sure if this change makes sense to the Kokkos core infrastructure. Feedbacks would be appreciated.