### PR TITLE
HPX: fix leak in `Test_HPX_IndependentInstances`

### DIFF
--- a/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
+++ b/core/unit_test/hpx/TestHPX_IndependentInstances.cpp
@@ -126,6 +126,10 @@ TEST(hpx, independent_instances) {
 
   const int expected_sum = n * (2 * c + d) + (n * (n - 1) / 2);
   ASSERT_EQ(expected_sum, sum_v());
+
+  hpx3.fence();
+  hpx2.fence();
+  hpx1.fence();
 }
 
 }  // namespace


### PR DESCRIPTION
`Kokkos_CoreUnitTest_HPX_IndependentInstances` fails in an `AddressSanitizer` build. There are several leaks at exit.

The underlying issue is the circular reference pattern that we had identified in:
- https://github.com/kokkos/kokkos/pull/9138
- https://github.com/kokkos/kokkos/pull/8992

In #8992, the circular reference pattern was described like:

> In the HPX case, a challenge is that the member m_default_instance_data stores a type erased "sender" with the members of the last (few) parallel region(s) that was (were) dispatched. Hence, this m_default_instance_data may end up storing itself as part of the policy of that last parallel region, thus causing a circular reference that would prevent HostSharedPtr from calling the destructor.

but the pattern holds for non-default instances too.

The fix proposed in this PR is to fence each created instance at the end of the test to make sure that each "sender" is drained, and the circular references are thus broken. 

@janciesko, would you have a moment to take a look? 

