### PR TITLE
Use raw pointers for vendor sort_by_key if possible

### DIFF
--- a/algorithms/perf_test/CMakeLists.txt
+++ b/algorithms/perf_test/CMakeLists.txt
@@ -1,2 +1,3 @@
 kokkos_add_benchmark(PerformanceTest_InclusiveScan SOURCES test_inclusive_scan.cpp)
 kokkos_add_benchmark(PerformanceTest_Random SOURCES test_random.cpp)
+kokkos_add_benchmark(PerformanceTest_SortByKey SOURCES test_sort_by_key.cpp)

--- a/algorithms/perf_test/test_sort_by_key.cpp
+++ b/algorithms/perf_test/test_sort_by_key.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#include <cstddef>
+
+#include <benchmark/benchmark.h>
+
+#include <Kokkos_Macros.hpp>
+#ifdef KOKKOS_ENABLE_EXPERIMENTAL_CXX20_MODULES
+import kokkos.core;
+import kokkos.random;
+import kokkos.std_algorithms;
+#else
+#include <Kokkos_Core.hpp>
+#include <Kokkos_Random.hpp>
+#include <Kokkos_Sort.hpp>
+#endif
+#include <Kokkos_Timer.hpp>
+// FIXME: Benchmark_Context.hpp should be moved to a common location
+#include "../../core/perf_test/Benchmark_Context.hpp"
+
+namespace {
+
+template <class T>
+void BM_sort_by_key(benchmark::State& state) {
+  const std::size_t n = state.range(0);
+
+  using ExecutionSpace = Kokkos::DefaultExecutionSpace;
+  using MemorySpace    = typename ExecutionSpace::memory_space;
+
+  ExecutionSpace space;
+
+  Kokkos::Random_XorShift1024_Pool<MemorySpace> rand_pool(5374857);
+
+  Kokkos::View<T*, MemorySpace> keys_orig(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "keys_orig"), n);
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n), KOKKOS_LAMBDA(int i) {
+        auto rand_gen = rand_pool.get_state();
+        keys_orig(i)  = rand_gen.urand();
+        rand_pool.free_state(rand_gen);
+      });
+
+  space.fence();
+
+  Kokkos::View<unsigned*, MemorySpace> values_orig(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "values_orig"), n);
+  Kokkos::parallel_for(
+      Kokkos::RangePolicy<ExecutionSpace>(space, 0, n),
+      KOKKOS_LAMBDA(int i) { values_orig(i) = i; });
+
+  Kokkos::View<T*, MemorySpace> keys(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "keys"), n);
+
+  Kokkos::View<unsigned*, MemorySpace> values(
+      Kokkos::view_alloc(space, Kokkos::WithoutInitializing, "values"), n);
+
+  auto data_ratio =
+      1 + sizeof(typename decltype(values)::value_type) / (double)sizeof(T);
+
+  for (auto _ : state) {
+    Kokkos::deep_copy(space, keys, keys_orig);
+    Kokkos::deep_copy(space, values, values_orig);
+
+    space.fence();
+    Kokkos::Timer timer;
+    Kokkos::Experimental::sort_by_key(space, keys, values);
+    space.fence();
+    double time = timer.seconds();
+
+    KokkosBenchmark::report_results(state, keys_orig, data_ratio, time);
+    state.counters["Passed"] = true;
+  }
+}
+
+constexpr std::size_t PROB_SIZE = 100'000;
+
+}  // anonymous namespace
+
+// FIXME: Add logic to pass min. warm-up time. Also, the value should be set
+// by the user. Say, via the environment variable BENCHMARK_MIN_WARMUP_TIME.
+
+BENCHMARK(BM_sort_by_key<unsigned>)->Arg(PROB_SIZE)->UseManualTime();
+BENCHMARK(BM_sort_by_key<int>)->Arg(PROB_SIZE)->UseManualTime();
+BENCHMARK(BM_sort_by_key<long long>)->Arg(PROB_SIZE)->UseManualTime();
+BENCHMARK(BM_sort_by_key<float>)->Arg(PROB_SIZE)->UseManualTime();
+BENCHMARK(BM_sort_by_key<double>)->Arg(PROB_SIZE)->UseManualTime();

--- a/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
+++ b/algorithms/src/sorting/impl/Kokkos_SortByKeyImpl.hpp
@@ -101,12 +101,34 @@ void sort_by_key_cudathrust(
     const Kokkos::View<KeysDataType, KeysProperties...>& keys,
     const Kokkos::View<ValuesDataType, ValuesProperties...>& values,
     MaybeComparator&&... maybeComparator) {
+  using KeysType    = Kokkos::View<KeysDataType, KeysProperties...>;
+  using ValuesType  = Kokkos::View<ValuesDataType, ValuesProperties...>;
   const auto policy = thrust::cuda::par.on(exec.cuda_stream());
-  auto keys_first   = ::Kokkos::Experimental::begin(keys);
-  auto keys_last    = ::Kokkos::Experimental::end(keys);
-  auto values_first = ::Kokkos::Experimental::begin(values);
-  thrust::sort_by_key(policy, keys_first, keys_last, values_first,
-                      std::forward<MaybeComparator>(maybeComparator)...);
+  static constexpr bool keys_are_contiguous =
+      KeysType::rank() == 1 &&
+      (std::is_same_v<typename KeysType::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename KeysType::traits::array_layout,
+                      Kokkos::LayoutRight>);
+  static constexpr bool values_are_contiguous =
+      ValuesType::rank() == 1 &&
+      (std::is_same_v<typename ValuesType::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename ValuesType::traits::array_layout,
+                      Kokkos::LayoutRight>);
+  if constexpr (keys_are_contiguous && values_are_contiguous) {
+    auto keys_first   = keys.data();
+    auto keys_last    = keys.data() + keys.extent(0);
+    auto values_first = values.data();
+    thrust::sort_by_key(policy, keys_first, keys_last, values_first,
+                        std::forward<MaybeComparator>(maybeComparator)...);
+  } else {
+    auto keys_first   = ::Kokkos::Experimental::begin(keys);
+    auto keys_last    = ::Kokkos::Experimental::end(keys);
+    auto values_first = ::Kokkos::Experimental::begin(values);
+    thrust::sort_by_key(policy, keys_first, keys_last, values_first,
+                        std::forward<MaybeComparator>(maybeComparator)...);
+  }
 }
 #endif
 
@@ -121,12 +143,34 @@ void sort_by_key_rocthrust(
     const Kokkos::View<KeysDataType, KeysProperties...>& keys,
     const Kokkos::View<ValuesDataType, ValuesProperties...>& values,
     MaybeComparator&&... maybeComparator) {
+  using KeysType    = Kokkos::View<KeysDataType, KeysProperties...>;
+  using ValuesType  = Kokkos::View<ValuesDataType, ValuesProperties...>;
   const auto policy = thrust::hip::par.on(exec.hip_stream());
-  auto keys_first   = ::Kokkos::Experimental::begin(keys);
-  auto keys_last    = ::Kokkos::Experimental::end(keys);
-  auto values_first = ::Kokkos::Experimental::begin(values);
-  thrust::sort_by_key(policy, keys_first, keys_last, values_first,
-                      std::forward<MaybeComparator>(maybeComparator)...);
+  static constexpr bool keys_are_contiguous =
+      KeysType::rank() == 1 &&
+      (std::is_same_v<typename KeysType::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename KeysType::traits::array_layout,
+                      Kokkos::LayoutRight>);
+  static constexpr bool values_are_contiguous =
+      ValuesType::rank() == 1 &&
+      (std::is_same_v<typename ValuesType::traits::array_layout,
+                      Kokkos::LayoutLeft> ||
+       std::is_same_v<typename ValuesType::traits::array_layout,
+                      Kokkos::LayoutRight>);
+  if constexpr (keys_are_contiguous && values_are_contiguous) {
+    auto keys_first   = keys.data();
+    auto keys_last    = keys.data() + keys.extent(0);
+    auto values_first = values.data();
+    thrust::sort_by_key(policy, keys_first, keys_last, values_first,
+                        std::forward<MaybeComparator>(maybeComparator)...);
+  } else {
+    auto keys_first   = ::Kokkos::Experimental::begin(keys);
+    auto keys_last    = ::Kokkos::Experimental::end(keys);
+    auto values_first = ::Kokkos::Experimental::begin(values);
+    thrust::sort_by_key(policy, keys_first, keys_last, values_first,
+                        std::forward<MaybeComparator>(maybeComparator)...);
+  }
 }
 #endif
 


### PR DESCRIPTION
The current performance of `sort_by_key` is slower using iterators than using raw pointers. For example, running 1B sort_by_key on H100 with Cuda 13.1:
```
number of points          : 1000000000
 === unsigned [CUDA] ===
Time [Kokkos]         :   0.055
Time [Thrust]         :   0.044
 === int [CUDA] ===
Time [Kokkos]         :   0.056
Time [Thrust]         :   0.044
 === long long [CUDA] ===
Time [Kokkos]         :   0.103
Time [Thrust]         :   0.089
 === float [CUDA] ===
Time [Kokkos]         :   0.055
Time [Thrust]         :   0.044
 === double [CUDA] ===
Time [Kokkos]         :   0.110
Time [Thrust]         :   0.094
```
This patch brings Kokkos sort to Thrust level by using raw pointers instead of iterators when the view is contiguous.

I cannot get reliable numbers on a HIP platform (Frontier), but assume it is subject to the same issue, so it is included in the patch.

### Related issues / PRs

#7304 did some improvements on iterator

### Changelog Entry
Unsure

### Documentation PR
Not required