### PR TITLE
Add direct register query to `clock_tic_device()` for backends without wrappers.

### DIFF
--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -34,11 +34,65 @@ namespace Impl {
  *  having different index-seed values.
  */
 
-KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
+#if defined(__HIP_DEVICE_COMPILE__) || defined(__AMDGCN__)
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t amd_get_cycle_counter() noexcept {
+  // See: https://gpuopen.com/amd-gpu-architecture-programming-documentation/
 
-  // Return value of 64-bit hi-res clock register.
-  return clock64();
+  // CDNA and RDNA1 expose a single 64-bit s_memtime instruction.
+#if defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__) ||  \
+    defined(__gfx90c__) || defined(__gfx940__) || defined(__gfx941__) ||  \
+    defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1010__) || \
+    defined(__gfx1011__) || defined(__gfx1012__) || defined(__gfx1013__)
+
+#if defined(__has_builtin) && __has_builtin(__builtin_amdgcn_s_memtime)
+  return __builtin_amdgcn_s_memtime();
+#else
+  uint64_t cycles;
+  asm volatile("s_memtime %0" : "=s"(cycles));
+  return cycles;
+#endif
+
+  // RDNA2, RDNA3 and RDNA3.5 replaced s_memtime with a single-instruction
+  // 20-bit cycle counter exposed via the SHADER_CYCLES hardware register
+  // (id 29). Used for measuring time-delta within a wave, not between waves.
+  // Acceptable for the "random" per-thread seed use case documented above.
+#elif defined(__gfx1030__) || defined(__gfx1100__) || defined(__gfx1101__) || \
+    defined(__gfx1102__) || defined(__gfx1103__) || defined(__gfx1150__) ||   \
+    defined(__gfx1151__) || defined(__gfx1152__) || defined(__gfx1153__)
+  uint32_t cycles;
+  asm volatile("s_getreg_b32 %0, hwreg(HW_REG_SHADER_CYCLES)" : "=s"(cycles));
+  return static_cast<uint64_t>(cycles & 0xFFFFF);
+
+  // RDNA4 splits the counter into SHADER_CYCLES_LO (id 29) and
+  // SHADER_CYCLES_HI (id 30). Since the two halves are read by separate
+  // instructions, the low half can roll over between the two reads; the
+  // ISA doc recommends re-reading the high half and retrying if it changed.
+#elif defined(__gfx1200__) || defined(__gfx1201__)
+  uint32_t hi0, lo, hi1;
+  do {
+    asm volatile("s_getreg_b32 %0, hwreg(HW_REG_SHADER_CYCLES_HI)" : "=s"(hi0));
+    asm volatile("s_getreg_b32 %0, hwreg(HW_REG_SHADER_CYCLES_LO)" : "=s"(lo));
+    asm volatile("s_getreg_b32 %0, hwreg(HW_REG_SHADER_CYCLES_HI)" : "=s"(hi1));
+  } while (hi0 != hi1);
+  return (static_cast<uint64_t>(hi1) << 32) | static_cast<uint64_t>(lo);
+
+  // Unsupported/unrecognized AMD architecture.
+#else
+  return 0;
+#endif
+}
+#endif
+
+KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
+#if defined(__CUDA_ARCH__) || defined(__NVPTX__) || defined(__PTX_SM__)
+  // See:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=clock64#special-registers-clock64
+  uint64_t cycles;
+  asm volatile("mov.u64 %0, %clock64;" : "=l"(cycles));
+  return cycles;
+
+#elif defined(__HIP_DEVICE_COMPILE__) || defined(__AMDGCN__)
+  return amd_get_cycle_counter();
 
 // FIXME_SYCL We can only return something useful for Intel GPUs and with RDC
 #elif defined(KOKKOS_ENABLE_SYCL) &&                       \

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -84,15 +84,10 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t amd_get_cycle_counter() noexcept {
 #endif
 
 KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
-#if defined(__CUDA_ARCH__) || defined(__NVPTX__) || defined(__PTX_SM__)
-  // See:
-  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=clock64#special-registers-clock64
-  uint64_t cycles;
-  asm volatile("mov.u64 %0, %%clock64;" : "=l"(cycles));
-  return cycles;
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
 
-#elif defined(__HIP_DEVICE_COMPILE__) || defined(__AMDGCN__)
-  return amd_get_cycle_counter();
+  // Return value of 64-bit hi-res clock register.
+  return clock64();
 
 // FIXME_SYCL We can only return something useful for Intel GPUs and with RDC
 #elif defined(KOKKOS_ENABLE_SYCL) &&                       \
@@ -100,6 +95,19 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
     defined(KOKKOS_ARCH_INTEL_GPU) && defined(__SYCL_DEVICE_ONLY__)
 
   return intel_get_cycle_counter();
+
+// Use asm for NVIDIA GPUs when on a different backend than CUDA.
+#elif defined(__CUDA_ARCH__) || defined(__NVPTX__) || defined(__PTX_SM__)
+  // See:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=clock64#special-registers-clock64
+  uint64_t cycles;
+  asm volatile("mov.u64 %0, %%clock64;" : "=l"(cycles));
+  return cycles;
+
+// Use asm for AMD GPUs when on a different backend than HIP.
+#elif defined(__HIP_DEVICE_COMPILE__) || defined(__AMDGCN__)
+
+  return amd_get_cycle_counter();
 
 #else
 

--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -88,7 +88,7 @@ KOKKOS_IMPL_DEVICE_FUNCTION inline uint64_t clock_tic_device() noexcept {
   // See:
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=clock64#special-registers-clock64
   uint64_t cycles;
-  asm volatile("mov.u64 %0, %clock64;" : "=l"(cycles));
+  asm volatile("mov.u64 %0, %%clock64;" : "=l"(cycles));
   return cycles;
 
 #elif defined(__HIP_DEVICE_COMPILE__) || defined(__AMDGCN__)


### PR DESCRIPTION
This is a proposal to add an architecture-based path in `Impl::clock_tic_device()` as a fallback for backends without higher-level function wrapper to access hardware cycle counters (e.g., when using OpenACC or SYCL). All hardware architectures officially supported by Kokkos (listed [here](https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html)) should now be covered.

~I completely replaced the existing backend-specific checks:~
```cpp
#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
  return clock64();
```
~I understand if we prefer keeping the backend intrinsic wrappers as the primary path with architecture assembly as a fallback. However, the current approach aligns `clock_tic_device()` with `clock_tic_host()`, where inline assembly is preferred when available over `std::chrono::high_resolution_clock::now().time_since_epoch().count()`.~

### Related issues / PRs

Should resolve the deadlock discussed in PR #9378 for OpenACC and SYCL backends targeting NVIDIA and AMD GPUs.

In a previous Slack discussion, it was mentioned that `clock_tic()` was placed in `Impl` because it could not be guaranteed to work across all hardware/backend combinations. This PR could remove that limitation.

### Changelog Entry
  - Unsure
