### PR TITLE
HPX: reorder default instance destruction in `impl_finalize`

### DIFF
--- a/core/src/HPX/Kokkos_HPX.cpp
+++ b/core/src/HPX/Kokkos_HPX.cpp
@@ -190,8 +190,6 @@ void HPX::impl_finalize() {
       "Kokkos::Experimental::HPX: fence "
       "to drain internal sender on finalize");
 
-  m_default_instance_data = nullptr;
-
   if (m_hpx_initialized) {
     hpx::runtime *rt = hpx::get_runtime_ptr();
     if (rt != nullptr) {
@@ -204,6 +202,8 @@ void HPX::impl_finalize() {
     }
     m_hpx_initialized = false;
   }
+
+  m_default_instance_data = nullptr;
 }
 
 int HPX::impl_thread_pool_size() noexcept {

--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -147,6 +147,7 @@ class HPX {
           name,
           Kokkos::Tools::Experimental::Impl::DirectFenceIDHandle{m_instance_id},
           [&]() {
+            if (hpx::get_runtime_ptr() == nullptr) return;
             auto &s = m_sender;
             hpx::this_thread::experimental::sync_wait(std::move(s));
             s = hpx::execution::experimental::unique_any_sender<>(


### PR DESCRIPTION
Partial fix for:
- #9442 

Fixes the leak/crash on finalize described in #9442: `hpx::stop()` in `impl_finalize` leads HPX to release the last reference to a `View`, which triggers a deallocation that triggers a global fence that dereferences`m_default_instance_data`, already destroyed by `impl_finalize`.

With the proposed reorder, `m_default_instance_data` is destroyed after HPX has been finalised, and so we must ensure that no HPX API calls are made. This is why the PR proposes to add the guard in `fence_locked`.

Just noting that destroying the "internal" at the end is consistent with other backends like Cuda:
- https://github.com/kokkos/kokkos/blob/837d0243138ac5c4dd5ca3e7fd058b63d5e713d9/core/src/Cuda/Kokkos_Cuda_Instance.cpp#L576

@janciesko 
