### PR TITLE
HIP: emit abort message on Windows device path

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Abort.hpp
+++ b/core/src/HIP/Kokkos_HIP_Abort.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_HIP_ABORT_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_Printf.hpp>
 
 #include <hip/hip_runtime.h>
 
@@ -16,7 +17,17 @@ namespace Impl {
 [[noreturn]] __device__ __attribute__((noinline)) inline void hip_abort(
     char const *msg) {
   const char empty[] = "";
+#if defined(_WIN32)
+  // ROCm's Windows device runtime ships no glibc __assert_fail. Emit the
+  // message via device printf (as the SYCL backend does on _MSC_VER), then
+  // abort(). The while(true) guard below preserves [[noreturn]] since abort()
+  // is not itself marked [[noreturn]].
+  (void)empty;
+  Kokkos::printf("Aborting with message %s.\n", msg);
+  abort();
+#else
   __assert_fail(msg, empty, 0, empty);
+#endif
   // This loop is never executed. It's intended to suppress warnings that the
   // function returns, even though it does not. This is necessary because
   // abort() is not marked as [[noreturn]], even though it does not return.


### PR DESCRIPTION
Guard the HIP device-abort's `__assert_fail` call behind `!_WIN32`. ROCm's Windows device runtime ships no glibc `__assert_fail`, so the HIP backend failed to build on Windows (`__assert_fail` undeclared in `Kokkos_HIP_Abort.hpp`). On Windows we now emit the abort message via `Kokkos::printf` and then call `abort()` — preserving the diagnostic message instead of terminating silently, and mirroring how the SYCL backend already handles this case (`_MSC_VER`) in [`Kokkos_SYCL_Abort.hpp`](core/src/SYCL/Kokkos_SYCL_Abort.hpp). The Linux path and `[[noreturn]]` semantics are unchanged.

### Related issues / PRs

Fixes #9097 (Windows + HIP build fails, `__assert_fail` undeclared).

### Changelog Entry

- Fix HIP `Kokkos::abort` on Windows: ROCm's Windows device runtime lacks glibc `__assert_fail`, which broke the HIP backend build (#9097). The abort message is now emitted via `Kokkos::printf` before `abort()`, so device aborts build and print their message on Windows.
