### PR TITLE
HIP: Synchronize before freeing device memory

### DIFF
--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -261,8 +261,8 @@ void HIPSpace::impl_deallocate(
   }
 #ifdef KOKKOS_ENABLE_IMPL_HIP_MALLOC_ASYNC
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_device));
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipFreeAsync(arg_alloc_ptr, m_stream));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipDeviceSynchronize());
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipFreeAsync(arg_alloc_ptr, m_stream));
 #else
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_device));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(arg_alloc_ptr));


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
We need to sync **before** releasing memory asynchronously to ensure that all operations enqueued have completed by the time we relinquish the allocation to the HIP runtime.

### Related issues / PRs

Fixes kokkos/kokkos-kernels#3189

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
- HIP bug fix: Synchronize before freeing device memory
