### PR TITLE
Use `omp` functionality to check for the number of threads

### DIFF
--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -125,22 +125,7 @@ void OpenMPInternal::resize_thread_data(size_t pool_reduce_bytes,
 }
 
 int OpenMPInternal::get_current_max_threads() noexcept {
-  // Using omp_get_max_threads(); is problematic in conjunction with
-  // Hwloc on Intel (essentially an initial call to the OpenMP runtime
-  // without a parallel region before will set a process mask for a single core
-  // The runtime will than bind threads for a parallel region to other cores on
-  // the entering the first parallel region and make the process mask the
-  // aggregate of the thread masks. The intend seems to be to make serial code
-  // run fast, if you compile with OpenMP enabled but don't actually use
-  // parallel regions or so static int omp_max_threads = omp_get_max_threads();
-
-  int count = 0;
-#pragma omp parallel
-  {
-#pragma omp atomic
-    ++count;
-  }
-  return count;
+  return omp_get_max_threads();
 }
 
 OpenMPInternal::OpenMPInternal(int arg_pool_size)


### PR DESCRIPTION
This originated from investigating https://kokkosteam.slack.com/archives/C5BGU5NDQ/p1786561648861479
I was not able to reproduce the error but had to modify the reproducer in order to get at least part of it to compile on my test system. I also did not use the same compiler versions, nor was I on LUMI.

This is mainly thought of as a test if the very old logic we have in https://github.com/kokkos/kokkos/blob/c85a56d8dba5cb623434fc371457d78c06f19765/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp#L127 which was introduced in https://github.com/kokkos/kokkos/pull/805 might not be valid anymore.
I might understand the docs wrong, but it might be indicated here https://www.openmp.org/spec-html/5.0/openmpsu112.html

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
