### PR TITLE
Allow selecting fast GTest death test style via environment variable

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -78,6 +78,7 @@ NVIDIA-GH200:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON"
     - export CTEST_BUILD_NAME="NVIDIA-GH200"
+    - export GTEST_DEATH_TEST_STYLE=fast
     - export GTEST_FILTER="-cuda.debug_pin_um_to_host"
     - ctest -VV
         -D CDASH_MODEL=${CDASH_MODEL}

--- a/algorithms/unit_tests/TestSortByKey.hpp
+++ b/algorithms/unit_tests/TestSortByKey.hpp
@@ -255,8 +255,6 @@ TEST(TEST_CATEGORY, SortByKeyWithStrides) {
 }
 
 TEST(TEST_CATEGORY_DEATH, SortByKeyKeysLargerThanValues) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using ExecutionSpace = TEST_EXECSPACE;
 
   // does not matter if we use int or something else

--- a/algorithms/unit_tests/TestStdAlgorithmsConstraints.cpp
+++ b/algorithms/unit_tests/TestStdAlgorithmsConstraints.cpp
@@ -98,7 +98,6 @@ TEST(std_algorithms_DeathTest, expect_no_overlap) {
 
 // Overlapping because iterators are identical
 #if defined(KOKKOS_ENABLE_DEBUG)
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   auto first_s = KE::begin(static_view_1d);
   auto last_s  = first_s + extent0;

--- a/algorithms/unit_tests/UnitTestMain.cpp
+++ b/algorithms/unit_tests/UnitTestMain.cpp
@@ -11,6 +11,9 @@ import kokkos.core;
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/algorithms/unit_tests/UnitTestMain.cpp
+++ b/algorithms/unit_tests/UnitTestMain.cpp
@@ -9,11 +9,14 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/containers/performance_tests/TestMain.cpp
+++ b/containers/performance_tests/TestMain.cpp
@@ -13,6 +13,9 @@ import kokkos.core;
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/containers/performance_tests/TestMain.cpp
+++ b/containers/performance_tests/TestMain.cpp
@@ -11,11 +11,14 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/containers/unit_tests/TestDualView.hpp
+++ b/containers/unit_tests/TestDualView.hpp
@@ -560,8 +560,6 @@ TEST(TEST_CATEGORY, dualview_resize) {
 
 template <typename ExecutionSpace>
 void check_dualview_external_view_construction() {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   Kokkos::View<int*, ExecutionSpace> view1("view1", 10);
   Kokkos::View<int*, ExecutionSpace> view2("view2", 10);
 

--- a/containers/unit_tests/TestDynRankView_Ctors.hpp
+++ b/containers/unit_tests/TestDynRankView_Ctors.hpp
@@ -42,8 +42,6 @@ void test_dyn_rank_view_ctor_from_members() {
 }
 template <class DataType, class ExecSpace, class LayOut>
 static void test_required_allocation_size() {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using DynRankType  = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   const size_t bytes = sizeof(DataType);
   auto size_length_1 = DynRankType::required_allocation_size(10);
@@ -64,7 +62,6 @@ static void test_required_allocation_size_death() {
   GTEST_SKIP() << "only enforced when debug checks are enabled";
   KOKKOS_IMPL_UNREACHABLE();
 #endif
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   using DynRankType = Kokkos::DynRankView<DataType, LayOut, ExecSpace>;
   ASSERT_DEATH(DynRankType::required_allocation_size(2, 3, 4, 5, 6, 7, 8, 9),
                "Cannot allocate 8 dimensions");

--- a/containers/unit_tests/TestOffsetView.hpp
+++ b/containers/unit_tests/TestOffsetView.hpp
@@ -726,7 +726,6 @@ TEST(TEST_CATEGORY, offsetview_unmanaged_construction) {
 }
 
 TEST(TEST_CATEGORY_DEATH, offsetview_unmanaged_construction) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_offsetview_unmanaged_construction_death<int, TEST_EXECSPACE>();
 }
 

--- a/containers/unit_tests/UnitTestMain.cpp
+++ b/containers/unit_tests/UnitTestMain.cpp
@@ -11,6 +11,9 @@ import kokkos.core;
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/containers/unit_tests/UnitTestMain.cpp
+++ b/containers/unit_tests/UnitTestMain.cpp
@@ -9,11 +9,14 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -13,6 +13,9 @@ import kokkos.core;
 #include <PerfTest_Category.hpp>
 
 int main(int argc, char* argv[]) {
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   Kokkos::initialize(argc, argv);
 

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -15,7 +15,8 @@ import kokkos.core;
 int main(int argc, char* argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   Kokkos::initialize(argc, argv);
 

--- a/core/src/impl/Kokkos_SetEnv.hpp
+++ b/core/src/impl/Kokkos_SetEnv.hpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_SETENV_HPP
+#define KOKKOS_SETENV_HPP
+
+#include <stdlib.h>
+
+namespace Kokkos::Impl {
+#ifdef _WIN32
+inline int setenv(const char *name, const char *value, int overwrite) {
+  int errcode = 0;
+  if (!overwrite) {
+    size_t envsize = 0;
+    errcode        = getenv_s(&envsize, NULL, 0, name);
+    if (errcode || envsize) return errcode;
+  }
+  return _putenv_s(name, value);
+}
+
+inline int unsetenv(const char *name) { return _putenv_s(name, ""); }
+
+#else
+using ::setenv;
+using ::unsetenv;
+#endif
+}  // namespace Kokkos::Impl
+
+#endif

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -12,8 +12,6 @@ import kokkos.core;
 #endif
 
 TEST(TEST_CATEGORY_DEATH, abort_from_host) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   char msg[] = "Goodbye cruel world";
   EXPECT_DEATH({ Kokkos::abort(msg); }, msg);
 }

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -66,21 +66,18 @@ TEST_F(ctest_environment, no_process_count) {
 }
 
 TEST_F(ctest_environment_DeathTest, invalid_rank) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(10),
                "Error: local rank 10 is outside the bounds of resource groups "
                "provided by CTest.");
 }
 
 TEST_F(ctest_environment_DeathTest, no_type_str) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(0),
                "Error: CTEST_RESOURCE_GROUP_0 is not specified. Raised by "
                "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, missing_type) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       Kokkos::Impl::get_ctest_gpu(1),
       "Error: device type 'gpus' not included in CTEST_RESOURCE_GROUP_1. "
@@ -92,14 +89,12 @@ TEST_F(ctest_environment_DeathTest, missing_type) {
 }
 
 TEST_F(ctest_environment_DeathTest, no_id_str) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(3),
                "Error: CTEST_RESOURCE_GROUP_3_GPUS is not specified. Raised by "
                "Kokkos::Impl::get_ctest_gpu\\(\\).");
 }
 
 TEST_F(ctest_environment_DeathTest, invalid_id_str) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(Kokkos::Impl::get_ctest_gpu(4),
                "Error: invalid value of CTEST_RESOURCE_GROUP_4_GPUS: 'id:2'. "
                "Raised by Kokkos::Impl::get_ctest_gpu\\(\\).");

--- a/core/unit_test/TestCTestDevice.cpp
+++ b/core/unit_test/TestCTestDevice.cpp
@@ -5,19 +5,7 @@
 
 #include <impl/Kokkos_DeviceManagement.hpp>  // get_ctest_gpu
 
-#ifdef _WIN32
-int setenv(const char *name, const char *value, int overwrite) {
-  int errcode = 0;
-  if (!overwrite) {
-    size_t envsize = 0;
-    errcode        = getenv_s(&envsize, NULL, 0, name);
-    if (errcode || envsize) return errcode;
-  }
-  return _putenv_s(name, value);
-}
-
-int unsetenv(const char *name) { return _putenv_s(name, ""); }
-#endif
+#include <impl/Kokkos_SetEnv.hpp>
 
 class ctest_environment : public ::testing::Test {
  protected:
@@ -25,43 +13,43 @@ class ctest_environment : public ::testing::Test {
 };
 
 void ctest_environment::SetUp() {
-  setenv("CTEST_KOKKOS_DEVICE_TYPE", "gpus", 1);
-  setenv("CTEST_RESOURCE_GROUP_COUNT", "10", 1);
-  unsetenv("CTEST_RESOURCE_GROUP_0");
-  setenv("CTEST_RESOURCE_GROUP_1", "threads", 1);
-  setenv("CTEST_RESOURCE_GROUP_2", "threads,cores", 1);
+  Kokkos::Impl::setenv("CTEST_KOKKOS_DEVICE_TYPE", "gpus", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_COUNT", "10", 1);
+  Kokkos::Impl::unsetenv("CTEST_RESOURCE_GROUP_0");
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_1", "threads", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_2", "threads,cores", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_3", "gpus", 1);
-  unsetenv("CTEST_RESOURCE_GROUP_3_GPUS");
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_3", "gpus", 1);
+  Kokkos::Impl::unsetenv("CTEST_RESOURCE_GROUP_3_GPUS");
 
-  setenv("CTEST_RESOURCE_GROUP_4", "gpus", 1);
-  setenv("CTEST_RESOURCE_GROUP_4_GPUS", "id:2", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_4", "gpus", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_4_GPUS", "id:2", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_5", "gpus", 1);
-  setenv("CTEST_RESOURCE_GROUP_5_GPUS", "slots:1,id:2", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_5", "gpus", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_5_GPUS", "slots:1,id:2", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_6", "gpus", 1);
-  setenv("CTEST_RESOURCE_GROUP_6_GPUS", "id:2,slots:1", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_6", "gpus", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_6_GPUS", "id:2,slots:1", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_7", "threads,gpus", 1);
-  setenv("CTEST_RESOURCE_GROUP_7_GPUS", "id:3,slots:1", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_7", "threads,gpus", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_7_GPUS", "id:3,slots:1", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_8", "gpus,threads", 1);
-  setenv("CTEST_RESOURCE_GROUP_8_GPUS", "id:1,slots:1", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_8", "gpus,threads", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_8_GPUS", "id:1,slots:1", 1);
 
-  setenv("CTEST_RESOURCE_GROUP_9", "cores,gpus,threads", 1);
-  setenv("CTEST_RESOURCE_GROUP_9_GPUS", "id:4,slots:1", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_9", "cores,gpus,threads", 1);
+  Kokkos::Impl::setenv("CTEST_RESOURCE_GROUP_9_GPUS", "id:4,slots:1", 1);
 }
 
 struct ctest_environment_DeathTest : public ctest_environment {};
 
 TEST_F(ctest_environment, no_device_type) {
-  unsetenv("CTEST_KOKKOS_DEVICE_TYPE");
+  Kokkos::Impl::unsetenv("CTEST_KOKKOS_DEVICE_TYPE");
   EXPECT_EQ(Kokkos::Impl::get_ctest_gpu(0), 0);
 }
 
 TEST_F(ctest_environment, no_process_count) {
-  unsetenv("CTEST_RESOURCE_GROUP_COUNT");
+  Kokkos::Impl::unsetenv("CTEST_RESOURCE_GROUP_COUNT");
   EXPECT_EQ(Kokkos::Impl::get_ctest_gpu(0), 0);
 }
 

--- a/core/unit_test/TestCheckedIntegerOps.hpp
+++ b/core/unit_test/TestCheckedIntegerOps.hpp
@@ -23,7 +23,6 @@ TEST(TEST_CATEGORY, checked_integer_operations_multiply_overflow) {
 }
 
 TEST(TEST_CATEGORY_DEATH, checked_integer_operations_multiply_overflow_abort) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     auto result = Kokkos::Impl::multiply_overflow_abort(1u, 2u);
     EXPECT_EQ(result, 2u);

--- a/core/unit_test/TestDeepCopy_SameArgument.hpp
+++ b/core/unit_test/TestDeepCopy_SameArgument.hpp
@@ -46,8 +46,6 @@ void test_deep_copy_same_argument(View v) {
 }
 
 TEST(TEST_CATEGORY_DEATH, deep_copy_same_view) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   test_deep_copy_same_argument(Kokkos::View<double, TEST_EXECSPACE>("v0"));
   test_deep_copy_same_argument(Kokkos::View<int*, TEST_EXECSPACE>("v1", 10));
 }

--- a/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
+++ b/core/unit_test/TestExecutionEnvironmentNonInitializedOrFinalized.cpp
@@ -28,8 +28,6 @@ static_assert(!std::is_trivially_default_constructible_v<NonTrivial>);
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        default_constructed_views) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   auto make_views = [] {
     Kokkos::View<int> v0;
     Kokkos::View<float*> v1;
@@ -66,8 +64,6 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
 }
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         {
@@ -114,8 +110,6 @@ TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, views) {
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        c_style_memory_management) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(
       { [[maybe_unused]] void* ptr = Kokkos::kokkos_malloc(1); },
       "Kokkos ERROR: attempting to perform C-style memory management via "
@@ -187,8 +181,6 @@ struct ForFunctor {
 };
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, parallel_for) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(
       {
         Kokkos::initialize();
@@ -222,8 +214,6 @@ struct ReduceFunctor {
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        parallel_reduce) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(
       {
         using functor_type = EmptyReduceFunctor<float>;
@@ -317,8 +307,6 @@ struct ScanFunctor {
 };
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest, parallel_scan) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(
       {
         Kokkos::initialize();
@@ -402,8 +390,6 @@ void test_execution_space() {
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        execution_space) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   test_execution_space<Kokkos::DefaultExecutionSpace>();
   if (!std::is_same_v<Kokkos::DefaultExecutionSpace,
                       Kokkos::DefaultHostExecutionSpace>) {
@@ -436,8 +422,6 @@ void compute_stuff(Kokkos::DefaultExecutionSpace exec) {
 
 TEST_F(ExecutionEnvironmentNonInitializedOrFinalized_DeathTest,
        static_execution_space) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         Kokkos::initialize();

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -168,7 +168,6 @@ struct TEST_CATEGORY_FIXTURE_DEATH(graph)
 //      checks that submission instantiates if need be).
 //   2. Instantiating twice in a row is invalid.
 TEST_F(TEST_CATEGORY_FIXTURE_DEATH(graph), can_instantiate_only_once) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     bool checked_assertions = false;
     // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
@@ -1351,7 +1350,6 @@ TEST(TEST_CATEGORY, execution_policy_with_default_execution_space_instance) {
   if (exec == TEST_EXECSPACE{}) {
     GTEST_SKIP();
   } else {
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH(graph.root_node().then_parallel_for(
                      Kokkos::RangePolicy(exec, 0, 1), NoOp{}),
                  "The execution space instance of the execution policy of a "

--- a/core/unit_test/TestInitializeFinalize.cpp
+++ b/core/unit_test/TestInitializeFinalize.cpp
@@ -19,8 +19,6 @@ namespace {
 using InitializeFinalize_DeathTest = KokkosExecutionEnvironmentNeverInitialized;
 
 TEST_F(InitializeFinalize_DeathTest, initialize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         Kokkos::initialize();
@@ -48,8 +46,6 @@ TEST_F(InitializeFinalize_DeathTest, initialize) {
 }
 
 TEST_F(InitializeFinalize_DeathTest, finalize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(
       { Kokkos::finalize(); },
       "Error: Kokkos::finalize\\(\\) may only be called after Kokkos has "
@@ -73,8 +69,6 @@ TEST_F(InitializeFinalize_DeathTest, finalize) {
 }
 
 TEST_F(InitializeFinalize_DeathTest, is_initialized) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         bool success = true;
@@ -89,8 +83,6 @@ TEST_F(InitializeFinalize_DeathTest, is_initialized) {
 }
 
 TEST_F(InitializeFinalize_DeathTest, is_finalized) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         bool success = true;

--- a/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
+++ b/core/unit_test/TestKokkosHelpCausesNormalProgramTermination.cpp
@@ -21,8 +21,6 @@ using KokkosHelpCausesNormalProgramTermination_DeathTest =
 
 TEST_F(KokkosHelpCausesNormalProgramTermination_DeathTest,
        print_help_and_exit_early) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   int argc = 1;
 
   char const *argv[] = {

--- a/core/unit_test/TestLegionInitialization.cpp
+++ b/core/unit_test/TestLegionInitialization.cpp
@@ -28,8 +28,6 @@ struct ReductionFunctor {
 // The purpose of this test is to mimic Legion's use case of initializing and
 // finalizing individual backends
 TEST(Legion_DeathTest, individual_backend_initialization) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_EXIT(
       {
         bool success = true;

--- a/core/unit_test/TestMDRangePolicyConstructors.hpp
+++ b/core/unit_test/TestMDRangePolicyConstructors.hpp
@@ -104,7 +104,6 @@ TEST(TEST_CATEGORY_DEATH, md_range_policy_bounds_unsafe_narrowing_conversions) {
       "original value.\n";
   std::string expected = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
 
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ (void)Rank1Policy({-1}, {2}); }, expected);
   ASSERT_DEATH({ (void)Rank2Policy({-1, 0}, {2, 3}); }, expected);
 }
@@ -112,8 +111,6 @@ TEST(TEST_CATEGORY_DEATH, md_range_policy_bounds_unsafe_narrowing_conversions) {
 TEST(TEST_CATEGORY_DEATH, md_range_policy_invalid_bounds) {
   using Rank1Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<1>>;
   using Rank2Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>>;
-
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   auto rank2_dim0 =
       (Rank2Policy::inner_direction == Kokkos::Iterate::Right) ? 1 : 0;
@@ -156,7 +153,6 @@ TEST(TEST_CATEGORY_DEATH, md_range_policy_tile_dims_exceed_launch_bounds) {
       "LaunchBounds (32) - choose smaller tile dims\n";
 
   std::string expected = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   using Policy = Kokkos::MDRangePolicy<TEST_EXECSPACE, Kokkos::Rank<2>,
                                        Kokkos::LaunchBounds<32>>;

--- a/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
+++ b/core/unit_test/TestParseCmdLineArgsAndEnvVars.cpp
@@ -7,6 +7,7 @@
 #include <impl/Kokkos_InitializationSettings.hpp>
 #include <impl/Kokkos_DeviceManagement.hpp>
 #include <impl/Kokkos_Command_Line_Parsing.hpp>
+#include <impl/Kokkos_SetEnv.hpp>
 
 #include <cstdlib>
 #include <mutex>
@@ -34,12 +35,8 @@ class EnvVarsHelper {
         skip_ = std::make_optional<std::string>(name);
         break;
       }
-#ifdef _WIN32
-      int const error_code = _putenv((name + "=" + value).c_str());
-#else
       int const error_code =
-          setenv(name.c_str(), value.c_str(), /*overwrite=*/0);
-#endif
+          Kokkos::Impl::setenv(name.c_str(), value.c_str(), /*overwrite=*/0);
       if (error_code != 0) {
         std::cerr << "failed to set environment variable '" << name << "="
                   << value << "'\n";
@@ -50,11 +47,7 @@ class EnvVarsHelper {
   }
   void teardown() {
     for (auto const& name : vars_) {
-#ifdef _WIN32
-      int const error_code = _putenv((name + "=").c_str());
-#else
-      int const error_code = unsetenv(name.c_str());
-#endif
+      int const error_code = Kokkos::Impl::unsetenv(name.c_str());
       if (error_code != 0) {
         std::cerr << "failed to unset environment variable '" << name << "'\n";
         std::abort();

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -49,8 +49,6 @@ struct Hook4 {
 };
 
 TEST_F(PushFinalizeHook_DeathTest, called_in_reverse_order) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   std::string const expectedOutput([] {
     std::ostringstream os;
     os << hook4str << '\n'
@@ -85,8 +83,6 @@ char const my_terminate_handler_msg[] = "my terminate handler was called\n";
 }
 
 TEST_F(PushFinalizeHook_DeathTest, terminate_on_throw) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   auto terminate_handler = std::get_terminate();
 
   std::set_terminate(my_terminate_handler);

--- a/core/unit_test/TestRangePolicyConstructors.hpp
+++ b/core/unit_test/TestRangePolicyConstructors.hpp
@@ -69,8 +69,6 @@ TEST(TEST_CATEGORY, range_policy_runtime_parameters) {
 }
 
 TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using Policy    = Kokkos::RangePolicy<TEST_EXECSPACE>;
   using ChunkSize = Kokkos::ChunkSize;
 
@@ -85,7 +83,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_invalid_bounds) {
                msg);
 }
 TEST(TEST_CATEGORY_DEATH, range_policy_check_exceeding_max) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // Trigger due to exceeding a policy's range maximum
   using IntPolicy = Kokkos::RangePolicy<int>;
 
@@ -97,7 +94,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_check_exceeding_max) {
 }
 
 TEST(TEST_CATEGORY_DEATH, range_policy_check_exceeding_min) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // Trigger due to exceeding a policy's range minimum
   using IntPolicy = Kokkos::RangePolicy<int>;
 
@@ -119,8 +115,6 @@ struct W {  // round-trip conversion check for narrowing should "fire"
 };
 
 TEST(TEST_CATEGORY_DEATH, range_policy_round_trip_conversion_fires) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using Policy = Kokkos::RangePolicy<>;
 
   static_assert(std::is_convertible_v<W, Policy::index_type>);
@@ -154,8 +148,6 @@ TEST(TEST_CATEGORY, range_policy_one_way_convertible_bounds) {
 }
 
 TEST(TEST_CATEGORY_DEATH, range_policy_check_sign_changes) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using UInt32Policy =
       Kokkos::RangePolicy<TEST_EXECSPACE, Kokkos::IndexType<std::uint32_t>>;
 
@@ -186,7 +178,6 @@ TEST(TEST_CATEGORY_DEATH, range_policy_implicitly_converted_bounds) {
   [[maybe_unused]] auto get_error_msg = [](auto str, auto val) {
     return str.insert(str.find("(") + 1, std::to_string(val).c_str());
   };
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
   std::string expected = std::regex_replace(msg, std::regex("\\(|\\)"), "\\$&");
   {

--- a/core/unit_test/TestScopeGuard.cpp
+++ b/core/unit_test/TestScopeGuard.cpp
@@ -20,7 +20,6 @@ using ScopeGuard_DeathTest = KokkosExecutionEnvironmentNeverInitialized;
  * Test to create a scope guard normally.
  */
 TEST_F(ScopeGuard_DeathTest, create) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // run it in a different process so side effects are not kept
   EXPECT_EXIT(
       {
@@ -43,7 +42,6 @@ TEST_F(ScopeGuard_DeathTest, create) {
  * Test to create a scope guard with an argument.
  */
 TEST_F(ScopeGuard_DeathTest, create_argument) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // run it in a different process so side effects are not kept
   EXPECT_EXIT(
       {
@@ -61,7 +59,6 @@ TEST_F(ScopeGuard_DeathTest, create_argument) {
  * Test to create another scope guard when one has been created.
  */
 TEST_F(ScopeGuard_DeathTest, create_while_initialize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         Kokkos::ScopeGuard guard1{};
@@ -76,7 +73,6 @@ TEST_F(ScopeGuard_DeathTest, create_while_initialize) {
  * Test to create a scope guard when initialization has been done manually.
  */
 TEST_F(ScopeGuard_DeathTest, create_after_initialize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         Kokkos::initialize();
@@ -91,7 +87,6 @@ TEST_F(ScopeGuard_DeathTest, create_after_initialize) {
  * Test to create another scope guard when one has been destroyed.
  */
 TEST_F(ScopeGuard_DeathTest, create_after_finalize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         { Kokkos::ScopeGuard guard1{}; }
@@ -107,7 +102,6 @@ TEST_F(ScopeGuard_DeathTest, create_after_finalize) {
  * Test to destroy a scope guard when finalization has been done manually.
  */
 TEST_F(ScopeGuard_DeathTest, destroy_after_finalize) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   EXPECT_DEATH(
       {
         // create a scope guard and finalize it manually

--- a/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
+++ b/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
@@ -76,8 +76,6 @@ void test_memory_access_violations_from_device() {
 
 TEST(TEST_CATEGORY_DEATH,
      mdspan_space_aware_accessor_invalid_access_from_host) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using ExecutionSpace = TEST_EXECSPACE;
 
   if (Kokkos::SpaceAccessibility<

--- a/core/unit_test/TestStackTrace.hpp
+++ b/core/unit_test/TestStackTrace.hpp
@@ -123,13 +123,11 @@ void test_stacktrace(bool bTerminate, bool bCustom = true) {
 TEST(defaultdevicetype, stacktrace_normal) { test_stacktrace(false); }
 
 TEST(defaultdevicetype_DeathTest, stacktrace_terminate) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ test_stacktrace(true); },
                "I am the custom std::terminate handler.");
 }
 
 TEST(defaultdevicetype_DeathTest, stacktrace_generic_term) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ test_stacktrace(true, false); },
                "Kokkos observes that std::terminate has been called");
 }

--- a/core/unit_test/TestSubView_a.hpp
+++ b/core/unit_test/TestSubView_a.hpp
@@ -61,8 +61,6 @@ TEST(TEST_CATEGORY, view_static_tests) {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_subview_wrong_extents) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
   KOKKOS_IMPL_UNREACHABLE();

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -12,8 +12,6 @@ import kokkos.core;
 namespace {
 
 TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   int N    = 10;
   using LR = Kokkos::LayoutRight;
   using LL = Kokkos::LayoutLeft;

--- a/core/unit_test/TestTeamBasic.hpp
+++ b/core/unit_test/TestTeamBasic.hpp
@@ -236,7 +236,6 @@ void test_exceed_max_team_scratch_size_0() {
 }
 
 TEST(TEST_CATEGORY_DEATH, exceed_max_team_scratch_size_0) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_exceed_max_team_scratch_size_0();
 }
 
@@ -269,7 +268,6 @@ void test_exceed_max_team_scratch_size_1() {
 }
 
 TEST(TEST_CATEGORY_DEATH, exceed_max_team_scratch_size_1) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   test_exceed_max_team_scratch_size_1();
 }
 #endif
@@ -301,10 +299,7 @@ void test_exceed_max_team_size() {
       std::runtime_error);
 }
 
-TEST(TEST_CATEGORY_DEATH, exceed_max_team_size) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  test_exceed_max_team_size();
-}
+TEST(TEST_CATEGORY_DEATH, exceed_max_team_size) { test_exceed_max_team_size(); }
 
 #if !defined(KOKKOS_ENABLE_OPENACC)
 TEST(TEST_CATEGORY, team_broadcast_long) {

--- a/core/unit_test/TestTeamPolicyConstructors.hpp
+++ b/core/unit_test/TestTeamPolicyConstructors.hpp
@@ -180,8 +180,6 @@ TEST(TEST_CATEGORY, team_policy_impl_set_space) {
 }
 
 TEST(TEST_CATEGORY_DEATH, team_policy_invalid_league_size) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(-1, 1),
                "Kokkos::TeamPolicy error: league_size \\(-1\\) must be greater "
                "than or equal to 0");
@@ -209,8 +207,6 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_league_size) {
 }
 
 TEST(TEST_CATEGORY_DEATH, team_policy_invalid_team_size) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 0),
                "Kokkos::TeamPolicy error: team_size \\(0\\) must be greater "
                "than or equal to 1");
@@ -225,8 +221,6 @@ TEST(TEST_CATEGORY_DEATH, team_policy_invalid_team_size) {
 }
 
 TEST(TEST_CATEGORY_DEATH, team_policy_invalid_vector_length) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   EXPECT_DEATH(Kokkos::TeamPolicy<TEST_EXECSPACE>(1, 1, -1),
                "Kokkos::TeamPolicy error: vector_length \\(-1\\) must be "
                "greater than or equal to 1");

--- a/core/unit_test/TestViewAPI_e.hpp
+++ b/core/unit_test/TestViewAPI_e.hpp
@@ -184,7 +184,6 @@ void test_view_stride_precondition_violation(V v) {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_stride_precondition_violation) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     bool checked_assertions = false;
     // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
@@ -230,7 +229,6 @@ void test_view_extent_precondition_violation(V v) {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_extent_precondition_violation) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   {
     bool checked_assertions = false;
     // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)

--- a/core/unit_test/TestViewCtorDimMatch.hpp
+++ b/core/unit_test/TestViewCtorDimMatch.hpp
@@ -83,8 +83,6 @@ struct DynamicRank<0> {
 };
 
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_dyn) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
   KOKKOS_IMPL_UNREACHABLE();
@@ -112,8 +110,6 @@ struct StaticRank<0> {
 };
 
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_stat) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
   KOKKOS_IMPL_UNREACHABLE();
@@ -141,8 +137,6 @@ struct MixedRank<0> {
 };
 
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
   KOKKOS_IMPL_UNREACHABLE();
@@ -173,8 +167,6 @@ TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_params_mix) {
       "extent is 2 but should be 1.")
 
 TEST(TEST_CATEGORY_DEATH, view_construction_with_wrong_static_extents) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
 #ifndef KOKKOS_ENABLE_DEBUG_BOUNDS_CHECK
   GTEST_SKIP() << "only enforced when debug bound checks is enabled";
   KOKKOS_IMPL_UNREACHABLE();

--- a/core/unit_test/TestViewLayoutStrideAssignment.hpp
+++ b/core/unit_test/TestViewLayoutStrideAssignment.hpp
@@ -639,7 +639,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double**, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -654,7 +653,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double***, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -669,7 +667,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double****, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -684,7 +681,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double*****, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -699,7 +695,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double******, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -714,7 +709,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double*******, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -729,7 +723,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_right_to_layoutleft_assignment) {
 
     Kokkos::View<double********, Kokkos::LayoutLeft, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -787,7 +780,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double**, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -802,7 +794,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double***, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -817,7 +808,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double****, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -832,7 +822,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double*****, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -847,7 +836,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double******, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -862,7 +850,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double*******, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }
@@ -877,7 +864,6 @@ TEST(TEST_CATEGORY_DEATH, view_layoutstride_left_to_layoutright_assignment) {
 
     Kokkos::View<double********, Kokkos::LayoutRight, exec_space> dst;
 
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_DEATH({ dst = src; },
                  "View assignment must have compatible layouts");
   }

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -141,8 +141,6 @@ void test_view_memory_access_violations_from_device() {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_host) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   using ExecutionSpace = TEST_EXECSPACE;
 
   if (Kokkos::SpaceAccessibility<

--- a/core/unit_test/UnitTestMain.cpp
+++ b/core/unit_test/UnitTestMain.cpp
@@ -4,6 +4,9 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char *argv[]) {
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/core/unit_test/UnitTestMain.cpp
+++ b/core/unit_test/UnitTestMain.cpp
@@ -3,10 +3,13 @@
 
 #include <gtest/gtest.h>
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/core/unit_test/UnitTestMainInit.cpp
+++ b/core/unit_test/UnitTestMainInit.cpp
@@ -12,6 +12,9 @@ import kokkos.core;
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/core/unit_test/UnitTestMainInit.cpp
+++ b/core/unit_test/UnitTestMainInit.cpp
@@ -10,11 +10,14 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/core/unit_test/UnitTest_CMakeTriBITSCompatibility.cpp
+++ b/core/unit_test/UnitTest_CMakeTriBITSCompatibility.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[]) {
   if (std::getenv("KOKKOS_TEST_TRIBITS_COMPATIBILITY")) {
     return EXIT_SUCCESS;
   }
-  if (argc >= 2 && std::string_view(argv[1]).find(
+  if (argc == 2 && std::string_view(argv[1]).find(
                        "--kokkos-test-tribits-compatibility") == 0) {
     return EXIT_SUCCESS;
   }

--- a/core/unit_test/UnitTest_CMakeTriBITSCompatibility.cpp
+++ b/core/unit_test/UnitTest_CMakeTriBITSCompatibility.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[]) {
   if (std::getenv("KOKKOS_TEST_TRIBITS_COMPATIBILITY")) {
     return EXIT_SUCCESS;
   }
-  if (argc == 2 && std::string_view(argv[1]).find(
+  if (argc >= 2 && std::string_view(argv[1]).find(
                        "--kokkos-test-tribits-compatibility") == 0) {
     return EXIT_SUCCESS;
   }

--- a/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
+++ b/core/unit_test/sycl/TestSYCL_InterOp_Init_Context.cpp
@@ -86,7 +86,6 @@ TEST(sycl_DeathTest, explicit_out_of_order_queue) {
   sycl::context default_context = default_space.sycl_queue().get_context();
   sycl::queue queue(default_context, sycl::default_selector_v);
 #ifdef KOKKOS_IMPL_SYCL_USE_IN_ORDER_QUEUES
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH(Kokkos::SYCL{queue},
                "User provided sycl::queues must be in-order!");
 #else

--- a/core/unit_test/tools/TestEmptyProfilingLibrary.cpp
+++ b/core/unit_test/tools/TestEmptyProfilingLibrary.cpp
@@ -6,8 +6,6 @@
 #include <Kokkos_Core.hpp>
 
 TEST(ProfilingDeathTest, EmptyProfilingLibraryErrors) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
   ASSERT_DEATH(
       {
         Kokkos::initialize();

--- a/simd/unit_tests/UnitTestMain.cpp
+++ b/simd/unit_tests/UnitTestMain.cpp
@@ -11,6 +11,9 @@ import kokkos.core;
 
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
+  // We want to use "threadsafe" by default while the default in GTest on Linux
+  // is "fast"
+  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/simd/unit_tests/UnitTestMain.cpp
+++ b/simd/unit_tests/UnitTestMain.cpp
@@ -9,11 +9,14 @@ import kokkos.core;
 #include <Kokkos_Core.hpp>
 #endif
 
+#include <impl/Kokkos_SetEnv.hpp>
+
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
-  setenv("GTEST_DEATH_TEST_STYLE", "threadsafe", /*overwrite=*/0);
+  Kokkos::Impl::setenv("GTEST_DEATH_TEST_STYLE", "threadsafe",
+                       /*overwrite=*/0);
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();


### PR DESCRIPTION
Fixes #9227. The pull requests suggests to add an option to use fast GTest death tests (accepting warninigs about death tests not being threadsafe). We still force `threadsafe` for some tests that always seem to need the thredsafe option.

### Related issues / PRs

- Timeouts due to death tests are an issue in #9410 that tests on a machine without a lot of hardware resources.

### Changelog Entry
 - No