### PR TITLE
Add padded layouts back into Experimental namespace

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -18,11 +18,11 @@ static_assert(false,
 
 // backport padded layouts to experimental
 namespace Kokkos::Experimental {
-template <size_t Pad>
+template <size_t Pad = dynamic_extent>
 using layout_left_padded KOKKOS_DEPRECATED_WITH_COMMENT(
     "Use Kokkos::layout_left_padded instead.") =
     Kokkos::layout_left_padded<Pad>;
-template <size_t Pad>
+template <size_t Pad = dynamic_extent>
 using layout_right_padded KOKKOS_DEPRECATED_WITH_COMMENT(
     "Use Kokkos::layout_right_padded instead.") =
     Kokkos::layout_right_padded<Pad>;

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Layout.hpp
@@ -16,6 +16,18 @@ static_assert(false,
 #include <iostream>
 #endif
 
+// backport padded layouts to experimental
+namespace Kokkos::Experimental {
+template <size_t Pad>
+using layout_left_padded KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::layout_left_padded instead.") =
+    Kokkos::layout_left_padded<Pad>;
+template <size_t Pad>
+using layout_right_padded KOKKOS_DEPRECATED_WITH_COMMENT(
+    "Use Kokkos::layout_right_padded instead.") =
+    Kokkos::layout_right_padded<Pad>;
+}  // namespace Kokkos::Experimental
+
 // The difference between a legacy Kokkos array layout and an
 // mdspan layout is that the array layouts can have state, but don't have the
 // nested mapping. This file provides interoperability helpers.

--- a/core/unit_test/TestViewTypedefs.cpp
+++ b/core/unit_test/TestViewTypedefs.cpp
@@ -162,12 +162,12 @@ KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
   // mdspan compatibility
   // ==================================
 
-  // FIXME: This typedef caused some weird issue with MSVC+NVCC
-  // static_assert(std::is_same_v<typename ViewType::layout_type, Layout>);
-  // FIXME: Not supported yet
-  // static_assert(std::is_same_v<typename ViewType::extents_type, >);
-  // static_assert(std::is_same_v<typename ViewType::mapping_type, >);
-  // static_assert(std::is_same_v<typename ViewType::accessor_type, >);
+  static_assert(std::is_same_v<typename ViewType::layout_type, typename Kokkos::Impl::LayoutFromArrayLayout<Layout>::type>);
+  static_assert(std::is_same_v<typename ViewType::extents_type, typename Kokkos::Impl::ExtentsFromDataType<size_t, DataType>::type>);
+  static_assert(std::is_same_v<typename ViewType::mapping_type, typename ViewType::layout_type::template mapping<typename ViewType::extents_type>>);
+  static_assert(std::is_same_v<typename ViewType::accessor_type, Kokkos::Experimental::Accessor<ValueType, typename Space::memory_space, MemoryTraitsType>>);
+  static_assert(std::is_same_v<typename ViewType::mdspan_type,
+                               Kokkos::mdspan<typename ViewType::element_type, typename ViewType::extents_type, typename ViewType::layout_type, typename ViewType::accessor_type>>);
 
   static_assert(std::is_same_v<typename ViewType::element_type, ValueType>);
   // FIXME: should be remove_const_t<element_type>

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
@@ -38,7 +38,7 @@ constexpr bool test_equivalence() {
                          Kokkos::Experimental::Accessor<
                              T, typename Space::memory_space, MemTraits>>>);
 
-  // These are constitutent types of mdspan_type
+  // These are constituent types of mdspan_type
   CHECK_SAME(element_type);
   CHECK_SAME(extents_type);
   CHECK_SAME(layout_type);

--- a/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
+++ b/core/unit_test/view/TestViewMDSpanTemplateArgumentEquivalence.cpp
@@ -19,12 +19,10 @@ namespace {
       std::is_same_v<typename new_view_t::type, typename old_view_t::type>)
 
 template <class T, class Extents, class DataType, class ArrayLayout,
-          class Space, class MemTraits>
+          class LayoutType, class Space, class MemTraits>
 constexpr bool test_equivalence() {
-  using layout_type =
-      typename Kokkos::Impl::LayoutFromArrayLayout<ArrayLayout>::type;
   using new_view_t =
-      Kokkos::View<T, Extents, layout_type,
+      Kokkos::View<T, Extents, LayoutType,
                    Kokkos::Experimental::Accessor<
                        T, typename Space::memory_space, MemTraits>>;
   using old_view_t = Kokkos::View<DataType, ArrayLayout, Space, MemTraits>;
@@ -33,6 +31,18 @@ constexpr bool test_equivalence() {
   // BasicView implementation, since mdspan_type comes from BasicView and uses
   // directly the template args of BasicView
   CHECK_SAME(mdspan_type);
+  static_assert(
+      std::is_same_v<
+          typename new_view_t::mdspan_type,
+          Kokkos::mdspan<T, Extents, LayoutType,
+                         Kokkos::Experimental::Accessor<
+                             T, typename Space::memory_space, MemTraits>>>);
+
+  // These are constitutent types of mdspan_type
+  CHECK_SAME(element_type);
+  CHECK_SAME(extents_type);
+  CHECK_SAME(layout_type);
+  CHECK_SAME(accessor_type);
 
   // Checking typedefs which come from ViewTraits and not from BasicView
   // Not currently the same
@@ -59,6 +69,9 @@ constexpr bool test_equivalence() {
 using LL           = Kokkos::LayoutLeft;
 using LR           = Kokkos::LayoutRight;
 using LS           = Kokkos::LayoutStride;
+using MDLL         = Kokkos::layout_left_padded<Kokkos::dynamic_extent>;
+using MDLR         = Kokkos::layout_right_padded<Kokkos::dynamic_extent>;
+using MDLS         = Kokkos::layout_stride;
 using ED           = Kokkos::DefaultExecutionSpace;
 using EH           = Kokkos::DefaultHostExecutionSpace;
 using SH           = Kokkos::HostSpace;
@@ -70,14 +83,26 @@ constexpr size_t d = Kokkos::dynamic_extent;
 
 // clang-format off
 
-static_assert(test_equivalence<f,  Kokkos::dextents<size_t, 0>,         f,          LL, ED, Kokkos::MemoryTraits<>>());
-static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 2>,         cf**,       LS, EH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
-static_assert(test_equivalence<f,  Kokkos::extents<size_t, 2, 3>,       f[2][3],    LR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
-static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 8>,         cf********, LS, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
-static_assert(test_equivalence<f,  Kokkos::extents<size_t, d, d, 2, 3>, f**[2][3],  LR, DD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
+static_assert(test_equivalence<f,  Kokkos::dextents<size_t, 0>,         f,          LL, MDLL, ED, Kokkos::MemoryTraits<>>());
+static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 2>,         cf**,       LS, MDLS, EH, Kokkos::MemoryTraits<Kokkos::Unmanaged>>());
+static_assert(test_equivalence<f,  Kokkos::extents<size_t, 2, 3>,       f[2][3],    LR, MDLR, SH, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::Atomic>>());
+static_assert(test_equivalence<cf, Kokkos::dextents<size_t, 8>,         cf********, LS, MDLS, SD, Kokkos::MemoryTraits<Kokkos::Atomic | Kokkos::RandomAccess>>());
+static_assert(test_equivalence<f,  Kokkos::extents<size_t, d, d, 2, 3>, f**[2][3],  LR, MDLR, DD, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
 // This can't give the same
 //static_assert(test_equivalence<f,  Kokkos::extents<size_t, 3, d, 2, 3>, f**[2][3],     LR, HS, Kokkos::MemoryTraits<Kokkos::RandomAccess>>());
 
 // clang-format on
 
 }  // namespace
+
+// We are not actually exporting the Experimental namespace symbols
+// in a modules build
+#ifndef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_PUSH()
+// Temporarly check we import the padded layouts into Experimental Namespace
+static_assert(std::is_same_v<Kokkos::layout_left_padded<4>,
+                             Kokkos::Experimental::layout_left_padded<4>>);
+static_assert(std::is_same_v<Kokkos::layout_right_padded<4>,
+                             Kokkos::Experimental::layout_right_padded<4>>);
+KOKKOS_IMPL_DISABLE_DEPRECATED_WARNINGS_POP()
+#endif


### PR DESCRIPTION
This adds `Kokkos::Experimental::layout_[left/right]_padded` using statements back in. At a minimum Trilinos will currently break with the mdspan update due to direct use of those symbols in Sacado and Stokhos. Since they test against last release and against develop they would need otherwise need to do ifdefs around that usage. Same for other folks who might use these symbols. I would only leave those back imports in for one release cycle giving folks a smoother transition cycle.

Note: we are not guaranteeing anything about Kokkos::Experimental, so we could also not do this. I would prefer to do it, Damien doesn't like it.

The reason we didn't do it in mdspan repo itself is that we don't have a release cycle there yet, and want a clean slate first proper release next time without any baggage. Kokkos Core on the other hand does promise a significant amount of stability, and generally we try to give people transition times with experimental symbols. 