### PR TITLE
Fix SYCL InterOp_Graph test for icpx 2026.1

### DIFF
--- a/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Graph.cpp
@@ -85,7 +85,7 @@ TEST(TEST_CATEGORY, graph_instantiate_and_debug_dot_print) {
   // Therefore, we just look for the functor and policy. Note that the
   // signature is mangled in the 'dot' output before icpx 2026.
 #if defined(KOKKOS_COMPILER_INTEL_LLVM) && \
-    KOKKOS_COMPILER_INTEL_LLVM >= 20260100
+    KOKKOS_COMPILER_INTEL_LLVM >= 20260200
   const std::string expected("Increment<Kokkos::View<int, Kokkos::SYCL> >");
 #else
   const std::string expected("[A-Za-z0-9_]+Increment[A-Za-z0-9_]+RangePolicy");


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/kokkos/pull/9006. Apparently, Intel decided in the end to release 2026.1.0 without https://github.com/intel/llvm/pull/21496.