### PR TITLE
Make host execution space destructors device-callable and honor TEST_EXECSPACE in TestRangePolicyExecutionTypes

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -186,8 +186,12 @@ class HPX {
 
 #pragma GCC diagnostic pop
 
-  ~HPX() {
-    Kokkos::Impl::check_execution_space_destructor_precondition(name());
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~HPX() {
+    KOKKOS_IF_ON_HOST(
+        (Kokkos::Impl::check_execution_space_destructor_precondition(name());))
   }
   explicit HPX(instance_mode mode)
       : m_instance_data(

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -19,10 +19,6 @@
 
 namespace Kokkos {
 
-OpenMP::~OpenMP() {
-  Impl::check_execution_space_destructor_precondition(name());
-}
-
 OpenMP::OpenMP()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -18,6 +18,7 @@ static_assert(false,
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Layout.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
@@ -59,7 +60,14 @@ class OpenMP {
   KOKKOS_FUNCTION OpenMP& operator=(OpenMP&& other) noexcept {
     return *this = static_cast<const OpenMP&>(other);
   }
-  ~OpenMP();
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~OpenMP() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
+
   OpenMP();
 
   explicit OpenMP(int pool_size);

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -152,10 +152,6 @@ void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
 }
 }  // namespace Impl
 
-Serial::~Serial() {
-  Impl::check_execution_space_destructor_precondition(name());
-}
-
 Serial::Serial()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>
@@ -107,7 +108,14 @@ class Serial {
   KOKKOS_FUNCTION Serial& operator=(Serial&& other) noexcept {
     return *this = static_cast<const Serial&>(other);
   }
-  ~Serial();
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~Serial() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
+
   Serial();
 
   explicit Serial(NewInstance);

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -110,7 +110,13 @@ class Threads {
     return *this = static_cast<const Threads&>(other);
   }
 
-  ~Threads() { Impl::check_execution_space_destructor_precondition(name()); }
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~Threads() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
 
   Threads() { Impl::check_execution_space_constructor_precondition(name()); }
 

--- a/core/unit_test/TestCXX11.hpp
+++ b/core/unit_test/TestCXX11.hpp
@@ -10,10 +10,9 @@ import kokkos.core;
 
 namespace TestCXX11 {
 
-template <class DeviceType>
 struct FunctorAddTest {
-  using view_type       = Kokkos::View<double**, DeviceType>;
-  using execution_space = DeviceType;
+  using execution_space = TEST_EXECSPACE;
+  using view_type       = Kokkos::View<double**, execution_space>;
   using team_member = typename Kokkos::TeamPolicy<execution_space>::member_type;
 
   view_type a_, b_;
@@ -43,15 +42,14 @@ struct FunctorAddTest {
   }
 };
 
-template <class DeviceType, bool PWRTest>
+template <bool PWRTest>
 double AddTestFunctor() {
-  using policy_type = Kokkos::TeamPolicy<DeviceType>;
-
-  Kokkos::View<double**, DeviceType> a("A", 100, 5);
-  Kokkos::View<double**, DeviceType> b("B", 100, 5);
-  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_a =
+  using execution_space = TEST_EXECSPACE;
+  Kokkos::View<double**, execution_space> a("A", 100, 5);
+  Kokkos::View<double**, execution_space> b("B", 100, 5);
+  typename Kokkos::View<double**, execution_space>::host_mirror_type h_a =
       Kokkos::create_mirror_view(a);
-  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_b =
+  typename Kokkos::View<double**, execution_space>::host_mirror_type h_b =
       Kokkos::create_mirror_view(b);
 
   for (int i = 0; i < 100; i++) {
@@ -62,10 +60,10 @@ double AddTestFunctor() {
   Kokkos::deep_copy(a, h_a);
 
   if (PWRTest == false) {
-    Kokkos::parallel_for(100, FunctorAddTest<DeviceType>(a, b));
+    Kokkos::parallel_for(100, FunctorAddTest(a, b));
   } else {
-    Kokkos::parallel_for(policy_type(25, Kokkos::AUTO),
-                         FunctorAddTest<DeviceType>(a, b));
+    using policy_type = Kokkos::TeamPolicy<execution_space>;
+    Kokkos::parallel_for(policy_type(25, Kokkos::AUTO), FunctorAddTest(a, b));
   }
   Kokkos::deep_copy(h_b, b);
 
@@ -79,13 +77,14 @@ double AddTestFunctor() {
   return result;
 }
 
-template <class DeviceType, bool PWRTest>
+template <bool PWRTest>
 double AddTestLambda() {
-  Kokkos::View<double**, DeviceType> a("A", 100, 5);
-  Kokkos::View<double**, DeviceType> b("B", 100, 5);
-  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_a =
+  using execution_space = TEST_EXECSPACE;
+  Kokkos::View<double**, execution_space> a("A", 100, 5);
+  Kokkos::View<double**, execution_space> b("B", 100, 5);
+  typename Kokkos::View<double**, execution_space>::host_mirror_type h_a =
       Kokkos::create_mirror_view(a);
-  typename Kokkos::View<double**, DeviceType>::host_mirror_type h_b =
+  typename Kokkos::View<double**, execution_space>::host_mirror_type h_b =
       Kokkos::create_mirror_view(b);
 
   for (int i = 0; i < 100; i++) {
@@ -96,8 +95,9 @@ double AddTestLambda() {
   Kokkos::deep_copy(a, h_a);
 
   if (PWRTest == false) {
+    using policy_type = Kokkos::RangePolicy<execution_space>;
     Kokkos::parallel_for(
-        100, KOKKOS_LAMBDA(const int& i) {
+        policy_type(0, 100), KOKKOS_LAMBDA(const int& i) {
           b(i, 0) = a(i, 1) + a(i, 2);
           b(i, 1) = a(i, 0) - a(i, 3);
           b(i, 2) = a(i, 4) + a(i, 0);
@@ -105,7 +105,7 @@ double AddTestLambda() {
           b(i, 4) = a(i, 3) + a(i, 4);
         });
   } else {
-    using policy_type = Kokkos::TeamPolicy<DeviceType>;
+    using policy_type = Kokkos::TeamPolicy<execution_space>;
     using team_member = typename policy_type::member_type;
 
     policy_type policy(25, Kokkos::AUTO);
@@ -136,10 +136,9 @@ double AddTestLambda() {
   return result;
 }
 
-template <class DeviceType>
 struct FunctorReduceTest {
-  using view_type       = Kokkos::View<double**, DeviceType>;
-  using execution_space = DeviceType;
+  using execution_space = TEST_EXECSPACE;
+  using view_type       = Kokkos::View<double**, TEST_EXECSPACE>;
   using value_type      = double;
   using team_member = typename Kokkos::TeamPolicy<execution_space>::member_type;
 
@@ -178,10 +177,10 @@ struct FunctorReduceTest {
   }
 };
 
-template <class DeviceType, bool PWRTest>
+template <bool PWRTest>
 double ReduceTestFunctor() {
-  using policy_type = Kokkos::TeamPolicy<DeviceType>;
-  using view_type   = Kokkos::View<double**, DeviceType>;
+  using execution_space = TEST_EXECSPACE;
+  using view_type       = Kokkos::View<double**, execution_space>;
   using unmanaged_result =
       Kokkos::View<double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
 
@@ -197,11 +196,11 @@ double ReduceTestFunctor() {
 
   double result = 0.0;
   if (PWRTest == false) {
-    Kokkos::parallel_reduce(100, FunctorReduceTest<DeviceType>(a),
+    Kokkos::parallel_reduce(100, FunctorReduceTest(a),
                             unmanaged_result(&result));
   } else {
-    Kokkos::parallel_reduce(policy_type(25, Kokkos::AUTO),
-                            FunctorReduceTest<DeviceType>(a),
+    using policy_type = Kokkos::TeamPolicy<execution_space>;
+    Kokkos::parallel_reduce(policy_type(25, Kokkos::AUTO), FunctorReduceTest(a),
                             unmanaged_result(&result));
   }
   Kokkos::fence();
@@ -209,10 +208,10 @@ double ReduceTestFunctor() {
   return result;
 }
 
-template <class DeviceType, bool PWRTest>
+template <bool PWRTest>
 double ReduceTestLambda() {
-  using policy_type = Kokkos::TeamPolicy<DeviceType>;
-  using view_type   = Kokkos::View<double**, DeviceType>;
+  using execution_space = TEST_EXECSPACE;
+  using view_type       = Kokkos::View<double**, execution_space>;
   using unmanaged_result =
       Kokkos::View<double, Kokkos::HostSpace, Kokkos::MemoryUnmanaged>;
 
@@ -229,8 +228,9 @@ double ReduceTestLambda() {
   double result = 0.0;
 
   if (PWRTest == false) {
+    using policy_type = Kokkos::RangePolicy<execution_space>;
     Kokkos::parallel_reduce(
-        100,
+        policy_type(0, 100),
         KOKKOS_LAMBDA(const int& i, double& sum) {
           sum += a(i, 1) + a(i, 2);
           sum += a(i, 0) - a(i, 3);
@@ -240,6 +240,7 @@ double ReduceTestLambda() {
         },
         unmanaged_result(&result));
   } else {
+    using policy_type = Kokkos::TeamPolicy<execution_space>;
     using team_member = typename policy_type::member_type;
     Kokkos::parallel_reduce(
         policy_type(25, Kokkos::AUTO),
@@ -262,36 +263,33 @@ double ReduceTestLambda() {
   return result;
 }
 
-template <class DeviceType>
 double TestVariantLambda(int test) {
   switch (test) {
-    case 1: return AddTestLambda<DeviceType, false>();
-    case 2: return AddTestLambda<DeviceType, true>();
-    case 3: return ReduceTestLambda<DeviceType, false>();
-    case 4: return ReduceTestLambda<DeviceType, true>();
+    case 1: return AddTestLambda<false>();
+    case 2: return AddTestLambda<true>();
+    case 3: return ReduceTestLambda<false>();
+    case 4: return ReduceTestLambda<true>();
     default: Kokkos::abort("unreachable");
   }
 
   return 0;
 }
 
-template <class DeviceType>
 double TestVariantFunctor(int test) {
   switch (test) {
-    case 1: return AddTestFunctor<DeviceType, false>();
-    case 2: return AddTestFunctor<DeviceType, true>();
-    case 3: return ReduceTestFunctor<DeviceType, false>();
-    case 4: return ReduceTestFunctor<DeviceType, true>();
+    case 1: return AddTestFunctor<false>();
+    case 2: return AddTestFunctor<true>();
+    case 3: return ReduceTestFunctor<false>();
+    case 4: return ReduceTestFunctor<true>();
     default: Kokkos::abort("unreachable");
   }
 
   return 0;
 }
 
-template <class DeviceType>
 bool Test(int test) {
-  double res_functor = TestVariantFunctor<DeviceType>(test);
-  double res_lambda  = TestVariantLambda<DeviceType>(test);
+  double res_functor = TestVariantFunctor(test);
+  double res_lambda  = TestVariantLambda(test);
 
   char testnames[5][256] = {" ", "AddTest", "AddTest TeamPolicy", "ReduceTest",
                             "ReduceTest TeamPolicy"};
@@ -318,12 +316,10 @@ bool Test(int test) {
 
 namespace Test {
 TEST(TEST_CATEGORY, cxx11) {
-  if (std::is_same_v<Kokkos::DefaultExecutionSpace, TEST_EXECSPACE>) {
-    ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(1)));
-    ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(2)));
-    ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(3)));
-    ASSERT_TRUE((TestCXX11::Test<TEST_EXECSPACE>(4)));
-  }
+  ASSERT_TRUE((TestCXX11::Test(1)));
+  ASSERT_TRUE((TestCXX11::Test(2)));
+  ASSERT_TRUE((TestCXX11::Test(3)));
+  ASSERT_TRUE((TestCXX11::Test(4)));
 }
 
 }  // namespace Test

--- a/core/unit_test/TestDeepCopy.hpp
+++ b/core/unit_test/TestDeepCopy.hpp
@@ -41,22 +41,67 @@ void test_deep_copy_assignable_types(Extents... exts) {
 
   ASSERT_TRUE(h_b((exts - 1)...) == 2.5);
 
-#ifdef KOKKOS_HAS_SHARED_SPACE
-  Kokkos::View<D1, Kokkos::SharedSpace> s("S", exts...);
-  Kokkos::deep_copy(s, 1.5);
+  // Read b back through its host mirror and check the value.
+  auto check_b = [&](double expected) {
+    Kokkos::deep_copy(h_b, b);
+    ASSERT_TRUE(h_b((exts - 1)...) == expected);
+  };
 
-  Kokkos::deep_copy(b, s);
-  Kokkos::deep_copy(h_b, b);
-  ASSERT_TRUE(h_b((exts - 1)...) == 1.5);
+#ifdef KOKKOS_HAS_SHARED_SPACE
+  // Gate on accessibility so every kernel below runs on TEST_EXECSPACE;
+  // otherwise deep_copy substitutes the view's own execution space.
+  if constexpr (Kokkos::SpaceAccessibility<TEST_EXECSPACE,
+                                           Kokkos::SharedSpace>::accessible) {
+    Kokkos::View<D1, Kokkos::SharedSpace> s("S", exts...);
+
+    // The explicit instance is required; without it this dispatches on
+    // SharedSpace::execution_space.
+    Kokkos::deep_copy(TEST_EXECSPACE{}, s, 1.5);
+
+    // No exec instance: destination-preferred dispatch resolves to
+    // TEST_EXECSPACE because b is the destination.
+    Kokkos::deep_copy(b, s);
+    check_b(1.5);
+
+    Kokkos::deep_copy(TEST_EXECSPACE{}, a, 3.5);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, s, a);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, b, s);
+    check_b(3.5);
+
+    Kokkos::View<D1, Kokkos::SharedSpace> s2("S2", exts...);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, s2, s);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, b, s2);
+    check_b(3.5);
+  }
 #endif
 
 #ifdef KOKKOS_HAS_SHARED_HOST_PINNED_SPACE
-  Kokkos::View<D1, Kokkos::SharedHostPinnedSpace> sp("S", exts...);
-  Kokkos::deep_copy(sp, 2.5);
+  // Gate on accessibility so every kernel below runs on TEST_EXECSPACE;
+  // otherwise deep_copy substitutes the view's own execution space.
+  if constexpr (Kokkos::SpaceAccessibility<
+                    TEST_EXECSPACE,
+                    Kokkos::SharedHostPinnedSpace>::accessible) {
+    Kokkos::View<D1, Kokkos::SharedHostPinnedSpace> sp("SP", exts...);
 
-  Kokkos::deep_copy(b, sp);
-  Kokkos::deep_copy(h_b, b);
-  ASSERT_TRUE(h_b((exts - 1)...) == 2.5);
+    // The explicit instance is required; without it this dispatches on
+    // SharedHostPinnedSpace::execution_space.
+    Kokkos::deep_copy(TEST_EXECSPACE{}, sp, 2.5);
+
+    // No exec instance: destination-preferred dispatch resolves to
+    // TEST_EXECSPACE because b is the destination.
+    Kokkos::deep_copy(b, sp);
+    check_b(2.5);
+
+    Kokkos::deep_copy(TEST_EXECSPACE{}, a, 4.5);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, sp, a);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, b, sp);
+    check_b(4.5);
+
+    Kokkos::View<D1, Kokkos::SharedHostPinnedSpace> sp2("SP2", exts...);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, sp2, sp);
+    Kokkos::deep_copy(TEST_EXECSPACE{}, b, sp2);
+    check_b(4.5);
+  }
 #endif
 }
 }  // namespace

--- a/core/unit_test/TestDeepCopy.hpp
+++ b/core/unit_test/TestDeepCopy.hpp
@@ -41,11 +41,14 @@ void test_deep_copy_assignable_types(Extents... exts) {
 
   ASSERT_TRUE(h_b((exts - 1)...) == 2.5);
 
+#if defined(KOKKOS_HAS_SHARED_SPACE) || \
+    defined(KOKKOS_HAS_SHARED_HOST_PINNED_SPACE)
   // Read b back through its host mirror and check the value.
   auto check_b = [&](double expected) {
     Kokkos::deep_copy(h_b, b);
     ASSERT_TRUE(h_b((exts - 1)...) == expected);
   };
+#endif
 
 #ifdef KOKKOS_HAS_SHARED_SPACE
   // Gate on accessibility so every kernel below runs on TEST_EXECSPACE;

--- a/core/unit_test/TestHalfConversion.hpp
+++ b/core/unit_test/TestHalfConversion.hpp
@@ -16,9 +16,11 @@ void test_half_conversion_type() {
   T b                            = Kokkos::Experimental::cast_from_half<T>(a);
   ASSERT_NEAR(b, base, epsilon);
 
-  Kokkos::View<T> b_v("b_v");
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+  Kokkos::View<T, MemorySpace> b_v("b_v");
   Kokkos::parallel_for(
-      "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
+      "TestHalfConversion", Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
+      KOKKOS_LAMBDA(int) {
         Kokkos::Experimental::half_t d_a =
             Kokkos::Experimental::cast_to_half(base);
         b_v() = Kokkos::Experimental::cast_from_half<T>(d_a);
@@ -38,9 +40,11 @@ void test_bhalf_conversion_type() {
   T b                             = Kokkos::Experimental::cast_from_bhalf<T>(a);
   ASSERT_NEAR(b, base, epsilon);
 
-  Kokkos::View<T> b_v("b_v");
+  using MemorySpace = typename TEST_EXECSPACE::memory_space;
+  Kokkos::View<T, MemorySpace> b_v("b_v");
   Kokkos::parallel_for(
-      "TestHalfConversion", 1, KOKKOS_LAMBDA(int) {
+      "TestHalfConversion", Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
+      KOKKOS_LAMBDA(int) {
         Kokkos::Experimental::bhalf_t d_a =
             Kokkos::Experimental::cast_to_bhalf(base);
         b_v() = Kokkos::Experimental::cast_from_bhalf<T>(d_a);

--- a/core/unit_test/TestMDSpanConversion.hpp
+++ b/core/unit_test/TestMDSpanConversion.hpp
@@ -506,11 +506,12 @@ TEST(TEST_CATEGORY, view_mdspan_conversion) {
 #if !(defined(KOKKOS_COMPILER_NVHPC) && defined(KOKKOS_ENABLE_OPENACC))
 TEST(TEST_CATEGORY, view_mdspan_conversion_with_stride) {
   {
-    Kokkos::View<int ***, Kokkos::LayoutLeft> source("S", 20, 40, 70);
+    Kokkos::View<int ***, Kokkos::LayoutLeft, TEST_EXECSPACE> source("S", 20,
+                                                                     40, 70);
     auto sub_v   = Kokkos::subview(source, Kokkos::pair{5, 15}, Kokkos::ALL(),
                                    Kokkos::pair{2, 38});
     auto sub_mds = sub_v.to_mdspan();
-    Kokkos::View<int ***, Kokkos::LayoutLeft> sub_v2(sub_mds);
+    Kokkos::View<int ***, Kokkos::LayoutLeft, TEST_EXECSPACE> sub_v2(sub_mds);
     ASSERT_EQ(static_cast<int>(sub_v.extent(0)), 10);
     ASSERT_EQ(static_cast<int>(sub_v.extent(1)), 40);
     ASSERT_EQ(static_cast<int>(sub_v.extent(2)), 36);
@@ -534,11 +535,12 @@ TEST(TEST_CATEGORY, view_mdspan_conversion_with_stride) {
     // layout_right_padded<dynamic_extent> has a custom stride for
     // stride(rank-2) LayoutRight has a custom stride for stride(0) That means
     // the "padding" only matches up for Rank-2 Views
-    Kokkos::View<int **, Kokkos::LayoutRight> source("S", 20, 40);
+    Kokkos::View<int **, Kokkos::LayoutRight, TEST_EXECSPACE> source("S", 20,
+                                                                     40);
     auto sub_v =
         Kokkos::subview(source, Kokkos::pair{5, 15}, Kokkos::pair{2, 38});
     auto sub_mds = sub_v.to_mdspan();
-    Kokkos::View<int **, Kokkos::LayoutRight> sub_v2(sub_mds);
+    Kokkos::View<int **, Kokkos::LayoutRight, TEST_EXECSPACE> sub_v2(sub_mds);
     ASSERT_EQ(static_cast<int>(sub_v.extent(0)), 10);
     ASSERT_EQ(static_cast<int>(sub_v.extent(1)), 36);
     ASSERT_EQ(static_cast<int>(sub_v.stride(0)), 40);

--- a/core/unit_test/TestMinMaxClamp.hpp
+++ b/core/unit_test/TestMinMaxClamp.hpp
@@ -62,6 +62,7 @@ TEST(TEST_CATEGORY, max) {
 
 template <class ViewType>
 struct StdAlgoMinMaxOpsTestMax {
+  using execution_space = TEST_EXECSPACE;
   ViewType m_view;
 
   KOKKOS_INLINE_FUNCTION
@@ -79,7 +80,7 @@ struct StdAlgoMinMaxOpsTestMax {
 TEST(TEST_CATEGORY, max_within_parfor) {
   namespace KE = Kokkos::Experimental;
 
-  using view_t = Kokkos::View<double*>;
+  using view_t = Kokkos::View<double*, TEST_EXECSPACE>;
   view_t a("a", 10);
 
   StdAlgoMinMaxOpsTestMax<view_t> fnc(a);
@@ -123,6 +124,7 @@ TEST(TEST_CATEGORY, min) {
 
 template <class ViewType>
 struct StdAlgoMinMaxOpsTestMin {
+  using execution_space = TEST_EXECSPACE;
   ViewType m_view;
 
   KOKKOS_INLINE_FUNCTION
@@ -139,7 +141,7 @@ struct StdAlgoMinMaxOpsTestMin {
 
 TEST(TEST_CATEGORY, min_within_parfor) {
   namespace KE = Kokkos::Experimental;
-  using view_t = Kokkos::View<double*>;
+  using view_t = Kokkos::View<double*, TEST_EXECSPACE>;
   view_t a("a", 10);
 
   StdAlgoMinMaxOpsTestMin<view_t> fnc(a);
@@ -200,6 +202,7 @@ TEST(TEST_CATEGORY, minmax) {
 
 template <class ViewType>
 struct StdAlgoMinMaxOpsTestMinMax {
+  using execution_space = TEST_EXECSPACE;
   ViewType m_view;
 
   KOKKOS_INLINE_FUNCTION
@@ -214,7 +217,7 @@ struct StdAlgoMinMaxOpsTestMinMax {
 };
 
 TEST(TEST_CATEGORY, minmax_within_parfor) {
-  using view_t = Kokkos::View<double*>;
+  using view_t = Kokkos::View<double*, TEST_EXECSPACE>;
   view_t a("a", 10);
 
   StdAlgoMinMaxOpsTestMinMax<view_t> fnc(a);
@@ -253,6 +256,7 @@ TEST(TEST_CATEGORY, clamp) {
 
 template <class ViewType>
 struct StdAlgoMinMaxOpsTestClamp {
+  using execution_space = TEST_EXECSPACE;
   ViewType m_view;
 
   KOKKOS_INLINE_FUNCTION
@@ -269,7 +273,7 @@ struct StdAlgoMinMaxOpsTestClamp {
 };
 
 TEST(TEST_CATEGORY, clamp_within_parfor) {
-  using view_t = Kokkos::View<double*>;
+  using view_t = Kokkos::View<double*, TEST_EXECSPACE>;
   view_t a("a", 10);
 
   StdAlgoMinMaxOpsTestClamp<view_t> fnc(a);

--- a/core/unit_test/TestReduce.hpp
+++ b/core/unit_test/TestReduce.hpp
@@ -772,9 +772,12 @@ TEST(TEST_CATEGORY, reduction_with_large_iteration_count) {
 
 /* Test that searching the Max of a View containing only -inf returns -inf and
    the Min of a View containing only +inf returns +inf. */
-template <typename ScalarType>
+template <typename ScalarType, class DeviceType>
 class TestReductionOverInfiniteFloat {
  public:
+  using execution_space = DeviceType;
+  using memory_space    = typename execution_space::memory_space;
+
   TestReductionOverInfiniteFloat() { runTest(); }
 
   void runTest() {
@@ -784,12 +787,12 @@ class TestReductionOverInfiniteFloat {
     // Ensure that inf correctly correspond to infinity for type `ScalarType`
     EXPECT_TRUE((inf == inf * inf) && (inf == inf + 1));
 
-    Kokkos::View<ScalarType*> view("view", N);
+    Kokkos::View<ScalarType*, memory_space> view("view", N);
 
     Kokkos::deep_copy(view, inf);
     ScalarType min;
     Kokkos::parallel_reduce(
-        N,
+        Kokkos::RangePolicy<execution_space>(0, N),
         KOKKOS_LAMBDA(const int i, ScalarType& partial_min) {
           if (view[i] < partial_min) {
             partial_min = view[i];
@@ -802,7 +805,7 @@ class TestReductionOverInfiniteFloat {
     Kokkos::deep_copy(view, -inf);
     ScalarType max;
     Kokkos::parallel_reduce(
-        N,
+        Kokkos::RangePolicy<execution_space>(0, N),
         KOKKOS_LAMBDA(const int i, ScalarType& partial_max) {
           if (view[i] > partial_max) {
             partial_max = view[i];
@@ -828,15 +831,17 @@ TEST(TEST_CATEGORY, reduction_identity_min_max_floating_point_types) {
   // FIXME_CUDA cuda-clang 17 cannot compile the max parallel_reduce for half_t
   // and bhalf_t. The min parallel_reduce works correctly.
 #if !defined(KOKKOS_ENABLE_CUDA) || !defined(KOKKOS_COMPILER_CLANG)
-  TestReductionOverInfiniteFloat<Kokkos::Experimental::half_t>();
-  TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t>();
+  TestReductionOverInfiniteFloat<Kokkos::Experimental::half_t,
+                                 TEST_EXECSPACE>();
+  TestReductionOverInfiniteFloat<Kokkos::Experimental::bhalf_t,
+                                 TEST_EXECSPACE>();
 #endif
-  TestReductionOverInfiniteFloat<float>();
-  TestReductionOverInfiniteFloat<double>();
+  TestReductionOverInfiniteFloat<float, TEST_EXECSPACE>();
+  TestReductionOverInfiniteFloat<double, TEST_EXECSPACE>();
 
 #if !defined(KOKKOS_ENABLE_CUDA) && !defined(KOKKOS_ENABLE_HIP) && \
     !defined(KOKKOS_ENABLE_SYCL) && !defined(KOKKOS_ENABLE_OPENACC)
-  TestReductionOverInfiniteFloat<long double>();
+  TestReductionOverInfiniteFloat<long double, TEST_EXECSPACE>();
 #endif
 }
 KOKKOS_IMPL_DISABLE_UNREACHABLE_WARNINGS_POP()

--- a/core/unit_test/TestReducers.hpp
+++ b/core/unit_test/TestReducers.hpp
@@ -409,7 +409,7 @@ struct TestReducers {
   // than 32.
   template <int N>
   static void test_launch_bounds() {
-    Kokkos::View<Scalar*> v("", N);
+    Kokkos::View<Scalar*, ExecSpace> v("", N);
     Kokkos::deep_copy(v, Scalar(2));
 
     // Functor
@@ -418,13 +418,14 @@ struct TestReducers {
 
     // This first reduction is necessary to ensure we trigger the bug #8443
     Scalar ret;
-    Kokkos::parallel_reduce(Kokkos::RangePolicy(0, 1), suml,
+    Kokkos::parallel_reduce(Kokkos::RangePolicy<ExecSpace>(0, 1), suml,
                             Kokkos::Sum<Scalar>(ret));
     EXPECT_EQ(ret, 2) << "N=" << N;
 
     // Test that LaunchBounds<N> works with Sum
-    Kokkos::parallel_reduce(Kokkos::RangePolicy<Kokkos::LaunchBounds<N>>(0, N),
-                            suml, Kokkos::Sum<Scalar>(ret));
+    Kokkos::parallel_reduce(
+        Kokkos::RangePolicy<ExecSpace, Kokkos::LaunchBounds<N>>(0, N), suml,
+        Kokkos::Sum<Scalar>(ret));
     EXPECT_EQ(ret, 2 * N) << "N=" << N;
 
     // This test can't be run on int32 with N>= 31 because of overflow
@@ -432,7 +433,7 @@ struct TestReducers {
                   N < 31) {
       // Test that LaunchBounds<N> works with Prod
       Kokkos::parallel_reduce(
-          Kokkos::RangePolicy<Kokkos::LaunchBounds<N>>(0, N), prodl,
+          Kokkos::RangePolicy<ExecSpace, Kokkos::LaunchBounds<N>>(0, N), prodl,
           Kokkos::Prod<Scalar>(ret));
 
       Scalar expected = Scalar(1ull << N);

--- a/core/unit_test/TestSubView_c15.hpp
+++ b/core/unit_test/TestSubView_c15.hpp
@@ -17,31 +17,35 @@ TEST(TEST_CATEGORY_DEATH, view_subview_constructor_layout_compatibility) {
   using LL = Kokkos::LayoutLeft;
   using LS = Kokkos::LayoutStride;
 
-  Kokkos::View<int**, LL> a1("A1", N, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE> a1("A1", N, N);
   {
     // Using subview dims (ALL, 1). For a LayoutLeft,
     // any subview layout should be appropriate.
-    (void)Kokkos::View<int*, LL>(a1, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LS>(a1, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE>(a1, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE>(a1, Kokkos::ALL, 1);
 
     // FIXME: This doesn't compile for BasicView, but should
-    // (void)Kokkos::View<int*, LR>(a1, Kokkos::ALL, 1);
+    // (void)Kokkos::View<int*, LR, TEST_EXECSPACE>(a1, Kokkos::ALL, 1);
   }
   {
     // Using subview dims (1, ALL). For a LayoutLeft,
     // resulting subview must be strided.
     const std::string msg = "View assignment must have compatible layouts";
-    ASSERT_DEATH(((void)Kokkos::View<int*, LL>(a1, 1, Kokkos::ALL)), msg);
-    (void)Kokkos::View<int*, LS>(a1, 1, Kokkos::ALL);
-    ASSERT_DEATH(((void)Kokkos::View<int*, LR>(a1, 1, Kokkos::ALL)), msg);
+    ASSERT_DEATH(
+        ((void)Kokkos::View<int*, LL, TEST_EXECSPACE>(a1, 1, Kokkos::ALL)),
+        msg);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE>(a1, 1, Kokkos::ALL);
+    ASSERT_DEATH(
+        ((void)Kokkos::View<int*, LR, TEST_EXECSPACE>(a1, 1, Kokkos::ALL)),
+        msg);
   }
 
-  Kokkos::View<int**, LL> a2("A2", 1, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE> a2("A2", 1, N);
   {
     // Using subview dims (0, ALL). Any subview layout should be appropriate.
-    (void)Kokkos::View<int*, LL>(a2, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LS>(a2, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LR>(a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE>(a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE>(a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LR, TEST_EXECSPACE>(a2, 0, Kokkos::ALL);
   }
 }
 }  // namespace

--- a/core/unit_test/TestSubView_c16.hpp
+++ b/core/unit_test/TestSubView_c16.hpp
@@ -18,38 +18,46 @@ TEST(TEST_CATEGORY, view_create_unmanaged_subview_from_managed) {
   using LL = Kokkos::LayoutLeft;
   using LS = Kokkos::LayoutStride;
 
-  Kokkos::View<int**, LL> a1("A1", N, N);
-  Kokkos::View<int**, LL, Kokkos::MemoryTraits<Kokkos::Unmanaged>> a1_unmanaged(
-      a1.data(), N, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE> a1("A1", N, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE,
+               Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      a1_unmanaged(a1.data(), N, N);
   {
     // Using subview dims (ALL, 1). For a LayoutLeft,
     // any subview layout should be appropriate.
-    (void)Kokkos::View<int*, LL, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-        a1, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LS, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-        a1, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(a1, Kokkos::ALL,
+                                                                1);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(a1, Kokkos::ALL,
+                                                                1);
 
-    (void)Kokkos::View<int*, LL>(a1_unmanaged, Kokkos::ALL, 1);
-    (void)Kokkos::View<int*, LS>(a1_unmanaged, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE>(a1_unmanaged, Kokkos::ALL, 1);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE>(a1_unmanaged, Kokkos::ALL, 1);
     // FIXME: This doesn't compile for BasicView, but should
-    // (void)Kokkos::View<int*, LR>(a1_unmanaged, Kokkos::ALL, 1);
+    // (void)Kokkos::View<int*, LR, TEST_EXECSPACE>(a1_unmanaged, Kokkos::ALL,
+    // 1);
   }
 
-  Kokkos::View<int**, LL> a2("A2", 1, N);
-  Kokkos::View<int**, LL, Kokkos::MemoryTraits<Kokkos::Unmanaged>> a2_unmanaged(
-      a2.data(), 1, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE> a2("A2", 1, N);
+  Kokkos::View<int**, LL, TEST_EXECSPACE,
+               Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+      a2_unmanaged(a2.data(), 1, N);
   {
     // Using subview dims (0, ALL). Any subview layout should be appropriate.
-    (void)Kokkos::View<int*, LL, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-        a2, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LS, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-        a2, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LR, Kokkos::MemoryTraits<Kokkos::Unmanaged>>(
-        a2, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(a2, 0,
+                                                                Kokkos::ALL);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(a2, 0,
+                                                                Kokkos::ALL);
+    (void)Kokkos::View<int*, LR, TEST_EXECSPACE,
+                       Kokkos::MemoryTraits<Kokkos::Unmanaged>>(a2, 0,
+                                                                Kokkos::ALL);
 
-    (void)Kokkos::View<int*, LL>(a2_unmanaged, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LS>(a2_unmanaged, 0, Kokkos::ALL);
-    (void)Kokkos::View<int*, LR>(a2_unmanaged, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LL, TEST_EXECSPACE>(a2_unmanaged, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LS, TEST_EXECSPACE>(a2_unmanaged, 0, Kokkos::ALL);
+    (void)Kokkos::View<int*, LR, TEST_EXECSPACE>(a2_unmanaged, 0, Kokkos::ALL);
   }
 }
 }  // namespace

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1317,7 +1317,7 @@ class TestViewAPI {
   }
 
   struct test_refcount_poison_copy_functor {
-    using view_type = Kokkos::View<double *>;
+    using view_type = Kokkos::View<double *, DeviceType>;
     explicit test_refcount_poison_copy_functor(view_type v) : view(v) {}
 
     test_refcount_poison_copy_functor(
@@ -1363,7 +1363,7 @@ class TestViewAPI {
   static void run_test_deep_copy_empty() {
     // Check Deep Copy of LayoutLeft to LayoutRight
     {
-      Kokkos::View<double *, Kokkos::LayoutLeft> dll("dll", 10);
+      Kokkos::View<double *, Kokkos::LayoutLeft, DeviceType> dll("dll", 10);
       Kokkos::View<double *, Kokkos::LayoutRight, Kokkos::HostSpace> hlr("hlr",
                                                                          10);
       Kokkos::deep_copy(dll, hlr);

--- a/core/unit_test/TestViewAPI_b.hpp
+++ b/core/unit_test/TestViewAPI_b.hpp
@@ -8,7 +8,7 @@ namespace Test {
 TEST(TEST_CATEGORY, view_layout_left_with_stride) {
   Kokkos::LayoutLeft ll(10, 20);
   ll.stride = 15;
-  Kokkos::View<int**, Kokkos::LayoutLeft> a("A", ll);
+  Kokkos::View<int**, Kokkos::LayoutLeft, TEST_EXECSPACE> a("A", ll);
   ASSERT_EQ(static_cast<int>(a.extent(0)), 10);
   ASSERT_EQ(static_cast<int>(a.extent(1)), 20);
   ASSERT_EQ(static_cast<int>(a.stride(0)), 1);
@@ -23,7 +23,7 @@ TEST(TEST_CATEGORY, view_layout_left_with_stride) {
 TEST(TEST_CATEGORY, view_layout_right_with_stride) {
   Kokkos::LayoutRight lr(10, 20);
   lr.stride = 25;
-  Kokkos::View<int**, Kokkos::LayoutRight> a("A", lr);
+  Kokkos::View<int**, Kokkos::LayoutRight, TEST_EXECSPACE> a("A", lr);
   ASSERT_EQ(static_cast<int>(a.extent(0)), 10);
   ASSERT_EQ(static_cast<int>(a.extent(1)), 20);
   ASSERT_EQ(static_cast<int>(a.stride(0)), 25);

--- a/core/unit_test/range_policy/TestRangePolicyExecutionTypes.hpp
+++ b/core/unit_test/range_policy/TestRangePolicyExecutionTypes.hpp
@@ -22,22 +22,21 @@ KOKKOS_INLINE_FUNCTION int check_runtime_inputs(
 }
 
 void test_self_similar_range_policy_runtime() {
-  using IndexType = typename Kokkos::DefaultExecutionSpace::size_type;
+  using IndexType = typename TEST_EXECSPACE::size_type;
 
   IndexType beg        = 5;
   IndexType end        = 15;
   IndexType chunk_size = 10;
 
-  auto p_execspace =
-      Kokkos::RangePolicy(Kokkos::DefaultExecutionSpace(), beg, end);
+  auto p_execspace = Kokkos::RangePolicy<TEST_EXECSPACE>(beg, end);
   auto nerrs_exec_space =
       check_runtime_inputs(p_execspace, beg, end, chunk_size);
   ASSERT_EQ(nerrs_exec_space, 0);
 
   int nerrs_team_handle;
-  using team_t = typename Kokkos::TeamPolicy<>::member_type;
+  using team_t = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
   Kokkos::parallel_reduce(
-      "check_runtime", Kokkos::TeamPolicy(1, Kokkos::AUTO()),
+      "check_runtime", Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const team_t& team, int& nerrs) {
         auto p_teamhandle = Kokkos::RangePolicy(team, beg, end);
         auto tvr          = Kokkos::TeamVectorRange(team, beg, end);
@@ -59,27 +58,28 @@ void test_self_similar_range_policy_computation() {
   size_t N         = 7;
   size_t num_teams = 5;
 
-  Kokkos::View<float*> v_x("v_x", N), v_y("v_y", N);
-  Kokkos::View<float**> M_x("M_x", num_teams, N), M_y("M_y", num_teams, N);
+  Kokkos::View<float*, TEST_EXECSPACE> v_x("v_x", N), v_y("v_y", N);
+  Kokkos::View<float**, TEST_EXECSPACE> M_x("M_x", num_teams, N),
+      M_y("M_y", num_teams, N);
 
   // Initialize v_x and v_y with values from 1 to N
   Kokkos::parallel_for(
-      "init_v_x", Kokkos::RangePolicy<>(0, N),
+      "init_v_x", Kokkos::RangePolicy<TEST_EXECSPACE>(0, N),
       KOKKOS_LAMBDA(const int& i) { v_x(i) = static_cast<float>(i + 1); });
   Kokkos::parallel_for(
-      "init_v_y", Kokkos::RangePolicy<>(0, N),
+      "init_v_y", Kokkos::RangePolicy<TEST_EXECSPACE>(0, N),
       KOKKOS_LAMBDA(const int& i) { v_y(i) = static_cast<float>(i + 1); });
 
   // Initialize M_x and M_y with values from 1 to M (flattened index)
   Kokkos::parallel_for(
-      "init_M_x", Kokkos::RangePolicy<>(0, num_teams),
+      "init_M_x", Kokkos::RangePolicy<TEST_EXECSPACE>(0, num_teams),
       KOKKOS_LAMBDA(const int& i) {
         for (size_t j = 0; j < N; j++) {
           M_x(i, j) = static_cast<float>(i * N + j + 1);
         }
       });
   Kokkos::parallel_for(
-      "init_M_y", Kokkos::RangePolicy<>(0, num_teams),
+      "init_M_y", Kokkos::RangePolicy<TEST_EXECSPACE>(0, num_teams),
       KOKKOS_LAMBDA(const int& i) {
         for (size_t j = 0; j < N; j++) {
           M_y(i, j) = static_cast<float>(i * N + j + 1);
@@ -87,12 +87,13 @@ void test_self_similar_range_policy_computation() {
       });
 
   // Call sum_views(ExecSpace):
-  sum_views(Kokkos::DefaultExecutionSpace(), v_x, v_y);
+  sum_views(TEST_EXECSPACE(), v_x, v_y);
 
   // Call sum_views(TeamHandle)
-  using team_t = typename Kokkos::TeamPolicy<>::member_type;
+  using team_t = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
   Kokkos::parallel_for(
-      "apxyFromTeam", Kokkos::TeamPolicy(num_teams, Kokkos::AUTO()),
+      "apxyFromTeam",
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(num_teams, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const team_t& team) {
         sum_views(team, Kokkos::subview(M_x, team.league_rank(), Kokkos::ALL()),
                   Kokkos::subview(M_y, team.league_rank(), Kokkos::ALL()));
@@ -101,14 +102,14 @@ void test_self_similar_range_policy_computation() {
   // Check v_x
   size_t result = 0;
   Kokkos::parallel_reduce(
-      "Check1", v_x.extent(0),
+      "Check1", Kokkos::RangePolicy<TEST_EXECSPACE>(0, v_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& val) { val += v_x(i); }, result);
   size_t expected_v_x = N * (N + 1);
   ASSERT_EQ(result, expected_v_x);
 
   // Check individual elements of v_x
   Kokkos::parallel_reduce(
-      "Check1_elements", v_x.extent(0),
+      "Check1_elements", Kokkos::RangePolicy<TEST_EXECSPACE>(0, v_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& errors) {
         float expected = static_cast<float>(2 * (i + 1));
         if (v_x(i) != expected) ++errors;
@@ -119,7 +120,7 @@ void test_self_similar_range_policy_computation() {
   // Check M_x
   result = 0;
   Kokkos::parallel_reduce(
-      "Check2", M_x.extent(0),
+      "Check2", Kokkos::RangePolicy<TEST_EXECSPACE>(0, M_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& val) {
         for (int j = 0; j < M_x.extent_int(1); j++) val += M_x(i, j);
       },
@@ -130,7 +131,7 @@ void test_self_similar_range_policy_computation() {
 
   // Check individual elements of M_x
   Kokkos::parallel_reduce(
-      "Check2_elements", M_x.extent(0),
+      "Check2_elements", Kokkos::RangePolicy<TEST_EXECSPACE>(0, M_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& errors) {
         for (int j = 0; j < M_x.extent_int(1); j++) {
           float expected = static_cast<float>(2 * (i * N + j + 1));

--- a/core/unit_test/view/TestViewCtorDataHandle.hpp
+++ b/core/unit_test/view/TestViewCtorDataHandle.hpp
@@ -16,22 +16,23 @@ namespace {
 template <class DeviceType>
 struct TestViewCtorDataHandle {
   static void test_view_data_handle_ctor_ref_counts() {
-    Kokkos::View<int *> a("A", 5);
+    Kokkos::View<int *, DeviceType> a("A", 5);
     ASSERT_EQ(a.use_count(), 1);
     {
-      Kokkos::View<int *> b(a.data_handle(), a.extents());
+      Kokkos::View<int *, DeviceType> b(a.data_handle(), a.extents());
       ASSERT_EQ(a.use_count(), 2);
       ASSERT_EQ(b.use_count(), 2);
     }
     ASSERT_EQ(a.use_count(), 1);
     {
-      Kokkos::View<int *> b(a.data_handle(), a.mapping());
+      Kokkos::View<int *, DeviceType> b(a.data_handle(), a.mapping());
       ASSERT_EQ(a.use_count(), 2);
       ASSERT_EQ(b.use_count(), 2);
     }
     ASSERT_EQ(a.use_count(), 1);
     {
-      Kokkos::View<int *> b(a.data_handle(), a.mapping(), a.accessor());
+      Kokkos::View<int *, DeviceType> b(a.data_handle(), a.mapping(),
+                                        a.accessor());
       ASSERT_EQ(a.use_count(), 2);
       ASSERT_EQ(b.use_count(), 2);
     }

--- a/core/unit_test/view/TestViewCustomizationAccessorArg.hpp
+++ b/core/unit_test/view/TestViewCustomizationAccessorArg.hpp
@@ -112,7 +112,7 @@ void test_accessor_arg() {
   // Test unmanaged ctors on GPU too (if GPU is enabled)
   int num_error = 0;
   Kokkos::parallel_reduce(
-      "test_accessor_arg", 1,
+      "test_accessor_arg", Kokkos::RangePolicy<TEST_EXECSPACE>(0, 1),
       KOKKOS_LAMBDA(int, int& errors) {
         view_t e(a.data(), 10);
         if (e.accessor().value != 0lu) errors++;


### PR DESCRIPTION
Depends on #9436. Fixes #9446.

The diff below also contains #9436's two commits; **review only the last two**, `core: make host execution space destructors device-callable` and `test: dispatch TestRangePolicyExecutionTypes on TEST_EXECSPACE`. Once #9436 merges, the diff reduces to those two on its own.

`core/unit_test/range_policy/TestRangePolicyExecutionTypes.hpp` never names `TEST_EXECSPACE` — it uses `Kokkos::DefaultExecutionSpace`, `RangePolicy<>`, `TeamPolicy<>`, views with no memory space, and bare-integer `parallel_*` dispatch. Every backend's translation unit therefore runs its kernels on the default execution space, so a `Serial` or `OpenMP` test binary launches device kernels.

Retargeting the file was attempted in #9436 and reverted at review request, because it breaks the CUDA build:

```
Kokkos_ExecPolicy.hpp: error #20011-D: calling a __host__ function("Kokkos::Serial::~Serial()")
from a __host__ __device__ function("Kokkos::Impl::ImplRangePolicy< ::Kokkos::Serial, ::Kokkos::Serial >::~ImplRangePolicy") is not allowed
```

### Root cause

`check_runtime_inputs` and `sum_views` are `KOKKOS_INLINE_FUNCTION`, because their team-handle call sites must be device-callable, so every instantiation is `__host__ __device__`. Each constructs a policy by value, and `ImplRangePolicy` stores the execution space by value, so the policy's destructor is instantiated in device context. With `TEST_EXECSPACE = Kokkos::Serial` that destructor calls host-only `Serial::~Serial()`, which nvcc rejects.

`RangePolicy<Cuda>` compiles only because b6d61de97 (#8367), the commit that introduced this test file, moved `Cuda::~Cuda()` out of `Kokkos_Cuda_Instance.cpp` into the header as `KOKKOS_FUNCTION` with its body wrapped in `KOKKOS_IF_ON_HOST`. The same treatment was never applied to any other execution space.

### Changes

`core: make host execution space destructors device-callable`

Give `Serial`, `OpenMP`, `Threads` and `HPX` the same destructor as `Cuda`. The bodies must be inline in the headers — a `__host__ __device__` function cannot be defined out-of-line without relocatable device code — so the `Serial` and `OpenMP` definitions move out of their .cpp files, and those two headers gain `#include <impl/Kokkos_CheckUsage.hpp>`.

Scope is the host execution spaces only. Only nvcc diagnoses this (per #8367: "None of the hip builds warn... the different way how host device function markups are treated in LLVM vs NVCC"), and nvcc only ever compiles `Cuda` alongside a host execution space, so the remaining device backends are left alone.

`HostSharedPtr`'s destructor is already `KOKKOS_FUNCTION` with a `KOKKOS_IF_ON_HOST` body, so no reference counting runs on device.

`test: dispatch TestRangePolicyExecutionTypes on TEST_EXECSPACE`

Retargets the whole file — index type, both `TeamPolicy` instantiations, both view allocations, the four initialization policies, the `sum_views` execution-space call site, and the four check kernels that used bare-integer dispatch.

The whole file, not only the lines reported in #9446: the views have to move with the policies, otherwise a kernel on the default execution space touches views in a memory space it cannot access.

### Notes for review

No new test machinery. Once retargeted, this test file is itself the regression guard: a future execution space with a host-only destructor fails to compile its translation unit in a CUDA build. There is no portable trait for "device-callable destructor", so this cannot be expressed as a `static_assert`.

The alternative of suppressing the diagnostic with `KOKKOS_IMPL_DISABLE_CALLING_HOST_FROM_DEVICE_WARNINGS_PUSH/POP` was rejected: that suppression silently stopped working under CUDA 12.8+/13.0 during #8367's own CI. Splitting the test's helpers into host-only and device-only copies was also rejected, since it duplicates the bodies and removes the single-generic-function property the self-similar interface exists to demonstrate.

Generated with machine assistance from Claude (claude-opus-5).
