### PR TITLE
Allow using sycl::is_device_copyable for all SYCL backends

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -209,21 +209,21 @@ class SYCLInternal {
 // GPUS for all arguments handed to a kernel, assume for now that the rest
 // doesn't need more than roughly 256 bytes.
 #ifdef KOKKOS_IMPL_ARCH_NVIDIA_GPU
-#define KOKKOS_SYCL_KERNEL_SIZE_LIMIT 3750
+#define KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT 3750
 #else  // assume the stricter Intel GPU limit
-#define KOKKOS_SYCL_KERNEL_SIZE_LIMIT 1800
+#define KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT 1800
 #endif
 #if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= KOKKOS_SYCL_KERNEL_SIZE_LIMIT)>
+          bool ManualCopy = (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT)>
 class SYCLFunctionWrapper;
 #else
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= KOKKOS_SYCL_KERNEL_SIZE_LIMIT ||
+          bool ManualCopy = (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT ||
                              !std::is_trivially_copyable_v<Functor>)>
 class SYCLFunctionWrapper;
 #endif
-#undef KOKKOS_SYCL_KERNEL_SIZE_LIMIT
+#undef KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT
 
 #if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage>

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -205,18 +205,25 @@ class SYCLInternal {
   }
 };
 
-// FIXME_SYCL the limit is 2048 bytes for all arguments handed to a kernel,
-// assume for now that the rest doesn't need more than 248 bytes.
+// FIXME_SYCL the limit is 2048 bytes for Intel GPUs and 4000 bytes for NVIDIA
+// GPUS for all arguments handed to a kernel, assume for now that the rest
+// doesn't need more than roughly 256 bytes.
+#ifdef KOKKOS_IMPL_ARCH_NVIDIA_GPU
+#define KOKKOS_SYCL_KERNEL_SIZE_LIMIT 3750
+#else  // assume the stricter Intel GPU limit
+#define KOKKOS_SYCL_KERNEL_SIZE_LIMIT 1800
+#endif
 #if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= 1800)>
+          bool ManualCopy = (sizeof(Functor) >= KOKKOS_SYCL_KERNEL_SIZE_LIMIT)>
 class SYCLFunctionWrapper;
 #else
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= 1800 ||
+          bool ManualCopy = (sizeof(Functor) >= KOKKOS_SYCL_KERNEL_SIZE_LIMIT ||
                              !std::is_trivially_copyable_v<Functor>)>
 class SYCLFunctionWrapper;
 #endif
+#undef KOKKOS_SYCL_KERNEL_SIZE_LIMIT
 
 #if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage>

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -215,12 +215,14 @@ class SYCLInternal {
 #endif
 #if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT)>
+          bool ManualCopy =
+              (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT)>
 class SYCLFunctionWrapper;
 #else
 template <typename Functor, typename Storage,
-          bool ManualCopy = (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT ||
-                             !std::is_trivially_copyable_v<Functor>)>
+          bool ManualCopy =
+              (sizeof(Functor) >= KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT ||
+               !std::is_trivially_copyable_v<Functor>)>
 class SYCLFunctionWrapper;
 #endif
 #undef KOKKOS_IMPL_SYCL_KERNEL_SIZE_LIMIT

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -207,7 +207,7 @@ class SYCLInternal {
 
 // FIXME_SYCL the limit is 2048 bytes for all arguments handed to a kernel,
 // assume for now that the rest doesn't need more than 248 bytes.
-#if defined(SYCL_DEVICE_COPYABLE) && defined(KOKKOS_ARCH_INTEL_GPU)
+#if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage,
           bool ManualCopy = (sizeof(Functor) >= 1800)>
 class SYCLFunctionWrapper;
@@ -218,7 +218,7 @@ template <typename Functor, typename Storage,
 class SYCLFunctionWrapper;
 #endif
 
-#if defined(SYCL_DEVICE_COPYABLE) && defined(KOKKOS_ARCH_INTEL_GPU)
+#if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage>
 class SYCLFunctionWrapper<Functor, Storage, false> {
   // We need a union here so that we can avoid calling a constructor for m_f
@@ -308,7 +308,7 @@ auto make_sycl_function_wrapper(const Functor& functor, Storage& storage) {
 }  // namespace Impl
 }  // namespace Kokkos
 
-#if defined(SYCL_DEVICE_COPYABLE) && defined(KOKKOS_ARCH_INTEL_GPU)
+#if defined(SYCL_DEVICE_COPYABLE)
 template <typename Functor, typename Storage>
 struct sycl::is_device_copyable<
     Kokkos::Impl::SYCLFunctionWrapper<Functor, Storage, false>>


### PR DESCRIPTION
The restriction for only using sycl::is_device_copyable with Intel GPUs is likely unnecessary by now. We might still need to adjust the maximum kernel argument size (which can be obtained via `device.get_info<sycl::info::device::max_parameter_size>()` at runtime).
On an A100, I'm seeing 4000.

### Related issues / PRs
Related to https://github.com/kokkos/kokkos/issues/9294.

### Changelog Entry
- Yes