### PR TITLE
Group dependabot codeql-action/* updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "pre-commit"
     directory: "/"


### PR DESCRIPTION
This PR groups dependabot updates for the `github/codeql-action/{analyze,init,upload-sarif}` actions.
Previously, they were updated in a single PR (for example #9238) but since a few weeks the updates are split into three separate PRs, leading to CI failures for the `init` PR using the wrong `analyze` version (see [here](https://github.com/kokkos/kokkos/actions/runs/30872161959/job/91879028775?pr=9396)), and the `analyze` PR using the wrong `init` version (see [here](https://github.com/kokkos/kokkos/actions/runs/30872291956/job/91880257249?pr=9398)).

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry

Not required