### PR TITLE
Don't redirect to prepend stage name to avoid 'laggy filesystems' errors

### DIFF
--- a/.jenkins/continuous.groovy
+++ b/.jenkins/continuous.groovy
@@ -29,8 +29,6 @@ pipeline {
             }
             steps {
                 sh '''#!/bin/bash
-                      exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                      echo "Hostname: ${NODE_NAME}" && \
                       pre-commit run --all-files'''
             }
         }
@@ -54,8 +52,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               set -x && \
                               cmake \
@@ -103,8 +99,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -143,8 +137,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -208,8 +200,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf install && mkdir -p install && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
@@ -294,8 +284,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && \
                               set -x && \
                               cmake \
@@ -346,8 +334,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               /opt/cmake/bin/cmake \
@@ -390,8 +376,6 @@ pipeline {
                     }
                     steps {
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               /opt/cmake/bin/cmake \
@@ -428,8 +412,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -480,8 +462,6 @@ pipeline {
                         sh 'ccache --zero-stats'
                         sh 'echo "/opt/rocm/llvm/lib" > /etc/ld.so.conf.d/llvm.conf && ldconfig'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -525,8 +505,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -566,8 +544,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -608,8 +584,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \
@@ -654,8 +628,6 @@ pipeline {
                     steps {
                         sh 'ccache --zero-stats'
                         sh '''#!/bin/bash
-                              exec > >(awk '{ print "[" ENVIRON["STAGE_NAME"] "]", $0 }') 2>&1 && \
-                              echo "Hostname: ${NODE_NAME}" && \
                               rm -rf build && mkdir -p build && cd build && \
                               set -x && \
                               cmake \


### PR DESCRIPTION
I suspect that the redirection to add stage names causes the laggy filesystems errors. Since we haven't found any other fix, this pull request proposes to just remove that indirection.
The drawback is that we can't associate known error types with particular builds or machines anymore in our monitoring script.