### PR TITLE
Fix compiling Kokkos_CoreTestCompileOnly with NVHPC

### DIFF
--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentSubview.hpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentSubview.hpp
@@ -224,6 +224,9 @@ void test_subview_expand(const E& exts, const A& acc) {
 }
 }  // namespace
 
+// FIXME_NVHPC This particular case causes internal compiler errors with
+// NVHPC 23.7
+#ifndef KOKKOS_COMPILER_NVHPC
 TEST(TEST_CATEGORY, view_mdspan_args_subview) {
   using mem_t = typename TEST_EXECSPACE::memory_space;
   // rank 1
@@ -301,3 +304,4 @@ TEST(TEST_CATEGORY, view_mdspan_args_subview) {
       Kokkos::Experimental::Accessor<float, mem_t,
                                      Kokkos::MemoryTraits<Kokkos::Atomic>>());
 }
+#endif

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentTypeDefs.cpp
@@ -146,8 +146,8 @@ static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, 
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
 static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, SD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
 
-// FIXME_OPENACC, FIXME_NVHPC This particular case causes internal compiler errors with NVHPC 23.7
-#ifndef KOKKOS_ENABLE_OPENACC
+// FIXME_NVHPC This particular case causes internal compiler errors with NVHPC 23.7
+#ifndef KOKKOS_COMPILER_NVHPC
 static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SH, Kokkos::MemoryTraits<>>());
 #endif
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
@@ -158,7 +158,10 @@ static_assert(test_derived_types<f,  Kokkos::extents<unsigned, d, d, 2, 3>, LL, 
 #ifdef KOKKOS_HAS_SHARED_SPACE
 using SS = Kokkos::SharedSpace;
 
+// FIXME_NVHPC This particular case causes internal compiler errors with NVHPC 23.7
+#ifndef KOKKOS_COMPILER_NVHPC
 static_assert(test_derived_types<f,  Kokkos::dextents<unsigned, 0>,         LL, SS, Kokkos::MemoryTraits<>>());
+#endif
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 2>,         LR, SS, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
 static_assert(test_derived_types<f,  Kokkos::extents<unsigned, 2, 3>,       LL, SS, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
 static_assert(test_derived_types<cf, Kokkos::dextents<unsigned, 8>,         LR, SS, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());


### PR DESCRIPTION
Fixes https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-9360/5/stages/?selected-node=370:
```
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] "/var/jenkins/workspace/Kokkos_PR-9360/tpls/mdspan/include/mdspan/../experimental/__p2630_bits/submdspan_mapping.hpp", line 62: internal error: assertion failed at: "lower_init.cpp", line 9766 in copy_non_static_data_member_initializers_if_necessary
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER]   one_slice_out_of_bounds(const IndexType &ext, const Slice &slice) { 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER]                                                              ^
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] 1 catastrophic error detected in the compilation of "/tmp/tmpxft_00001f23_00000000-6_TestOpenMP_View_ViewMDSpanTemplateArgumentSubview.cudafe1.cpp".
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] Compilation aborted.
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] nvc++-Fatal-/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/tools/cpp1 TERMINATED by signal 6
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] Arguments to /opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/tools/cpp1
[CUDA-12.2-NVHPC-AS-HOST-COMPILER] /opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/bin/tools/cpp1 --llalign -Dunix -D__unix -D__unix__ -Dlinux -D__linux -D__linux__ -D__NO_MATH_INLINES -D__LP64__ -D__x86_64 -D__x86_64__ -D__LONG_MAX__=9223372036854775807L '-D__SIZE_TYPE__=unsigned long int' '-D__PTRDIFF_TYPE__=long int' -D__amd64 -D__amd64__ -D__k8 -D__k8__ -D__MMX__ -D__SSE__ -D__SSE2__ -D__SSE3__ -D__SSSE3__ -D__ABM__ -D__SSE4_1__ -D__SSE4_2__ -D__AVX__ -D__AVX2__ -D__AVX512F__ -D__AVX512CD__ -D__AVX512VL__ -D__AVX512BW__ -D__AVX512DQ__ -D__AVX512VNNI__ -D__F16C__ -D__FMA__ -D__XSAVE__ -D__XSAVEOPT__ -D__XSAVEC__ -D__XSAVES__ -D__POPCNT__ -D__AES__ -D__PCLMUL__ -D__CLFLUSHOPT__ -D__FSGSBASE__ -D__RDRND__ -D__BMI__ -D__BMI2__ -D__LZCNT__ -D__FXSR__ -D__PKU__ -D__PGI -D__NVCOMPILER -D_GNU_SOURCE -D_PGCG_SOURCE --c++20 -I- -I/var/jenkins/workspace/Kokkos_PR-9360/build/core/unit_test -I/var/jenkins/workspace/Kokkos_PR-9360/core/unit_test -I/var/jenkins/workspace/Kokkos_PR-9360/core/unit_test/category_files -I/var/jenkins/workspace/Kokkos_PR-9360/build -I/var/jenkins/workspace/Kokkos_PR-9360/build/core/src -I/var/jenkins/workspace/Kokkos_PR-9360/core/src -I/var/jenkins/workspace/Kokkos_PR-9360/build/containers/src -I/var/jenkins/workspace/Kokkos_PR-9360/containers/src -I/var/jenkins/workspace/Kokkos_PR-9360/build/algorithms/src -I/var/jenkins/workspace/Kokkos_PR-9360/algorithms/src -I/var/jenkins/workspace/Kokkos_PR-9360/build/simd/src -I/var/jenkins/workspace/Kokkos_PR-9360/simd/src -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/include -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/bin/../targets/x86_64-linux/include -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/nvshmem/include -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/comm_libs/nccl/include -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/extras/qd/include/qd -I/opt/nvidia/hpc_sdk/Linux_x86_64/23.7/math_libs/include -I/usr/local/gdrcopy/include --sys_include /var/jenkins/workspace/Kokkos_PR-9360/tpls/gtest --sys_include /var/jenkins/workspace/Kokkos_PR-9360/tpls/desul/include --sys_include /var/jenkins/workspace/Kokkos_PR-9360/tpls/mdspan/include --sys_include /opt/nvidia/hpc_sdk/Linux_x86_64/23.7/cuda/12.2/include --sys_include /opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include --sys_include /opt/nvidia/hpc_sdk/Linux_x86_64/23.7/compilers/include-stdexec --sys_include /usr/local/gdrcopy/include --sys_include . --sys_include /usr/include/c++/11 --sys_include /usr/include/x86_64-linux-gnu/c++/11 --sys_include /usr/include/c++/11/backward --sys_include /usr/lib/gcc/x86_64-linux-gnu/11/include --sys_include /usr/local/include --sys_include /usr/include/x86_64-linux-gnu --sys_include /usr/include -D__PGLLVM__ -D__NVCOMPILER_LLVM__ -D__extension__= -D_OPENMP=202011 -DPGI_TESLA_TARGET -D__CUDA_ARCH__=700 -D__CUDA_ARCH_LIST__=700 -DCUDA_DOUBLE_MATH_FUNCTIONS --gnu_version=110400 -D__pgnu_vsn=110400 --no_fixed_bp --nvcchost --preinclude _cplus_nvcc.h -D__NVCC_HOST__ --diag_all_error --diag_suppress implicit_return_from_non_void_function -g --no_rtti --mp -D_OPENMP=202011 --diag_all_error -q -o /tmp/nvc++9eac3ormn92s.il /tmp/tmpxft_00001f23_00000000-6_TestOpenMP_View_ViewMDSpanTemplateArgumentSubview.cudafe1.cpp
```