### PR TITLE
`ReferenceCountedAccessor` gets `element_type` from `NestedAccessor`

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -358,7 +358,7 @@ class ReferenceCountedDataHandle {
   template <class OtherElementType, class OtherSpace>
   friend class ReferenceCountedDataHandle;
 
-  template <class OtherElementType, class OtherSpace, class NestedAccessor>
+  template <class OtherSpace, class NestedAccessor>
   friend class ReferenceCountedAccessor;
 
   SharedAllocationTracker m_tracker;
@@ -383,29 +383,29 @@ template <class T>
 constexpr bool IsReferenceCountedDataHandleV =
     IsReferenceCountedDataHandle<T>::value;
 
-template <class ElementType, class MemorySpace, class NestedAccessor>
+template <class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor;
 
 template <class Accessor>
 struct IsReferenceCountedAccessor : std::false_type {};
 
-template <class ElementType, class MemorySpace, class NestedAccessor>
+template <class MemorySpace, class NestedAccessor>
 struct IsReferenceCountedAccessor<
-    ReferenceCountedAccessor<ElementType, MemorySpace, NestedAccessor>>
-    : std::true_type {};
+    ReferenceCountedAccessor<MemorySpace, NestedAccessor>> : std::true_type {};
 
 template <class T>
 constexpr bool IsReferenceCountedAccessorV =
     IsReferenceCountedAccessor<T>::value;
 
-template <class ElementType, class MemorySpace, class NestedAccessor>
+template <class MemorySpace, class NestedAccessor>
 class ReferenceCountedAccessor {
  public:
-  using element_type     = ElementType;
-  using data_handle_type = ReferenceCountedDataHandle<ElementType, MemorySpace>;
-  using reference        = typename NestedAccessor::reference;
+  using element_type = typename NestedAccessor::element_type;
+  using data_handle_type =
+      ReferenceCountedDataHandle<element_type, MemorySpace>;
+  using reference = typename NestedAccessor::reference;
   using offset_policy =
-      ReferenceCountedAccessor<ElementType, MemorySpace,
+      ReferenceCountedAccessor<MemorySpace,
                                typename NestedAccessor::offset_policy>;
   using memory_space         = MemorySpace;
   using nested_accessor_type = NestedAccessor;
@@ -429,25 +429,26 @@ class ReferenceCountedAccessor {
   KOKKOS_DEFAULTED_FUNCTION
   constexpr ReferenceCountedAccessor() noexcept = default;
 
-  template <
-      class OtherElementType, class OtherNestedAccessor,
-      class = std::enable_if_t<
-          std::is_convertible_v<OtherElementType (*)[], element_type (*)[]> &&
-          std::is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
+  template <class OtherNestedAccessor,
+            class = std::enable_if_t<
+                std::is_convertible_v<
+                    typename OtherNestedAccessor::element_type (*)[],
+                    element_type (*)[]> &&
+                std::is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
   KOKKOS_FUNCTION constexpr ReferenceCountedAccessor(
-      const ReferenceCountedAccessor<OtherElementType, MemorySpace,
-                                     OtherNestedAccessor>&) {}
+      const ReferenceCountedAccessor<MemorySpace, OtherNestedAccessor>&) {}
 
   template <
-      class OtherElementType, class OtherSpace, class OtherNestedAccessor,
+      class OtherSpace, class OtherNestedAccessor,
       class = std::enable_if_t<
-          std::is_convertible_v<OtherElementType (*)[], element_type (*)[]> &&
+          std::is_convertible_v<
+              typename OtherNestedAccessor::element_type (*)[],
+              element_type (*)[]> &&
           SpaceAccessibility<memory_space,
                              typename OtherSpace::memory_space>::assignable &&
           std::is_constructible_v<NestedAccessor, OtherNestedAccessor>>>
   KOKKOS_FUNCTION constexpr ReferenceCountedAccessor(
-      const ReferenceCountedAccessor<OtherElementType, OtherSpace,
-                                     OtherNestedAccessor>&) {}
+      const ReferenceCountedAccessor<OtherSpace, OtherNestedAccessor>&) {}
 
   template <class OtherElementType,
             class = std::enable_if_t<std::is_convertible_v<
@@ -500,10 +501,9 @@ class ReferenceCountedAccessor {
 };
 
 template <class ElementType, class MemorySpace>
-using CheckedReferenceCountedAccessor =
-    SpaceAwareAccessor<MemorySpace,
-                       ReferenceCountedAccessor<ElementType, MemorySpace,
-                                                default_accessor<ElementType>>>;
+using CheckedReferenceCountedAccessor = SpaceAwareAccessor<
+    MemorySpace,
+    ReferenceCountedAccessor<MemorySpace, default_accessor<ElementType>>>;
 
 template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
@@ -515,7 +515,7 @@ template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
 using CheckedReferenceCountedRelaxedAtomicAccessor = SpaceAwareAccessor<
     MemorySpace,
-    ReferenceCountedAccessor<ElementType, MemorySpace,
+    ReferenceCountedAccessor<MemorySpace,
                              AtomicAccessorRelaxed<ElementType, MemoryScope>>>;
 
 // Implements the deduction of accessors from ElementType, Space, and MemTraits

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -102,7 +102,7 @@ static_assert(
         Kokkos::Impl::SpaceAwareAccessor<
             Kokkos::HostSpace,
             Kokkos::Impl::ReferenceCountedAccessor<
-                float, Kokkos::HostSpace,
+                Kokkos::HostSpace,
                 Kokkos::Impl::AtomicAccessorRelaxed<float, memory_scope>>>>);
 
 static_assert(test_equivalence<float, Kokkos::DefaultExecutionSpace>());

--- a/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
+++ b/core/unit_test/view/TestBasicViewMDSpanConversion.cpp
@@ -41,10 +41,10 @@ static_assert(
                       const long long, Kokkos::HostSpace>>>);
 #endif
 
-static_assert(std::is_convertible_v<Kokkos::default_accessor<double>,
-                                    Kokkos::Impl::ReferenceCountedAccessor<
-                                        double, Kokkos::HostSpace,
-                                        Kokkos::default_accessor<double>>>);
+static_assert(std::is_convertible_v<
+              Kokkos::default_accessor<double>,
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  Kokkos::HostSpace, Kokkos::default_accessor<double>>>);
 
 static_assert(std::is_constructible_v<Kokkos::default_accessor<const double>,
                                       Kokkos::default_accessor<double>>);
@@ -52,31 +52,27 @@ static_assert(std::is_constructible_v<Kokkos::default_accessor<const double>,
 static_assert(std::is_convertible_v<Kokkos::default_accessor<double>,
                                     Kokkos::default_accessor<const double>>);
 
-static_assert(
-    std::is_constructible_v<
-        Kokkos::Impl::ReferenceCountedAccessor<
-            const double, Kokkos::HostSpace,
-            Kokkos::default_accessor<const double>>,
-        Kokkos::Impl::ReferenceCountedAccessor<
-            double, Kokkos::HostSpace, Kokkos::default_accessor<double>>>);
+static_assert(std::is_constructible_v<
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  Kokkos::HostSpace, Kokkos::default_accessor<const double>>,
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  Kokkos::HostSpace, Kokkos::default_accessor<double>>>);
 
 static_assert(std::is_convertible_v<
               Kokkos::Impl::ReferenceCountedAccessor<
-                  double, Kokkos::HostSpace, Kokkos::default_accessor<double>>,
+                  Kokkos::HostSpace, Kokkos::default_accessor<double>>,
               Kokkos::Impl::ReferenceCountedAccessor<
-                  const double, Kokkos::HostSpace,
-                  Kokkos::default_accessor<const double>>>);
+                  Kokkos::HostSpace, Kokkos::default_accessor<const double>>>);
 
-static_assert(std::is_constructible_v<Kokkos::default_accessor<const double>,
-                                      Kokkos::Impl::ReferenceCountedAccessor<
-                                          double, Kokkos::HostSpace,
-                                          Kokkos::default_accessor<double>>>);
+static_assert(std::is_constructible_v<
+              Kokkos::default_accessor<const double>,
+              Kokkos::Impl::ReferenceCountedAccessor<
+                  Kokkos::HostSpace, Kokkos::default_accessor<double>>>);
 
-static_assert(
-    std::is_convertible_v<
-        Kokkos::Impl::SpaceAwareAccessor<
-            Kokkos::HostSpace,
-            Kokkos::Impl::ReferenceCountedAccessor<
-                double, Kokkos::HostSpace, Kokkos::default_accessor<double>>>,
-        Kokkos::Impl::SpaceAwareAccessor<
-            Kokkos::HostSpace, Kokkos::default_accessor<const double>>>);
+static_assert(std::is_convertible_v<
+              Kokkos::Impl::SpaceAwareAccessor<
+                  Kokkos::HostSpace,
+                  Kokkos::Impl::ReferenceCountedAccessor<
+                      Kokkos::HostSpace, Kokkos::default_accessor<double>>>,
+              Kokkos::Impl::SpaceAwareAccessor<
+                  Kokkos::HostSpace, Kokkos::default_accessor<const double>>>);

--- a/core/unit_test/view/TestReferenceCountedAccessor.hpp
+++ b/core/unit_test/view/TestReferenceCountedAccessor.hpp
@@ -16,11 +16,9 @@ using element_t      = float;
 using memory_space_t = TEST_EXECSPACE::memory_space;
 using defacc_t       = Kokkos::default_accessor<element_t>;
 using const_defacc_t = Kokkos::default_accessor<const element_t>;
-using acc_t =
-    Kokkos::Impl::ReferenceCountedAccessor<element_t, memory_space_t, defacc_t>;
+using acc_t = Kokkos::Impl::ReferenceCountedAccessor<memory_space_t, defacc_t>;
 using const_acc_t =
-    Kokkos::Impl::ReferenceCountedAccessor<const element_t, memory_space_t,
-                                           const_defacc_t>;
+    Kokkos::Impl::ReferenceCountedAccessor<memory_space_t, const_defacc_t>;
 using data_handle_t       = typename acc_t::data_handle_type;
 using const_data_handle_t = typename const_acc_t::data_handle_type;
 }  // namespace
@@ -34,10 +32,9 @@ TEST(TEST_CATEGORY, RefCountedAcc_Typedefs) {
   static_assert(
       std::is_same_v<typename acc_t::reference, typename defacc_t::reference>);
   static_assert(
-      std::is_same_v<
-          typename acc_t::offset_policy,
-          Kokkos::Impl::ReferenceCountedAccessor<
-              element_t, memory_space_t, typename defacc_t::offset_policy>>);
+      std::is_same_v<typename acc_t::offset_policy,
+                     Kokkos::Impl::ReferenceCountedAccessor<
+                         memory_space_t, typename defacc_t::offset_policy>>);
 }
 
 template <class T>
@@ -120,10 +117,12 @@ TEST(TEST_CATEGORY, RefCountedAcc_Access) { test_refcountedacc_access(); }
 void test_refcountedacc_conversion() {
   Kokkos::parallel_for(
       Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1), KOKKOS_LAMBDA(int) {
-        using acc_anonym_t = Kokkos::Impl::ReferenceCountedAccessor<
-            element_t, Kokkos::AnonymousSpace, defacc_t>;
-        using const_acc_anonym_t = Kokkos::Impl::ReferenceCountedAccessor<
-            const element_t, Kokkos::AnonymousSpace, const_defacc_t>;
+        using acc_anonym_t =
+            Kokkos::Impl::ReferenceCountedAccessor<Kokkos::AnonymousSpace,
+                                                   defacc_t>;
+        using const_acc_anonym_t =
+            Kokkos::Impl::ReferenceCountedAccessor<Kokkos::AnonymousSpace,
+                                                   const_defacc_t>;
         acc_t acc;
         const_acc_t c_acc(acc);
         acc_anonym_t acc_anonym(acc);
@@ -134,10 +133,10 @@ void test_refcountedacc_conversion() {
         static_assert(!std::is_constructible_v<acc_anonym_t, const_acc_t>);
         static_assert(
             !std::is_constructible_v<acc_anonym_t, const_acc_anonym_t>);
-        static_assert(
-            !std::is_constructible_v<Kokkos::Impl::ReferenceCountedAccessor<
-                                         double, memory_space_t, defacc_t>,
-                                     acc_t>);
+        static_assert(!std::is_constructible_v<
+                      Kokkos::Impl::ReferenceCountedAccessor<
+                          memory_space_t, Kokkos::default_accessor<double>>,
+                      acc_t>);
 
         unused_variable_sink(c_acc);
         unused_variable_sink(c_acc_anonym);


### PR DESCRIPTION
`ElementType` was a redundant template parameter. We should get it from `NestedAccessor`.

See https://eel.is/c++draft/linalg.conj.conjugatedaccessor for an example from the standard.

Motivation: streamline View internals somewhat. 
