### PR TITLE
Re-enable bugprone-exception-escape

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,6 @@ Checks: >
   bugprone-*,
   -bugprone-argument-comment,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,

--- a/core/src/Kokkos_ScopeGuard.hpp
+++ b/core/src/Kokkos_ScopeGuard.hpp
@@ -58,6 +58,7 @@ class [[nodiscard]] ScopeGuard {
     initialize(static_cast<Args&&>(args)...);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ScopeGuard() {
     if (is_finalized()) {
       Kokkos::abort(Impl::scopeguard_destruct_after_finalize_warning().c_str());

--- a/core/src/Kokkos_WorkGraphPolicy.hpp
+++ b/core/src/Kokkos_WorkGraphPolicy.hpp
@@ -52,6 +52,7 @@ class WorkGraphPolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
   graph_type const m_graph;
   ints_type m_queue;
 
+  // NOLINTBEGIN(bugprone-exception-escape)
   KOKKOS_INLINE_FUNCTION
   void push_work(const std::int32_t w) const noexcept {
     const std::int32_t N = m_graph.numRows();
@@ -165,6 +166,7 @@ class WorkGraphPolicy : public Kokkos::Impl::PolicyTraits<Properties...> {
 
     if (0 == count_queue[w]) push_work(w);
   }
+  // NOLINTEND(bugprone-exception-escape)
 
   execution_space space() const { return execution_space(); }
 

--- a/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_Instance.cpp
@@ -175,6 +175,7 @@ void OpenMPInternal::fence(const std::string &name) {
       [this]() { std::lock_guard<std::mutex> lock(m_instance_mutex); });
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 OpenMPInternal::~OpenMPInternal() {
   if (omp_in_parallel()) {
     std::string msg("Kokkos::OpenMP::finalize ERROR : in parallel");

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -20,13 +20,13 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     const TagType t{};
     m_functor(t, w);
   }

--- a/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP_WorkGraphPolicy.hpp
@@ -18,18 +18,20 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   Policy m_policy;
   FunctorType m_functor;
 
+  // NOLINTBEGIN(bugprone-exception-escape)
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);
   }
+  // NOLINTEND(bugprone-exception-escape)
 
  public:
   inline void execute() {

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -57,6 +57,7 @@ void SerialInternal::fence(const std::string& name) {
 #endif
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 SerialInternal::~SerialInternal() {
   fence("Kokkos::SerialInternal: fence on destruction");
 

--- a/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
+++ b/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
@@ -16,18 +16,20 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   Policy m_policy;
   FunctorType m_functor;
 
+  // NOLINTBEGIN(bugprone-exception-escape)
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);
   }
+  // NOLINTEND(bugprone-exception-escape)
 
  public:
   void execute() const {

--- a/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
+++ b/core/src/Serial/Kokkos_Serial_WorkGraphPolicy.hpp
@@ -18,19 +18,19 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     const TagType t{};
     m_functor(t, w);
   }
 
  public:
-  inline void execute() const noexcept {
+  void execute() const {
     // Spin until COMPLETED_TOKEN.
     // END_TOKEN indicates no work is currently available.
 
@@ -43,7 +43,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     }
   }
 
-  inline ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
+  ParallelFor(const FunctorType& arg_functor, const Policy& arg_policy)
       : m_policy(arg_policy), m_functor(arg_functor) {}
 };
 

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -24,18 +24,18 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
 
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const noexcept {
+      const std::int32_t w) const {
     const TagType t{};
     m_functor(t, w);
   }
 
-  inline void exec_one_thread() const noexcept {
+  inline void exec_one_thread() const {
     // Spin until COMPLETED_TOKEN.
     // END_TOKEN indicates no work is currently available.
 
@@ -48,8 +48,7 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
     }
   }
 
-  static inline void thread_main(ThreadsInternal& instance,
-                                 const void* arg) noexcept {
+  static inline void thread_main(ThreadsInternal& instance, const void* arg) {
     const Self& self = *(static_cast<const Self*>(arg));
     self.exec_one_thread();
     instance.fan_in();

--- a/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
+++ b/core/src/Threads/Kokkos_Threads_WorkGraphPolicy.hpp
@@ -22,18 +22,20 @@ class ParallelFor<FunctorType, Kokkos::WorkGraphPolicy<Traits...>,
   Policy m_policy;
   FunctorType m_functor;
 
+  // NOLINTBEGIN(bugprone-exception-escape)
   template <class TagType>
   std::enable_if_t<std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     m_functor(w);
   }
 
   template <class TagType>
   std::enable_if_t<!std::is_void_v<TagType>> exec_one(
-      const std::int32_t w) const {
+      const std::int32_t w) const noexcept {
     const TagType t{};
     m_functor(t, w);
   }
+  // NOLINTEND(bugprone-exception-escape)
 
   inline void exec_one_thread() const {
     // Spin until COMPLETED_TOKEN.

--- a/core/src/impl/Kokkos_Combined_Reducer.hpp
+++ b/core/src/impl/Kokkos_Combined_Reducer.hpp
@@ -155,20 +155,20 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
 
   template <class... ReducersDeduced>
   KOKKOS_FUNCTION constexpr explicit CombinedReducerImpl(
-      value_type& value, ReducersDeduced&&... reducers) noexcept
+      value_type& value, ReducersDeduced&&... reducers)
       : CombinedReducerStorageImpl<Idxs, Reducers>(
             (ReducersDeduced&&)reducers)...,
         m_value_view(&value) {}
 
   KOKKOS_FUNCTION constexpr void join(value_type& dest,
-                                      value_type const& src) const noexcept {
+                                      value_type const& src) const {
     (this->CombinedReducerStorageImpl<Idxs, Reducers>::_join(
          dest.template get<Idxs, typename Reducers::value_type>(),
          src.template get<Idxs, typename Reducers::value_type>()),
      ...);
   }
 
-  KOKKOS_FUNCTION constexpr void init(value_type& dest) const noexcept {
+  KOKKOS_FUNCTION constexpr void init(value_type& dest) const {
     (this->CombinedReducerStorageImpl<Idxs, Reducers>::_init(
          dest.template get<Idxs, typename Reducers::value_type>()),
      ...);
@@ -216,14 +216,14 @@ struct CombinedReducerImpl<std::integer_sequence<size_t, Idxs...>, Space,
 
   template <int Idx, class View>
   KOKKOS_FUNCTION static void write_one_value_back_on_device(
-      View const& inputView, typename View::const_value_type& value) noexcept {
+      View const& inputView, typename View::const_value_type& value) {
     *inputView.data() = value;
   }
 
   template <typename... CombinedReducers>
   KOKKOS_FUNCTION void write_value_back_to_original_references_on_device(
       value_type const& value,
-      CombinedReducers const&... reducers_that_reference_original_values) noexcept {
+      CombinedReducers const&... reducers_that_reference_original_values) {
     (write_one_value_back_on_device<Idxs>(
          reducers_that_reference_original_values.view(),
          value.template get<Idxs, typename CombinedReducers::value_type>()),

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -179,6 +179,7 @@ std::vector<int> const& Kokkos::Impl::get_visible_devices() {
   return -1;
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] int Kokkos::num_devices() noexcept {
   if constexpr (std::is_same_v<DefaultExecutionSpace,
                                DefaultHostExecutionSpace>) {

--- a/core/src/impl/Kokkos_FunctorAnalysis.hpp
+++ b/core/src/impl/Kokkos_FunctorAnalysis.hpp
@@ -572,23 +572,21 @@ struct FunctorAnalysis {
     }
 
     KOKKOS_INLINE_FUNCTION
-    void copy(ValueType* const dst, ValueType const* const src) const noexcept {
+    void copy(ValueType* const dst, ValueType const* const src) const {
       for (int i = 0; i < length(); ++i) dst[i] = src[i];
     }
 
     KOKKOS_INLINE_FUNCTION
-    void join(ValueType* dst, ValueType const* src) const noexcept {
+    void join(ValueType* dst, ValueType const* src) const {
       DeduceJoin<>::join(&m_functor, dst, src);
     }
 
-    KOKKOS_INLINE_FUNCTION reference_type
-    init(ValueType* const dst) const noexcept {
+    KOKKOS_INLINE_FUNCTION reference_type init(ValueType* const dst) const {
       DeduceInit<>::init(&m_functor, dst);
       return reference(dst);
     }
 
-    KOKKOS_INLINE_FUNCTION
-    void final(ValueType* dst) const noexcept {
+    KOKKOS_INLINE_FUNCTION void final(ValueType* dst) const {
       DeduceFinal<>::final(&m_functor, dst);
     }
 
@@ -602,7 +600,7 @@ struct FunctorAnalysis {
     ~Reducer()                         = default;
 
     KOKKOS_INLINE_FUNCTION explicit constexpr Reducer(
-        Functor const& arg_functor) noexcept
+        Functor const& arg_functor)
         : m_functor(arg_functor) {}
   };
 };

--- a/core/unit_test/TestGraph.hpp
+++ b/core/unit_test/TestGraph.hpp
@@ -42,7 +42,7 @@ struct CountTestFunctor {
   int expected_count_max;
 
   template <class... Ts>
-  KOKKOS_FUNCTION void operator()(Ts&&...) const noexcept {
+  KOKKOS_FUNCTION void operator()(Ts&&...) const {
     bugs() += int(count() > expected_count_max || count() < expected_count_min);
     count()++;
   }
@@ -57,7 +57,7 @@ struct SetViewToValueFunctor {
   T value;
 
   template <class... Ts>
-  KOKKOS_FUNCTION void operator()(Ts&&...) const noexcept {
+  KOKKOS_FUNCTION void operator()(Ts&&...) const {
     v() = value;
   }
 };
@@ -70,7 +70,7 @@ struct SetResultToViewFunctor {
   view_type v;
 
   template <class U>
-  KOKKOS_FUNCTION void operator()(U&&, value_type& val) const noexcept {
+  KOKKOS_FUNCTION void operator()(U&&, value_type& val) const {
     val += v();
   }
 };

--- a/core/unit_test/TestMemoryPool.hpp
+++ b/core/unit_test/TestMemoryPool.hpp
@@ -154,7 +154,7 @@ struct TestMemoryPool_Functor {
   struct TagAlloc {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagAlloc, int i, long& update) const noexcept {
+  void operator()(TagAlloc, int i, long& update) const {
     unsigned alloc_size = 32 * (1 + (i % 5));
     ptrs(i)             = (uintptr_t)pool.allocate(alloc_size);
     if (ptrs(i)) {
@@ -165,7 +165,7 @@ struct TestMemoryPool_Functor {
   struct TagDealloc {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagDealloc, int i, long& update) const noexcept {
+  void operator()(TagDealloc, int i, long& update) const {
     if (ptrs(i) && (0 == i % 3)) {
       unsigned alloc_size = 32 * (1 + (i % 5));
       pool.deallocate((void*)ptrs(i), alloc_size);
@@ -177,7 +177,7 @@ struct TestMemoryPool_Functor {
   struct TagRealloc {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagRealloc, int i, long& update) const noexcept {
+  void operator()(TagRealloc, int i, long& update) const {
     if (0 == ptrs(i)) {
       unsigned alloc_size = 32 * (1 + (i % 5));
       ptrs(i)             = (uintptr_t)pool.allocate(alloc_size);
@@ -190,7 +190,7 @@ struct TestMemoryPool_Functor {
   struct TagMixItUp {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagMixItUp, int i, long& update) const noexcept {
+  void operator()(TagMixItUp, int i, long& update) const {
     if (ptrs(i) && (0 == i % 3)) {
       unsigned alloc_size = 32 * (1 + (i % 5));
 
@@ -341,7 +341,7 @@ struct TestMemoryPoolCorners {
   using value_type = long;
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i, long& err) const noexcept {
+  void operator()(int i, long& err) const {
     unsigned alloc_size = size << (i % stride);
     if (0 == ptrs(i)) {
       ptrs(i) = (uintptr_t)pool.allocate(alloc_size);
@@ -354,7 +354,7 @@ struct TestMemoryPoolCorners {
   struct TagDealloc {};
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(int i) const noexcept {
+  void operator()(int i) const {
     unsigned alloc_size = size << (i % stride);
     if (ptrs(i)) {
       pool.deallocate((void*)ptrs(i), alloc_size);
@@ -474,7 +474,7 @@ struct TestMemoryPoolHuge<
 
   using value_type = long;
 
-  void operator()(int i, long& err) const noexcept {
+  void operator()(int i, long& err) const {
     if (i < int(num_superblock)) {
       ptrs(i) = (uintptr_t)pool.allocate(max_block_size);
 #if 0
@@ -489,7 +489,7 @@ struct TestMemoryPoolHuge<
     }
   }
 
-  void operator()(int i) const noexcept {
+  void operator()(int i) const {
     if (i < int(num_superblock)) {
       pool.deallocate((void*)ptrs(i), max_block_size);
       ptrs(i) = 0;

--- a/core/unit_test/TestViewOfClass.hpp
+++ b/core/unit_test/TestViewOfClass.hpp
@@ -35,7 +35,7 @@ struct NestedView {
   KOKKOS_DEFAULTED_FUNCTION NestedView &operator=(NestedView &&)      = default;
 
   KOKKOS_INLINE_FUNCTION
-  ~NestedView() {
+  ~NestedView() /* NOLINT(bugprone-exception-escape) */ {
     if (member.extent(0)) {
       Kokkos::atomic_add(&member(0), -1);
     }

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2076,8 +2076,7 @@ template <class Space>
 struct TestUnmanagedSubviewReset {
   Kokkos::View<int****, Space> a;
 
-  KOKKOS_INLINE_FUNCTION
-  void operator()(int) const noexcept {
+  KOKKOS_FUNCTION void operator()(int) const {
     auto sub_a = Kokkos::subview(a, 0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);
 
     for (int i = 0; i < int(a.extent(0)); ++i) {
@@ -2202,8 +2201,7 @@ struct TestSubviewStaticSizes {
   Kokkos::View<int* [10][5][2], Layout, Space> a;
   Kokkos::View<int[6][7][8], Layout, Space> b;
 
-  KOKKOS_INLINE_FUNCTION
-  int operator()() const noexcept {
+  KOKKOS_FUNCTION int operator()() const {
     /* Doesn't actually do anything; just static assertions */
 
     auto sub_a = Kokkos::subview(a, 0, Kokkos::ALL, Kokkos::ALL, Kokkos::ALL);

--- a/core/unit_test/UnitTest_CMakePassCmdLineArgs.cpp
+++ b/core/unit_test/UnitTest_CMakePassCmdLineArgs.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char* argv[]) {
   if (argc != 4 || std::string(argv[1]) != "one" ||
       std::string(argv[2]) != "2" || std::string(argv[3]) != "THREE") {

--- a/core/unit_test/tools/TestIndependence.cpp
+++ b/core/unit_test/tools/TestIndependence.cpp
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
 #include <impl/Kokkos_Tools.hpp>
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 int main(int argc, char* argv[]) {
   Kokkos::Tools::initialize(argc, argv);
   Kokkos::Tools::pushRegion(
@@ -14,4 +15,5 @@ int main(int argc, char* argv[]) {
       "declare the causes which impel them to the separation.");
   Kokkos::Tools::popRegion();
   Kokkos::Tools::finalize();
+  return 0;
 }


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
This is PR is intended to (partially) address #7575 and close #8932
The clang-tidy warnings raised by the `bugprone-exception-escape` check do point to some actual issues that we should address instead of ignoring them all.

### Related issues / PRs
PR that disabled the check: https://github.com/kokkos/kokkos/pull/8930
Competing resolution: https://github.com/kokkos/kokkos/pull/8932
Tracking issue: https://github.com/kokkos/kokkos/issues/7575

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
~Not required~ 
Incompatibility:
* Exception thrown from reducer init/join/finalize that may have caused program termination in previous versions may now escape


**Disclosure:** I had an AI agent do a first pass and adjusted as I saw fit.  I followed our guidelines and used `Assisted-by` when appropriate.