### PR TITLE
Fix missing desul header in modules builds

### DIFF
--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -8,7 +8,15 @@ import kokkos.core;
 import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.core_impl;
+#else
+#include <Kokkos_Core.hpp>
 #endif
+
+#include <desul/atomics.hpp>
 
 #include <type_traits>
 

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <Kokkos_Macros.hpp>
+#include <desul/atomics.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.core_impl;

--- a/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
+++ b/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
@@ -2,13 +2,6 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 
 #include <Kokkos_Macros.hpp>
-#include <desul/atomics.hpp>
-#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
-import kokkos.core;
-import kokkos.core_impl;
-#else
-#include <Kokkos_Core.hpp>
-#include <Kokkos_Macros.hpp>
 #ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
 import kokkos.core;
 import kokkos.core_impl;


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

Adds the desul header to fix compilation errors in clang-19 modules builds:
```
FAILED: core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/view/TestAccessorFromMemoryTraits.cpp.o 
/usr/bin/clang++-19 -DKOKKOS_DEPENDENCE -I/kokkos/build/core/unit_test -I/kokkos/core/unit_test -I/kokkos/core/unit_test/category_files -I/kokkos/build -I/kokkos/build/core/src -I/kokkos/core/src -I/kokkos/build/containers/src -I/kokkos/containers/src -I/kokkos/build/algorithms/src -I/kokkos/algorithms/src -I/kokkos/build/simd/src -I/kokkos/simd/src -isystem /kokkos/tpls/desul/include -isystem /kokkos/tpls/mdspan/include -x c++ -Werror -Wall -Wextra -Wextra-semi -Wunused-parameter -Wshadow -pedantic -Wsign-compare -Wtype-limits -Wuninitialized -Wsuggest-override -Wimplicit-fallthrough -g -std=gnu++20 -MD -MT core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/view/TestAccessorFromMemoryTraits.cpp.o -MF core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/view/TestAccessorFromMemoryTraits.cpp.o.d @core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/view/TestAccessorFromMemoryTraits.cpp.o.modmap -o core/unit_test/CMakeFiles/Kokkos_CoreTestCompileOnly.dir/view/TestAccessorFromMemoryTraits.cpp.o -c /kokkos/core/unit_test/view/TestAccessorFromMemoryTraits.cpp
/kokkos/core/unit_test/view/TestAccessorFromMemoryTraits.cpp:85:29: error: missing '#include <desul/atomics/Common.hpp>'; 'MemoryScopeCore' must be declared before it is used
   85 | using memory_scope = desul::MemoryScopeCore;
      |                             ^
/kokkos/tpls/desul/include/desul/atomics/Common.hpp:53:8: note: declaration here is not visible
   53 | struct MemoryScopeCore {};
```

### Related issues / PRs

See https://github.com/kokkos/kokkos/pull/9414#issuecomment-5244234113

<!-- Link any related issues or PRs. -->

### Changelog Entry
  - Not required
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:

  - Unsure
-->
