### PR TITLE
CICD: use `UR_ADAPTERS_SEARCH_PATH` in `Dockerfile.sycl`

### DIFF
--- a/scripts/docker/Dockerfile.sycl
+++ b/scripts/docker/Dockerfile.sycl
@@ -55,18 +55,21 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cd /tmp && git clone https://github.com/intel/llvm.git -b v6.2.0 --depth=1 && cd llvm && \
+ARG UNIFIED_RUNTIME_VERSION=6.2.0
+RUN cd /tmp && git clone https://github.com/intel/llvm.git -b v${UNIFIED_RUNTIME_VERSION} --depth=1 && cd llvm && \
     cmake -S unified-runtime -B build_ur \
       -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
       -DUR_BUILD_TESTS=OFF \
       -DUR_ENABLE_TRACING=ON \
       -DUR_BUILD_ADAPTER_CUDA=ON \
-      -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build build_ur -j 8 && \
-    cp -r build_ur/lib/* /opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib/ && \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/opt/ur-${UNIFIED_RUNTIME_VERSION} && \
+    cmake --build build_ur -j 8 --target=install && \
     rm -r /tmp/llvm
 
 # sycl-ls, icpx
-ENV PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/bin/:$PATH
-# libsycl, libsvml
-ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/${ONEAPI_VERSION}/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/intel/oneapi/compiler/latest/bin/:$PATH
+# libsycl, libsvml, libumf
+ENV LD_LIBRARY_PATH=/opt/intel/oneapi/compiler/latest/lib:/opt/intel/oneapi/umf/latest/lib:$LD_LIBRARY_PATH
+# libur_adapter_cuda
+ENV UR_ADAPTERS_SEARCH_PATH=/opt/ur-${UNIFIED_RUNTIME_VERSION}/lib


### PR DESCRIPTION
Currently, the `Dockerfile.sycl` builds the "unified runtime" and then manually copies all the compiled libraries from the build directory into the installed compiler's lib directory.

This PR proposes to use the `install` target of "unified runtime" and then the `UR_ADAPTERS_SEARCH_PATH` environment variable used by the intel compiler. This follows:
- https://oneapi-src.github.io/unified-runtime/core/INTRO.html#adapter-discovery.

Note that I've also tried updating to Cuda 12.8.1, oneapi 2026.0 and unified runtime 7.0.0. However, there is a compilation error in one of the Kokkos tests with this newer version.

<details>
<summary>
compilation error with 12.8.1/2026.0/7.0.0
</summary>

```
In file included from /home/costmo-user/kokkos/build-sycl/core/unit_test/serial/TestSerial_MathematicalFunctions2.cpp:2:
In file included from /home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions2.hpp:6:
/home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions.hpp:639:1: error: static assertion failed due to requirement 'std::is_same_v<double, float>'
  639 | DEFINE_BINARY_INT_PTR_FUNCTION_EVAL(frexp, 0);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions.hpp:624:21: note: expanded from macro 'DEFINE_BINARY_INT_PTR_FUNCTION_EVAL'
  624 |       static_assert(std::is_same_v<decltype(std::FUNC((T)0, (U*)0)),       \
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  625 |                                    math_unary_function_return_type_t<T>>); \
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions.hpp:982:32: note: in instantiation of function template specialization 'MathBinaryIntPtrFunction_frexp::eval_std<float, int>' requested here
  982 |       : val_(val), res2_(Func::eval_std(val, &res1_)) {
      |                                ^
/home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions.hpp:1010:8: note: in instantiation of member function 'TestMathBinaryIntPtrFunction<Kokkos::Serial, MathBinaryIntPtrFunction_frexp, float>::TestMathBinaryIntPtrFunction' requested here
 1010 |       (TestMathBinaryIntPtrFunction<Space, Func, Arg>(x), 0)...};
      |        ^
/home/costmo-user/kokkos/core/unit_test/TestMathematicalFunctions.hpp:1304:3: note: in instantiation of function template specialization 'do_test_math_binary_int_ptr_function<Kokkos::Serial, MathBinaryIntPtrFunction_frexp, float>' requested here
 1304 |   do_test_math_binary_int_ptr_function<TEST_EXECSPACE, Func>(42.765f);
      |   ^
1 error generated.
gmake[2]: *** [core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial1.dir/build.make:566: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial1.dir/serial/TestSerial_MathematicalFunctions2.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:2193: core/unit_test/CMakeFiles/Kokkos_CoreUnitTest_Serial1.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```
</details>

@masterleinad, would you have a moment to take a look?





