### PR TITLE
SYCL: Introspect kernels for maximum team size

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelReduce_Team.hpp
@@ -47,6 +47,137 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
   int m_team_size;
   const size_type m_vector_size;
 
+ public:
+  static auto create_team_reduction_lambda(
+      const sycl::local_accessor<value_type, 1> local_mem,
+      const sycl::global_ptr<value_type> results_ptr,
+      const sycl::global_ptr<value_type> device_accessible_result_ptr,
+      const auto& functor_reducer_wrapper, const int value_count,
+      const size_type league_size,
+      const sycl::local_accessor<char, 1>& team_scratch_memory_L0,
+      const size_t (&scratch_size)[2], const int shmem_begin,
+      const sycl::global_ptr<char> global_scratch_ptr,
+      const sycl::local_accessor<unsigned int> num_teams_done,
+      const sycl::global_ptr<unsigned int> scratch_flags) {
+    auto lambda = [=](sycl::nd_item<2> item) {
+      auto n_wgroups  = item.get_group_range()[1];
+      int wgroup_size = item.get_local_range()[0] * item.get_local_range()[1];
+      auto group_id   = item.get_group_linear_id();
+      auto size       = n_wgroups * wgroup_size;
+
+      const auto local_id = item.get_local_linear_id();
+      const CombinedFunctorReducerType& functor_reducer =
+          functor_reducer_wrapper.get_functor();
+      const FunctorType& functor = functor_reducer.get_functor();
+      const ReducerType& reducer = functor_reducer.get_reducer();
+
+      if constexpr (!SYCLReduction::use_shuffle_based_algorithm<ReducerType>) {
+        reference_type update =
+            reducer.init(&local_mem[local_id * value_count]);
+        for (size_type league_rank = group_id; league_rank < league_size;
+             league_rank += n_wgroups) {
+          const member_type team_member(
+              team_scratch_memory_L0
+                  .get_multi_ptr<sycl::access::decorated::yes>(),
+              shmem_begin, scratch_size[0],
+              global_scratch_ptr + item.get_group(1) * scratch_size[1],
+              scratch_size[1], item, league_rank, league_size);
+          if constexpr (std::is_void_v<WorkTag>)
+            functor(team_member, update);
+          else
+            functor(WorkTag(), team_member, update);
+        }
+        sycl::group_barrier(item.get_group());
+
+        SYCLReduction::workgroup_reduction<>(
+            item, local_mem, results_ptr, device_accessible_result_ptr,
+            value_count, reducer, false,
+            std::min<std::size_t>(
+                size, item.get_local_range()[0] * item.get_local_range()[1]));
+
+        if (local_id == 0) {
+          sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
+                           sycl::memory_scope::device,
+                           sycl::access::address_space::global_space>
+              scratch_flags_ref(*scratch_flags);
+          num_teams_done[0] = ++scratch_flags_ref;
+        }
+        sycl::group_barrier(item.get_group());
+        if (num_teams_done[0] == n_wgroups) {
+          if (local_id == 0) *scratch_flags = 0;
+          if (local_id >= n_wgroups)
+            reducer.init(&local_mem[local_id * value_count]);
+          else {
+            reducer.copy(&local_mem[local_id * value_count],
+                         &results_ptr[local_id * value_count]);
+            for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
+                 id += wgroup_size) {
+              reducer.join(&local_mem[local_id * value_count],
+                           &results_ptr[id * value_count]);
+            }
+          }
+
+          SYCLReduction::workgroup_reduction<>(
+              item, local_mem, results_ptr, device_accessible_result_ptr,
+              value_count, reducer, true,
+              std::min(n_wgroups,
+                       item.get_local_range()[0] * item.get_local_range()[1]));
+        }
+      } else {
+        value_type local_value;
+        reference_type update = reducer.init(&local_value);
+        for (int league_rank = group_id; league_rank < league_size;
+             league_rank += n_wgroups) {
+          const member_type team_member(
+              team_scratch_memory_L0
+                  .get_multi_ptr<sycl::access::decorated::yes>(),
+              shmem_begin, scratch_size[0],
+              global_scratch_ptr + item.get_group(1) * scratch_size[1],
+              scratch_size[1], item, league_rank, league_size);
+          if constexpr (std::is_void_v<WorkTag>)
+            functor(team_member, update);
+          else
+            functor(WorkTag(), team_member, update);
+        }
+
+        SYCLReduction::workgroup_reduction<>(
+            item, local_mem, local_value, results_ptr,
+            device_accessible_result_ptr, reducer, false,
+            std::min<std::size_t>(
+                size, item.get_local_range()[0] * item.get_local_range()[1]));
+
+        if (local_id == 0) {
+          sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
+                           sycl::memory_scope::device,
+                           sycl::access::address_space::global_space>
+              scratch_flags_ref(*scratch_flags);
+          num_teams_done[0] = ++scratch_flags_ref;
+        }
+        sycl::group_barrier(item.get_group());
+        if (num_teams_done[0] == n_wgroups) {
+          if (local_id == 0) *scratch_flags = 0;
+          if (local_id >= n_wgroups)
+            reducer.init(&local_value);
+          else {
+            local_value = results_ptr[local_id];
+            for (unsigned int id = local_id + wgroup_size; id < n_wgroups;
+                 id += wgroup_size) {
+              reducer.join(&local_value, &results_ptr[id]);
+            }
+          }
+
+          SYCLReduction::workgroup_reduction<>(
+              item, local_mem, local_value, results_ptr,
+              device_accessible_result_ptr, reducer, true,
+              std::min(n_wgroups,
+                       item.get_local_range()[0] * item.get_local_range()[1]));
+        }
+      }
+    };
+    return lambda;
+  }
+
+ private:
   template <typename CombinedFunctorReducerWrapper>
   sycl::event sycl_direct_launch(
       const sycl::global_ptr<char> global_scratch_ptr,
@@ -67,6 +198,10 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
             ? static_cast<sycl::global_ptr<value_type>>(
                   instance.scratch_host(sizeof(value_type) * value_count))
             : nullptr;
+    auto device_accessible_result_ptr =
+        m_result_ptr_device_accessible
+            ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
+            : static_cast<sycl::global_ptr<value_type>>(host_result_ptr);
 
     sycl::event last_reduction_event;
 
@@ -79,10 +214,6 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       results_ptr =
           static_cast<sycl::global_ptr<value_type>>(instance.scratch_space(
               sizeof(value_type) * std::max(value_count, 1u)));
-      auto device_accessible_result_ptr =
-          m_result_ptr_device_accessible
-              ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
-              : static_cast<sycl::global_ptr<value_type>>(host_result_ptr);
 
       auto cgh_lambda = [&](sycl::handler& cgh) {
         // FIXME_SYCL accessors seem to need a size greater than zero at least
@@ -160,140 +291,12 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
         sycl::local_accessor<unsigned int> num_teams_done(1, cgh);
 
-        auto team_reduction_factory =
-            [&](sycl::local_accessor<value_type, 1> local_mem,
-                sycl::global_ptr<value_type> results_ptr) {
-              auto device_accessible_result_ptr =
-                  m_result_ptr_device_accessible
-                      ? static_cast<sycl::global_ptr<value_type>>(m_result_ptr)
-                      : static_cast<sycl::global_ptr<value_type>>(
-                            host_result_ptr);
-              auto lambda = [=](sycl::nd_item<2> item) {
-                auto n_wgroups = item.get_group_range()[1];
-                int wgroup_size =
-                    item.get_local_range()[0] * item.get_local_range()[1];
-                auto group_id = item.get_group_linear_id();
-                auto size     = n_wgroups * wgroup_size;
-
-                const auto local_id = item.get_local_linear_id();
-                const CombinedFunctorReducerType& functor_reducer =
-                    functor_reducer_wrapper.get_functor();
-                const FunctorType& functor = functor_reducer.get_functor();
-                const ReducerType& reducer = functor_reducer.get_reducer();
-
-                if constexpr (!SYCLReduction::use_shuffle_based_algorithm<
-                                  ReducerType>) {
-                  reference_type update =
-                      reducer.init(&local_mem[local_id * value_count]);
-                  for (size_type league_rank = group_id;
-                       league_rank < league_size; league_rank += n_wgroups) {
-                    const member_type team_member(
-                        team_scratch_memory_L0
-                            .get_multi_ptr<sycl::access::decorated::yes>(),
-                        shmem_begin, scratch_size[0],
-                        global_scratch_ptr +
-                            item.get_group(1) * scratch_size[1],
-                        scratch_size[1], item, league_rank, league_size);
-                    if constexpr (std::is_void_v<WorkTag>)
-                      functor(team_member, update);
-                    else
-                      functor(WorkTag(), team_member, update);
-                  }
-                  sycl::group_barrier(item.get_group());
-
-                  SYCLReduction::workgroup_reduction<>(
-                      item, local_mem, results_ptr,
-                      device_accessible_result_ptr, value_count, reducer, false,
-                      std::min<std::size_t>(size,
-                                            item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-
-                  if (local_id == 0) {
-                    sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
-                                     sycl::memory_scope::device,
-                                     sycl::access::address_space::global_space>
-                        scratch_flags_ref(*scratch_flags);
-                    num_teams_done[0] = ++scratch_flags_ref;
-                  }
-                  sycl::group_barrier(item.get_group());
-                  if (num_teams_done[0] == n_wgroups) {
-                    if (local_id == 0) *scratch_flags = 0;
-                    if (local_id >= n_wgroups)
-                      reducer.init(&local_mem[local_id * value_count]);
-                    else {
-                      reducer.copy(&local_mem[local_id * value_count],
-                                   &results_ptr[local_id * value_count]);
-                      for (unsigned int id = local_id + wgroup_size;
-                           id < n_wgroups; id += wgroup_size) {
-                        reducer.join(&local_mem[local_id * value_count],
-                                     &results_ptr[id * value_count]);
-                      }
-                    }
-
-                    SYCLReduction::workgroup_reduction<>(
-                        item, local_mem, results_ptr,
-                        device_accessible_result_ptr, value_count, reducer,
-                        true,
-                        std::min(n_wgroups, item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-                  }
-                } else {
-                  value_type local_value;
-                  reference_type update = reducer.init(&local_value);
-                  for (int league_rank = group_id; league_rank < league_size;
-                       league_rank += n_wgroups) {
-                    const member_type team_member(
-                        team_scratch_memory_L0
-                            .get_multi_ptr<sycl::access::decorated::yes>(),
-                        shmem_begin, scratch_size[0],
-                        global_scratch_ptr +
-                            item.get_group(1) * scratch_size[1],
-                        scratch_size[1], item, league_rank, league_size);
-                    if constexpr (std::is_void_v<WorkTag>)
-                      functor(team_member, update);
-                    else
-                      functor(WorkTag(), team_member, update);
-                  }
-
-                  SYCLReduction::workgroup_reduction<>(
-                      item, local_mem, local_value, results_ptr,
-                      device_accessible_result_ptr, reducer, false,
-                      std::min<std::size_t>(size,
-                                            item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-
-                  if (local_id == 0) {
-                    sycl::atomic_ref<unsigned, sycl::memory_order::acq_rel,
-                                     sycl::memory_scope::device,
-                                     sycl::access::address_space::global_space>
-                        scratch_flags_ref(*scratch_flags);
-                    num_teams_done[0] = ++scratch_flags_ref;
-                  }
-                  sycl::group_barrier(item.get_group());
-                  if (num_teams_done[0] == n_wgroups) {
-                    if (local_id == 0) *scratch_flags = 0;
-                    if (local_id >= n_wgroups)
-                      reducer.init(&local_value);
-                    else {
-                      local_value = results_ptr[local_id];
-                      for (unsigned int id = local_id + wgroup_size;
-                           id < n_wgroups; id += wgroup_size) {
-                        reducer.join(&local_value, &results_ptr[id]);
-                      }
-                    }
-
-                    SYCLReduction::workgroup_reduction<>(
-                        item, local_mem, local_value, results_ptr,
-                        device_accessible_result_ptr, reducer, true,
-                        std::min(n_wgroups, item.get_local_range()[0] *
-                                                item.get_local_range()[1]));
-                  }
-                }
-              };
-              return lambda;
-            };
-
-        auto dummy_reduction_lambda = team_reduction_factory({1, cgh}, nullptr);
+        auto dummy_reduction_lambda = create_team_reduction_lambda(
+            /* local_mem */ {1, cgh},
+            /* results_ptr */ nullptr,
+            /* device_accessible_result_ptr */ nullptr, functor_reducer_wrapper,
+            value_count, league_size, team_scratch_memory_L0, scratch_size,
+            shmem_begin, global_scratch_ptr, num_teams_done, scratch_flags);
 
         static sycl::kernel kernel = [&] {
           sycl::kernel_id functor_kernel_id =
@@ -337,7 +340,11 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
               wgroup_size;
         }
 
-        auto reduction_lambda = team_reduction_factory(local_mem, results_ptr);
+        auto reduction_lambda = create_team_reduction_lambda(
+            local_mem, results_ptr, device_accessible_result_ptr,
+            functor_reducer_wrapper, value_count, league_size,
+            team_scratch_memory_L0, scratch_size, shmem_begin,
+            global_scratch_ptr, num_teams_done, scratch_flags);
 
 #ifndef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
         cgh.depends_on(memcpy_event);
@@ -430,7 +437,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
         m_team_size(arg_policy.team_size()),
         m_vector_size(arg_policy.impl_vector_length()) {
     if (m_team_size < 0) {
-      m_team_size = m_policy.team_size_recommended(
+      m_team_size = m_policy.team_size_recommended_internal(
           m_functor_reducer.get_functor(), m_functor_reducer.get_reducer(),
           ParallelReduceTag{});
       if (m_team_size <= 0)
@@ -475,7 +482,7 @@ class Kokkos::Impl::ParallelReduce<CombinedFunctorReducerType,
       Kokkos::Impl::throw_runtime_exception(out.str());
     }
 
-    const auto max_team_size = m_policy.team_size_max(
+    const auto max_team_size = m_policy.team_size_max_internal(
         m_functor_reducer.get_functor(), m_functor_reducer.get_reducer(),
         ParallelReduceTag{});
     if (m_team_size > max_team_size) {

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -6,6 +6,7 @@
 
 #include <SYCL/Kokkos_SYCL_Team.hpp>
 #include <Kokkos_BitManipulation.hpp>
+#include <SYCL/Kokkos_SYCL_Instance.hpp>
 
 #include <vector>
 
@@ -57,13 +58,36 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
   template <class FunctorType>
   inline int team_size_max(const FunctorType& f,
                            const ParallelReduceTag&) const {
-    return internal_team_size_max_reduce<void>(f);
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, FunctorType, void>;
+    typename functor_analysis_type::Reducer reducer(f);
+    return internal_team_size_max_reduce<
+        typename functor_analysis_type::value_type>(
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>(
+            f, reducer));
   }
 
   template <class FunctorType, class ReducerType>
-  inline int team_size_max(const FunctorType& f, const ReducerType& /*r*/,
+  inline int team_size_max(const FunctorType& f, const ReducerType& r,
                            const ParallelReduceTag&) const {
-    return internal_team_size_max_reduce<typename ReducerType::value_type>(f);
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, ReducerType, void>;
+    typename functor_analysis_type::Reducer reducer(r);
+    return internal_team_size_max_reduce<
+        typename functor_analysis_type::value_type>(
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>(
+            f, reducer));
+  }
+
+  template <class FunctorType, class ReducerType>
+  int team_size_max_internal(FunctorType const& f, ReducerType const& r,
+                             ParallelReduceTag const&) const {
+    return internal_team_size_max_reduce<typename ReducerType::value_type>(
+        CombinedFunctorReducer<FunctorType, ReducerType>(f, r));
   }
 
   template <typename FunctorType>
@@ -74,15 +98,39 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
   template <typename FunctorType>
   inline int team_size_recommended(FunctorType const& f,
                                    ParallelReduceTag const&) const {
-    return internal_team_size_recommended_reduce<void>(f);
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, FunctorType, void>;
+    typename functor_analysis_type::Reducer reducer(f);
+    return internal_team_size_recommended_reduce<
+        typename functor_analysis_type::value_type>(
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>(
+            f, reducer));
   }
 
   template <class FunctorType, class ReducerType>
-  int team_size_recommended(FunctorType const& f, ReducerType const&,
+  int team_size_recommended(FunctorType const& f, ReducerType const& r,
                             ParallelReduceTag const&) const {
+    using functor_analysis_type =
+        Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
+                              TeamPolicyInternal, ReducerType, void>;
+    typename functor_analysis_type::Reducer reducer(r);
     return internal_team_size_recommended_reduce<
-        typename ReducerType::value_type>(f);
+        typename functor_analysis_type::value_type>(
+        CombinedFunctorReducer<FunctorType,
+                               typename functor_analysis_type::Reducer>(
+            f, reducer));
   }
+
+  template <class FunctorType, class ReducerType>
+  int team_size_recommended_internal(FunctorType const& f, ReducerType const& r,
+                                     ParallelReduceTag const&) const {
+    return internal_team_size_recommended_reduce<
+        typename ReducerType::value_type>(
+        CombinedFunctorReducer<FunctorType, ReducerType>(f, r));
+  }
+
   inline bool impl_auto_vector_length() const { return m_tune_vector_length; }
   inline bool impl_auto_team_size() const { return m_tune_team_size; }
   // FIXME_SYCL This is correct in most cases, but not necessarily in case a
@@ -284,7 +332,7 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
 
  protected:
   template <class FunctorType>
-  int internal_team_size_max_for(const FunctorType& /*f*/) const {
+  int internal_team_size_max_for(const FunctorType& f) const {
     // nested_reducer_memsize = (sizeof(double) * (m_team_size + 2)
     // custom: m_team_scratch_size[0] + m_thread_scratch_size[0] * m_team_size
     // total:
@@ -294,22 +342,66 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
         (space().impl_internal_space_instance()->m_maxShmemPerBlock -
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + m_thread_scratch_size[0]);
-    return std::min({
-             int(m_space.impl_internal_space_instance()->m_maxWorkgroupSize),
-      // FIXME_SYCL Avoid requesting too many registers on NVIDIA GPUs.
-#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-                 256,
-#endif
-                 max_threads_for_memory
-           }) /
+
+    auto& instance          = *m_space.impl_internal_space_instance();
+    auto& indirectKernelMem = instance.get_indirect_kernel_mem();
+    auto functor_wrapper =
+        Impl::make_sycl_function_wrapper(f, indirectKernelMem);
+    sycl::queue& q = m_space.sycl_queue();
+
+    int max_threads_kernel = 0;
+    auto event             = q.submit([&](sycl::handler& cgh) {
+      // minimal local accessor to create the same lambda type used at
+      // launch-time
+      sycl::local_accessor<char, 1> team_scratch_memory_L0(sycl::range<1>(1),
+                                                                       cgh);
+
+      const auto shmem_begin       = 0u;
+      const size_t scratch_size[2] = {0, 0};
+
+      // Create a dummy kernel mirroring the TeamPolicy parallel_for
+      // implementation for introspection. The kernel call has an empty range
+      // and hence the kernel isn't actually executed but the kernel still needs
+      // to be submitted for it to be introspected.
+      auto lambda = [=](sycl::nd_item<2> item) {
+        const member_type team_member(
+            team_scratch_memory_L0
+                .get_multi_ptr<sycl::access::decorated::yes>(),
+            shmem_begin, scratch_size[0],
+            static_cast<sycl::global_ptr<char>>(nullptr), scratch_size[1], item,
+            item.get_group_linear_id(), item.get_group_range(1));
+        if constexpr (std::is_same_v<typename traits::work_tag, void>)
+          functor_wrapper.get_functor()(team_member);
+        else
+          functor_wrapper.get_functor()(typename traits::work_tag{},
+                                        team_member);
+      };
+
+      sycl::kernel_id functor_kernel_id =
+          sycl::get_kernel_id<decltype(lambda)>();
+      auto kernel_bundle =
+          sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+              q.get_context(), std::vector{functor_kernel_id});
+      auto kernel = kernel_bundle.get_kernel(functor_kernel_id);
+      max_threads_kernel =
+          kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
+              q.get_device());
+
+      cgh.parallel_for(
+          sycl::nd_range<2>(sycl::range<2>(0, 0), sycl::range<2>(1, 1)),
+          lambda);
+    });
+    functor_wrapper.register_event(event);
+
+    return std::min({max_threads_kernel, max_threads_for_memory}) /
            impl_vector_length();
   }
 
-  template <class ValueType, class FunctorType>
-  int internal_team_size_max_reduce(const FunctorType& f) const {
+  template <class ValueType, class CombinedFunctorReducerType>
+  int internal_team_size_max_reduce(const CombinedFunctorReducerType& f) const {
     using Analysis =
         FunctorAnalysis<FunctorPatternInterface::REDUCE, TeamPolicyInternal,
-                        FunctorType, ValueType>;
+                        CombinedFunctorReducerType, ValueType>;
     using value_type      = typename Analysis::value_type;
     const int value_count = Analysis::value_count(f);
 
@@ -325,14 +417,57 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
          2 * sizeof(double) - m_team_scratch_size[0]) /
         (sizeof(double) + sizeof(value_type) * value_count +
          m_thread_scratch_size[0]);
-    return std::min<int>({
-             int(m_space.impl_internal_space_instance()->m_maxWorkgroupSize),
-      // FIXME_SYCL Avoid requesting too many registers on NVIDIA GPUs.
-#if defined(KOKKOS_IMPL_ARCH_NVIDIA_GPU)
-                 256,
-#endif
-                 max_threads_for_memory
-           }) /
+
+    auto& instance          = *m_space.impl_internal_space_instance();
+    auto& indirectKernelMem = instance.get_indirect_kernel_mem();
+    auto functor_wrapper =
+        Impl::make_sycl_function_wrapper(f, indirectKernelMem);
+    sycl::queue& q = m_space.sycl_queue();
+
+    int max_threads_kernel = 0;
+    auto event             = q.submit([&](sycl::handler& cgh) {
+      // minimal local accessor to form the expected lambda type
+      sycl::local_accessor<char, 1> team_scratch_memory_L0(sycl::range<1>(1),
+                                                                       cgh);
+
+      const auto shmem_begin       = 0u;
+      const size_t scratch_size[2] = {0, 0};
+
+      // Create a dummy kernel using the actual TeamPolicy parallel_reduce
+      // implementation for introspection. The kernel call has an empty range
+      // and hence the kernel isn't actually executed but the kernel still needs
+      // to be submitted for it to be introspected.
+      auto lambda =
+          Impl::ParallelReduce<CombinedFunctorReducerType,
+                               TeamPolicy<Properties...>, Kokkos::SYCL>::
+              create_team_reduction_lambda(
+                  /* local_mem */ {1, cgh},
+                  /* results_ptr */ nullptr,
+                  /* device_accessible_result_ptr */ nullptr, functor_wrapper,
+                  value_count,
+                  /*league_size*/ 0, team_scratch_memory_L0, scratch_size,
+                  shmem_begin,
+                  /*global_scratch_ptr*/ nullptr,
+                  /*num_teams_done*/ {1, cgh},
+                  /*scratch_flags*/ nullptr);
+
+      sycl::kernel_id functor_kernel_id =
+          sycl::get_kernel_id<decltype(lambda)>();
+      auto kernel_bundle =
+          sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+              q.get_context(), std::vector{functor_kernel_id});
+      auto kernel = kernel_bundle.get_kernel(functor_kernel_id);
+      max_threads_kernel =
+          kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
+              q.get_device());
+
+      cgh.parallel_for(
+          sycl::nd_range<2>(sycl::range<2>(0, 0), sycl::range<2>(1, 1)),
+          lambda);
+    });
+    functor_wrapper.register_event(event);
+
+    return std::min({max_threads_kernel, max_threads_for_memory}) /
            impl_vector_length();
   }
 

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -57,30 +57,22 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
 
   template <class FunctorType>
   inline int team_size_max(const FunctorType& f,
-                           const ParallelReduceTag&) const {
+                           const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, FunctorType, void>;
     typename functor_analysis_type::Reducer reducer(f);
-    return internal_team_size_max_reduce<
-        typename functor_analysis_type::value_type>(
-        CombinedFunctorReducer<FunctorType,
-                               typename functor_analysis_type::Reducer>(
-            f, reducer));
+    return team_size_max_internal(f, reducer, tag);
   }
 
   template <class FunctorType, class ReducerType>
   inline int team_size_max(const FunctorType& f, const ReducerType& r,
-                           const ParallelReduceTag&) const {
+                           const ParallelReduceTag& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, ReducerType, void>;
     typename functor_analysis_type::Reducer reducer(r);
-    return internal_team_size_max_reduce<
-        typename functor_analysis_type::value_type>(
-        CombinedFunctorReducer<FunctorType,
-                               typename functor_analysis_type::Reducer>(
-            f, reducer));
+    return team_size_max_internal(f, reducer, tag);
   }
 
   template <class FunctorType, class ReducerType>
@@ -97,30 +89,22 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
 
   template <typename FunctorType>
   inline int team_size_recommended(FunctorType const& f,
-                                   ParallelReduceTag const&) const {
+                                   ParallelReduceTag const& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, FunctorType, void>;
     typename functor_analysis_type::Reducer reducer(f);
-    return internal_team_size_recommended_reduce<
-        typename functor_analysis_type::value_type>(
-        CombinedFunctorReducer<FunctorType,
-                               typename functor_analysis_type::Reducer>(
-            f, reducer));
+    return team_size_recommended_internal(f, reducer, tag);
   }
 
   template <class FunctorType, class ReducerType>
   int team_size_recommended(FunctorType const& f, ReducerType const& r,
-                            ParallelReduceTag const&) const {
+                            ParallelReduceTag const& tag) const {
     using functor_analysis_type =
         Impl::FunctorAnalysis<Impl::FunctorPatternInterface::REDUCE,
                               TeamPolicyInternal, ReducerType, void>;
     typename functor_analysis_type::Reducer reducer(r);
-    return internal_team_size_recommended_reduce<
-        typename functor_analysis_type::value_type>(
-        CombinedFunctorReducer<FunctorType,
-                               typename functor_analysis_type::Reducer>(
-            f, reducer));
+    return team_size_recommended_internal(f, reducer, tag);
   }
 
   template <class FunctorType, class ReducerType>


### PR DESCRIPTION
This should fix the failures in https://my.cdash.org/builds/3774254/tests?filters=%7B%22all%22%3A%5B%7B%22eq%22%3A%7B%22status%22%3A%22FAILED%22%7D%7D%5D%7D.

Up to this point, we didn't introspect kernel limits (mostly max registers) when the maximum team size was queried but only took maximum workgroup size and shared memory limitations into account. Issues resulting from that when running on NVIDIA GPUs were addressed by explicitly setting a lower maximum workgroup size.
After updating to the oneAPI 2026.0 release, we were also seeing issues on Intel GPUs in Debug mode.
This pull request finally introspects kernels for the maximum team size. Since the implementation for `TeamPolicy` `parallel_for` is quite straightforward, it's just copied into the respective `TeamPolicy` function.
For `parallel_reduce`, we introduce a `static` function that creates the SYCL kernel we ultimately execute (ignoring the case of an empty range which shouldn't be problematic and have lower limits anyway) which we can then use in the `TeamPolicy` implementation for introspection. It turned out that just creatign a kernel using the user's functor (ignoring all the other functionality needed for the parallel_reduce implementation) wasn't sufficient.
Actually taking the functor into account then also required adding an internal interface for maximum and recommended team size that can be used with a wrapped reducer object (which is what `ParallelReduce` receives). This is analogous to what we are doing for `Cuda` and `HIP`.

### Changelog Entry
- Yes, this is bugfix/improvement.