### PR TITLE
Fix RangePolicy parallel_for with small IndexType

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -99,8 +99,8 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     KOKKOS_ASSERT(block_size > 0);
     dim3 block(1, block_size, 1);
     const int maxGridSizeX = m_policy.space().cuda_device_prop().maxGridSize[0];
-    dim3 grid(std::min(uint64_t((nwork + block.y - 1) / block.y),
-                       uint64_t(maxGridSizeX)),
+    dim3 grid(std::min(static_cast<uint32_t>((nwork + block.y - 1) / block.y),
+                       static_cast<uint32_t>(maxGridSizeX)),
               1, 1);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_Range.hpp
@@ -99,10 +99,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::Cuda> {
     KOKKOS_ASSERT(block_size > 0);
     dim3 block(1, block_size, 1);
     const int maxGridSizeX = m_policy.space().cuda_device_prop().maxGridSize[0];
-    dim3 grid(
-        std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
-                 typename Policy::index_type(maxGridSizeX)),
-        1, 1);
+    dim3 grid(std::min(uint64_t((nwork + block.y - 1) / block.y),
+                       uint64_t(maxGridSizeX)),
+              1, 1);
 #ifdef KOKKOS_IMPL_DEBUG_CUDA_SERIAL_EXECUTION
     if (Kokkos::Impl::CudaInternal::cuda_use_serial_execution()) {
       block = dim3(1, 1, 1);

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -95,10 +95,9 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     }
     const dim3 block(1, block_size, 1);
     const int maxGridSizeX = m_policy.space().hip_device_prop().maxGridSize[0];
-    const dim3 grid(
-        std::min(typename Policy::index_type((nwork + block.y - 1) / block.y),
-                 typename Policy::index_type(maxGridSizeX)),
-        1, 1);
+    const dim3 grid(std::min(uint64_t((nwork + block.y - 1) / block.y),
+                             uint64_t(maxGridSizeX)),
+                    1, 1);
 
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),

--- a/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
+++ b/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp
@@ -95,9 +95,10 @@ class ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>, Kokkos::HIP> {
     }
     const dim3 block(1, block_size, 1);
     const int maxGridSizeX = m_policy.space().hip_device_prop().maxGridSize[0];
-    const dim3 grid(std::min(uint64_t((nwork + block.y - 1) / block.y),
-                             uint64_t(maxGridSizeX)),
-                    1, 1);
+    const dim3 grid(
+        std::min(static_cast<uint32_t>((nwork + block.y - 1) / block.y),
+                 static_cast<uint32_t>(maxGridSizeX)),
+        1, 1);
 
     Kokkos::Impl::hip_parallel_launch<DriverType, LaunchBounds>(
         *this, grid, block, 0, m_policy.space().impl_internal_space_instance(),

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -91,7 +91,7 @@ template <typename T>
 constexpr hpx_range<T> get_chunk_range(const T i_chunk, const T offset,
                                        const T chunk_size, const T max) {
   const T begin = offset + i_chunk * chunk_size;
-  const T end   = (std::min)(begin + chunk_size, max);
+  const T end   = std::min(static_cast<T>(begin + chunk_size), max);
   return {begin, end};
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -101,8 +101,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
       (void)memcpy_event;
 #endif
 
-      const typename Policy::index_type actual_range =
-          policy.end() - policy.begin();
+      const auto actual_range = static_cast<typename Policy::index_type>(
+          policy.end() - policy.begin());
       if (policy.chunk_size() <= 1) {
 #ifdef SYCL_EXT_ONEAPI_AUTO_LOCAL_RANGE
         FunctorWrapperRangePolicyParallelForCustom<Functor, Policy> f{

--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Range.hpp
@@ -101,7 +101,8 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::RangePolicy<Traits...>,
       (void)memcpy_event;
 #endif
 
-      const auto actual_range = policy.end() - policy.begin();
+      const typename Policy::index_type actual_range =
+          policy.end() - policy.begin();
       if (policy.chunk_size() <= 1) {
 #ifdef SYCL_EXT_ONEAPI_AUTO_LOCAL_RANGE
         FunctorWrapperRangePolicyParallelForCustom<Functor, Policy> f{

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -487,6 +487,8 @@ void test_small_index_type() {
 }
 
 TEST(TEST_CATEGORY, small_index_type) {
+  // FIXME_OPENACC: device parallel loops using a type smaller than int for
+  // their loop variable are not executed
 #if defined(KOKKOS_ENABLE_OPENACC)
   if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
     GTEST_SKIP() << "OpenACC doesn't support index types smaller than int";

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -466,6 +466,24 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
 }
 #endif
 
+void test_small_index_type() {
+  using ExecutionSpace = typename TEST_EXECSPACE::execution_space;
+  constexpr int size   = 1024;
+  Kokkos::View<int *, TEST_EXECSPACE::memory_space> v("v", size);
+
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
+      KOKKOS_LAMBDA(short i) { v(i) += i; });
+
+  int sum;
+  Kokkos::parallel_reduce(
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
+      KOKKOS_LAMBDA(short i, int &partial_sum) { partial_sum += v(i); }, sum);
+  ASSERT_EQ(sum, ((size - 1) * size) / 2);
+}
+
+TEST(TEST_CATEGORY, small_index_type) { test_small_index_type(); }
+
 TEST(TEST_CATEGORY, check_batch_size) {
   ASSERT_TRUE(Kokkos::Experimental::StaticBatchSize<1>::batch_size == 1);
   ASSERT_TRUE(Kokkos::Experimental::StaticBatchSize<4>::batch_size == 4);

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -466,28 +466,36 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
 }
 #endif
 
+template <class IndexType>
 void test_small_index_type() {
   using ExecutionSpace = typename TEST_EXECSPACE::execution_space;
   constexpr int size   = 1024;
   Kokkos::View<int*, TEST_EXECSPACE::memory_space> v("v", size);
 
   Kokkos::parallel_for(
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
-      KOKKOS_LAMBDA(short i) { v(i) += i; });
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>(0,
+                                                                        size),
+      KOKKOS_LAMBDA(IndexType i) { v(i) += i; });
 
   int sum;
   Kokkos::parallel_reduce(
-      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
-      KOKKOS_LAMBDA(short i, int& partial_sum) { partial_sum += v(i); }, sum);
+      Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<IndexType>>(0,
+                                                                        size),
+      KOKKOS_LAMBDA(IndexType i, int& partial_sum) { partial_sum += v(i); },
+      sum);
   ASSERT_EQ(sum, ((size - 1) * size) / 2);
 }
 
 TEST(TEST_CATEGORY, small_index_type) {
 #if defined(KOKKOS_ENABLE_OPENACC)
-  GTEST_SKIP() << "OpenACC doesn't support index types smaller than int";
-#else
-  test_small_index_type();
+  if constexpr (std::is_same_v<TEST_EXECSPACE, Kokkos::Experimental::OpenACC>) {
+    GTEST_SKIP() << "OpenACC doesn't support index types smaller than int";
+  } else
 #endif
+  {
+    test_small_index_type<short>();
+    test_small_index_type<unsigned short>();
+  }
 }
 
 TEST(TEST_CATEGORY, check_batch_size) {

--- a/core/unit_test/TestRange.hpp
+++ b/core/unit_test/TestRange.hpp
@@ -18,7 +18,7 @@ template <class ExecSpace, class ScheduleType>
 struct TestRange {
   using value_type = int;  ///< alias required for the parallel_reduce
 
-  using view_type = Kokkos::View<value_type *, ExecSpace>;
+  using view_type = Kokkos::View<value_type*, ExecSpace>;
 
   view_type m_flags;
   view_type result_view;
@@ -115,36 +115,36 @@ struct TestRange {
   void operator()(const int i) const { m_flags(i) = i; }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const VerifyInitTag &, const int i) const {
+  void operator()(const VerifyInitTag&, const int i) const {
     if (i != m_flags(i)) {
       Kokkos::printf("TestRange::test_for_error at %d != %d\n", i, m_flags(i));
     }
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const ResetTag &, const int i) const {
+  void operator()(const ResetTag&, const int i) const {
     m_flags(i) = 2 * m_flags(i);
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const VerifyResetTag &, const int i) const {
+  void operator()(const VerifyResetTag&, const int i) const {
     if (2 * i != m_flags(i)) {
       Kokkos::printf("TestRange::test_for_error at %d != %d\n", i, m_flags(i));
     }
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const PosOffsetTag &, const int i) const {
+  void operator()(const PosOffsetTag&, const int i) const {
     m_flags(i - offset) = i;
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const NegOffsetTag &, const int i) const {
+  void operator()(const NegOffsetTag&, const int i) const {
     m_flags(i + offset) = i;
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const VerifyPosOffsetTag &, const int i) const {
+  void operator()(const VerifyPosOffsetTag&, const int i) const {
     if (i + offset != m_flags(i)) {
       Kokkos::printf("TestRange::test_for_error at %d != %d\n", i + offset,
                      m_flags(i));
@@ -152,7 +152,7 @@ struct TestRange {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const VerifyNegOffsetTag &, const int i) const {
+  void operator()(const VerifyNegOffsetTag&, const int i) const {
     if (i - offset != m_flags(i)) {
       Kokkos::printf("TestRange::test_for_error at %d != %d\n", i - offset,
                      m_flags(i));
@@ -195,17 +195,17 @@ struct TestRange {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const int i, value_type &update) const {
+  void operator()(const int i, value_type& update) const {
     update += m_flags(i);
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const PosOffsetTag &, const int i, value_type &update) const {
+  void operator()(const PosOffsetTag&, const int i, value_type& update) const {
     update += 1 + m_flags(i - offset);
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const NegOffsetTag &, const int i, value_type &update) const {
+  void operator()(const NegOffsetTag&, const int i, value_type& update) const {
     update += 1 + m_flags(i + offset);
   }
 
@@ -216,12 +216,12 @@ struct TestRange {
     int const concurrency = ExecSpace().concurrency();
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
+      Kokkos::View<size_t*, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
-      Kokkos::View<int *, ExecSpace> a("A", N);
+      Kokkos::View<int*, ExecSpace> a("A", N);
 
       Kokkos::parallel_for(
-          policy_t(0, N), KOKKOS_LAMBDA(const int &i) {
+          policy_t(0, N), KOKKOS_LAMBDA(const int& i) {
             for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
                  k++) {
               a(i)++;
@@ -232,7 +232,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int &i, value_type &lsum) {
+          KOKKOS_LAMBDA(const int& i, value_type& lsum) {
             lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
           },
           error);
@@ -254,14 +254,14 @@ struct TestRange {
     }
 
     {
-      Kokkos::View<size_t *, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
+      Kokkos::View<size_t*, ExecSpace, Kokkos::MemoryTraits<Kokkos::Atomic>>
           count("Count", concurrency);
-      Kokkos::View<int *, ExecSpace> a("A", N);
+      Kokkos::View<int*, ExecSpace> a("A", N);
 
       value_type sum = 0;
       Kokkos::parallel_reduce(
           policy_t(0, N),
-          KOKKOS_LAMBDA(const int &i, value_type &lsum) {
+          KOKKOS_LAMBDA(const int& i, value_type& lsum) {
             for (int k = 0; k < (i < N_no_implicit_capture / 2 ? 1 : 10000);
                  k++) {
               a(i)++;
@@ -275,7 +275,7 @@ struct TestRange {
       int error = 0;
       Kokkos::parallel_reduce(
           Kokkos::RangePolicy<ExecSpace>(0, N),
-          KOKKOS_LAMBDA(const int &i, value_type &lsum) {
+          KOKKOS_LAMBDA(const int& i, value_type& lsum) {
             lsum += (a(i) != (i < N_no_implicit_capture / 2 ? 1 : 10000));
           },
           error);
@@ -360,7 +360,7 @@ TEST(TEST_CATEGORY, range_reduce) {
 
 template <typename ExecSpace, typename StaticBatchSize>
 struct TestStaticBatchSize {
-  using view_type = Kokkos::View<int *, ExecSpace>;
+  using view_type = Kokkos::View<int*, ExecSpace>;
 
   view_type m_flags;
   view_type result_view;
@@ -397,7 +397,7 @@ struct TestStaticBatchSize {
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const VerifyAtomicAddTag, const int i, bool &success) const {
+  void operator()(const VerifyAtomicAddTag, const int i, bool& success) const {
     if (m_flags(i) != 1) {
       Kokkos::printf(
           "TestStaticBatchSize {::test_batch_size_error at %d != %d\n", i,
@@ -430,7 +430,7 @@ TEST(TEST_CATEGORY, range_dynamic_policy) {
 void test_large_parallel_for_reduce() {
   using ExecutionSpace              = typename TEST_EXECSPACE::execution_space;
   constexpr long long unsigned size = 1llu << 32;
-  Kokkos::View<char *, TEST_EXECSPACE::memory_space> v(
+  Kokkos::View<char*, TEST_EXECSPACE::memory_space> v(
       Kokkos::view_alloc(Kokkos::WithoutInitializing, "v"), size);
 
   // We want to explicitly test that using a parallel_for for filling the View
@@ -444,7 +444,7 @@ void test_large_parallel_for_reduce() {
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy<ExecutionSpace,
                           Kokkos::IndexType<long long unsigned>>(0, size),
-      KOKKOS_LAMBDA(long long unsigned, long long unsigned &partial_sum) {
+      KOKKOS_LAMBDA(long long unsigned, long long unsigned& partial_sum) {
         partial_sum += 1;
       },
       sum);
@@ -469,7 +469,7 @@ TEST(TEST_CATEGORY, large_parallel_for_reduce) {
 void test_small_index_type() {
   using ExecutionSpace = typename TEST_EXECSPACE::execution_space;
   constexpr int size   = 1024;
-  Kokkos::View<int *, TEST_EXECSPACE::memory_space> v("v", size);
+  Kokkos::View<int*, TEST_EXECSPACE::memory_space> v("v", size);
 
   Kokkos::parallel_for(
       Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
@@ -478,11 +478,17 @@ void test_small_index_type() {
   int sum;
   Kokkos::parallel_reduce(
       Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<short>>(0, size),
-      KOKKOS_LAMBDA(short i, int &partial_sum) { partial_sum += v(i); }, sum);
+      KOKKOS_LAMBDA(short i, int& partial_sum) { partial_sum += v(i); }, sum);
   ASSERT_EQ(sum, ((size - 1) * size) / 2);
 }
 
-TEST(TEST_CATEGORY, small_index_type) { test_small_index_type(); }
+TEST(TEST_CATEGORY, small_index_type) {
+#if defined(KOKKOS_ENABLE_OPENACC)
+  GTEST_SKIP() << "OpenACC doesn't support index types smaller than int";
+#else
+  test_small_index_type();
+#endif
+}
 
 TEST(TEST_CATEGORY, check_batch_size) {
   ASSERT_TRUE(Kokkos::Experimental::StaticBatchSize<1>::batch_size == 1);


### PR DESCRIPTION
When using `RangePolicy<IndexType<short>>` in a `parallel_for` on the HIP and CUDA backends, an overflow would occur when converting `maxGridSizeX` to `Policy::index_type`, leading to the wrong number of iterations being performed.
https://github.com/kokkos/kokkos/blob/2cb653f351240ef7c7806c1b0dc14dab130bc118/core/src/HIP/Kokkos_HIP_ParallelFor_Range.hpp#L97-L101 
Using `IndexType<short>` on SYCL or HPX led to compile errors related to int -> short implicit conversions

This PR fixes the HIP and CUDA issue by converting to `uint64_t` instead of `index_type`, I also added a test for this

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

Fix `parallel_for` with `RangePolicy` doing the wrong number of iterations when using an index type smaller than `int` on device backends
