### PR TITLE
Fix inverted NDEBUG logic in mdspan precondition checking

### DIFF
--- a/tpls/mdspan/include/experimental/__p0009_bits/macros.hpp
+++ b/tpls/mdspan/include/experimental/__p0009_bits/macros.hpp
@@ -147,7 +147,7 @@ MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* c
 #endif
 
 #ifndef MDSPAN_IMPL_CHECK_PRECONDITION
-  #ifndef NDEBUG
+  #ifdef NDEBUG
     #define MDSPAN_IMPL_CHECK_PRECONDITION 0
   #else
     #define MDSPAN_IMPL_CHECK_PRECONDITION 1


### PR DESCRIPTION
MDSPAN_IMPL_CHECK_PRECONDITION defaulted to enabled when NDEBUG was defined (Release builds) and disabled when NDEBUG was undefined (Debug builds) -- backwards from the usual assert()/NDEBUG convention. As a result, every View/DynRankView mapping construction paid for O(rank) overflow-checked multiplications in optimized builds, causing a large performance regression relative to the legacy View implementation (observed ~20x slower DynRankView construction in a Release build).

Swap the branches so precondition checks are enabled for debug builds and disabled for release builds, matching normal convention.


Assisted-by: Claude

### Related issues / PRs
Closes #9368 


### Changelog Entry
