### PR TITLE
Add RISC-V cycle counter support to clock_tic_host()

### DIFF
--- a/core/src/impl/Kokkos_ClockTic.hpp
+++ b/core/src/impl/Kokkos_ClockTic.hpp
@@ -94,6 +94,26 @@ KOKKOS_IMPL_HOST_FUNCTION inline uint64_t clock_tic_host() noexcept {
 
   return (result);
 
+#elif defined(__riscv) || defined(__riscv__)  // RISC-V
+  // see : https://riscv.github.io/riscv-isa-manual/snapshot/spec/#ext:zicntr
+  uint64_t cycles;
+
+#if __riscv_xlen == 64  // RISC-V 64-bit
+  asm volatile("rdcycle %0" : "=r"(cycles));
+
+#else  // RISC-V 32-bit
+  uint32_t upper, lower, tmp;
+  do {
+    asm volatile("rdcycleh %0\n\trdcycle %1\n\trdcycleh %2"
+                 : "=r"(upper), "=r"(lower), "=r"(tmp));
+  } while (upper != tmp);
+
+  cycles = (static_cast<uint64_t>(upper) << 32) | lower;
+
+#endif
+
+  return cycles;  // RISC-V
+
 #else
 
   return std::chrono::high_resolution_clock::now().time_since_epoch().count();


### PR DESCRIPTION
Add RISC-V hardware cycle counter support to `Impl::clock_tic_host()`.

While working on #9392 and reviewing Kokkos hardware support (listed [here](https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html)), I noticed that RISC-V was the only supported CPU architecture lacking direct support for hardware cycle counters, despite ISA support being available (at least for the RISC-V architectures supported by Kokkos). This PR aims to fill that gap.

*Note*: I have not tested this implementation on physical RISC-V hardware.

### Related issues / PRs

PR #9392

### Changelog Entry

  - Unsure