### PR TITLE
Add googletest version check workflow

### DIFF
--- a/.github/workflows/googletest-version-check.yml
+++ b/.github/workflows/googletest-version-check.yml
@@ -20,8 +20,7 @@ jobs:
         ref: v1.14.0
         path: googletest-upstream
     - run: |
-        git -C googletest-upstream -c user.email=ci@kokkos.org -c user.name=CI \
-          am "$GITHUB_WORKSPACE"/tpls/googletest-1.14.0.patches/*.patch
+        git -C googletest-upstream apply "$GITHUB_WORKSPACE"/tpls/googletest-1.14.0.patches/*.patch
     - run: |
         rm googletest-upstream/.clang-format
         rm -r googletest-upstream/.github

--- a/.github/workflows/googletest-version-check.yml
+++ b/.github/workflows/googletest-version-check.yml
@@ -1,0 +1,52 @@
+name: googletest version check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/googletest-version-check.yml'
+      - 'tpls/googletest-1.14.0/**'
+      - 'tpls/googletest-1.14.0.patches/**'
+
+permissions: read-all
+
+jobs:
+  googletest-version-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: google/googletest
+        ref: v1.14.0
+        path: googletest-upstream
+    - run: |
+        git -C googletest-upstream -c user.email=ci@kokkos.org -c user.name=CI \
+          am "$GITHUB_WORKSPACE"/tpls/googletest-1.14.0.patches/*.patch
+    - run: |
+        rm googletest-upstream/.clang-format
+        rm -r googletest-upstream/.github
+        rm googletest-upstream/.gitignore
+        rm googletest-upstream/BUILD.bazel
+        rm googletest-upstream/CONTRIBUTING.md
+        rm googletest-upstream/CONTRIBUTORS
+        rm googletest-upstream/README.md
+        rm googletest-upstream/WORKSPACE
+        rm -r googletest-upstream/ci
+        rm -r googletest-upstream/docs
+        rm googletest-upstream/googletest_deps.bzl
+        rm -r googletest-upstream/googlemock/cmake
+        rm -r googletest-upstream/googlemock/docs
+        rm googletest-upstream/googlemock/README.md
+        rm -r googletest-upstream/googlemock/test
+        rm googletest-upstream/googlemock/include/gmock/internal/custom/README.md
+        rm googletest-upstream/googletest/cmake/Config.cmake.in
+        rm googletest-upstream/googletest/cmake/gtest.pc.in
+        rm googletest-upstream/googletest/cmake/gtest_main.pc.in
+        rm googletest-upstream/googletest/cmake/libgtest.la.in
+        rm -r googletest-upstream/googletest/docs
+        rm googletest-upstream/googletest/README.md
+        rm -r googletest-upstream/googletest/samples
+        rm -r googletest-upstream/googletest/test
+        rm googletest-upstream/googletest/include/gtest/internal/custom/README.md
+        rm -r googletest-upstream/.git
+        diff --unified=3 --recursive googletest-upstream tpls/googletest-1.14.0

--- a/tpls/googletest-1.14.0.patches/0001-CMake-Do-not-enable-the-C-language-unnecessary.patch
+++ b/tpls/googletest-1.14.0.patches/0001-CMake-Do-not-enable-the-C-language-unnecessary.patch
@@ -1,0 +1,67 @@
+From 54af6b0c691529574d29046e08ebd0c0ef034fb7 Mon Sep 17 00:00:00 2001
+From: Damien L-G <dalg24@gmail.com>
+Date: Fri, 24 Oct 2025 07:54:17 -0400
+Subject: [PATCH 1/3] CMake: Do not enable the C language (unnecessary)
+
+The project() command in the top-level CMakeLists.txt was not specifying
+languages which default to enabling C and CXX.
+The googlemock and googletest project() commands were explicitly enabing
+both the C and CXX languages in their respective subdirectories,
+although all their source file are correctly identified as CXX and the C
+language is effectively never used.
+
+Enabling the C language forces CXX-only projects downstream that embed
+this repo (via FetchContent or add subdirectory) to detect a C compiler
+at configuration-time.
+
+This PR proposes to properly only enable the CXX language.
+
+Signed-off-by: Damien L-G <dalg24@gmail.com>
+---
+ CMakeLists.txt            | 2 +-
+ googlemock/CMakeLists.txt | 2 +-
+ googletest/CMakeLists.txt | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 089ac987..42bd1cb2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,7 +3,7 @@
+ 
+ cmake_minimum_required(VERSION 3.13)
+ 
+-project(googletest-distribution)
++project(googletest-distribution CXX)
+ set(GOOGLETEST_VERSION 1.14.0)
+ 
+ if(NOT CYGWIN AND NOT MSYS AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL QNX)
+diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
+index a9aa0723..58cc83fb 100644
+--- a/googlemock/CMakeLists.txt
++++ b/googlemock/CMakeLists.txt
+@@ -37,7 +37,7 @@ endif()
+ # ${gmock_BINARY_DIR}.
+ # Language "C" is required for find_package(Threads).
+ cmake_minimum_required(VERSION 3.13)
+-project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
++project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
+ 
+ if (COMMAND set_up_hermetic_build)
+   set_up_hermetic_build()
+diff --git a/googletest/CMakeLists.txt b/googletest/CMakeLists.txt
+index caafa8c7..27ba4136 100644
+--- a/googletest/CMakeLists.txt
++++ b/googletest/CMakeLists.txt
+@@ -47,7 +47,7 @@ endif()
+ # Project version:
+ 
+ cmake_minimum_required(VERSION 3.13)
+-project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
++project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX)
+ 
+ if (COMMAND set_up_hermetic_build)
+   set_up_hermetic_build()
+-- 
+2.53.0
+

--- a/tpls/googletest-1.14.0.patches/0002-cmake-Fix-declspec-of-gtest-flag-when-using-BUILD_SH.patch
+++ b/tpls/googletest-1.14.0.patches/0002-cmake-Fix-declspec-of-gtest-flag-when-using-BUILD_SH.patch
@@ -1,0 +1,117 @@
+From 4025dd843c1ff930d7d77e7fd44af8f9506455b2 Mon Sep 17 00:00:00 2001
+From: Corentin Le Molgat <corentinl@google.com>
+Date: Fri, 9 Jan 2026 07:33:40 -0800
+Subject: [PATCH 2/3] cmake: Fix declspec of gtest flag when using
+ BUILD_SHARED_LIBS=ON and absl
+
+On windows flags declaration must be prepend by `GTEST_API_`
+to have the correct declspec (dllexport or dllimport)
+
+This patch also fix super build integration of googletest by adding the necessary `INSTALL_RPATH` and `$<BUILD_INTERFACE:` needed to be able to `FetchContent` or `add_subdirectory()` googletest in a user CMake project.
+
+Fix #4718
+related to abseil/abseil-cpp#1817
+
+PiperOrigin-RevId: 854187933
+Change-Id: I4341fdb7e88a51c5f9a1c72c58bcc8c4d6bfd1c5
+---
+ .../include/gmock/internal/gmock-port.h       |  6 +++---
+ googletest/cmake/internal_utils.cmake         | 21 ++++++++++++-------
+ .../include/gtest/internal/gtest-port.h       | 12 +++++------
+ 3 files changed, 23 insertions(+), 16 deletions(-)
+
+diff --git a/googlemock/include/gmock/internal/gmock-port.h b/googlemock/include/gmock/internal/gmock-port.h
+index 55ddfb6c..5522ec64 100644
+--- a/googlemock/include/gmock/internal/gmock-port.h
++++ b/googlemock/include/gmock/internal/gmock-port.h
+@@ -85,11 +85,11 @@
+ 
+ // Macros for declaring flags.
+ #define GMOCK_DECLARE_bool_(name) \
+-  ABSL_DECLARE_FLAG(bool, GMOCK_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(bool, GMOCK_FLAG_NAME_(name))
+ #define GMOCK_DECLARE_int32_(name) \
+-  ABSL_DECLARE_FLAG(int32_t, GMOCK_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(int32_t, GMOCK_FLAG_NAME_(name))
+ #define GMOCK_DECLARE_string_(name) \
+-  ABSL_DECLARE_FLAG(std::string, GMOCK_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(std::string, GMOCK_FLAG_NAME_(name))
+ 
+ #define GMOCK_FLAG_GET(name) ::absl::GetFlag(GMOCK_FLAG(name))
+ #define GMOCK_FLAG_SET(name, value) \
+diff --git a/googletest/cmake/internal_utils.cmake b/googletest/cmake/internal_utils.cmake
+index 64fa340f..b1f52f73 100644
+--- a/googletest/cmake/internal_utils.cmake
++++ b/googletest/cmake/internal_utils.cmake
+@@ -185,11 +185,19 @@ function(cxx_library_with_type name type cxx_flags)
+     COMPILE_PDB_NAME_DEBUG "${name}${pdb_debug_postfix}")
+ 
+   if (BUILD_SHARED_LIBS OR type STREQUAL "SHARED")
+-    set_target_properties(${name}
+-      PROPERTIES
+-      COMPILE_DEFINITIONS "GTEST_CREATE_SHARED_LIBRARY=1")
++    target_compile_definitions(${name} PRIVATE
++      "GTEST_CREATE_SHARED_LIBRARY=1")
+     target_compile_definitions(${name} INTERFACE
+-      $<INSTALL_INTERFACE:GTEST_LINKED_AS_SHARED_LIBRARY=1>)
++      $<BUILD_INTERFACE:GTEST_LINKED_AS_SHARED_LIBRARY=1>
++      $<INSTALL_INTERFACE:GTEST_LINKED_AS_SHARED_LIBRARY=1>
++    )
++    if(APPLE)
++      set_target_properties(${name} PROPERTIES
++        INSTALL_RPATH "@loader_path")
++    elseif(UNIX)
++      set_target_properties(${name} PROPERTIES
++        INSTALL_RPATH "$ORIGIN")
++    endif()
+   endif()
+   if (DEFINED GTEST_HAS_PTHREAD)
+     target_link_libraries(${name} PUBLIC Threads::Threads)
+@@ -226,9 +234,8 @@ function(cxx_executable_with_flags name cxx_flags libs)
+       COMPILE_FLAGS "${cxx_flags}")
+   endif()
+   if (BUILD_SHARED_LIBS)
+-    set_target_properties(${name}
+-      PROPERTIES
+-      COMPILE_DEFINITIONS "GTEST_LINKED_AS_SHARED_LIBRARY=1")
++    target_compile_definitions(${name} PRIVATE
++      "GTEST_LINKED_AS_SHARED_LIBRARY=1")
+   endif()
+   # To support mixing linking in static and dynamic libraries, link each
+   # library in with an extra call to target_link_libraries.
+diff --git a/googletest/include/gtest/internal/gtest-port.h b/googletest/include/gtest/internal/gtest-port.h
+index b887e24e..dc9479fc 100644
+--- a/googletest/include/gtest/internal/gtest-port.h
++++ b/googletest/include/gtest/internal/gtest-port.h
+@@ -827,10 +827,10 @@ typedef struct _RTL_CRITICAL_SECTION GTEST_CRITICAL_SECTION;
+ #ifndef GTEST_API_
+ 
+ #ifdef _MSC_VER
+-#if GTEST_LINKED_AS_SHARED_LIBRARY
+-#define GTEST_API_ __declspec(dllimport)
+-#elif GTEST_CREATE_SHARED_LIBRARY
++#if GTEST_CREATE_SHARED_LIBRARY
+ #define GTEST_API_ __declspec(dllexport)
++#elif GTEST_LINKED_AS_SHARED_LIBRARY
++#define GTEST_API_ __declspec(dllimport)
+ #endif
+ #elif GTEST_HAVE_ATTRIBUTE_(visibility)
+ #define GTEST_API_ __attribute__((visibility("default")))
+@@ -2239,11 +2239,11 @@ using TimeInMillis = int64_t;  // Represents time in milliseconds.
+ 
+ // Macros for declaring flags.
+ #define GTEST_DECLARE_bool_(name) \
+-  ABSL_DECLARE_FLAG(bool, GTEST_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(bool, GTEST_FLAG_NAME_(name))
+ #define GTEST_DECLARE_int32_(name) \
+-  ABSL_DECLARE_FLAG(int32_t, GTEST_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(int32_t, GTEST_FLAG_NAME_(name))
+ #define GTEST_DECLARE_string_(name) \
+-  ABSL_DECLARE_FLAG(std::string, GTEST_FLAG_NAME_(name))
++  GTEST_API_ ABSL_DECLARE_FLAG(std::string, GTEST_FLAG_NAME_(name))
+ 
+ #define GTEST_FLAG_SAVER_ ::absl::FlagSaver
+ 
+-- 
+2.53.0
+

--- a/tpls/googletest-1.14.0.patches/0003-Use-pragma-nv_diag_suppress-177-to-disable-spurious-.patch
+++ b/tpls/googletest-1.14.0.patches/0003-Use-pragma-nv_diag_suppress-177-to-disable-spurious-.patch
@@ -1,0 +1,39 @@
+From 765f4445f73ee829b91c0ae35f4985ad7ed25e93 Mon Sep 17 00:00:00 2001
+From: Daniel Arndt <arndtd@ornl.gov>
+Date: Fri, 14 Aug 2026 11:29:13 -0400
+Subject: [PATCH 3/3] Use pragma nv_diag_suppress 177 to disable spurious nvc++
+ warning
+
+Kokkos-specific workaround; no corresponding fix exists upstream.
+---
+ googletest/include/gtest/gtest.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/googletest/include/gtest/gtest.h b/googletest/include/gtest/gtest.h
+index de7d528f..e6bc35cf 100644
+--- a/googletest/include/gtest/gtest.h
++++ b/googletest/include/gtest/gtest.h
+@@ -49,6 +49,11 @@
+ #ifndef GOOGLETEST_INCLUDE_GTEST_GTEST_H_
+ #define GOOGLETEST_INCLUDE_GTEST_GTEST_H_
+ 
++#ifdef __NVCOMPILER
++#pragma nv_diagnostic push
++#pragma nv_diag_suppress 177
++#endif
++
+ #include <cstddef>
+ #include <cstdint>
+ #include <iomanip>
+@@ -2318,4 +2323,8 @@ inline int RUN_ALL_TESTS() { return ::testing::UnitTest::GetInstance()->Run(); }
+ 
+ GTEST_DISABLE_MSC_WARNINGS_POP_()  //  4251
+ 
++#ifdef __NVCOMPILER
++#pragma nv_diagnostic pop
++#endif
++
+ #endif  // GOOGLETEST_INCLUDE_GTEST_GTEST_H_
+-- 
+2.53.0
+

--- a/tpls/googletest-1.14.0/googlemock/include/gmock/internal/gmock-port.h
+++ b/tpls/googletest-1.14.0/googlemock/include/gmock/internal/gmock-port.h
@@ -85,11 +85,11 @@
 
 // Macros for declaring flags.
 #define GMOCK_DECLARE_bool_(name) \
-  ABSL_DECLARE_FLAG(bool, GMOCK_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(bool, GMOCK_FLAG_NAME_(name))
 #define GMOCK_DECLARE_int32_(name) \
-  ABSL_DECLARE_FLAG(int32_t, GMOCK_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(int32_t, GMOCK_FLAG_NAME_(name))
 #define GMOCK_DECLARE_string_(name) \
-  ABSL_DECLARE_FLAG(std::string, GMOCK_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(std::string, GMOCK_FLAG_NAME_(name))
 
 #define GMOCK_FLAG_GET(name) ::absl::GetFlag(GMOCK_FLAG(name))
 #define GMOCK_FLAG_SET(name, value) \

--- a/tpls/googletest-1.14.0/googletest/include/gtest/internal/gtest-port.h
+++ b/tpls/googletest-1.14.0/googletest/include/gtest/internal/gtest-port.h
@@ -2239,11 +2239,11 @@ using TimeInMillis = int64_t;  // Represents time in milliseconds.
 
 // Macros for declaring flags.
 #define GTEST_DECLARE_bool_(name) \
-  ABSL_DECLARE_FLAG(bool, GTEST_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(bool, GTEST_FLAG_NAME_(name))
 #define GTEST_DECLARE_int32_(name) \
-  ABSL_DECLARE_FLAG(int32_t, GTEST_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(int32_t, GTEST_FLAG_NAME_(name))
 #define GTEST_DECLARE_string_(name) \
-  ABSL_DECLARE_FLAG(std::string, GTEST_FLAG_NAME_(name))
+  GTEST_API_ ABSL_DECLARE_FLAG(std::string, GTEST_FLAG_NAME_(name))
 
 #define GTEST_FLAG_SAVER_ ::absl::FlagSaver
 


### PR DESCRIPTION
Adds a CI workflow that checks out google/googletest at v1.14.0, applies the patches we carry on top of it, strips the files we don't vendor, and diffs the result against tpls/googletest-1.14.0 to catch drift, mirroring the existing mdspan/desul version-check workflows.

The two CMake patches are cherry-picked from real upstream commits (one from an unmerged PR, one already merged) rather than hand-written diffs, so they carry proper provenance. The nv_diag_suppress pragma has no upstream equivalent and remains a Kokkos-only patch.

Assisted-by: Claude:claude-sonnet-5

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
