### PR TITLE
nextsilicon: pin device mutex to host

### DIFF
--- a/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_Instance.hpp
@@ -21,7 +21,7 @@ namespace Kokkos::Experimental::Impl {
 class NextSiliconInternal {
   Impl::NextSiliconHeapBuffer functorBuffer_;
   ::Kokkos::Impl::PageAlignedData<std::mutex,
-                                  ::Kokkos::Impl::PageLocation::Device>
+                                  ::Kokkos::Impl::PageLocation::Host>
       device_mutex_;
 
   NextSiliconInternal(const NextSiliconInternal&)            = delete;


### PR DESCRIPTION
This mutex is intended to control access to the device from multiple host threads, and is only ever accessed from the host. It should be pinned to the host.

@kc9jud 