### PR TITLE
Remove duplicate `PolicyTraitMatch` definition

### DIFF
--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -8,6 +8,7 @@
 #include <Kokkos_Concepts.hpp>  // IndexType
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
 #include <traits/Kokkos_ExecutionSpaceTrait.hpp>
 #include <traits/Kokkos_TeamHandleTrait.hpp>
@@ -20,7 +21,6 @@
 #include <traits/Kokkos_ScheduleTrait.hpp>
 #include <traits/Kokkos_WorkItemPropertyTrait.hpp>
 #include <traits/Kokkos_WorkTagTrait.hpp>
-#include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/impl/Kokkos_AnalyzePolicy.hpp
+++ b/core/src/impl/Kokkos_AnalyzePolicy.hpp
@@ -20,6 +20,7 @@
 #include <traits/Kokkos_ScheduleTrait.hpp>
 #include <traits/Kokkos_WorkItemPropertyTrait.hpp>
 #include <traits/Kokkos_WorkTagTrait.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -8,6 +8,8 @@
 #include <Kokkos_Concepts.hpp>  // is_execution_space
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
+++ b/core/src/traits/Kokkos_ExecutionSpaceTrait.hpp
@@ -10,7 +10,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -9,6 +9,8 @@
 #include <impl/Kokkos_GraphImpl_fwd.hpp>  // IsGraphKernelTag
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <impl/Kokkos_Utilities.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_GraphKernelTrait.hpp
+++ b/core/src/traits/Kokkos_GraphKernelTrait.hpp
@@ -11,7 +11,6 @@
 #include <impl/Kokkos_Utilities.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -10,7 +10,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/traits/Kokkos_IndexTypeTrait.hpp
+++ b/core/src/traits/Kokkos_IndexTypeTrait.hpp
@@ -8,6 +8,8 @@
 #include <Kokkos_Concepts.hpp>  // IndexType
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -9,6 +9,8 @@
 #include <Kokkos_Rank.hpp>                       // Rank
 #include <Kokkos_Layout.hpp>                     // Iterate
 #include <type_traits>                           // is_void
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_IterationPatternTrait.hpp
+++ b/core/src/traits/Kokkos_IterationPatternTrait.hpp
@@ -11,7 +11,6 @@
 #include <type_traits>                           // is_void
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -8,6 +8,8 @@
 #include <Kokkos_Concepts.hpp>  // LaunchBounds
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
+++ b/core/src/traits/Kokkos_LaunchBoundsTrait.hpp
@@ -10,7 +10,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 namespace Impl {
 

--- a/core/src/traits/Kokkos_OccupancyControlTrait.hpp
+++ b/core/src/traits/Kokkos_OccupancyControlTrait.hpp
@@ -7,7 +7,7 @@
 #include <impl/Kokkos_Error.hpp>  // KOKKOS_EXPECTS macro
 
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
-
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
 
 namespace Kokkos {

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -25,24 +25,7 @@ namespace Impl {
 
 //------------------------------------------------------------------------------
 
-//------------------------------------------------------------------------------
-// <editor-fold desc="PolicyTraitMatcher"> {{{2
 
-// To handle the WorkTag case, we need more than just a predicate; we need
-// something that we can default to in the unspecialized case, just like we
-// do for AnalyzeExecPolicy
-template <class TraitSpec, class Trait, class Enable = void>
-struct PolicyTraitMatcher : std::false_type {};
-
-template <class TraitSpec, class Trait>
-struct PolicyTraitMatcher<
-    TraitSpec, Trait,
-    std::enable_if_t<
-        TraitSpec::template trait_matches_specification<Trait>::value>>
-    : std::true_type {};
-
-// </editor-fold> end PolicyTraitMatcher }}}2
-//------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
 // <editor-fold desc="PolicyTraitAdaptorImpl specializations"> {{{2

--- a/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
+++ b/core/src/traits/Kokkos_PolicyTraitAdaptor.hpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <impl/Kokkos_Utilities.hpp>  // type_list
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
 #include <traits/Kokkos_Traits_fwd.hpp>
 
@@ -23,11 +24,6 @@ namespace Impl {
 // ignored, and the trait can specialize PolicyTraitAdapterImpl to get the
 // desired behavior.
 
-//------------------------------------------------------------------------------
-
-
-
-//------------------------------------------------------------------------------
 // <editor-fold desc="PolicyTraitAdaptorImpl specializations"> {{{2
 
 // Matching version, replace the trait

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -8,6 +8,8 @@
 #include <Kokkos_Concepts.hpp>  // is_schedule_type, Schedule
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos {
 

--- a/core/src/traits/Kokkos_ScheduleTrait.hpp
+++ b/core/src/traits/Kokkos_ScheduleTrait.hpp
@@ -10,7 +10,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos {
 
 namespace Impl {

--- a/core/src/traits/Kokkos_StaticBatchSizeTrait.hpp
+++ b/core/src/traits/Kokkos_StaticBatchSizeTrait.hpp
@@ -7,6 +7,8 @@
 #include <Kokkos_Macros.hpp>
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos::Experimental {
 

--- a/core/src/traits/Kokkos_StaticBatchSizeTrait.hpp
+++ b/core/src/traits/Kokkos_StaticBatchSizeTrait.hpp
@@ -9,7 +9,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos::Experimental {
 
 template <unsigned int BatchSize = 1>

--- a/core/src/traits/Kokkos_TeamHandleTrait.hpp
+++ b/core/src/traits/Kokkos_TeamHandleTrait.hpp
@@ -7,6 +7,8 @@
 #include <Kokkos_Macros.hpp>
 #include <traits/Kokkos_PolicyTraitAdaptor.hpp>
 #include <traits/Kokkos_Traits_fwd.hpp>
+#include <traits/Kokkos_PolicyTraitMatcher.hpp>
+
 
 namespace Kokkos::Impl {
 

--- a/core/src/traits/Kokkos_TeamHandleTrait.hpp
+++ b/core/src/traits/Kokkos_TeamHandleTrait.hpp
@@ -9,7 +9,6 @@
 #include <traits/Kokkos_Traits_fwd.hpp>
 #include <traits/Kokkos_PolicyTraitMatcher.hpp>
 
-
 namespace Kokkos::Impl {
 
 //==============================================================================


### PR DESCRIPTION
Currently the `PolicyTraitMatcher` contains both in `core/src/traits/Kokkos_PolicyTraitAdaptor.hpp` and `core/src/traits/Kokkos_PolicyTraitMatcher.hpp`.
same intent but in different file.

*Changes:*

* Removed the `PolicyTraitMatcher` from `core/src/traits/Kokkos_PolicyTraitAdaptor.hpp`  

* Added the file header of `core/src/traits/Kokkos_PolicyTraitMatcher.hpp` in `core/src/impl/Kokkos_AnalyzePolicy.hpp` keeping the intent what policytraits header file providing and across all trait files

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
