### PR TITLE
Do not guard a requires clause with #if defined(KOKKOS_ENABLE_CXX20)

### DIFF
--- a/core/src/Kokkos_Graph.hpp
+++ b/core/src/Kokkos_Graph.hpp
@@ -74,14 +74,11 @@ struct [[nodiscard]] Graph {
     defined(KOKKOS_ENABLE_SYCL)
   // Construct a graph from a native graph, add a root node.
   template <typename T>
-#if defined(KOKKOS_ENABLE_CXX20)
     requires std::same_as<ExecutionSpace, Kokkos::DefaultExecutionSpace>
-#endif
   Graph(const device_handle_t& device_handle, T&& native_graph)
       : m_impl_ptr{std::make_shared<impl_t>(device_handle,
                                             std::forward<T>(native_graph))},
-        m_root{m_impl_ptr->create_root_node_ptr()} {
-  }
+        m_root{m_impl_ptr->create_root_node_ptr()} {}
 #endif
 
   const auto& get_device_handle() const {


### PR DESCRIPTION
There are certain places in the code base, where we are guarding features for the arrival of C++23, by checking if `KOKKOS_ENABLE_CXX20` is not defined. In this case, this is a check for `KOKKOS_ENABLE_CXX20` being defined that was needed before Kokkos moved to C++20. This is no longer needed.

### Related issues / PRs

I came across this when reviewing https://github.com/kokkos/kokkos/pull/9239.

### Changelog Entry

 Not required
