### PR TITLE
Introduce a new LockPolicy feature to perform atomic_locked_action

### DIFF
--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -12,6 +12,8 @@ import kokkos.core_impl;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_ClockTic.hpp>
+
 #include <cstdint>
 #include <type_traits>
 #include <utility>

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -53,7 +53,7 @@ KOKKOS_INLINE_FUNCTION uint32_t get_hardware_thread_id() {
 KOKKOS_INLINE_FUNCTION uint32_t generate_thread_seed() {
   uint32_t tid = get_hardware_thread_id();
   auto tic     = static_cast<uint64_t>(Kokkos::Impl::clock_tic());
-  // Combine the tid and tic together as original seed
+  // Combine tid and tic together into the initial seed.
   uint32_t seed = tid ^ static_cast<uint32_t>(tic ^ (tic >> 32));
 
   // Thomas Wang's hash function to spread entropy.
@@ -119,7 +119,7 @@ class TickExponentialBackoff {
 
   KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
     for (uint32_t tick = 0; tick < m_delay; ++tick) {
-      // The fence should keep the compiler from proving this loop has no
+      // The fence keeps the compiler from proving this loop has no
       // observable effect and hoisting or collapsing it away, and forces a
       // fresh read each iteration.
       Kokkos::load_fence();
@@ -156,8 +156,7 @@ class ClockExponentialBackoff {
     int shift               = (m_attempt < max_shift) ? m_attempt : max_shift;
     uint32_t raw_delay      = (static_cast<uint32_t>(1) << shift);
     auto delay              = static_cast<decltype(start)>(
-        raw_delay < m_max_delay ? raw_delay
-                                             : static_cast<uint64_t>(m_max_delay));
+        raw_delay < m_max_delay ? raw_delay : m_max_delay);
 
     while (static_cast<decltype(start)>(Kokkos::Impl::clock_tic()) - start <
            delay) {
@@ -249,7 +248,7 @@ class BackoffLockPolicy {
 
 // RAII guard. Using a guard instead of a manual acquire/action/release
 // sequence to ensure that the lock is still released if `action` throws on the
-// host side (device code never throws exeception, but a host lambda passed to
+// host side (device code never throws exceptions, but a host lambda passed to
 // the same generic API might).
 template <typename LockType, typename LockPolicy>
 class LockGuard {
@@ -314,13 +313,13 @@ inline constexpr bool is_sycl_execution_space_v<Kokkos::SYCL> = true;
 // NVIDIA warps on architectures older than Volta (compute capability
 // < 7.0), which predate Independent Thread Scheduling, and Intel sub-groups.
 //
-// Originally, this has deliberately avoiding the use of warp-vote/shuffle
-// intrinsics (__ballot, __shfl, __activemask, and friends) for the
-// lane-election logic itself because their use under divergent control flow
-// (like here) was affected by at least a confirmed HIP compiler bug that
-// produced wrong results (see ROCm/hip#952 and the follow-up ROCm/hip#2474),
-// reported present as late as 2022 and fixed in 2023. Now, it also allow to
-// have a common algorithm for HIP, CUDA pre-Volta, and Intel GPUs.
+// This deliberately avoids warp-vote/shuffle intrinsics (__ballot, __shfl,
+// __activemask, and friends) for the lane-election logic itself: their use
+// under divergent control flow (like here) was affected by at least a
+// confirmed HIP compiler bug that produced wrong results (see ROCm/hip#952
+// and the follow-up ROCm/hip#2474), reported present as late as 2022 and
+// fixed in 2023. This choice also lets HIP, pre-Volta CUDA, and SYCL share
+// the same algorithm.
 //
 // Every lane in the group runs the "same" uniform, convergent loop over lane
 // indices. The loop structure never depends on any other lane's state. Within
@@ -334,7 +333,7 @@ inline constexpr bool is_sycl_execution_space_v<Kokkos::SYCL> = true;
 // Cost: this serializes the whole group through this call, one lane at a time,
 // even when the individual locks are all different and uncontended. It trades
 // away all intra-group parallelism for this operation in exchange for
-// correctness on those hardware. (A better solution could be considered, but it
+// correctness on that hardware. (A better solution could be considered, but it
 // is not trivial.)
 //
 // Open question for a later pass: given the failure was a compiler bug and not
@@ -346,9 +345,9 @@ inline constexpr bool is_sycl_execution_space_v<Kokkos::SYCL> = true;
 //
 // NOTE: This does NOT remove the more general (and universal) concern that a
 // lock could be held by a thread in a different group that isn't currently
-// scheduled. This also apply to CPU if a thread is never rescheduled by the
-// kernel, that's a launch/occupancy concern for any hardware spinlock, not
-// something fixable at this layer.
+// scheduled. This also applies on CPU, where a thread might never be
+// rescheduled by the kernel: that's a launch/occupancy concern for any
+// hardware spinlock, not something fixable at this layer.
 template <typename LockType, typename LockPolicy, typename Function>
 KOKKOS_INLINE_FUNCTION decltype(auto) lane_serialized_locked_action_core(
     unsigned int my_lane, unsigned int group_size, LockType* lock,
@@ -410,8 +409,8 @@ KOKKOS_INLINE_FUNCTION decltype(auto) lane_serialized_locked_action(
 
 #if defined(KOKKOS_ENABLE_SYCL)
 // Getting the current sub-group requires
-// sycl::ext::oneapi::this_work_item::get_sub_group() an Intel DPC++ extension,
-// with no core SYCL equivalent to my knowledge.
+// sycl::ext::oneapi::this_work_item::get_sub_group(), an Intel DPC++
+// extension, with no core SYCL equivalent we know of.
 #if !defined(SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES)
 #error \
     "atomic_locked_action's SYCL path needs sycl_ext_oneapi_free_function_queries " \
@@ -471,15 +470,15 @@ namespace LockPolicy {
 //
 // NOTE: taken on its own, those are naive algorithms with no special handling
 // for GPUs that do not guarantee independent forward progress within a
-// warp/wavefront (e.g. AMD HIP, and NVIDIA pre-Volta): two lanes of the same
-// group contending for the same lock can deadlock if one holds the lock
+// warp/wavefront (e.g. AMD HIP, NVIDIA pre-Volta, and SYCL): two lanes of the
+// same group contending for the same lock can deadlock if one holds the lock
 // while another spins here, because the hardware may not reschedule the
 // holder until the waiter's SIMD step completes. `atomic_locked_action`
-// (below) handles this correctly for `ExecutionSpace = Kokkos::HIP` and for
-// pre-Volta `Kokkos::Cuda` via lane-serialized dispatch, see
-// `Impl::lane_serialized_locked_action` (above). Using these LockPolicy
-// types directly on such hardware (or any other lacking forward progress)
-// outside a carefully crafted dispatch remains unsafe.
+// (below) handles this correctly for `ExecutionSpace = Kokkos::HIP`,
+// pre-Volta `Kokkos::Cuda`, and `Kokkos::SYCL` via lane-serialized dispatch,
+// see `Impl::lane_serialized_locked_action_core` (above). Using these
+// LockPolicy types directly on such hardware (or any other lacking forward
+// progress) outside a carefully crafted dispatch remains unsafe.
 
 // ==============================================================================
 // SPINLOCK POLICIES
@@ -490,7 +489,7 @@ struct PureSpinlock {
   template <typename LockType>
   KOKKOS_INLINE_FUNCTION void acquire(LockType* lock) const {
     while (!Impl::try_lock_cas(lock)) {
-      // The fence should prevent the compiler from optimizing this loop away
+      // The fence prevents the compiler from optimizing this loop away
       // and forces a fresh attempt each iteration.
       Kokkos::load_fence();
     }
@@ -572,8 +571,8 @@ using ClockRandomBackoffTTAS =
 //     on pre-Volta architectures (compute capability < 7.0). Volta and later
 //     have Independent Thread Scheduling and use the generic path below
 //     instead.
-//   - ExecutionSpace = Kokkos::SYCL: also the lane-serialized dispatch (see
-//     Impl::sycl_lane_serialized_locked_action).
+//   - ExecutionSpace = Kokkos::SYCL: also uses the lane-serialized dispatch
+//     (see Impl::sycl_lane_serialized_locked_action), unconditionally.
 //   - Everything else (OpenMP, Threads, Volta+ Cuda, HPX, ...): the generic
 //     LockPolicy-based spin loop via Impl::LockGuard.
 //
@@ -592,7 +591,7 @@ using ClockRandomBackoffTTAS =
 
 /**
  * @brief Acquires `lock` using `policy`, runs `action` atomically, then
- * releases `lock`. Dispatch using `ExecutionSpace`.
+ * releases `lock`. Dispatches on `ExecutionSpace`.
  *
  * @tparam ExecutionSpace The Kokkos execution space this call runs under.
  * @tparam LockType   Underlying type of the lock word (e.g. int32_t,

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -275,17 +275,20 @@ class LockGuard {
 template <typename ExecutionSpace>
 struct is_serial_execution_space : std::false_type {};
 
+template <typename ExecutionSpace>
+inline constexpr bool is_serial_execution_space_v = false;
+
 #if defined(KOKKOS_ENABLE_SERIAL)
 template <>
-struct is_serial_execution_space<Kokkos::Serial> : std::true_type {};
+inline constexpr bool is_serial_execution_space_v<Kokkos::Serial> = true;
 #endif
 
 template <typename ExecutionSpace>
-struct is_hip_execution_space : std::false_type {};
+inline constexpr bool is_hip_execution_space_v = false;
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct is_hip_execution_space<Kokkos::HIP> : std::true_type {};
+inline constexpr bool is_hip_execution_space_v<Kokkos::HIP> = true;
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
@@ -522,17 +525,17 @@ template <typename ExecutionSpace, typename LockType, typename LockPolicy,
 KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
                                                            LockPolicy policy,
                                                            Function&& action) {
-  static_assert(std::is_integral<LockType>::value,
+  static_assert(std::is_integral_v<LockType>,
                 "LockType must be an integral type supported by Kokkos "
                 "atomics.");
 
-  if constexpr (Impl::is_serial_execution_space<ExecutionSpace>::value) {
+  if constexpr (Impl::is_serial_execution_space_v<ExecutionSpace>) {
     // Serial: only one thread ever exists, so nothing else can be
     // contending for this lock. Skip the atomic dance entirely.
     return action();
   }
 #if defined(KOKKOS_ENABLE_HIP)
-  else if constexpr (Impl::is_hip_execution_space<ExecutionSpace>::value) {
+  else if constexpr (Impl::is_hip_execution_space_v<ExecutionSpace>) {
     return Impl::hip_wavefront_serialized_locked_action(
         lock, policy, std::forward<Function>(action));
   }

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -1,0 +1,583 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_LOCKPOLICY_HPP
+#define KOKKOS_LOCKPOLICY_HPP
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+namespace Kokkos {
+namespace Experimental {
+
+// ==============================================================================
+// Internal utilities (hardware thread id, seeding, and backoff helpers)
+// ==============================================================================
+namespace Impl {
+
+// Default cap on the busy-wait delay (in clock_tic() units, or instruction
+// cost) used by backoff policies.
+inline constexpr uint32_t default_backoff_max_delay = 512;
+
+// A hardware thread identifier (device / host).
+// This is only used to seed per-thread pseudo-random backoff jitter, never
+// as a lock key or as a stable/unique thread identity.
+KOKKOS_INLINE_FUNCTION uint32_t get_hardware_thread_id() {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+  // Unique global lane/thread id on GPU.
+  return static_cast<uint32_t>(
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z) +
+      (blockIdx.x + gridDim.x * (blockIdx.y + gridDim.y * blockIdx.z)) *
+          (blockDim.x * blockDim.y * blockDim.z));
+#else
+  // On host: combine the calling thread's stack address with the clock.
+  int dummy = 0;
+  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&dummy) ^
+                               Kokkos::Impl::clock_tic());
+#endif
+}
+
+// Generates a pseudo-random seed from the hardware thread id and clock_tic().
+// The tic is used to have a different initial state between 2 calls.
+KOKKOS_INLINE_FUNCTION uint32_t generate_thread_seed() {
+  uint32_t tid = get_hardware_thread_id();
+  auto tic     = static_cast<uint64_t>(Kokkos::Impl::clock_tic());
+  // Combine the tid and tic together as original seed
+  uint32_t seed = tid ^ static_cast<uint32_t>(tic ^ (tic >> 32));
+
+  // Thomas Wang's hash function to spread entropy.
+  seed = (seed ^ 61) ^ (seed >> 16);
+  seed *= 9;
+  seed = seed ^ (seed >> 4);
+  seed *= 0x27d4eb2d;
+  return seed ^ (seed >> 15);
+}
+
+// Draws a delay in [0, max_delay] from `seed`, then advances `seed` so the next
+// draw differs. `max_delay` is assumed well below UINT32_MAX (true for any sane
+// backoff cap).
+KOKKOS_INLINE_FUNCTION uint32_t next_random_delay(uint32_t& seed,
+                                                  uint32_t max_delay) {
+  uint32_t delay = seed % (max_delay + 1);
+  seed           = seed * 1103515245 + 12345;
+  return delay;
+}
+
+// Single compare-and-swap (CAS) attempt to acquire the lock.
+template <typename LockType>
+KOKKOS_INLINE_FUNCTION bool try_lock_cas(LockType* lock) {
+  return Kokkos::atomic_compare_exchange(lock, LockType(0), LockType(1)) ==
+         LockType(0);
+}
+
+// Single test-then-test-and-set (TTAS) attempt to acquire the lock.
+template <typename LockType>
+KOKKOS_INLINE_FUNCTION bool try_lock_ttas(LockType* lock) {
+  return Kokkos::atomic_load(lock) == LockType(0) &&
+         Kokkos::atomic_compare_exchange(lock, LockType(0), LockType(1)) ==
+             LockType(0);
+}
+
+// TryLock strategies: the CAS/TTAS axis of variation, factored out so
+// BackoffLockPolicy (below) can be built once and combined with either.
+struct CasTryLock {
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION static bool try_lock(LockType* lock) {
+    return try_lock_cas(lock);
+  }
+};
+
+struct TtasTryLock {
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION static bool try_lock(LockType* lock) {
+    return try_lock_ttas(lock);
+  }
+};
+
+// Backoff strategies: the "how do we wait between attempts" axis of variation.
+// Each type is constructed fresh at the start of every `acquire()` call and
+// exposes `on_failed_attempt()`, called once per failed try_lock.
+
+// Exponential backoff timed by counting load_fence() iterations: cheap, but the
+// actual wait scales with instruction cost, not wall time.
+class TickExponentialBackoff {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  explicit TickExponentialBackoff(uint32_t max_delay)
+      : m_max_delay(max_delay), m_delay(1) {}
+
+  KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
+    for (uint32_t tick = 0; tick < m_delay; ++tick) {
+      // The fence should keep the compiler from proving this loop has no
+      // observable effect and hoisting or collapsing it away, and forces a
+      // fresh read each iteration.
+      Kokkos::load_fence();
+    }
+    if (m_delay < m_max_delay) m_delay *= 2;
+  }
+
+ private:
+  uint32_t m_max_delay;
+  uint32_t m_delay;
+};
+
+// Exponential backoff timed against Kokkos' abstract cycle counter
+// clock_tic(). This is closer to actual elapsed time regardless of how
+// expensive load_fence() happens to be on a given backend.
+
+// Spinning on the clock instead of retrying the atomic keeps traffic off the
+// lock's cache line while still not requiring an OS-level sleep, which is
+// not available on device.
+class ClockExponentialBackoff {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  explicit ClockExponentialBackoff(uint32_t max_delay)
+      : m_max_delay(max_delay), m_attempt(0) {}
+
+  // `m_max_delay` bounds the actual wait time (in clock_tic() units), so
+  // callers can tune how long a single backoff step may last. `max_shift` below
+  // is a separate, fixed safety cap on the shift amount itself, only there to
+  // avoid undefined behavior / overflow if `m_attempt` grows very large.
+  KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
+    auto start = Kokkos::Impl::clock_tic();
+
+    constexpr int max_shift = 17;
+    int shift               = (m_attempt < max_shift) ? m_attempt : max_shift;
+    uint32_t raw_delay      = (static_cast<uint32_t>(1) << shift);
+    auto delay              = static_cast<decltype(start)>(
+        raw_delay < m_max_delay ? raw_delay
+                                             : static_cast<uint64_t>(m_max_delay));
+
+    while (static_cast<decltype(start)>(Kokkos::Impl::clock_tic()) - start <
+           delay) {
+      // Active, non-blocking wait on the cycle counter.
+      Kokkos::load_fence();
+    }
+    ++m_attempt;
+  }
+
+ private:
+  uint32_t m_max_delay;
+  int m_attempt;
+};
+
+// Random backoff timed by counting load_fence() iterations.
+class TickRandomBackoff {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  explicit TickRandomBackoff(uint32_t max_delay)
+      : m_max_delay(max_delay), m_seed(generate_thread_seed()) {}
+
+  KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
+    uint32_t delay = next_random_delay(m_seed, m_max_delay);
+    for (uint32_t tick = 0; tick < delay; ++tick) {
+      Kokkos::load_fence();
+    }
+  }
+
+ private:
+  uint32_t m_max_delay;
+  uint32_t m_seed;
+};
+
+// Random backoff timed against Kokkos' abstract cycle counter clock_tic().
+class ClockRandomBackoff {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  explicit ClockRandomBackoff(uint32_t max_delay)
+      : m_max_delay(max_delay), m_seed(generate_thread_seed()) {}
+
+  KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
+    uint32_t delay = next_random_delay(m_seed, m_max_delay);
+    auto start     = Kokkos::Impl::clock_tic();
+    while (static_cast<decltype(start)>(Kokkos::Impl::clock_tic()) - start <
+           delay) {
+      Kokkos::load_fence();
+    }
+  }
+
+ private:
+  uint32_t m_max_delay;
+  uint32_t m_seed;
+};
+
+// Combines a TryLock strategy (CasTryLock / TtasTryLock) with a Backoff
+// type into a full LockPolicy. LockPolicy::ExponentialBackoff,
+// ::RandomBackoffTTAS, etc. (below) are aliases of this template.
+template <typename TryLock, typename Backoff>
+class BackoffLockPolicy {
+ public:
+  static constexpr uint32_t default_max_delay = default_backoff_max_delay;
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr BackoffLockPolicy() : m_max_delay(default_max_delay) {}
+
+  // Caps how long a single backoff step may wait (ticks or clock_tic()
+  // units, depending on Backoff).
+  KOKKOS_INLINE_FUNCTION
+  explicit constexpr BackoffLockPolicy(uint32_t max_delay)
+      : m_max_delay(max_delay) {}
+
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void acquire(LockType* lock) const {
+    Backoff backoff(m_max_delay);
+    while (!TryLock::try_lock(lock)) {
+      backoff.on_failed_attempt();
+    }
+  }
+
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
+    Kokkos::memory_fence();
+    Kokkos::atomic_store(lock, LockType(0));
+  }
+
+ private:
+  uint32_t m_max_delay;
+};
+
+// RAII guard. Using a guard instead of a manual acquire/action/release
+// sequence to ensure that the lock is still released if `action` throws on the
+// host side (device code never throws exeception, but a host lambda passed to
+// the same generic API might).
+template <typename LockType, typename LockPolicy>
+class LockGuard {
+ public:
+  KOKKOS_INLINE_FUNCTION
+  LockGuard(LockType* lock, LockPolicy policy)
+      : m_lock(lock), m_policy(policy) {
+    m_policy.acquire(m_lock);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  ~LockGuard() { m_policy.release(m_lock); }
+
+  LockGuard(const LockGuard&)            = delete;
+  LockGuard& operator=(const LockGuard&) = delete;
+  LockGuard(LockGuard&&)                 = delete;
+  LockGuard& operator=(LockGuard&&)      = delete;
+
+ private:
+  LockType* m_lock;
+  LockPolicy m_policy;
+};
+
+// ExecutionSpace traits used for backend dispatch in atomic_locked_action
+template <typename ExecutionSpace>
+struct is_serial_execution_space : std::false_type {};
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+template <>
+struct is_serial_execution_space<Kokkos::Serial> : std::true_type {};
+#endif
+
+template <typename ExecutionSpace>
+struct is_hip_execution_space : std::false_type {};
+
+#if defined(KOKKOS_ENABLE_HIP)
+template <>
+struct is_hip_execution_space<Kokkos::HIP> : std::true_type {};
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP)
+// Runs `action` atomically under `lock`, safe for AMD wavefronts that do not
+// guarantee independent forward progress between lanes.
+//
+// This deliberately avoids warp-vote/shuffle intrinsics (__ballot, __shfl,
+// __activemask, and friends) for the lane-election logic itself. Their use
+// under divergent control flow (like here) was affected by at least a confirmed
+// HIP compiler bug that produced wrong results (see ROCm/hip#952 and the
+// follow-up ROCm/hip#2474), reported present as late as 2022 and fixed in 2023.
+// The `_sync` variants (explicit participation mask) became available, and
+// enabled by default, starting with ROCm 7.0. Even though current ROCm is
+// expected to have this fixed, the plain uniform-loop approach below avoids
+// depending on that fix being present for whichever ROCm version and hardware
+// this ends up compiled against, and sidesteps the question entirely.
+//
+// Instead, every lane in the wavefront runs the "same" uniform, convergent
+// loop over lane indices. The loop structure never depends on any
+// other lane's state. Within that loop, only the lane whose own index
+// matches the current iteration ever touches `lock`, every other lane's
+// iteration is a no-op. This means at most one lane per wavefront is ever
+// inside the acquire/action/release sequence at a time, which is what
+// actually removes the lockstep hazard. Because only one lane is ever
+// spinning at a time, it's safe to reuse the same LockPolicy types used by
+// the generic path for the elected lane's own acquire/release.
+//
+// Cost: this serializes the whole wavefront through this call, one lane at
+// a time, even when the individual locks are all different and
+// uncontended. It trades away all intra-wavefront parallelism for this
+// operation in exchange for correctness on this hardware. (A better solution
+// could be considered, but it is not trivial.)
+//
+// Open question for a later pass: given the failure was a compiler bug and
+// not a design limitation, would it be worth maintaining a second, faster
+// implementation on top of __ballot/__shfl for ROCm versions known to have
+// the fix, selected at compile time via HIP_VERSION (or
+// HIP_VERSION_MAJOR/HIP_VERSION_MINOR), falling back to this uniform loop
+// to recover intra-wavefront parallelism for uncontended locks?
+//
+// NOTE: This does NOT remove the more general (and universal, CUDA included)
+// concern that a lock could be held by a thread in a different wavefront
+// that isn't currently scheduled. This also apply to CPU if a thread is never
+// rescheduled by the kernel, that's a launch/occupancy concern for any hardware
+// spinlock, not something fixable at this layer.
+template <typename LockType, typename LockPolicy, typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) hip_wavefront_serialized_locked_action(
+    LockType* lock, LockPolicy policy, Function&& action) {
+  KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+                     return action();))
+
+  KOKKOS_IF_ON_DEVICE((
+      unsigned int flat_local_id =
+          threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+      unsigned int my_lane =
+          flat_local_id % static_cast<unsigned int>(warpSize);
+
+      using ReturnType = decltype(action());
+
+      // Handles void and non-void return type.
+      if constexpr (std::is_void_v<ReturnType>) {
+        for (unsigned int elected_lane = 0;
+             elected_lane < static_cast<unsigned int>(warpSize);
+             ++elected_lane) {
+          if (my_lane == elected_lane) {
+            Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+            action();
+          }
+        }
+      } else {
+        static_assert(
+            std::is_default_constructible_v<ReturnType>,
+            "On HIP, atomic_locked_action requires the action's return "
+            "type to be default-constructible (or void).");
+        ReturnType result{};
+        for (unsigned int elected_lane = 0;
+             elected_lane < static_cast<unsigned int>(warpSize);
+             ++elected_lane) {
+          if (my_lane == elected_lane) {
+            Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+            result = action();
+          }
+        }
+        // The return is performed uniformly by each active lane outside the
+        // loop to avoid divergence.
+        return result;
+      }))
+}
+#endif  // KOKKOS_ENABLE_HIP
+
+}  // namespace Impl
+
+// ==============================================================================
+// Kokkos::Experimental::LockPolicy
+// ==============================================================================
+namespace LockPolicy {
+// A LockPolicy type must be default-constructible, copyable, and expose two
+// member functions, callable from both host and device:
+//
+//   template <typename LockType> void acquire(LockType* lock) const;
+//   template <typename LockType> void release(LockType* lock) const;
+//
+// `lock` points at a zero-initialized location (0 = free, 1 = held).
+//
+// NOTE: taken on its own, those are naive algorithms with no special handling
+// for GPUs that do not guarantee independent forward progress within a
+// wavefront (e.g. AMD HIP): two lanes of the same wavefront contending for
+// the same lock can deadlock if one holds the lock while another spins
+// here, because the hardware may not reschedule the holder until the
+// waiter's SIMD step completes. `atomic_locked_action` (below) handles this
+// correctly for `ExecutionSpace = Kokkos::HIP` via wavefront-serialized
+// dispatch, see `hip_wavefront_serialized_locked_action`(above). Using these
+// LockPolicy types on HIP (or an other harware without forward progress)
+// outside a carefully crafted dispatch remain unsafe.
+
+// ==============================================================================
+// SPINLOCK POLICIES
+// ==============================================================================
+
+// Pure spinlock: retries the CAS immediately. Kept deliberately minimal.
+struct PureSpinlock {
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void acquire(LockType* lock) const {
+    while (!Impl::try_lock_cas(lock)) {
+      // The fence should prevent the compiler from optimizing this loop away
+      // and forces a fresh attempt each iteration.
+      Kokkos::load_fence();
+    }
+  }
+
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
+    Kokkos::memory_fence();  // Ensure writes made in the critical section
+                             // are visible before the lock is cleared.
+    Kokkos::atomic_store(lock, LockType(0));
+  }
+};
+
+// Spinlock with test-then-test-and-set: polls with a plain load
+// before attempting the CAS, so contending threads are not all
+// hammering the atomic unit / cache line with a CAS while the lock
+// is held by someone else.
+struct SpinlockTTAS {
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void acquire(LockType* lock) const {
+    while (!Impl::try_lock_ttas(lock)) {
+      Kokkos::load_fence();
+    }
+  }
+
+  template <typename LockType>
+  KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
+    Kokkos::memory_fence();
+    Kokkos::atomic_store(lock, LockType(0));
+  }
+};
+
+// ==============================================================================
+// EXPONENTIAL BACKOFF POLICIES
+// ==============================================================================
+//
+// All four are Impl::BackoffLockPolicy instantiations (CAS/TTAS combined
+// with a tick- or clock-timed exponential backoff state).
+
+using ExponentialBackoff =
+    Impl::BackoffLockPolicy<Impl::CasTryLock, Impl::TickExponentialBackoff>;
+using ExponentialBackoffTTAS =
+    Impl::BackoffLockPolicy<Impl::TtasTryLock, Impl::TickExponentialBackoff>;
+using ClockExponentialBackoff =
+    Impl::BackoffLockPolicy<Impl::CasTryLock, Impl::ClockExponentialBackoff>;
+using ClockExponentialBackoffTTAS =
+    Impl::BackoffLockPolicy<Impl::TtasTryLock, Impl::ClockExponentialBackoff>;
+
+// ==============================================================================
+// RANDOM BACKOFF POLICIES
+// ==============================================================================
+//
+// Same idea as the exponential family above: CAS/TTAS combined with a
+// tick- or clock-timed random backoff state.
+
+using RandomBackoff =
+    Impl::BackoffLockPolicy<Impl::CasTryLock, Impl::TickRandomBackoff>;
+using RandomBackoffTTAS =
+    Impl::BackoffLockPolicy<Impl::TtasTryLock, Impl::TickRandomBackoff>;
+using ClockRandomBackoff =
+    Impl::BackoffLockPolicy<Impl::CasTryLock, Impl::ClockRandomBackoff>;
+using ClockRandomBackoffTTAS =
+    Impl::BackoffLockPolicy<Impl::TtasTryLock, Impl::ClockRandomBackoff>;
+
+}  // namespace LockPolicy
+
+// ==============================================================================
+// atomic_locked_action: runs a user action atomically while holding a lock,
+// dispatching on ExecutionSpace and using the given LockPolicy to decide how
+// to wait for the lock.
+//
+// Dispatch:
+//   - ExecutionSpace = Kokkos::Serial: no-op lock -- a single thread can
+//     never contend with itself, so `action` just runs directly.
+//   - ExecutionSpace = Kokkos::HIP: wavefront-serialized dispatch (see
+//     Impl::hip_wavefront_serialized_locked_action) to avoid the
+//     lockstep/forward-progress hazard.
+//   - Everything else (OpenMP, Threads, Cuda, SYCL, HPX, ...): the generic
+//     LockPolicy-based spin loop via Impl::LockGuard.
+//
+// Four overloads are provided, differing in how much you want to specify
+// explicitly (LockType and Function are always deduced from `lock` and
+// `action`):
+//
+//   atomic_locked_action<ES>(lock, my_policy_instance, action);       // (1)
+//   atomic_locked_action<ES, LockPolicy::SpinlockTTAS>(lock, action); // (2)
+//   atomic_locked_action<ES>(lock, action);                           // (3)
+//   atomic_locked_action(lock, action);                               // (4)
+//
+// (3) uses LockPolicy::ExponentialBackoff by default;
+// (4) additionally defaults ExecutionSpace to Kokkos::DefaultExecutionSpace.
+// ==============================================================================
+
+/**
+ * @brief Acquires `lock` using `policy`, runs `action` atomically, then
+ * releases `lock`. Dispatch using `ExecutionSpace`.
+ *
+ * @tparam ExecutionSpace The Kokkos execution space this call runs under.
+ * @tparam LockType   Underlying type of the lock word (e.g. int32_t,
+ *                     uint32_t). Must be an integral type supported by
+ *                     Kokkos atomics.
+ * @tparam LockPolicy Policy instance type (e.g. LockPolicy::PureSpinlock).
+ * @tparam Function   User function/lambda type (e.g. KOKKOS_LAMBDA). May
+ *                     return void or a value; a returned value is forwarded
+ *                     back to the caller.
+ */
+template <typename ExecutionSpace, typename LockType, typename LockPolicy,
+          typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
+                                                           LockPolicy policy,
+                                                           Function&& action) {
+  static_assert(std::is_integral<LockType>::value,
+                "LockType must be an integral type supported by Kokkos "
+                "atomics.");
+
+  if constexpr (Impl::is_serial_execution_space<ExecutionSpace>::value) {
+    // Serial: only one thread ever exists, so nothing else can be
+    // contending for this lock. Skip the atomic dance entirely.
+    return action();
+  }
+#if defined(KOKKOS_ENABLE_HIP)
+  else if constexpr (Impl::is_hip_execution_space<ExecutionSpace>::value) {
+    return Impl::hip_wavefront_serialized_locked_action(
+        lock, policy, std::forward<Function>(action));
+  }
+#endif
+  else {
+    Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+    return action();
+  }
+}
+
+// Overload (2): explicit ExecutionSpace and explicit LockPolicy type,
+// default-constructed instead of passed as an instance. Delegates to the
+// overload above so the dispatch logic is defined in exactly one place.
+template <typename ExecutionSpace, typename LockPolicy, typename LockType,
+          typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
+                                                           Function&& action) {
+  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
+                                              std::forward<Function>(action));
+}
+
+// Overload (3): explicit ExecutionSpace, default LockPolicy
+// (ExponentialBackoff).
+template <
+    typename ExecutionSpace, typename LockType, typename Function,
+    typename LockPolicy = Kokkos::Experimental::LockPolicy::ExponentialBackoff>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
+                                                           Function&& action) {
+  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
+                                              std::forward<Function>(action));
+}
+
+// Overload (4): fully implicit, ExecutionSpace defaults to
+// Kokkos::DefaultExecutionSpace, LockPolicy defaults to ExponentialBackoff.
+template <
+    typename LockType, typename Function,
+    typename ExecutionSpace = Kokkos::DefaultExecutionSpace,
+    typename LockPolicy = Kokkos::Experimental::LockPolicy::ExponentialBackoff>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
+                                                           Function&& action) {
+  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
+                                              std::forward<Function>(action));
+}
+
+}  // namespace Experimental
+}  // namespace Kokkos
+
+#endif  // KOKKOS_LOCKPOLICY_HPP

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -275,9 +275,6 @@ class LockGuard {
 
 // ExecutionSpace traits used for backend dispatch in atomic_locked_action
 template <typename ExecutionSpace>
-struct is_serial_execution_space : std::false_type {};
-
-template <typename ExecutionSpace>
 inline constexpr bool is_serial_execution_space_v = false;
 
 #if defined(KOKKOS_ENABLE_SERIAL)
@@ -293,9 +290,20 @@ template <>
 inline constexpr bool is_hip_execution_space_v<Kokkos::HIP> = true;
 #endif
 
-#if defined(KOKKOS_ENABLE_HIP)
-// Runs `action` atomically under `lock`, safe for AMD wavefronts that do not
-// guarantee independent forward progress between lanes.
+template <typename ExecutionSpace>
+inline constexpr bool is_cuda_execution_space_v = false;
+
+#if defined(KOKKOS_ENABLE_CUDA)
+template <>
+inline constexpr bool is_cuda_execution_space_v<Kokkos::Cuda> = true;
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA)
+// Runs `action` atomically under `lock`, safe for SIMT execution groups that
+// do not guarantee independent forward progress between lanes: AMD
+// wavefronts (always, on every ROCm/architecture combination we know of),
+// and NVIDIA warps on architectures older than Volta (compute capability
+// < 7.0), which predate Independent Thread Scheduling.
 //
 // This deliberately avoids warp-vote/shuffle intrinsics (__ballot, __shfl,
 // __activemask, and friends) for the lane-election logic itself. Their use
@@ -308,19 +316,19 @@ inline constexpr bool is_hip_execution_space_v<Kokkos::HIP> = true;
 // depending on that fix being present for whichever ROCm version and hardware
 // this ends up compiled against, and sidesteps the question entirely.
 //
-// Instead, every lane in the wavefront runs the "same" uniform, convergent
+// Instead, every lane in the group runs the "same" uniform, convergent
 // loop over lane indices. The loop structure never depends on any
 // other lane's state. Within that loop, only the lane whose own index
 // matches the current iteration ever touches `lock`, every other lane's
-// iteration is a no-op. This means at most one lane per wavefront is ever
+// iteration is a no-op. This means at most one lane per group is ever
 // inside the acquire/action/release sequence at a time, which is what
 // actually removes the lockstep hazard. Because only one lane is ever
 // spinning at a time, it's safe to reuse the same LockPolicy types used by
 // the generic path for the elected lane's own acquire/release.
 //
-// Cost: this serializes the whole wavefront through this call, one lane at
+// Cost: this serializes the whole group through this call, one lane at
 // a time, even when the individual locks are all different and
-// uncontended. It trades away all intra-wavefront parallelism for this
+// uncontended. It trades away all intra-group parallelism for this
 // operation in exchange for correctness on this hardware. (A better solution
 // could be considered, but it is not trivial.)
 //
@@ -329,15 +337,15 @@ inline constexpr bool is_hip_execution_space_v<Kokkos::HIP> = true;
 // implementation on top of __ballot/__shfl for ROCm versions known to have
 // the fix, selected at compile time via HIP_VERSION (or
 // HIP_VERSION_MAJOR/HIP_VERSION_MINOR), falling back to this uniform loop
-// to recover intra-wavefront parallelism for uncontended locks?
+// to recover intra-group parallelism for uncontended locks?
 //
-// NOTE: This does NOT remove the more general (and universal, CUDA included)
-// concern that a lock could be held by a thread in a different wavefront
-// that isn't currently scheduled. This also apply to CPU if a thread is never
-// rescheduled by the kernel, that's a launch/occupancy concern for any hardware
-// spinlock, not something fixable at this layer.
+// NOTE: This does NOT remove the more general (and universal, Volta+ CUDA
+// included) concern that a lock could be held by a thread in a different
+// group that isn't currently scheduled. This also apply to CPU if a thread is
+// never rescheduled by the kernel, that's a launch/occupancy concern for any
+// hardware spinlock, not something fixable at this layer.
 template <typename LockType, typename LockPolicy, typename Function>
-KOKKOS_INLINE_FUNCTION decltype(auto) hip_wavefront_serialized_locked_action(
+KOKKOS_INLINE_FUNCTION decltype(auto) lane_serialized_locked_action(
     LockType* lock, LockPolicy policy, Function&& action) {
   KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
                      return action();))
@@ -363,8 +371,8 @@ KOKKOS_INLINE_FUNCTION decltype(auto) hip_wavefront_serialized_locked_action(
       } else {
         static_assert(
             std::is_default_constructible_v<ReturnType>,
-            "On HIP, atomic_locked_action requires the action's return "
-            "type to be default-constructible (or void).");
+            "atomic_locked_action's lane-serialized path requires the "
+            "action's return type to be default-constructible (or void).");
         ReturnType result{};
         for (unsigned int elected_lane = 0;
              elected_lane < static_cast<unsigned int>(warpSize);
@@ -379,7 +387,28 @@ KOKKOS_INLINE_FUNCTION decltype(auto) hip_wavefront_serialized_locked_action(
         return result;
       }))
 }
-#endif  // KOKKOS_ENABLE_HIP
+#endif  // KOKKOS_ENABLE_HIP || KOKKOS_ENABLE_CUDA
+
+#if defined(KOKKOS_ENABLE_CUDA)
+// CUDA-specific dispatch: routes to the lane-serialized path above only on
+// pre-Volta architectures (compute capability < 7.0).
+template <typename LockType, typename LockPolicy, typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) cuda_dispatch_locked_action(
+    LockType* lock, LockPolicy policy, Function&& action) {
+  KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+                     return action();))
+
+  KOKKOS_IF_ON_DEVICE((
+#if __CUDA_ARCH__ < 700
+      return Impl::lane_serialized_locked_action(
+                 lock, policy, std::forward<Function>(action));
+#else
+      Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+      return action();
+#endif
+      ))
+}
+#endif  // KOKKOS_ENABLE_CUDA
 
 }  // namespace Impl
 
@@ -397,14 +426,15 @@ namespace LockPolicy {
 //
 // NOTE: taken on its own, those are naive algorithms with no special handling
 // for GPUs that do not guarantee independent forward progress within a
-// wavefront (e.g. AMD HIP): two lanes of the same wavefront contending for
-// the same lock can deadlock if one holds the lock while another spins
-// here, because the hardware may not reschedule the holder until the
-// waiter's SIMD step completes. `atomic_locked_action` (below) handles this
-// correctly for `ExecutionSpace = Kokkos::HIP` via wavefront-serialized
-// dispatch, see `hip_wavefront_serialized_locked_action`(above). Using these
-// LockPolicy types on HIP (or an other harware without forward progress)
-// outside a carefully crafted dispatch remain unsafe.
+// warp/wavefront (e.g. AMD HIP, and NVIDIA pre-Volta): two lanes of the same
+// group contending for the same lock can deadlock if one holds the lock
+// while another spins here, because the hardware may not reschedule the
+// holder until the waiter's SIMD step completes. `atomic_locked_action`
+// (below) handles this correctly for `ExecutionSpace = Kokkos::HIP` and for
+// pre-Volta `Kokkos::Cuda` via lane-serialized dispatch, see
+// `Impl::lane_serialized_locked_action` (above). Using these LockPolicy
+// types directly on such hardware (or any other lacking forward progress)
+// outside a carefully crafted dispatch remains unsafe.
 
 // ==============================================================================
 // SPINLOCK POLICIES
@@ -490,11 +520,15 @@ using ClockRandomBackoffTTAS =
 // Dispatch:
 //   - ExecutionSpace = Kokkos::Serial: no-op lock -- a single thread can
 //     never contend with itself, so `action` just runs directly.
-//   - ExecutionSpace = Kokkos::HIP: wavefront-serialized dispatch (see
-//     Impl::hip_wavefront_serialized_locked_action) to avoid the
-//     lockstep/forward-progress hazard.
-//   - Everything else (OpenMP, Threads, Cuda, SYCL, HPX, ...): the generic
-//     LockPolicy-based spin loop via Impl::LockGuard.
+//   - ExecutionSpace = Kokkos::HIP: lane-serialized dispatch (see
+//     Impl::lane_serialized_locked_action) to avoid the lockstep/forward-
+//     progress hazard.
+//   - ExecutionSpace = Kokkos::Cuda: lane-serialized dispatch too, but only
+//     on pre-Volta architectures (compute capability < 7.0). Volta and later
+//     have Independent Thread Scheduling and use the generic path below
+//     instead.
+//   - Everything else (OpenMP, Threads, Volta+ Cuda, SYCL, HPX, ...): the
+//     generic LockPolicy-based spin loop via Impl::LockGuard.
 //
 // Four overloads are provided, differing in how much you want to specify
 // explicitly (LockType and Function are always deduced from `lock` and
@@ -538,8 +572,14 @@ KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
   }
 #if defined(KOKKOS_ENABLE_HIP)
   else if constexpr (Impl::is_hip_execution_space_v<ExecutionSpace>) {
-    return Impl::hip_wavefront_serialized_locked_action(
-        lock, policy, std::forward<Function>(action));
+    return Impl::lane_serialized_locked_action(lock, policy,
+                                               std::forward<Function>(action));
+  }
+#endif
+#if defined(KOKKOS_ENABLE_CUDA)
+  else if constexpr (Impl::is_cuda_execution_space_v<ExecutionSpace>) {
+    return Impl::cuda_dispatch_locked_action(lock, policy,
+                                             std::forward<Function>(action));
   }
 #endif
   else {

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -158,7 +158,7 @@ class ClockExponentialBackoff {
     auto delay              = static_cast<decltype(start)>(
         raw_delay < m_max_delay ? raw_delay : m_max_delay);
 
-    while (static_cast<decltype(start)>(Kokkos::Impl::clock_tic()) - start <
+    while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
            delay) {
       // Active, non-blocking wait on the cycle counter.
       Kokkos::load_fence();
@@ -200,7 +200,7 @@ class ClockRandomBackoff {
   KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
     uint32_t delay = next_random_delay(m_seed, m_max_delay);
     auto start     = Kokkos::Impl::clock_tic();
-    while (static_cast<decltype(start)>(Kokkos::Impl::clock_tic()) - start <
+    while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
            delay) {
       Kokkos::load_fence();
     }

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -298,96 +298,141 @@ template <>
 inline constexpr bool is_cuda_execution_space_v<Kokkos::Cuda> = true;
 #endif
 
-#if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA)
+template <typename ExecutionSpace>
+inline constexpr bool is_sycl_execution_space_v = false;
+
+#if defined(KOKKOS_ENABLE_SYCL)
+template <>
+inline constexpr bool is_sycl_execution_space_v<Kokkos::SYCL> = true;
+#endif
+
+#if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA) || \
+    defined(KOKKOS_ENABLE_SYCL)
 // Runs `action` atomically under `lock`, safe for SIMT execution groups that
 // do not guarantee independent forward progress between lanes: AMD
 // wavefronts (always, on every ROCm/architecture combination we know of),
-// and NVIDIA warps on architectures older than Volta (compute capability
-// < 7.0), which predate Independent Thread Scheduling.
+// NVIDIA warps on architectures older than Volta (compute capability
+// < 7.0), which predate Independent Thread Scheduling, and Intel sub-groups.
 //
-// This deliberately avoids warp-vote/shuffle intrinsics (__ballot, __shfl,
-// __activemask, and friends) for the lane-election logic itself. Their use
-// under divergent control flow (like here) was affected by at least a confirmed
-// HIP compiler bug that produced wrong results (see ROCm/hip#952 and the
-// follow-up ROCm/hip#2474), reported present as late as 2022 and fixed in 2023.
-// The `_sync` variants (explicit participation mask) became available, and
-// enabled by default, starting with ROCm 7.0. Even though current ROCm is
-// expected to have this fixed, the plain uniform-loop approach below avoids
-// depending on that fix being present for whichever ROCm version and hardware
-// this ends up compiled against, and sidesteps the question entirely.
+// Originally, this has deliberately avoiding the use of warp-vote/shuffle
+// intrinsics (__ballot, __shfl, __activemask, and friends) for the
+// lane-election logic itself because their use under divergent control flow
+// (like here) was affected by at least a confirmed HIP compiler bug that
+// produced wrong results (see ROCm/hip#952 and the follow-up ROCm/hip#2474),
+// reported present as late as 2022 and fixed in 2023. Now, it also allow to
+// have a common algorithm for HIP, CUDA pre-Volta, and Intel GPUs.
 //
-// Instead, every lane in the group runs the "same" uniform, convergent
-// loop over lane indices. The loop structure never depends on any
-// other lane's state. Within that loop, only the lane whose own index
-// matches the current iteration ever touches `lock`, every other lane's
-// iteration is a no-op. This means at most one lane per group is ever
-// inside the acquire/action/release sequence at a time, which is what
-// actually removes the lockstep hazard. Because only one lane is ever
-// spinning at a time, it's safe to reuse the same LockPolicy types used by
-// the generic path for the elected lane's own acquire/release.
+// Every lane in the group runs the "same" uniform, convergent loop over lane
+// indices. The loop structure never depends on any other lane's state. Within
+// that loop, only the lane whose own index matches the current iteration ever
+// touches `lock`, every other lane's iteration is a no-op. This means at most
+// one lane per group is ever inside the acquire/action/release sequence at a
+// time, which is what actually removes the lockstep hazard. Because only one
+// lane is ever spinning at a time, it's safe to reuse the same LockPolicy types
+// used by the generic path for the elected lane's own acquire/release.
 //
-// Cost: this serializes the whole group through this call, one lane at
-// a time, even when the individual locks are all different and
-// uncontended. It trades away all intra-group parallelism for this
-// operation in exchange for correctness on this hardware. (A better solution
-// could be considered, but it is not trivial.)
+// Cost: this serializes the whole group through this call, one lane at a time,
+// even when the individual locks are all different and uncontended. It trades
+// away all intra-group parallelism for this operation in exchange for
+// correctness on those hardware. (A better solution could be considered, but it
+// is not trivial.)
 //
-// Open question for a later pass: given the failure was a compiler bug and
-// not a design limitation, would it be worth maintaining a second, faster
-// implementation on top of __ballot/__shfl for ROCm versions known to have
-// the fix, selected at compile time via HIP_VERSION (or
-// HIP_VERSION_MAJOR/HIP_VERSION_MINOR), falling back to this uniform loop
-// to recover intra-group parallelism for uncontended locks?
+// Open question for a later pass: given the failure was a compiler bug and not
+// a design limitation, would it be worth maintaining a second, faster
+// implementation on top of __ballot/__shfl for ROCm versions known to have the
+// fix, selected at compile time via HIP_VERSION (or
+// HIP_VERSION_MAJOR/HIP_VERSION_MINOR), falling back to this uniform loop to
+// recover intra-group parallelism for uncontended locks?
 //
-// NOTE: This does NOT remove the more general (and universal, Volta+ CUDA
-// included) concern that a lock could be held by a thread in a different
-// group that isn't currently scheduled. This also apply to CPU if a thread is
-// never rescheduled by the kernel, that's a launch/occupancy concern for any
-// hardware spinlock, not something fixable at this layer.
+// NOTE: This does NOT remove the more general (and universal) concern that a
+// lock could be held by a thread in a different group that isn't currently
+// scheduled. This also apply to CPU if a thread is never rescheduled by the
+// kernel, that's a launch/occupancy concern for any hardware spinlock, not
+// something fixable at this layer.
+template <typename LockType, typename LockPolicy, typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) lane_serialized_locked_action_core(
+    unsigned int my_lane, unsigned int group_size, LockType* lock,
+    LockPolicy policy, Function&& action) {
+  // `my_lane` and `group_size` are computed by each backend-specific caller
+  // below using whatever native mechanism that backend exposes (CUDA/HIP:
+  // threadIdx + warpSize; SYCL: sub-group queries), since none of that is
+  // portable, but the election logic itself is identical once you have those
+  // two numbers.
+
+  using ReturnType = decltype(action());
+
+  // Handles void and non-void return type.
+  if constexpr (std::is_void_v<ReturnType>) {
+    for (unsigned int elected_lane = 0; elected_lane < group_size;
+         ++elected_lane) {
+      if (my_lane == elected_lane) {
+        Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+        action();
+      }
+    }
+  } else {
+    static_assert(
+        std::is_default_constructible_v<ReturnType>,
+        "atomic_locked_action's lane-serialized path requires the "
+        "action's return type to be default-constructible (or void).");
+    ReturnType result{};
+    for (unsigned int elected_lane = 0; elected_lane < group_size;
+         ++elected_lane) {
+      if (my_lane == elected_lane) {
+        Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+        result = action();
+      }
+    }
+    // The return is performed uniformly by each active lane outside the
+    // loop to avoid divergence.
+    return result;
+  }
+}
+#endif  // KOKKOS_ENABLE_HIP || KOKKOS_ENABLE_CUDA || KOKKOS_ENABLE_SYCL
+
+#if defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_CUDA)
 template <typename LockType, typename LockPolicy, typename Function>
 KOKKOS_INLINE_FUNCTION decltype(auto) lane_serialized_locked_action(
     LockType* lock, LockPolicy policy, Function&& action) {
   KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
                      return action();))
 
-  KOKKOS_IF_ON_DEVICE((
-      unsigned int flat_local_id =
-          threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
-      unsigned int my_lane =
-          flat_local_id % static_cast<unsigned int>(warpSize);
-
-      using ReturnType = decltype(action());
-
-      // Handles void and non-void return type.
-      if constexpr (std::is_void_v<ReturnType>) {
-        for (unsigned int elected_lane = 0;
-             elected_lane < static_cast<unsigned int>(warpSize);
-             ++elected_lane) {
-          if (my_lane == elected_lane) {
-            Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
-            action();
-          }
-        }
-      } else {
-        static_assert(
-            std::is_default_constructible_v<ReturnType>,
-            "atomic_locked_action's lane-serialized path requires the "
-            "action's return type to be default-constructible (or void).");
-        ReturnType result{};
-        for (unsigned int elected_lane = 0;
-             elected_lane < static_cast<unsigned int>(warpSize);
-             ++elected_lane) {
-          if (my_lane == elected_lane) {
-            Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
-            result = action();
-          }
-        }
-        // The return is performed uniformly by each active lane outside the
-        // loop to avoid divergence.
-        return result;
-      }))
+  KOKKOS_IF_ON_DEVICE(
+      (unsigned int flat_local_id =
+           threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+       unsigned int my_lane =
+           flat_local_id % static_cast<unsigned int>(warpSize);
+       return lane_serialized_locked_action_core(
+           my_lane, static_cast<unsigned int>(warpSize), lock, policy,
+           std::forward<Function>(action));))
 }
 #endif  // KOKKOS_ENABLE_HIP || KOKKOS_ENABLE_CUDA
+
+#if defined(KOKKOS_ENABLE_SYCL)
+// Getting the current sub-group requires
+// sycl::ext::oneapi::this_work_item::get_sub_group() an Intel DPC++ extension,
+// with no core SYCL equivalent to my knowledge.
+#if !defined(SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES)
+#error \
+    "atomic_locked_action's SYCL path needs sycl_ext_oneapi_free_function_queries " \
+    "to query the current sub-group without an nd_item in scope."
+#endif
+template <typename LockType, typename LockPolicy, typename Function>
+KOKKOS_INLINE_FUNCTION decltype(auto) sycl_lane_serialized_locked_action(
+    LockType* lock, LockPolicy policy, Function&& action) {
+  KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+                     return action();))
+
+  KOKKOS_IF_ON_DEVICE(
+      (auto sub_group = sycl::ext::oneapi::this_work_item::get_sub_group();
+       unsigned int my_lane =
+           static_cast<unsigned int>(sub_group.get_local_id()[0]);
+       unsigned int group_size =
+           static_cast<unsigned int>(sub_group.get_local_range()[0]);
+       return lane_serialized_locked_action_core(
+           my_lane, group_size, lock, policy, std::forward<Function>(action));))
+}
+#endif  // KOKKOS_ENABLE_SYCL
 
 #if defined(KOKKOS_ENABLE_CUDA)
 // CUDA-specific dispatch: routes to the lane-serialized path above only on
@@ -399,15 +444,13 @@ KOKKOS_INLINE_FUNCTION decltype(auto) cuda_dispatch_locked_action(
                      return action();))
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
-  KOKKOS_IF_ON_DEVICE((
-      return Impl::lane_serialized_locked_action(
-          lock, policy, std::forward<Function>(action));
-  ))
+  KOKKOS_IF_ON_DEVICE(
+      (return Impl::lane_serialized_locked_action(
+                  lock, policy, std::forward<Function>(action));))
 #else
-  KOKKOS_IF_ON_DEVICE((
-      Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
-      return action();
-  ))
+  KOKKOS_IF_ON_DEVICE(
+      (Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
+       return action();))
 #endif
 }
 #endif  // KOKKOS_ENABLE_CUDA
@@ -529,8 +572,10 @@ using ClockRandomBackoffTTAS =
 //     on pre-Volta architectures (compute capability < 7.0). Volta and later
 //     have Independent Thread Scheduling and use the generic path below
 //     instead.
-//   - Everything else (OpenMP, Threads, Volta+ Cuda, SYCL, HPX, ...): the
-//     generic LockPolicy-based spin loop via Impl::LockGuard.
+//   - ExecutionSpace = Kokkos::SYCL: also the lane-serialized dispatch (see
+//     Impl::sycl_lane_serialized_locked_action).
+//   - Everything else (OpenMP, Threads, Volta+ Cuda, HPX, ...): the generic
+//     LockPolicy-based spin loop via Impl::LockGuard.
 //
 // Four overloads are provided, differing in how much you want to specify
 // explicitly (LockType and Function are always deduced from `lock` and
@@ -582,6 +627,12 @@ KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
   else if constexpr (Impl::is_cuda_execution_space_v<ExecutionSpace>) {
     return Impl::cuda_dispatch_locked_action(lock, policy,
                                              std::forward<Function>(action));
+  }
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+  else if constexpr (Impl::is_sycl_execution_space_v<ExecutionSpace>) {
+    return Impl::sycl_lane_serialized_locked_action(
+        lock, policy, std::forward<Function>(action));
   }
 #endif
   else {

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -398,15 +398,17 @@ KOKKOS_INLINE_FUNCTION decltype(auto) cuda_dispatch_locked_action(
   KOKKOS_IF_ON_HOST((Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
                      return action();))
 
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
   KOKKOS_IF_ON_DEVICE((
-#if __CUDA_ARCH__ < 700
       return Impl::lane_serialized_locked_action(
-                 lock, policy, std::forward<Function>(action));
+          lock, policy, std::forward<Function>(action));
+  ))
 #else
+  KOKKOS_IF_ON_DEVICE((
       Impl::LockGuard<LockType, LockPolicy> guard(lock, policy);
       return action();
+  ))
 #endif
-      ))
 }
 #endif  // KOKKOS_ENABLE_CUDA
 

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -74,19 +74,30 @@ KOKKOS_INLINE_FUNCTION uint32_t next_random_delay(uint32_t& seed,
   return delay;
 }
 
+template <typename LockType>
+struct LockState {
+  static_assert(std::is_integral_v<LockType>,
+                "LockType must be an integral type supported by Kokkos "
+                "atomics.");
+  static constexpr LockType Free   = 0;
+  static constexpr LockType Locked = 1;
+};
+
 // Single compare-and-swap (CAS) attempt to acquire the lock.
 template <typename LockType>
 KOKKOS_INLINE_FUNCTION bool try_lock_cas(LockType* lock) {
-  return Kokkos::atomic_compare_exchange(lock, LockType(0), LockType(1)) ==
-         LockType(0);
+  using State = LockState<LockType>;
+  return Kokkos::atomic_compare_exchange(lock, State::Free, State::Locked) ==
+         State::Free;
 }
 
 // Single test-then-test-and-set (TTAS) attempt to acquire the lock.
 template <typename LockType>
 KOKKOS_INLINE_FUNCTION bool try_lock_ttas(LockType* lock) {
-  return Kokkos::atomic_load(lock) == LockType(0) &&
-         Kokkos::atomic_compare_exchange(lock, LockType(0), LockType(1)) ==
-             LockType(0);
+  using State = LockState<LockType>;
+  return Kokkos::atomic_load(lock) == State::Free &&
+         Kokkos::atomic_compare_exchange(lock, State::Free, State::Locked) ==
+             State::Free;
 }
 
 // TryLock strategies: the CAS/TTAS axis of variation, factored out so
@@ -240,7 +251,7 @@ class BackoffLockPolicy {
   template <typename LockType>
   KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
     Kokkos::memory_fence();
-    Kokkos::atomic_store(lock, LockType(0));
+    Kokkos::atomic_store(lock, LockState<LockType>::Free);
   }
 
  private:
@@ -501,7 +512,7 @@ struct PureSpinlock {
   KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
     Kokkos::memory_fence();  // Ensure writes made in the critical section
                              // are visible before the lock is cleared.
-    Kokkos::atomic_store(lock, LockType(0));
+    Kokkos::atomic_store(lock, Impl::LockState<LockType>::Free);
   }
 };
 
@@ -521,7 +532,7 @@ struct SpinlockTTAS {
   template <typename LockType>
   KOKKOS_INLINE_FUNCTION void release(LockType* lock) const {
     Kokkos::memory_fence();
-    Kokkos::atomic_store(lock, LockType(0));
+    Kokkos::atomic_store(lock, Impl::LockState<LockType>::Free);
   }
 };
 

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -234,6 +234,7 @@ class BackoffLockPolicy {
     while (!TryLock::try_lock(lock)) {
       backoff.on_failed_attempt();
     }
+    Kokkos::memory_fence();  // Prevent speculative execution of action()
   }
 
   template <typename LockType>
@@ -493,6 +494,7 @@ struct PureSpinlock {
       // and forces a fresh attempt each iteration.
       Kokkos::load_fence();
     }
+    Kokkos::memory_fence();  // Prevent speculative execution of action()
   }
 
   template <typename LockType>
@@ -513,6 +515,7 @@ struct SpinlockTTAS {
     while (!Impl::try_lock_ttas(lock)) {
       Kokkos::load_fence();
     }
+    Kokkos::memory_fence();  // Prevent speculative execution of action()
   }
 
   template <typename LockType>

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -285,11 +285,11 @@ class LockGuard {
 
 // ExecutionSpace traits used for backend dispatch in atomic_locked_action
 template <typename ExecutionSpace>
-inline constexpr bool is_serial_execution_space_v = false;
+inline constexpr bool bypass_atomic_lock_v = false;
 
-#if defined(KOKKOS_ENABLE_SERIAL)
+#if defined(KOKKOS_ENABLE_SERIAL) && defined(KOKKOS_ENABLE_ATOMICS_BYPASS)
 template <>
-inline constexpr bool is_serial_execution_space_v<Kokkos::Serial> = true;
+inline constexpr bool bypass_atomic_lock_v<Kokkos::Serial> = true;
 #endif
 
 template <typename ExecutionSpace>
@@ -575,8 +575,8 @@ using ClockRandomBackoffTTAS =
 // to wait for the lock.
 //
 // Dispatch:
-//   - ExecutionSpace = Kokkos::Serial: no-op lock -- a single thread can
-//     never contend with itself, so `action` just runs directly.
+//   - ExecutionSpace = Kokkos::Serial && KOKKOS_ENABLE_ATOMICS_BYPASS: no-op
+//     lock, so `action` just runs directly.
 //   - ExecutionSpace = Kokkos::HIP: lane-serialized dispatch (see
 //     Impl::lane_serialized_locked_action) to avoid the lockstep/forward-
 //     progress hazard.
@@ -624,9 +624,7 @@ KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
                 "LockType must be an integral type supported by Kokkos "
                 "atomics.");
 
-  if constexpr (Impl::is_serial_execution_space_v<ExecutionSpace>) {
-    // Serial: only one thread ever exists, so nothing else can be
-    // contending for this lock. Skip the atomic dance entirely.
+  if constexpr (Impl::bypass_atomic_lock_v<ExecutionSpace>) {
     return action();
   }
 #if defined(KOKKOS_ENABLE_HIP)

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -614,8 +614,12 @@ using ClockRandomBackoffTTAS =
 
 // ==============================================================================
 // atomic_locked_action: runs a user action atomically while holding a lock,
-// dispatching on ExecutionSpace and using the given LockPolicy to decide how
-// to wait for the lock.
+// dispatching on ExecutionSpace and using the given LockPolicy to decide how to
+// wait for the lock.
+//
+// For the execution space, only the type is used for dispatch below. The
+// instance itself carries no runtime state we need yet, but this keeps it
+// consistent with other Kokkos APIs and leaves room for change later.
 //
 // Dispatch:
 //   - ExecutionSpace = Kokkos::Serial && KOKKOS_ENABLE_ATOMICS_BYPASS: no-op
@@ -633,36 +637,28 @@ using ClockRandomBackoffTTAS =
 //     LockPolicy-based spin loop via Impl::LockGuard.
 //
 // Four overloads are provided, differing in how much you want to specify
-// explicitly (LockType and Function are always deduced from `lock` and
-// `action`):
+// explicitly (ExecutionSpace, LockType, and Function are always deduced
+// from `exec_space`, `lock`, and `action` when provided):
 //
-//   atomic_locked_action<ES>(lock, my_policy_instance, action);       // (1)
-//   atomic_locked_action<ES, LockPolicy::SpinlockTTAS>(lock, action); // (2)
-//   atomic_locked_action<ES>(lock, action);                           // (3)
-//   atomic_locked_action(lock, action);                               // (4)
+//   atomic_locked_action(exec_space, my_policy_instance, lock, action); // (1)
+//   atomic_locked_action<LockPolicy>(exec_space, lock, action);         // (2)
+//   atomic_locked_action(my_policy_instance, lock, action);             // (3)
+//   atomic_locked_action(lock, action);                                 // (4)
 //
-// (3) uses LockPolicy::ExponentialBackoff by default;
-// (4) additionally defaults ExecutionSpace to Kokkos::DefaultExecutionSpace.
+// (3) and (4) don't take an execution space instance at all and default to
+// Kokkos::DefaultExecutionSpace; (4) additionally defaults LockPolicy to
+// LockPolicy::ExponentialBackoff.
 // ==============================================================================
 
-/**
- * @brief Acquires `lock` using `policy`, runs `action` atomically, then
- * releases `lock`. Dispatches on `ExecutionSpace`.
- *
- * @tparam ExecutionSpace The Kokkos execution space this call runs under.
- * @tparam LockType   Underlying type of the lock word (e.g. int32_t,
- *                     uint32_t). Must be an integral type supported by
- *                     Kokkos atomics.
- * @tparam LockPolicy Policy instance type (e.g. LockPolicy::PureSpinlock).
- * @tparam Function   User function/lambda type (e.g. KOKKOS_LAMBDA). May
- *                     return void or a value; a returned value is forwarded
- *                     back to the caller.
- */
-template <typename ExecutionSpace, typename LockType, typename LockPolicy,
-          typename Function>
-KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
-                                                           LockPolicy policy,
-                                                           Function&& action) {
+namespace Impl {
+
+// Dispatch on the ExecutionSpace type.
+template <typename ExecutionSpace, typename LockPolicy, typename LockType,
+          typename Function,
+          typename = std::enable_if_t<
+              Kokkos::is_execution_space<ExecutionSpace>::value>>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action_dispatch(
+    LockPolicy policy, LockType* lock, Function&& action) {
   static_assert(std::is_integral_v<LockType>,
                 "LockType must be an integral type supported by Kokkos "
                 "atomics.");
@@ -694,38 +690,71 @@ KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
   }
 }
 
-// Overload (2): explicit ExecutionSpace and explicit LockPolicy type,
-// default-constructed instead of passed as an instance. Delegates to the
-// overload above so the dispatch logic is defined in exactly one place.
+}  // namespace Impl
+
+/**
+ * @brief Acquires `lock` using `policy`, runs `action` atomically, then
+ * releases `lock`. Dispatches on the type of `exec_space`.
+ *
+ * @param exec_space An instance of the Kokkos execution space this call runs
+ *                    under (only its type is used, see above).
+ * @tparam LockPolicy Policy instance type (e.g. LockPolicy::PureSpinlock).
+ * @tparam LockType   Underlying type of the lock word (e.g. int32_t,
+ *                     uint32_t). Must be an integral type supported by
+ *                     Kokkos atomics.
+ * @tparam Function   User function/lambda type (e.g. KOKKOS_LAMBDA). May
+ *                     return void or a value; a returned value is forwarded
+ *                     back to the caller.
+ */
 template <typename ExecutionSpace, typename LockPolicy, typename LockType,
-          typename Function>
-KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
-                                                           Function&& action) {
-  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
-                                              std::forward<Function>(action));
+          typename Function,
+          typename = std::enable_if_t<
+              Kokkos::is_execution_space<ExecutionSpace>::value>>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(
+    const ExecutionSpace&, LockPolicy policy, LockType* lock,
+    Function&& action) {
+  return Impl::atomic_locked_action_dispatch<ExecutionSpace>(
+      policy, lock, std::forward<Function>(action));
 }
 
-// Overload (3): explicit ExecutionSpace, default LockPolicy
-// (ExponentialBackoff).
-template <
-    typename ExecutionSpace, typename LockType, typename Function,
-    typename LockPolicy = Kokkos::Experimental::LockPolicy::ExponentialBackoff>
-KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
-                                                           Function&& action) {
-  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
-                                              std::forward<Function>(action));
+// Overload (2): explicit LockPolicy type, default-constructed instead of
+// passed as an instance. ExecutionSpace, LockType, and Function are all
+// deduced from the arguments.
+template <typename ExecutionSpace, typename LockPolicy, typename LockType,
+          typename Function,
+          typename = std::enable_if_t<
+              Kokkos::is_execution_space<ExecutionSpace>::value>>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(
+    const ExecutionSpace&, LockType* lock, Function&& action) {
+  return Impl::atomic_locked_action_dispatch<ExecutionSpace>(
+      LockPolicy{}, lock, std::forward<Function>(action));
 }
 
-// Overload (4): fully implicit, ExecutionSpace defaults to
-// Kokkos::DefaultExecutionSpace, LockPolicy defaults to ExponentialBackoff.
+// Overload (3): no execution space instance, defaults to
+// Kokkos::DefaultExecutionSpace with an explicit LockPolicy instance.
+template <typename ExecutionSpace = Kokkos::DefaultExecutionSpace,
+          typename LockPolicy, typename LockType, typename Function,
+          typename = std::enable_if_t<
+              Kokkos::is_execution_space<ExecutionSpace>::value>>
+KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockPolicy policy,
+                                                           LockType* lock,
+                                                           Function&& action) {
+  return Impl::atomic_locked_action_dispatch<ExecutionSpace>(
+      policy, lock, std::forward<Function>(action));
+}
+
+// Overload (4): fully implicit, defaults to Kokkos::DefaultExecutionSpace and
+// to LockPolicy::ExponentialBackoff.
 template <
-    typename LockType, typename Function,
     typename ExecutionSpace = Kokkos::DefaultExecutionSpace,
-    typename LockPolicy = Kokkos::Experimental::LockPolicy::ExponentialBackoff>
+    typename LockPolicy = Kokkos::Experimental::LockPolicy::ExponentialBackoff,
+    typename LockType, typename Function,
+    typename =
+        std::enable_if_t<Kokkos::is_execution_space<ExecutionSpace>::value>>
 KOKKOS_INLINE_FUNCTION decltype(auto) atomic_locked_action(LockType* lock,
                                                            Function&& action) {
-  return atomic_locked_action<ExecutionSpace>(lock, LockPolicy{},
-                                              std::forward<Function>(action));
+  return Impl::atomic_locked_action_dispatch<ExecutionSpace>(
+      LockPolicy{}, lock, std::forward<Function>(action));
 }
 
 }  // namespace Experimental

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -116,6 +116,16 @@ KOKKOS_INLINE_FUNCTION uint32_t next_random_delay(uint32_t& seed,
   return delay;
 }
 
+// Used to produce a warning at runtime
+KOKKOS_INLINE_FUNCTION void warn_clock_tic_fallback_once() noexcept {
+  static int warned = 0;
+  if (Kokkos::atomic_compare_exchange(&warned, 0, 1) == 0) {
+    Kokkos::printf(
+        "Kokkos::Impl::clock_tic() is not supported on this device/backend "
+        "combination; falling back to tick-based backoff.\n");
+  }
+}
+
 template <typename LockType>
 struct LockState {
   static_assert(std::is_integral_v<LockType>,
@@ -203,20 +213,30 @@ class ClockExponentialBackoff {
   // is a separate, fixed safety cap on the shift amount itself, only there to
   // avoid undefined behavior / overflow if `m_attempt` grows very large.
   KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
-    auto start = Kokkos::Impl::clock_tic();
+    if constexpr (Kokkos::Impl::has_clock_tic()) {
+      auto start = Kokkos::Impl::clock_tic();
 
-    constexpr int max_shift = 17;
-    int shift               = (m_attempt < max_shift) ? m_attempt : max_shift;
-    uint32_t raw_delay      = (static_cast<uint32_t>(1) << shift);
-    auto delay              = static_cast<decltype(start)>(
-        raw_delay < m_max_delay ? raw_delay : m_max_delay);
+      constexpr int max_shift = 17;
+      int shift               = (m_attempt < max_shift) ? m_attempt : max_shift;
+      uint32_t raw_delay      = (static_cast<uint32_t>(1) << shift);
+      auto delay              = static_cast<decltype(start)>(
+          raw_delay < m_max_delay ? raw_delay : m_max_delay);
 
-    while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
-           delay) {
-      // Active, non-blocking wait on the cycle counter.
-      Kokkos::load_fence();
+      while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
+             delay) {
+        // Active, non-blocking wait on the cycle counter.
+        Kokkos::load_fence();
+      }
+      ++m_attempt;
+    } else {  // Fallback on a tick behavior since the clock is unavailable.
+      warn_clock_tic_fallback_once();
+
+      uint32_t delay = 1;
+      for (uint32_t tick = 0; tick < delay; ++tick) {
+        Kokkos::load_fence();
+      }
+      if (delay < m_max_delay) delay *= 2;
     }
-    ++m_attempt;
   }
 
  private:
@@ -251,11 +271,19 @@ class ClockRandomBackoff {
       : m_max_delay(max_delay), m_seed(generate_thread_seed()) {}
 
   KOKKOS_INLINE_FUNCTION void on_failed_attempt() {
-    uint32_t delay = next_random_delay(m_seed, m_max_delay);
-    auto start     = Kokkos::Impl::clock_tic();
-    while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
-           delay) {
-      Kokkos::load_fence();
+    if constexpr (Kokkos::Impl::has_clock_tic()) {
+      uint32_t delay = next_random_delay(m_seed, m_max_delay);
+      auto start     = Kokkos::Impl::clock_tic();
+      while (static_cast<decltype(delay)>(Kokkos::Impl::clock_tic() - start) <
+             delay) {
+        Kokkos::load_fence();
+      }
+    } else {  // Fallback on a tick behavior since the clock is unavailable.
+      warn_clock_tic_fallback_once();
+      uint32_t delay = next_random_delay(m_seed, m_max_delay);
+      for (uint32_t tick = 0; tick < delay; ++tick) {
+        Kokkos::load_fence();
+      }
     }
   }
 

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -18,6 +18,20 @@ import kokkos.core_impl;
 #include <type_traits>
 #include <utility>
 
+#if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVCC)
+#include <openacc.h>
+
+extern "C" {
+int __pgi_gangidx(void);
+int __pgi_workeridx(void);
+int __pgi_vectoridx(void);
+
+int __pgi_vectorlen(void);
+int __pgi_workerlen(void);
+}
+
+#endif  // KOKKOS_ENABLE_OPENACC && KOKKOS_COMPILER_NVCC
+
 namespace Kokkos {
 namespace Experimental {
 
@@ -30,21 +44,50 @@ namespace Impl {
 // cost) used by backoff policies.
 inline constexpr uint32_t default_backoff_max_delay = 512;
 
-// A hardware thread identifier (device / host).
-// This is only used to seed per-thread pseudo-random backoff jitter, never
-// as a lock key or as a stable/unique thread identity.
-KOKKOS_INLINE_FUNCTION uint32_t get_hardware_thread_id() {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-  // Unique global lane/thread id on GPU.
+// On device: Unique global lane/thread id per backend.
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint32_t get_device_thread_id() noexcept {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+
   return static_cast<uint32_t>(
       threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z) +
       (blockIdx.x + gridDim.x * (blockIdx.y + gridDim.y * blockIdx.z)) *
           (blockDim.x * blockDim.y * blockDim.z));
+
+#elif defined(KOKKOS_ENABLE_SYCL) && \
+    defined(SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES)
+
+  auto item = sycl::ext::oneapi::this_work_item::get_nd_item<3>();
+  return static_cast<uint32_t>(item.get_global_linear_id());
+
+#elif defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVCC)
+
+  int g = __pgi_gangidx();
+  int w = __pgi_workeridx();
+  int v = __pgi_vectoridx();
+
+  int w_len = __pgi_workerlen();
+  int v_len = __pgi_vectorlen();
+
+  return static_cast<uint32_t>((g * w_len + w) * v_len + v);
+
 #else
-  // On host: use the calling thread's stack address.
+  return 1;  // Unsupported Backend/arch combination
+#endif
+}
+
+// On host: use the calling thread's stack address.
+KOKKOS_IMPL_HOST_FUNCTION inline uint32_t get_host_thread_id() noexcept {
   thread_local int dummy = 0;
   return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&dummy));
-#endif
+}
+
+// A hardware thread identifier (device / host).
+// This is only used to seed per-thread pseudo-random backoff jitter, never
+// as a lock key or as a stable/unique thread identity.
+KOKKOS_FORCEINLINE_FUNCTION uint32_t get_hardware_thread_id() noexcept {
+  KOKKOS_IF_ON_DEVICE((return get_device_thread_id();))
+  KOKKOS_IF_ON_HOST((return get_host_thread_id();))
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 // Generates a pseudo-random seed from the hardware thread id and clock_tic().

--- a/core/src/Kokkos_LockPolicy.hpp
+++ b/core/src/Kokkos_LockPolicy.hpp
@@ -41,10 +41,9 @@ KOKKOS_INLINE_FUNCTION uint32_t get_hardware_thread_id() {
       (blockIdx.x + gridDim.x * (blockIdx.y + gridDim.y * blockIdx.z)) *
           (blockDim.x * blockDim.y * blockDim.z));
 #else
-  // On host: combine the calling thread's stack address with the clock.
-  int dummy = 0;
-  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&dummy) ^
-                               Kokkos::Impl::clock_tic());
+  // On host: use the calling thread's stack address.
+  thread_local int dummy = 0;
+  return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&dummy));
 #endif
 }
 

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -21,283 +21,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// New Loop Macros...
-// parallel_for, non-tagged
-#define KOKKOS_IMPL_APPLY(func, ...) func(__VA_ARGS__);
-
-// LayoutRight
-// d = 0 to start
-#define KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d, ...)   \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
-    KOKKOS_IMPL_APPLY(func, __VA_ARGS__, i0 + m_offset[d])           \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d, ...)         \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {       \
-    KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i1 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d, ...)         \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {       \
-    KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i2 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d, ...)         \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {       \
-    KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i3 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d, ...)         \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {       \
-    KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i4 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d, ...)         \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {       \
-    KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i5 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d, ...)         \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {       \
-    KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i6 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_8(func, type, m_offset, extent, d, ...)         \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {       \
-    KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i7 + m_offset[d])                                 \
-  }
-
-// LayoutLeft
-// d = rank-1 to start
-#define KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d, ...)   \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
-    KOKKOS_IMPL_APPLY(func, i0 + m_offset[d], __VA_ARGS__)           \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d, ...)   \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) { \
-    KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d - 1,        \
-                         i1 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d, ...)   \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) { \
-    KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d - 1,        \
-                         i2 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d, ...)   \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) { \
-    KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d - 1,        \
-                         i3 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d, ...)   \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) { \
-    KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d - 1,        \
-                         i4 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d, ...)   \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) { \
-    KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d - 1,        \
-                         i5 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d, ...)   \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) { \
-    KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d - 1,        \
-                         i6 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_8(func, type, m_offset, extent, d, ...)   \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) { \
-    KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d - 1,        \
-                         i7 + m_offset[d], __VA_ARGS__)              \
-  }
-
-// Left vs Right
-// TODO: rank not necessary to pass through, can hardcode the values
-#define KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent, rank) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {           \
-    KOKKOS_IMPL_APPLY(func, i0 + m_offset[0])                                  \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
-      KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, rank - 2,             \
-                           i1 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
-      KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, 1, i1 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
-      KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, rank - 2,             \
-                           i2 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
-      KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, 1, i2 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
-      KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, rank - 2,             \
-                           i3 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
-      KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, 1, i3 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
-      KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, rank - 2,             \
-                           i4 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
-      KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, 1, i4 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
-      KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, rank - 2,             \
-                           i5 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
-      KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, 1, i5 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
-      KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, rank - 2,             \
-                           i6 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
-      KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, 1, i6 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
-      KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, rank - 2,             \
-                           i7 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
-      KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, 1, i7 + m_offset[0])  \
-    }                                                                          \
-  }
-
-// Partial vs Full Tile
-#define KOKKOS_IMPL_TILE_LOOP_1(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_2(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_3(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_4(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_5(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_6(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_7(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_8(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
 // parallel_reduce, non-tagged
 // Reduction version
 #define KOKKOS_IMPL_APPLY_REDUX(val, func, ...) func(__VA_ARGS__, val);
@@ -596,305 +319,301 @@ namespace Impl {
     KOKKOS_IMPL_LOOP_LAYOUT_8_REDUX(val, func, type, is_left, m_offset,      \
                                     extent_partial, rank)                    \
   }
-// end New Loop Macros
 
-// tagged macros
-#define KOKKOS_IMPL_TAGGED_APPLY(tag, func, ...) func(tag, __VA_ARGS__);
+// parallel_for macros: combine tagged and non-tagged
+
+#define KOKKOS_IMPL_APPLY(tag, func, ...) \
+  if constexpr (std::is_void_v<tag>)      \
+    func(__VA_ARGS__);                    \
+  else                                    \
+    func(tag{}, __VA_ARGS__);
 
 // LayoutRight
 // d = 0 to start
-#define KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d, ...) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, __VA_ARGS__, i0 + m_offset[d])         \
+#define KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                           \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {    \
+    KOKKOS_IMPL_APPLY(tag, func, __VA_ARGS__, i0 + m_offset[d])         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d, ...) \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i1 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {    \
+    KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i1 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d, ...) \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i2 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {    \
+    KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i2 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d, ...) \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i3 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {    \
+    KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i3 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d, ...) \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i4 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {    \
+    KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i4 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d, ...) \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i5 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {    \
+    KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i5 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d, ...) \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i6 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {    \
+    KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i6 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_8(tag, func, type, m_offset, extent, d, ...) \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i7 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {    \
+    KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i7 + m_offset[d])                 \
   }
 
 // LayoutLeft
 // d = rank-1 to start
-#define KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d, ...) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[d], __VA_ARGS__)         \
+#define KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                           \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {    \
+    KOKKOS_IMPL_APPLY(tag, func, i0 + m_offset[d], __VA_ARGS__)         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d, ...) \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d - 1,      \
-                                i1 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {    \
+    KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, d - 1,      \
+                         i1 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d, ...) \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d - 1,      \
-                                i2 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {    \
+    KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, d - 1,      \
+                         i2 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d, ...) \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d - 1,      \
-                                i3 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {    \
+    KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, d - 1,      \
+                         i3 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d, ...) \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d - 1,      \
-                                i4 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {    \
+    KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, d - 1,      \
+                         i4 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d, ...) \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d - 1,      \
-                                i5 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {    \
+    KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, d - 1,      \
+                         i5 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d, ...) \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d - 1,      \
-                                i6 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {    \
+    KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, d - 1,      \
+                         i6 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_8(tag, func, type, m_offset, extent, d, ...) \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d - 1,      \
-                                i7 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {    \
+    KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, d - 1,      \
+                         i7 + m_offset[d], __VA_ARGS__)                 \
   }
 
 // Left vs Right
 // TODO: rank not necessary to pass through, can hardcode the values
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, \
-                                         extent, rank)                       \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {         \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[0])                    \
+#define KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                 \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {          \
+    KOKKOS_IMPL_APPLY(tag, func, i0 + m_offset[0])                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, rank - 2, \
-                                  i1 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, 1,        \
-                                  i1 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) { \
+      KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, rank - 2,       \
+                           i1 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {        \
+      KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, 1,              \
+                           i1 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, rank - 2, \
-                                  i2 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, 1,        \
-                                  i2 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) { \
+      KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, rank - 2,       \
+                           i2 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {        \
+      KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, 1,              \
+                           i2 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, rank - 2, \
-                                  i3 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, 1,        \
-                                  i3 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) { \
+      KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, rank - 2,       \
+                           i3 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {        \
+      KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, 1,              \
+                           i3 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, rank - 2, \
-                                  i4 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, 1,        \
-                                  i4 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) { \
+      KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, rank - 2,       \
+                           i4 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {        \
+      KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, 1,              \
+                           i4 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, rank - 2, \
-                                  i5 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, 1,        \
-                                  i5 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) { \
+      KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, rank - 2,       \
+                           i5 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {        \
+      KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, 1,              \
+                           i5 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, rank - 2, \
-                                  i6 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, 1,        \
-                                  i6 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) { \
+      KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, rank - 2,       \
+                           i6 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {        \
+      KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, 1,              \
+                           i6 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, rank - 2, \
-                                  i7 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, 1,        \
-                                  i7 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) { \
+      KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, rank - 2,       \
+                           i7 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {        \
+      KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, 1,              \
+                           i7 + m_offset[0])                                  \
+    }                                                                         \
   }
 
 // Partial vs Full Tile
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_1(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_1(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_2(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_2(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_3(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_3(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_4(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_4(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_5(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_5(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_6(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_6(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_7(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_7(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_8(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_8(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
 // parallel_reduce, tagged
@@ -1225,160 +944,29 @@ namespace Impl {
 // end tagged macros
 
 // Structs for calling loops
-template <int Rank, bool IsLeft, typename IType, typename Tagged,
-          typename Enable = void>
+template <int Rank, bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type;
 
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<1, IsLeft, IType, void, void> {
+template <bool IsLeft, typename IType, typename Tagged>
+struct Tile_Loop_Type<1, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_1(func, IType, IsLeft, cond, offset, a, b, 1);
+    KOKKOS_IMPL_TILE_LOOP_1(Tagged, func, IType, IsLeft, cond, offset, a, b, 1);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TILE_LOOP_1_REDUX(value, func, IType, IsLeft, cond, offset, a,
                                   b, 1);
   }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<2, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_2(func, IType, IsLeft, cond, offset, a, b, 2);
-  }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_2_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 2);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<3, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_3(func, IType, IsLeft, cond, offset, a, b, 3);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_3_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 3);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<4, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_4(func, IType, IsLeft, cond, offset, a, b, 4);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_4_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 4);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<5, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_5(func, IType, IsLeft, cond, offset, a, b, 5);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_5_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 5);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<6, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_6(func, IType, IsLeft, cond, offset, a, b, 6);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_6_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 6);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<7, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_7(func, IType, IsLeft, cond, offset, a, b, 7);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_7_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 7);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<8, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_8(func, IType, IsLeft, cond, offset, a, b, 8);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_8_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 8);
-  }
-};
-
-// tagged versions
-
-template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_1(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 1);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_1_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1387,17 +975,25 @@ struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<2, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_2(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 2);
+    KOKKOS_IMPL_TILE_LOOP_2(Tagged, func, IType, IsLeft, cond, offset, a, b, 2);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_2_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 2);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_2_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1406,17 +1002,25 @@ struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<3, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_3(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 3);
+    KOKKOS_IMPL_TILE_LOOP_3(Tagged, func, IType, IsLeft, cond, offset, a, b, 3);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_3_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 3);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_3_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1425,17 +1029,25 @@ struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<4, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_4(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 4);
+    KOKKOS_IMPL_TILE_LOOP_4(Tagged, func, IType, IsLeft, cond, offset, a, b, 4);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_4_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 4);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_4_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1444,17 +1056,25 @@ struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<5, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_5(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 5);
+    KOKKOS_IMPL_TILE_LOOP_5(Tagged, func, IType, IsLeft, cond, offset, a, b, 5);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_5_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 5);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_5_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1463,17 +1083,25 @@ struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<6, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_6(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 6);
+    KOKKOS_IMPL_TILE_LOOP_6(Tagged, func, IType, IsLeft, cond, offset, a, b, 6);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_6_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 6);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_6_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1482,17 +1110,25 @@ struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<7, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_7(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 7);
+    KOKKOS_IMPL_TILE_LOOP_7(Tagged, func, IType, IsLeft, cond, offset, a, b, 7);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_7_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 7);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_7_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1501,23 +1137,32 @@ struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<8, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<8, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_8(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 8);
+    KOKKOS_IMPL_TILE_LOOP_8(Tagged, func, IType, IsLeft, cond, offset, a, b, 8);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_8_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 8);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_8_REDUX(value, Tagged(), func, IType, IsLeft,
                                          cond, offset, a, b, 8);
   }
 };
+
 // end Structs for calling loops
 
 template <typename RP, typename Functor, typename Tag, typename ReferenceType>
@@ -1693,39 +1338,6 @@ struct HostIterateTile {
 #undef KOKKOS_IMPL_TILE_LOOP_6_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_7_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_8_REDUX
-#undef KOKKOS_IMPL_TAGGED_APPLY
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_8
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_8
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_1
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_2
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_3
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_4
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_5
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_6
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_7
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_8
 #undef KOKKOS_IMPL_TAGGED_APPLY_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_1_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_2_REDUX

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -34,25 +34,35 @@ namespace Impl {
  *  having different index-seed values.
  */
 
-KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 
+inline constexpr bool has_clock_tic_device_v = true;
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
   // Return value of 64-bit hi-res clock register.
   return clock64();
+}
 
 // FIXME_SYCL We can only return something useful for Intel GPUs and with RDC
 #elif defined(KOKKOS_ENABLE_SYCL) &&                       \
     defined(KOKKOS_ENABLE_SYCL_RELOCATABLE_DEVICE_CODE) && \
     defined(KOKKOS_ARCH_INTEL_GPU) && defined(__SYCL_DEVICE_ONLY__)
 
+inline constexpr bool has_clock_tic_device_v = true;
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
   return intel_get_cycle_counter();
+}
 
 #else
 
+inline constexpr bool has_clock_tic_device_v = false;
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
   return 0;
+}
 
 #endif
-}
 
 KOKKOS_IMPL_HOST_FUNCTION inline uint64_t clock_tic_host() noexcept {
 #if defined(__i386__) || defined(__x86_64)
@@ -99,6 +109,13 @@ KOKKOS_IMPL_HOST_FUNCTION inline uint64_t clock_tic_host() noexcept {
   return std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
 #endif
+}
+
+// Compile-time information on the support of clock_tic()
+KOKKOS_FORCEINLINE_FUNCTION constexpr bool has_clock_tic() noexcept {
+  KOKKOS_IF_ON_DEVICE((return has_clock_tic_device_v;))
+  KOKKOS_IF_ON_HOST((return true;))
+  KOKKOS_IMPL_UNREACHABLE();
 }
 
 KOKKOS_FORCEINLINE_FUNCTION

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -164,6 +164,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       HostSharedPtrAccessOnDevice
       JoinBackwardCompatibility
       LocalDeepCopy
+      LockPolicy
       MathematicalConstants
       MathematicalFunctions1
       MathematicalFunctions2

--- a/core/unit_test/CMakeLists.txt
+++ b/core/unit_test/CMakeLists.txt
@@ -159,6 +159,7 @@ foreach(Tag Threads;Serial;OpenMP;Cuda;HPX;OpenACC;HIP;SYCL;NextSilicon)
       HostSharedPtrAccessOnDevice
       JoinBackwardCompatibility
       LocalDeepCopy
+      LockPolicy
       MathematicalConstants
       MathematicalFunctions1
       MathematicalFunctions2

--- a/core/unit_test/TestLockPolicy.hpp
+++ b/core/unit_test/TestLockPolicy.hpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+#ifndef KOKKOS_TEST_LOCKPOLICY_HPP
+#define KOKKOS_TEST_LOCKPOLICY_HPP
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+#else
+#include <Kokkos_Core.hpp>
+#endif
+
+#include <Kokkos_LockPolicy.hpp>
+
+namespace Test {
+
+// Generic helper function to test lock contention for a given policy and
+// execution space
+template <typename ExecutionSpace, typename LockPolicy>
+void run_lock_contention_test(const int num_increments) {
+  // The lock and counter must be accessible on the target ExecutionSpace.
+  // A scalar View is initialized to zero by default, which matches
+  // the free state expected by try_lock and LockGuard (0 = free).
+  Kokkos::View<int32_t, ExecutionSpace> counter("counter");
+  Kokkos::View<int32_t, ExecutionSpace> lock("lock");
+
+  Kokkos::parallel_for(
+      "TestLockContention",
+      Kokkos::RangePolicy<ExecutionSpace>(0, num_increments),
+      KOKKOS_LAMBDA(const int) {
+        LockPolicy policy{};
+        // Pass the lock address and execute the atomic increment within the
+        // critical section.
+        Kokkos::Experimental::atomic_locked_action<ExecutionSpace>(
+            &lock(), policy, [=]() { counter()++; });
+      });
+
+  Kokkos::fence("Fence after lock contention test");
+
+  // Copy result back to host for GTest verification
+  auto h_counter =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counter);
+
+  EXPECT_EQ(h_counter(), num_increments);
+}
+
+// GTest test definitions for each LockPolicy
+
+TEST(TEST_CATEGORY, lock_policy_pure_spinlock) {
+  // Test using PureSpinlock policy
+  run_lock_contention_test<TEST_EXECSPACE,
+                           Kokkos::Experimental::LockPolicy::PureSpinlock>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_spinlock_ttas) {
+  // Test using SpinlockTTAS policy
+  run_lock_contention_test<TEST_EXECSPACE,
+                           Kokkos::Experimental::LockPolicy::SpinlockTTAS>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_exponential_backoff) {
+  // Test using ExponentialBackoff policy (default for overloads 3 and 4)
+  run_lock_contention_test<
+      TEST_EXECSPACE, Kokkos::Experimental::LockPolicy::ExponentialBackoff>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_exponential_backoff_ttas) {
+  // Test using ExponentialBackoffTTAS policy
+  run_lock_contention_test<
+      TEST_EXECSPACE, Kokkos::Experimental::LockPolicy::ExponentialBackoffTTAS>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_clock_exponential_backoff) {
+  // Test using ClockExponentialBackoff policy
+  run_lock_contention_test<
+      TEST_EXECSPACE,
+      Kokkos::Experimental::LockPolicy::ClockExponentialBackoff>(10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_clock_exponential_backoff_ttas) {
+  // Test using ClockExponentialBackoffTTAS policy
+  run_lock_contention_test<
+      TEST_EXECSPACE,
+      Kokkos::Experimental::LockPolicy::ClockExponentialBackoffTTAS>(10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_random_backoff) {
+  // Test using RandomBackoff policy
+  run_lock_contention_test<TEST_EXECSPACE,
+                           Kokkos::Experimental::LockPolicy::RandomBackoff>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_random_backoff_ttas) {
+  // Test using RandomBackoffTTAS policy
+  run_lock_contention_test<TEST_EXECSPACE,
+                           Kokkos::Experimental::LockPolicy::RandomBackoffTTAS>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_clock_random_backoff) {
+  // Test using ClockRandomBackoff policy
+  run_lock_contention_test<
+      TEST_EXECSPACE, Kokkos::Experimental::LockPolicy::ClockRandomBackoff>(
+      10000);
+}
+
+TEST(TEST_CATEGORY, lock_policy_clock_random_backoff_ttas) {
+  // Test using ClockRandomBackoffTTAS policy
+  run_lock_contention_test<
+      TEST_EXECSPACE, Kokkos::Experimental::LockPolicy::ClockRandomBackoffTTAS>(
+      10000);
+}
+
+// Test overload (4) which defaults ExecutionSpace to DefaultExecutionSpace
+// and LockPolicy to ExponentialBackoff.
+template <typename ExecutionSpace>
+void run_lock_contention_test_default(const int num_increments) {
+  Kokkos::View<int32_t, ExecutionSpace> counter("counter");
+  Kokkos::View<int32_t, ExecutionSpace> lock("lock");
+
+  Kokkos::parallel_for(
+      "TestLockContentionImplicit",
+      Kokkos::RangePolicy<ExecutionSpace>(0, num_increments),
+      KOKKOS_LAMBDA(const int) {
+        // Calls overload (4): fully implicit ExecutionSpace and LockPolicy.
+        Kokkos::Experimental::atomic_locked_action(&lock(),
+                                                   [=]() { counter()++; });
+      });
+
+  Kokkos::fence("Fence after implicit lock test");
+  auto h_counter =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), counter);
+  EXPECT_EQ(h_counter(), num_increments);
+}
+
+TEST(TEST_CATEGORY, lock_policy_implicit_overloads) {
+  run_lock_contention_test_default<TEST_EXECSPACE>(10000);
+}
+
+}  // namespace Test
+
+#endif  // KOKKOS_TEST_LOCKPOLICY_HPP

--- a/core/unit_test/TestLockPolicy.hpp
+++ b/core/unit_test/TestLockPolicy.hpp
@@ -34,7 +34,7 @@ void run_lock_contention_test(const int num_increments) {
         // Pass the lock address and execute the atomic increment within the
         // critical section.
         Kokkos::Experimental::atomic_locked_action<ExecutionSpace>(
-            &lock(), policy, [=]() { counter()++; });
+            policy, &lock(), [=]() { counter()++; });
       });
 
   Kokkos::fence("Fence after lock contention test");


### PR DESCRIPTION
This PR introduces `Kokkos::Experimental::atomic_locked_action`, a small generic utility to acquire a user-provided lock, run a user-provided action atomically, and release the lock. The waiting strategy is selectable via a `LockPolicy` template parameter, and the underlying implementation dispatched on `ExecutionSpace`: a no-op on `Kokkos::Serial`, a thread-serialized intra-group implementation on SIMT archs without independent scheduling (`Kokkos::HIP`, CUDA pre-Volta, `Kokkos::SYCL`) to avoid a lockstep/forward-progress hazard on wavefronts/sub-groups, and a generic spin-based implementation everywhere else.

The motivating use case is fine-grained, per-element locking: for example, drawing a random number from one specific state of a `Random_SFC64_Pool` (`atomic_draw_from_state(state_idx)`) without a race condition against other threads drawing from the same state, without having to lock the whole pool. This will be introduced in a follow-up PR. See [Usage Examples](#usage-examples) section for more details.

Ten `LockPolicy` types are provided out of the box, covering two independent axes: the lock-acquisition check (plain compare-and-set (CAS) vs. test-then-test-and-set (TTAS)) and, for the backoff srtategies, the wait mechanism (a tick-counted loop vs. one timed against Kokkos' abstract cycle counter) and the backoff shape (exponential vs. random). All ten are built by combining two small strategy types through a single `Impl::BackoffLockPolicy` template, so this costs nothing at runtime.

This feature is being introduced under `Kokkos::Experimental` and is **not yet considered stable**:
- It has only been tested on Serial, OpenMP, CUDA, and HIP so far. The behavior on other backends (SYCL, NextSilicon, ...) is not yet verified. _Help with this is welcome._
- No default `LockPolicy` per backend has been chosen based on real performance data yet; the current defaults are reasonable starting points, not the result of benchmarking across contention levels. More thorough performance testing, varying contention rate per backend, is needed before recommending (or hard-coding) a default per backend.

### Related issues / PRs

Related to #9231, #4726, #9288

*Note for reviewers*: This PR now builds on top of #9524 which should be merge before this one. Only the changes in [‎core/src/Kokkos_LockPolicy.hpp](https://github.com/kokkos/kokkos/pull/9378/changes#diff-e35f73f55ebebcc024c4c5371de37a1bd275a828975b2b38bad62903c1f22bd3), [‎core/unit_test/TestLockPolicy.hpp‎](https://github.com/kokkos/kokkos/pull/9378/changes#diff-c2b0b56e254449f9b9c80f578f05d4be181a57cf2460514ca3febf2bc3aaa008) and [‎core/unit_test/CMakeLists.txt](https://github.com/kokkos/kokkos/pull/9378/changes#diff-3b1b58692f137b8d5da01ac74cce73ee0be6d04fdac5ad0c2bca1bb513e642fb) are related to this PR.

### Changelog Entry

Required and targeting the 5.3 release.

**New Features**
- Added `Kokkos::Experimental::atomic_locked_action` and the `Kokkos::Experimental::LockPolicy` family of lock-acquisition policies (`PureSpinlock`, `SpinlockTTAS`, `ExponentialBackoff`, `ExponentialBackoffTTAS`, `ClockExponentialBackoff`, `ClockExponentialBackoffTTAS`, `RandomBackoff`, `RandomBackoffTTAS`, `ClockRandomBackoff`, `ClockRandomBackoffTTAS`) for running a user action atomically under a user-provided lock, with per-`ExecutionSpace` dispatch (experimental).

---
## Usage Examples

### 1. Basic Example: Atomic Counter Increment (used as unit test)

This basic example demonstrates how to use `atomic_locked_action` to protect a critical section updating a shared variable:

```cpp
#include <Kokkos_Core.hpp>
#include <Kokkos_LockPolicy.hpp>

void increment_example() {
  using ExecutionSpace = Kokkos::DefaultExecutionSpace;

  Kokkos::View<int, ExecutionSpace> counter("counter");
  Kokkos::View<int, ExecutionSpace> lock("lock"); // Initialized to 0 (unlocked)

  const int N = 10000;
  Kokkos::parallel_for("CounterIncrement", Kokkos::RangePolicy<ExecutionSpace>(0, N),
    KOKKOS_LAMBDA(const int i) {
      // Execute the lambda atomically under the lock
      Kokkos::Experimental::atomic_locked_action<ExecutionSpace>(
        lock.data(),
        [&]() {
          counter() += 1;
        }
      );
    }
  );
}
```
*Note on Performance*:

While this simple example illustrates the API usage, doing a global counter increment using a spinlock will lead to heavy lock contention. For simple operations like scalar accumulation, built-in Kokkos constructs such as `Kokkos::atomic_add` or `Kokkos::parallel_reduce` achieve the same result with significantly better performance. `atomic_locked_action` is intended for multi-word or non-atomic critical sections where native atomic instructions are not available.

### 2. Representative Real-World Example: `Random_SFC64_Pool` (or any other Random Pool)

A more realistic use case involves updating non-trivial internal state (such as pseudo-random generator state vectors) atomically without requiring the user to manually handle lock checkout/checkin sequences (`get_state()` / `free_state()`).

By leveraging `atomic_locked_action`, we can add an `atomic_draw_from_state` helper directly to `Random_SFC64_Pool`:
```cpp
template <class DeviceType = Kokkos::DefaultExecutionSpace>
class Random_SFC64_Pool {
  // ... (existing members and constructors) ...

 public:
  /**
   * @brief Atomically draws a random number from a given state index.
   *
   * Locks state_idx, advances the SFC64 generator state, updates memory, 
   * and safely releases the lock.
   */
  KOKKOS_INLINE_FUNCTION
  uint64_t atomic_draw_from_state(const uint64_t state_idx) const {
    uint64_t result = 0;

    // Acquire lock for this state_idx, run action, release lock
    Kokkos::Experimental::atomic_locked_action<execution_space>(
      &locks_(state_idx, 0),
      [&]() {
        // Instantiate temporary generator from state
        Random_SFC64<DeviceType> gen(state_, state_idx);

        // Advance generator state and draw sample
        result = gen.urand64();

        // Write updated state back to memory before releasing lock
        for (int i = 0; i < 4; ++i) {
          state_(state_idx, i) = gen.state_[i];
        }
      }
    );

    return result;
  }
};
```
Some benefits of this approach:

- Safety: Prevents accidental *deadlock* or state corruption if a user forgets to call `free_state()`.

- Backend Interoperability: Automatically uses the correct execution strategy for the target backend (e.g., wavefront serialization on AMD GPUs under `Kokkos::HIP` to prevent lockstep deadlocks).
---

### Future work

If this feature is judged useful enough to move past `Experimental`, follow-up ideas include:
- More elaborate locking policies: a ticket lock (FIFO fairness, which none of the current policies provide), and a warp/wavefront-aggregation policy for GPUs that elects one leader thread per contended lock among threads targeting the same address, instead of serializing or retrying independently.
- A passive-wait policy option for CPU backends. Currently every policy spins actively; a policy that yields or blocks after some threshold would be worth adding for host execution spaces.
- Exploring lock-elision approaches based on hardware transactional memory where available.
