### PR TITLE
propagate memory scope in accessor aliases

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -508,13 +508,15 @@ using CheckedReferenceCountedAccessor =
 template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
 using CheckedRelaxedAtomicAccessor =
-    SpaceAwareAccessor<MemorySpace, AtomicAccessorRelaxed<ElementType>>;
+    SpaceAwareAccessor<MemorySpace,
+                       AtomicAccessorRelaxed<ElementType, MemoryScope>>;
 
 template <class ElementType, class MemorySpace,
           class MemoryScope = desul::MemoryScopeDevice>
 using CheckedReferenceCountedRelaxedAtomicAccessor = SpaceAwareAccessor<
-    MemorySpace, ReferenceCountedAccessor<ElementType, MemorySpace,
-                                          AtomicAccessorRelaxed<ElementType>>>;
+    MemorySpace,
+    ReferenceCountedAccessor<ElementType, MemorySpace,
+                             AtomicAccessorRelaxed<ElementType, MemoryScope>>>;
 
 // Implements the deduction of accessors from ElementType, Space, and MemTraits
 template <class ElementType, class Space, class MemTraits>

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -82,6 +82,27 @@ constexpr bool test_equivalence() {
   return true;
 }
 
+using memory_scope = desul::MemoryScopeCore;
+
+// Check that CheckedRelaxedAtomicAccessor preserves memory scope.
+static_assert(std::is_same_v<
+              Kokkos::Impl::CheckedRelaxedAtomicAccessor<
+                  float, Kokkos::HostSpace, memory_scope>,
+              Kokkos::Impl::SpaceAwareAccessor<
+                  Kokkos::HostSpace,
+                  Kokkos::Impl::AtomicAccessorRelaxed<float, memory_scope>>>);
+// Check that CheckedReferenceCountedRelaxedAtomicAccessor preserves memory
+// scope.
+static_assert(
+    std::is_same_v<
+        Kokkos::Impl::CheckedReferenceCountedRelaxedAtomicAccessor<
+            float, Kokkos::HostSpace, memory_scope>,
+        Kokkos::Impl::SpaceAwareAccessor<
+            Kokkos::HostSpace,
+            Kokkos::Impl::ReferenceCountedAccessor<
+                float, Kokkos::HostSpace,
+                Kokkos::Impl::AtomicAccessorRelaxed<float, memory_scope>>>>);
+
 static_assert(test_equivalence<float, Kokkos::DefaultExecutionSpace>());
 static_assert(
     test_equivalence<const float, Kokkos::DefaultHostExecutionSpace>());


### PR DESCRIPTION
`CheckedRelaxedAtomicAccessor` and
`CheckedReferenceCountedRelaxedAtomicAccessor` respect the provided memory scope.

Fixes https://github.com/kokkos/kokkos/issues/9413
