### PR TITLE
Trying to fix issues with OLCF nightly.

### DIFF
--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -3,7 +3,6 @@ variables:
 
 stages:
   - test
-  - clean_up
 
 hipcc:
   stage: test

--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -65,3 +65,19 @@ include:
   ref: main
   file:
     - /runners.yml
+
+root-clenaup:
+  stage: .pre
+  tags: [frontier, shell]
+  variables:
+    GIT_STRATEGY: none
+    OLCF_SERVICE_ACCOUNT: ums018_auser
+  id_tokens:
+    OLCF_ID_TOKEN:
+      aud: https://code.olcf.ornl.gov
+  script:
+  - rm -rf $HOME/.jacamar-ci/builds
+  - ls -la $HOME/.jacamar-ci
+  rules:
+  - when: manual
+    allow_failure: true

--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -1,5 +1,6 @@
 variables:
   FF_ENABLE_JOB_CLEANUP: 1
+  FF_GIT_URLS_WITHOUT_TOKENS: 1
 
 stages:
   - test


### PR DESCRIPTION
This PR is built on top of https://github.com/kokkos/kokkos/pull/9407 It does two things: 
1. It adds a manual pre-stage that removes the build directory.  We can use it if we get a problem with permission again.
2. After fixing the permissions, we now have an issue with git. OLCF told me to use `FF_GIT_URLS_WITHOUT_TOKENS: 1` to work around the problem.