### PR TITLE
SNL CI: rename for frequent NextSilicon releases

### DIFF
--- a/.github/workflows/snl-ci.yml
+++ b/.github/workflows/snl-ci.yml
@@ -417,9 +417,9 @@ jobs:
         working-directory: kokkos/build
         run: ctest --output-on-failure --timeout 3600
 
-  NextSilicon_1_2_0:
-    name: SNL_NextSilicon_1_2_0
-    runs-on: [ns-1.2.0]
+  NextSilicon_Latest:
+    name: SNL_NextSilicon_Latest
+    runs-on: [next-latest]
     continue-on-error: true
 
     steps:


### PR DESCRIPTION
We get frequent toolchain releases. Currently `1.3.0-46`. This way, we can just swap out the software in the runner without making any more changes here.

When the toolchain stabilizes, we will pin this to a supported version like other backends.

