### PR TITLE
[5.2.1] HIP: Synchronize before freeing device memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 * Fix inverted `NDEBUG `logic in mdspan precondition checking [\#9405](https://github.com/kokkos/kokkos/pull/9405)
-* HIP: Synchronize before freeing device memory [\#9433](https://github.com/kokkos/kokkos/pull/9433)
+* HIP: Synchronize before freeing device memory when using async allocations [\#9433](https://github.com/kokkos/kokkos/pull/9433)
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 * Fix inverted `NDEBUG `logic in mdspan precondition checking [\#9405](https://github.com/kokkos/kokkos/pull/9405)
+* HIP: Synchronize before freeing device memory [\#9433](https://github.com/kokkos/kokkos/pull/9433)
 
 ## 5.2.0
 

--- a/core/src/HIP/Kokkos_HIP_Space.cpp
+++ b/core/src/HIP/Kokkos_HIP_Space.cpp
@@ -242,8 +242,8 @@ void HIPSpace::impl_deallocate(
   }
 #ifdef KOKKOS_ENABLE_IMPL_HIP_MALLOC_ASYNC
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_device));
-  KOKKOS_IMPL_HIP_SAFE_CALL(hipFreeAsync(arg_alloc_ptr, m_stream));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipDeviceSynchronize());
+  KOKKOS_IMPL_HIP_SAFE_CALL(hipFreeAsync(arg_alloc_ptr, m_stream));
 #else
   KOKKOS_IMPL_HIP_SAFE_CALL(hipSetDevice(m_device));
   KOKKOS_IMPL_HIP_SAFE_CALL(hipFree(arg_alloc_ptr));


### PR DESCRIPTION
Cherry-picking https://github.com/kokkos/kokkos/pull/9433 bug fix for 5.2.1

(cherry picked from commit 41f6c2c59259dee23a11ce33314c0af51fa57a17)

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
- HIP: Synchronize before freeing device memory
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
