### PR TITLE
nextsilicon: defer uses of NextAPI until Kokkos::initialize

### DIFF
--- a/core/src/NextSilicon/Kokkos_NextSilicon.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.cpp
@@ -30,10 +30,6 @@ void Kokkos::Experimental::NextSilicon::impl_initialize(
 
   Impl::NextSiliconInternal::default_instance =
       Kokkos::Impl::HostSharedPtr(new Impl::NextSiliconInternal);
-
-  // Kokkos::is_initialized is false still
-  // Run any callbacks registered while creating the default instance.
-  Kokkos::Impl::run_nextsilicon_initialization_callbacks();
 }
 
 void Kokkos::Experimental::NextSilicon::impl_finalize() {

--- a/core/src/NextSilicon/Kokkos_NextSilicon.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.cpp
@@ -4,6 +4,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE
 
 #include <NextSilicon/Kokkos_NextSilicon.hpp>
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
 #include <NextSilicon/Kokkos_NextSilicon_Instance.hpp>
 #include <impl/Kokkos_Profiling.hpp>
 #include <impl/Kokkos_ExecSpaceManager.hpp>
@@ -25,6 +26,8 @@ void Kokkos::Experimental::NextSilicon::impl_initialize(
     InitializationSettings const& /*settings*/) {
   Impl::NextSiliconInternal::default_instance =
       Kokkos::Impl::HostSharedPtr(new Impl::NextSiliconInternal);
+
+  Kokkos::Impl::run_nextsilicon_initialization_callbacks();
 }
 
 void Kokkos::Experimental::NextSilicon::impl_finalize() {

--- a/core/src/NextSilicon/Kokkos_NextSilicon.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.cpp
@@ -24,8 +24,6 @@ Kokkos::Experimental::NextSilicon::~NextSilicon() {
 
 void Kokkos::Experimental::NextSilicon::impl_initialize(
     InitializationSettings const& /*settings*/) {
-  // Kokkos::is_initialized is false still
-  // Run callbacks registered before Kokkos::initialize().
   Kokkos::Impl::run_nextsilicon_initialization_callbacks();
 
   Impl::NextSiliconInternal::default_instance =

--- a/core/src/NextSilicon/Kokkos_NextSilicon.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon.cpp
@@ -24,9 +24,15 @@ Kokkos::Experimental::NextSilicon::~NextSilicon() {
 
 void Kokkos::Experimental::NextSilicon::impl_initialize(
     InitializationSettings const& /*settings*/) {
+  // Kokkos::is_initialized is false still
+  // Run callbacks registered before Kokkos::initialize().
+  Kokkos::Impl::run_nextsilicon_initialization_callbacks();
+
   Impl::NextSiliconInternal::default_instance =
       Kokkos::Impl::HostSharedPtr(new Impl::NextSiliconInternal);
 
+  // Kokkos::is_initialized is false still
+  // Run any callbacks registered while creating the default instance.
   Kokkos::Impl::run_nextsilicon_initialization_callbacks();
 }
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -5,8 +5,8 @@
 
 #include <Kokkos_Abort.hpp>
 
-#include <mutex>
-#include <utility>
+#include <optional>
+#include <utility>  // std::in_place
 #include <vector>
 
 namespace Kokkos::Impl {

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
+
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace Kokkos::Impl {
+
+struct NextSiliconInitializationCallbackEntry {
+  std::string label;
+  std::function<void()> callback;
+};
+
+namespace {
+
+struct NextSiliconInitializationCallbacks {
+  std::mutex mutex;
+  std::vector<NextSiliconInitializationCallbackEntry> pending;
+  bool initialized = false;
+};
+
+NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
+  static NextSiliconInitializationCallbacks callbacks;
+  return callbacks;
+}
+
+}  // namespace
+
+void register_nextsilicon_initialization_callback(
+    std::string label, std::function<void()> callback) {
+  auto& callbacks = nextsilicon_initialization_callbacks();
+  {
+    std::lock_guard<std::mutex> lock(callbacks.mutex);
+    if (!callbacks.initialized) {
+      callbacks.pending.push_back({std::move(label), std::move(callback)});
+      return;
+    }
+  }
+  callback();
+}
+
+void run_nextsilicon_initialization_callbacks() {
+  auto& callbacks = nextsilicon_initialization_callbacks();
+  while (true) {
+    std::vector<NextSiliconInitializationCallbackEntry> pending;
+    {
+      std::lock_guard<std::mutex> lock(callbacks.mutex);
+      if (callbacks.pending.empty()) {
+        callbacks.initialized = true;
+        return;
+      }
+      // Drop the mutex before running callbacks in case callback registers a
+      // callback. Next iteration will pick it up.
+      pending.swap(callbacks.pending);
+    }
+    for (auto& callback : pending) {
+      callback.callback();
+    }
+  }
+}
+
+}  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -44,22 +44,11 @@ void register_nextsilicon_initialization_callback(
 
 void run_nextsilicon_initialization_callbacks() {
   auto& callbacks = nextsilicon_initialization_callbacks();
-  while (true) {
-    std::vector<NextSiliconInitializationCallbackEntry> pending;
-    {
-      std::lock_guard<std::mutex> lock(callbacks.mutex);
-      if (callbacks.pending.empty()) {
-        callbacks.initialized = true;
-        return;
-      }
-      // Drop the mutex before running callbacks in case callback registers a
-      // callback. Next iteration will pick it up.
-      pending.swap(callbacks.pending);
-    }
-    for (auto& callback : pending) {
-      callback.callback();
-    }
+  std::lock_guard<std::mutex> lock(callbacks.mutex);
+  for (auto& callback : callbacks.pending) {
+    callback.callback();
   }
+  callbacks.initialized = true;
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -19,7 +19,6 @@ namespace {
 struct NextSiliconInitializationCallbacks {
   std::mutex mutex;
   std::vector<NextSiliconInitializationCallbackEntry> pending;
-  bool initialized = false;
 };
 
 NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
@@ -32,14 +31,8 @@ NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
 void register_nextsilicon_initialization_callback(
     std::string label, std::function<void()> callback) {
   auto& callbacks = nextsilicon_initialization_callbacks();
-  {
-    std::lock_guard<std::mutex> lock(callbacks.mutex);
-    if (!callbacks.initialized) {
-      callbacks.pending.push_back({std::move(label), std::move(callback)});
-      return;
-    }
-  }
-  callback();
+  std::lock_guard<std::mutex> lock(callbacks.mutex);
+  callbacks.pending.push_back({std::move(label), std::move(callback)});
 }
 
 void run_nextsilicon_initialization_callbacks() {
@@ -48,7 +41,7 @@ void run_nextsilicon_initialization_callbacks() {
   for (auto& callback : callbacks.pending) {
     callback.callback();
   }
-  callbacks.initialized = true;
+  callbacks.pending.clear();
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -3,6 +3,8 @@
 
 #include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
 
+#include <Kokkos_Abort.hpp>
+
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -10,33 +12,27 @@
 namespace Kokkos::Impl {
 
 namespace {
-
-struct NextSiliconInitializationCallbacks {
-  std::mutex mutex;
-  std::vector<std::function<void()>> pending;
-};
-
-NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
-  static NextSiliconInitializationCallbacks callbacks;
-  return callbacks;
-}
-
+std::optional<std::vector<std::function<void()>>> pending{std::in_place};
 }  // namespace
 
 void register_nextsilicon_initialization_callback(
     std::function<void()> callback) {
-  auto& callbacks = nextsilicon_initialization_callbacks();
-  std::lock_guard<std::mutex> lock(callbacks.mutex);
-  callbacks.pending.push_back(std::move(callback));
+  if (!pending)
+    Kokkos::abort(
+        "nextsilicon: initialization callbacks improperly initialized (1). "
+        "Please report this.");
+  pending->push_back(std::move(callback));
 }
 
 void run_nextsilicon_initialization_callbacks() {
-  auto& callbacks = nextsilicon_initialization_callbacks();
-  std::lock_guard<std::mutex> lock(callbacks.mutex);
-  for (auto& callback : callbacks.pending) {
+  if (!pending)
+    Kokkos::abort(
+        "nextsilicon: initialization callbacks improperly initialized (2). "
+        "Please report this.");
+  for (auto& callback : *pending) {
     callback();
   }
-  callbacks.pending.clear();
+  pending->clear();
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -9,16 +9,11 @@
 
 namespace Kokkos::Impl {
 
-struct NextSiliconInitializationCallbackEntry {
-  std::string label;
-  std::function<void()> callback;
-};
-
 namespace {
 
 struct NextSiliconInitializationCallbacks {
   std::mutex mutex;
-  std::vector<NextSiliconInitializationCallbackEntry> pending;
+  std::vector<std::function<void()>> pending;
 };
 
 NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
@@ -29,17 +24,17 @@ NextSiliconInitializationCallbacks& nextsilicon_initialization_callbacks() {
 }  // namespace
 
 void register_nextsilicon_initialization_callback(
-    std::string label, std::function<void()> callback) {
+    std::function<void()> callback) {
   auto& callbacks = nextsilicon_initialization_callbacks();
   std::lock_guard<std::mutex> lock(callbacks.mutex);
-  callbacks.pending.push_back({std::move(label), std::move(callback)});
+  callbacks.pending.push_back(std::move(callback));
 }
 
 void run_nextsilicon_initialization_callbacks() {
   auto& callbacks = nextsilicon_initialization_callbacks();
   std::lock_guard<std::mutex> lock(callbacks.mutex);
   for (auto& callback : callbacks.pending) {
-    callback.callback();
+    callback();
   }
   callbacks.pending.clear();
 }

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
@@ -5,7 +5,6 @@
 #define KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP
 
 #include <functional>
-#include <string>
 
 namespace Kokkos::Impl {
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
@@ -11,7 +11,7 @@ namespace Kokkos::Impl {
 
 // Callbacks must not register additional initialization callbacks.
 void register_nextsilicon_initialization_callback(
-    std::string label, std::function<void()> callback);
+    std::function<void()> callback);
 
 void run_nextsilicon_initialization_callbacks();
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP
+#define KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP
+
+#include <functional>
+#include <string>
+
+namespace Kokkos::Impl {
+
+void register_nextsilicon_initialization_callback(
+    std::string label, std::function<void()> callback);
+
+void run_nextsilicon_initialization_callbacks();
+
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
@@ -9,6 +9,7 @@
 
 namespace Kokkos::Impl {
 
+// Callbacks must not register additional initialization callbacks.
 void register_nextsilicon_initialization_callback(
     std::string label, std::function<void()> callback);
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp>
-
 #include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
 
 #include <Kokkos_InitializeFinalize.hpp>

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp>
+
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
+
+#include <Kokkos_InitializeFinalize.hpp>
+
+#include <nextapi/memory.h>
+
+namespace {
+void impl_migrate_after_initialize(void *obj, size_t size, auto loc) {
+  auto pin = [=] { nextapi_mem_migrate(obj, size, loc, true /*pin*/); };
+  if (Kokkos::is_initialized()) {
+    pin();
+  } else {
+    Kokkos::Impl::register_nextsilicon_initialization_callback(std::move(pin));
+  }
+}
+}  // namespace
+
+namespace Kokkos::Impl {
+
+template <>
+void migrate_after_initialize<PageLocation::Any>(void *, size_t) {
+  // no specific migration requested
+}
+
+template <>
+void migrate_after_initialize<PageLocation::Host>(void *obj, size_t size) {
+  impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_HOST);
+}
+
+template <>
+void migrate_after_initialize<PageLocation::Device>(void *obj, size_t size) {
+  impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_DEVICE);
+}
+
+}  //  namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 void impl_migrate_after_initialize(void *obj, size_t size, auto loc) {
-  auto pin = [=] { nextapi_mem_migrate(obj, size, loc, true /*pin*/); };
+  auto pin = [=] { nextapi_mem_migrate(obj, size, loc, /*pin=*/true); };
   if (Kokkos::is_initialized()) {
     pin();
   } else {

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
@@ -4,8 +4,12 @@
 #ifndef KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 #define KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 
-#include <utility>
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
+
 #include <nextapi/memory.h>
+
+#include <type_traits>
+#include <utility>
 
 namespace Kokkos::Impl {
 
@@ -23,6 +27,8 @@ enum class PageLocation {
 // cause problems when we try to access it from the host.
 template <typename T, PageLocation Location = PageLocation::Any>
 struct alignas(PAGE_SIZE) PageAlignedData {
+  static constexpr PageLocation location = Location;
+
   T data;
 
   operator T&() { return data; }
@@ -32,9 +38,19 @@ struct alignas(PAGE_SIZE) PageAlignedData {
     requires(!(sizeof...(Args) == 1 &&
                (std::is_same_v<std::decay_t<Args>, PageAlignedData> && ...)))
   PageAlignedData(Args&&... args) : data{std::forward<Args>(args)...} {
-    if constexpr (Location == PageLocation::Host) {
-      // Pin this variable to host memory to prevent migration to device.
-      nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST, true);
+    if constexpr (location != PageLocation::Any) {
+      register_nextsilicon_initialization_callback(
+          "PageAlignedData pin in ctor", [this] {
+            if constexpr (location == PageLocation::Host) {
+              // Move this object to system DRAM and pin it there.
+              nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST,
+                                  true /*pin*/);
+            } else if constexpr (location == PageLocation::Device) {
+              // Move this object to accelerator HBM and pin it there.
+              nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_DEVICE,
+                                  true /*pin*/);
+            }
+          });
     }
   }
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
@@ -6,6 +6,8 @@
 
 #include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
 
+#include <impl/Kokkos_InitializeFinalize.hpp>
+
 #include <nextapi/memory.h>
 
 #include <type_traits>
@@ -39,18 +41,23 @@ struct alignas(PAGE_SIZE) PageAlignedData {
                (std::is_same_v<std::decay_t<Args>, PageAlignedData> && ...)))
   PageAlignedData(Args&&... args) : data{std::forward<Args>(args)...} {
     if constexpr (location != PageLocation::Any) {
-      register_nextsilicon_initialization_callback(
-          "PageAlignedData pin in ctor", [this] {
-            if constexpr (location == PageLocation::Host) {
-              // Move this object to system DRAM and pin it there.
-              nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST,
-                                  true /*pin*/);
-            } else if constexpr (location == PageLocation::Device) {
-              // Move this object to accelerator HBM and pin it there.
-              nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_DEVICE,
-                                  true /*pin*/);
-            }
-          });
+      auto pin = [this] {
+        if constexpr (location == PageLocation::Host) {
+          // Move this object to system DRAM and pin it there.
+          nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST,
+                              true /*pin*/);
+        } else if constexpr (location == PageLocation::Device) {
+          // Move this object to accelerator HBM and pin it there.
+          nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_DEVICE,
+                              true /*pin*/);
+        }
+      };
+      if (Kokkos::is_initialized()) {
+        pin();
+      } else {
+        register_nextsilicon_initialization_callback(
+            "PageAlignedData pin in ctor", std::move(pin));
+      }
     }
   }
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
@@ -55,8 +55,7 @@ struct alignas(PAGE_SIZE) PageAlignedData {
       if (Kokkos::is_initialized()) {
         pin();
       } else {
-        register_nextsilicon_initialization_callback(
-            "PageAlignedData pin in ctor", std::move(pin));
+        register_nextsilicon_initialization_callback(std::move(pin));
       }
     }
   }

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
@@ -4,12 +4,6 @@
 #ifndef KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 #define KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 
-#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
-
-#include <impl/Kokkos_InitializeFinalize.hpp>
-
-#include <nextapi/memory.h>
-
 #include <type_traits>
 #include <utility>
 
@@ -22,6 +16,9 @@ enum class PageLocation {
   Device,
   Any,
 };
+
+template <PageLocation>
+void migrate_after_initialize(void* obj, size_t size);
 
 // This struct is aligned to 4096 bytes (page size) to work around
 // issues with NextSilicon page migration. It can be pinned to the host
@@ -40,24 +37,7 @@ struct alignas(PAGE_SIZE) PageAlignedData {
     requires(!(sizeof...(Args) == 1 &&
                (std::is_same_v<std::decay_t<Args>, PageAlignedData> && ...)))
   PageAlignedData(Args&&... args) : data{std::forward<Args>(args)...} {
-    if constexpr (location != PageLocation::Any) {
-      auto pin = [this] {
-        if constexpr (location == PageLocation::Host) {
-          // Move this object to system DRAM and pin it there.
-          nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_HOST,
-                              true /*pin*/);
-        } else if constexpr (location == PageLocation::Device) {
-          // Move this object to accelerator HBM and pin it there.
-          nextapi_mem_migrate(this, sizeof(*this), NEXTAPI_PAGE_LOC_DEVICE,
-                              true /*pin*/);
-        }
-      };
-      if (Kokkos::is_initialized()) {
-        pin();
-      } else {
-        register_nextsilicon_initialization_callback(std::move(pin));
-      }
-    }
+    migrate_after_initialize<location>(this, sizeof(*this));
   }
 
   PageAlignedData& operator=(const T& data_) {

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -835,6 +835,9 @@ if(Kokkos_ENABLE_NEXTSILICON)
       # ${CMAKE_CURRENT_BINARY_DIR}/nextsilicon/TestNextSilicon_DeepCopyAlignment.cpp # MDRange parallel for
   )
   kokkos_add_executable_and_test(CoreUnitTest_NextSilicon SOURCES UnitTestMainInit.cpp ${NEXTSILICON_SOURCES})
+  kokkos_add_executable_and_test(
+    CoreUnitTest_NextSiliconInitializationCallbacks SOURCES nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+  )
 endif()
 
 set(DEFAULT_DEVICE_SOURCES

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -8,16 +8,11 @@
 
 namespace {
 
-bool callback_ran        = false;
-bool nested_callback_ran = false;
+bool callback_ran = false;
 
 TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_TRUE(callback_ran); }
 
-TEST(nextsilicon, InitializationNestedCallbacksRun) {
-  EXPECT_TRUE(nested_callback_ran);
-}
-
-// reset the callback state and check that the callback runs immediately
+// Check that callbacks registered after initialization run immediately.
 TEST(nextsilicon, InitializationCallbacksRunImmediately) {
   bool local_callback_ran = false;
   Kokkos::Impl::register_nextsilicon_initialization_callback(
@@ -30,12 +25,8 @@ TEST(nextsilicon, InitializationCallbacksRunImmediately) {
 
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
-      "TestNextSilicon_InitializationCallbacks::deferred", [&] {
-        callback_ran = true;
-        Kokkos::Impl::register_nextsilicon_initialization_callback(
-            "TestNextSilicon_InitializationCallbacks::while_draining",
-            [&] { nested_callback_ran = true; });
-      });
+      "TestNextSilicon_InitializationCallbacks::deferred",
+      [] { callback_ran = true; });
 
   Kokkos::initialize(argc, argv);
 

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -8,16 +8,16 @@
 
 namespace {
 
-bool callback_ran = false;
+int callback_ran = 0;
 
-TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_TRUE(callback_ran); }
+TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_EQ(callback_ran, 1); }
 
 }  // namespace
 
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
       "TestNextSilicon_InitializationCallbacks::deferred",
-      [] { callback_ran = true; });
+      [] { ++callback_ran; });
 
   Kokkos::initialize(argc, argv);
 

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -16,7 +16,6 @@ TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_EQ(callback_ran, 1); }
 
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
-      "TestNextSilicon_InitializationCallbacks::deferred",
       [] { ++callback_ran; });
 
   Kokkos::initialize(argc, argv);

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[]) {
 
   Kokkos::initialize(argc, argv);
 
-  // Force linker to pull in Kokkos_NextSilicon.cpp so NextSilicon backend get
+  // Force linker to pull in Kokkos_NextSilicon.cpp so NextSilicon backend gets
   // registered via initialize_space_factory
   { Kokkos::Experimental::NextSilicon sp{}; }
 

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -14,6 +14,8 @@ TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_EQ(callback_ran, 1); }
 
 }  // namespace
 
+// FIXME_NEXTSILICON: integrate with existing InitializeFinalize tests once
+// DeathTests are supported by NextSilicon toolchain.
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
       [] { ++callback_ran; });

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -12,15 +12,6 @@ bool callback_ran = false;
 
 TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_TRUE(callback_ran); }
 
-// Check that callbacks registered after initialization run immediately.
-TEST(nextsilicon, InitializationCallbacksRunImmediately) {
-  bool local_callback_ran = false;
-  Kokkos::Impl::register_nextsilicon_initialization_callback(
-      "TestNextSilicon_InitializationCallbacks::immediate",
-      [&] { local_callback_ran = true; });
-  EXPECT_TRUE(local_callback_ran);
-}
-
 }  // namespace
 
 int main(int argc, char* argv[]) {

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <gtest/gtest.h>
+
+namespace {
+
+bool callback_ran        = false;
+bool nested_callback_ran = false;
+
+TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_TRUE(callback_ran); }
+
+TEST(nextsilicon, InitializationNestedCallbacksRun) {
+  EXPECT_TRUE(nested_callback_ran);
+}
+
+// reset the callback state and check that the callback runs immediately
+TEST(nextsilicon, InitializationCallbacksRunImmediately) {
+  bool local_callback_ran = false;
+  Kokkos::Impl::register_nextsilicon_initialization_callback(
+      "TestNextSilicon_InitializationCallbacks::immediate",
+      [&] { local_callback_ran = true; });
+  EXPECT_TRUE(local_callback_ran);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  Kokkos::Impl::register_nextsilicon_initialization_callback(
+      "TestNextSilicon_InitializationCallbacks::deferred", [] {
+        callback_ran = true;
+        Kokkos::Impl::register_nextsilicon_initialization_callback(
+            "TestNextSilicon_InitializationCallbacks::while_draining",
+            [] { nested_callback_ran = true; });
+      });
+
+  Kokkos::initialize(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int result = RUN_ALL_TESTS();
+  Kokkos::finalize();
+  return result;
+}

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -30,14 +30,19 @@ TEST(nextsilicon, InitializationCallbacksRunImmediately) {
 
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
-      "TestNextSilicon_InitializationCallbacks::deferred", [] {
+      "TestNextSilicon_InitializationCallbacks::deferred", [&] {
         callback_ran = true;
         Kokkos::Impl::register_nextsilicon_initialization_callback(
             "TestNextSilicon_InitializationCallbacks::while_draining",
-            [] { nested_callback_ran = true; });
+            [&] { nested_callback_ran = true; });
       });
 
   Kokkos::initialize(argc, argv);
+
+  // Force linker to pull in Kokkos_NextSilicon.cpp so NextSilicon backend get
+  // registered via initialize_space_factory
+  { Kokkos::Experimental::NextSilicon sp{}; }
+
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();


### PR DESCRIPTION
In general, it's probably best to defer as much as possible to `Kokkos::initialize`.

Specifically, using NextAPI before `MPI_Init` can cause MPI errors. Since applications usually call `MPI_Init` before `Kokkos::initialize`, deferring NextAPI calls fix a common cause of MPI errors on NextSilicon.

NextAPI is used within a global static PageAlignedData to implement `KOKKOS_IF_ON_HOST` / `KOKKOS_IF_ON_DEVICE`, which prior to this PR, happened before `main()` and therefore before `MPI_Init`.

This PR adds a initialization callback queue: before Kokkos::initialize, callbacks are saved up. At Kokkos::initialize, they are executed. PageAlignedData checks whether Kokoks has been initialized and either registers a callback, or invokes the pinning function directly.