### PR TITLE
Also generate the TeamPolicy parallel_for lambda

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_ParallelFor_Team.hpp
@@ -34,6 +34,27 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
   int m_shmem_size;
   size_t m_scratch_size[2];
 
+ public:
+  static auto create_team_for_lambda(
+      const auto& functor_wrapper,
+      const sycl::local_accessor<char, 1>& team_scratch_memory_L0,
+      const size_t (&scratch_size)[2], const int shmem_begin,
+      const sycl::global_ptr<char> global_scratch_ptr) {
+    return [=](sycl::nd_item<2> item) {
+      const member_type team_member(
+          team_scratch_memory_L0.get_multi_ptr<sycl::access::decorated::yes>(),
+          shmem_begin, scratch_size[0],
+          global_scratch_ptr + item.get_group(1) * scratch_size[1],
+          scratch_size[1], item, item.get_group_linear_id(),
+          item.get_group_range(1));
+      if constexpr (std::is_void_v<work_tag>)
+        functor_wrapper.get_functor()(team_member);
+      else
+        functor_wrapper.get_functor()(work_tag(), team_member);
+    };
+  }
+
+ private:
   template <typename FunctorWrapper>
   sycl::event sycl_direct_launch(
       const sycl::global_ptr<char> global_scratch_ptr,
@@ -57,19 +78,9 @@ class Kokkos::Impl::ParallelFor<FunctorType, Kokkos::TeamPolicy<Properties...>,
       const auto shmem_begin       = m_shmem_begin;
       const size_t scratch_size[2] = {m_scratch_size[0], m_scratch_size[1]};
 
-      auto lambda = [=](sycl::nd_item<2> item) {
-        const member_type team_member(
-            team_scratch_memory_L0
-                .get_multi_ptr<sycl::access::decorated::yes>(),
-            shmem_begin, scratch_size[0],
-            global_scratch_ptr + item.get_group(1) * scratch_size[1],
-            scratch_size[1], item, item.get_group_linear_id(),
-            item.get_group_range(1));
-        if constexpr (std::is_void_v<work_tag>)
-          functor_wrapper.get_functor()(team_member);
-        else
-          functor_wrapper.get_functor()(work_tag(), team_member);
-      };
+      auto lambda =
+          create_team_for_lambda(functor_wrapper, team_scratch_memory_L0,
+                                 scratch_size, shmem_begin, global_scratch_ptr);
 
       static sycl::kernel kernel = [&] {
         sycl::kernel_id functor_kernel_id =

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -347,12 +347,12 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
       // implementation for introspection. The kernel call has an empty range
       // and hence the kernel isn't actually executed but the kernel still needs
       // to be submitted for it to be introspected.
-      auto lambda = Impl::ParallelFor<
-          FunctorType, TeamPolicy<Properties...>,
-          Kokkos::SYCL>::create_team_for_lambda(functor_wrapper,
-                                                            team_scratch_memory_L0,
-                                                            scratch_size, shmem_begin,
-                                                            /*global_scratch_ptr*/ nullptr);
+      using ParallelForImpl =
+          Impl::ParallelFor<FunctorType, TeamPolicy<Properties...>,
+                            Kokkos::SYCL>;
+      auto lambda = ParallelForImpl::create_team_for_lambda(
+          functor_wrapper, team_scratch_memory_L0, scratch_size, shmem_begin,
+          /*global_scratch_ptr*/ nullptr);
 
       sycl::kernel_id functor_kernel_id =
           sycl::get_kernel_id<decltype(lambda)>();

--- a/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_TeamPolicy.hpp
@@ -347,19 +347,12 @@ class Kokkos::Impl::TeamPolicyInternal<Kokkos::SYCL, Properties...>
       // implementation for introspection. The kernel call has an empty range
       // and hence the kernel isn't actually executed but the kernel still needs
       // to be submitted for it to be introspected.
-      auto lambda = [=](sycl::nd_item<2> item) {
-        const member_type team_member(
-            team_scratch_memory_L0
-                .get_multi_ptr<sycl::access::decorated::yes>(),
-            shmem_begin, scratch_size[0],
-            static_cast<sycl::global_ptr<char>>(nullptr), scratch_size[1], item,
-            item.get_group_linear_id(), item.get_group_range(1));
-        if constexpr (std::is_same_v<typename traits::work_tag, void>)
-          functor_wrapper.get_functor()(team_member);
-        else
-          functor_wrapper.get_functor()(typename traits::work_tag{},
-                                        team_member);
-      };
+      auto lambda = Impl::ParallelFor<
+          FunctorType, TeamPolicy<Properties...>,
+          Kokkos::SYCL>::create_team_for_lambda(functor_wrapper,
+                                                            team_scratch_memory_L0,
+                                                            scratch_size, shmem_begin,
+                                                            /*global_scratch_ptr*/ nullptr);
 
       sycl::kernel_id functor_kernel_id =
           sycl::get_kernel_id<decltype(lambda)>();


### PR DESCRIPTION
Fixes https://my.cdash.org/tests/443889771. Follow-up to #9353. #9353 still duplicated the `parallel_for` lambda for the TeamPolicy introspection while the `parallel_reduce` lambda was generated by the ParallelReduce implementation.
Apparently, that still caused inconsistencies for the maximum team size even though the implementation appears identical.
Also generating the same lambda fixes the problem.

### Changelog Entry
- No, we already have one for #9353.
