### PR TITLE
Relax check for stacktrace support

### DIFF
--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -665,7 +665,9 @@
 #if __has_include(<execinfo.h>)
 #define KOKKOS_IMPL_ENABLE_STACKTRACE
 #endif
+#if __has_include(<cxxabi.h>)
 #define KOKKOS_IMPL_ENABLE_CXXABI
+#endif
 #endif
 
 #if (defined(KOKKOS_IMPL_WINDOWS_CUDA) || defined(KOKKOS_COMPILER_MSVC)) && \

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -661,10 +661,7 @@
 #endif
 // clang-format on
 
-#if (defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG) ||        \
-     defined(KOKKOS_COMPILER_INTEL_LLVM) ||                                   \
-     defined(KOKKOS_COMPILER_NEXT_LLVM) || defined(KOKKOS_COMPILER_NVHPC)) && \
-    !defined(_WIN32) && !defined(__ANDROID__)
+#if !defined(_WIN32) && !defined(__ANDROID__)
 #if __has_include(<execinfo.h>)
 #define KOKKOS_IMPL_ENABLE_STACKTRACE
 #endif


### PR DESCRIPTION
I noticed that I didn't get a stacktrace printed on abort when using `AppleClang`. Just adding the compiler to the current list worked fine. Since the list already contains pretty much every compiler, I relaxed the check to just look at the target platform.