### PR TITLE
Remove redundant clean-up step in OLCF GitLab CI

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -66,16 +66,3 @@ include:
   ref: main
   file:
     - /runners.yml
-
-clear-ci-builds:
-  stage: clean_up
-  extends:
-    - .frontier-shell-runner
-  variables:
-    GIT_STRATEGY: none
-    OLCF_SERVICE_ACCOUNT: ums018_auser
-  script:
-    - ls -la $HOME
-    - rm -rf $HOME/.jacamar-ci/{builds,cache}
-  rules:
-    - when: always

--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -77,3 +77,5 @@ clear-ci-builds:
   script:
     - ls -la $HOME
     - rm -rf $HOME/.jacamar-ci/{builds,cache}
+  rules:
+    - when: always


### PR DESCRIPTION
We are currently skipping the clean-up stage when one of the builds failed which isn't what we want. Since the `crayclang` build has been failing for quite some time, we also haven't run the cleanup step for a long time.

### Changelog Entry
  - Not required
