### PR TITLE
Move Imp::View{Copy,Fill} forward declaration right above their partial template specialization

### DIFF
--- a/core/src/Kokkos_CopyViews.hpp
+++ b/core/src/Kokkos_CopyViews.hpp
@@ -60,6 +60,11 @@ KOKKOS_INLINE_FUNCTION constexpr bool view_equal_strides(
 namespace Kokkos {
 namespace Impl {
 
+template <class ViewType, class Layout = typename ViewType::array_layout,
+          class ExecSpace = typename ViewType::execution_space,
+          int Rank = ViewType::rank, typename iType = int64_t>
+struct ViewFill;
+
 template <class ViewType, class Layout, class ExecSpace, typename iType>
 struct ViewFill<ViewType, Layout, ExecSpace, 0, iType> {
   ViewType a;
@@ -313,6 +318,10 @@ struct ViewFill<ViewType, Layout, ExecSpace, 8, iType> {
         a(i0, i1, i2, i3, i4, i5, i6, i7) = val;
   }
 };
+
+template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
+          int Rank, typename iType>
+struct ViewCopy;
 
 template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
           typename iType>

--- a/core/src/Kokkos_Core_fwd.hpp
+++ b/core/src/Kokkos_Core_fwd.hpp
@@ -264,15 +264,6 @@ template <class DstSpace, class SrcSpace,
           class Enable         = void>
 struct DeepCopy;
 
-template <class ViewType, class Layout = typename ViewType::array_layout,
-          class ExecSpace = typename ViewType::execution_space,
-          int Rank = ViewType::rank, typename iType = int64_t>
-struct ViewFill;
-
-template <class ViewTypeA, class ViewTypeB, class Layout, class ExecSpace,
-          int Rank, typename iType>
-struct ViewCopy;
-
 template <class Functor, class Policy>
 struct FunctorPolicyExecutionSpace;
 


### PR DESCRIPTION
Motivation: general book keeping, and moving out of the way the uncontroversial part in revisiting what goes into the `<Kokkos_Core_fwd.hpp>`

Both `Imp::View{Copy,Fill}` are exclusively used in the (imply-only) `<Kokkos_CopyView.hpp>` header.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
N/A

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
N/A