### PR TITLE
Prefer `GTEST_FLAG_SET(death_test_style, "threadsafe")` with newer GTest

### DIFF
--- a/algorithms/unit_tests/UnitTestMain.cpp
+++ b/algorithms/unit_tests/UnitTestMain.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/containers/performance_tests/TestMain.cpp
+++ b/containers/performance_tests/TestMain.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/containers/unit_tests/UnitTestMain.cpp
+++ b/containers/unit_tests/UnitTestMain.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();

--- a/core/perf_test/PerfTestMain.cpp
+++ b/core/perf_test/PerfTestMain.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
   Kokkos::initialize(argc, argv);
 

--- a/core/unit_test/TestAbort.hpp
+++ b/core/unit_test/TestAbort.hpp
@@ -86,7 +86,7 @@ void test_abort_from_device() {
 }
 
 TEST(TEST_CATEGORY_DEATH, abort_from_device) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
 // FIXME_OPENACC FIXME_NVHPC: NVHPC fails when targetting CPUs.
 #if defined(KOKKOS_ENABLE_OPENACC) && defined(KOKKOS_COMPILER_NVHPC) && \
     defined(KOKKOS_ENABLE_OPENACC_FORCE_HOST_AS_DEVICE)

--- a/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
+++ b/core/unit_test/TestSpaceAwareAccessorAccessViolation.hpp
@@ -89,7 +89,7 @@ TEST(TEST_CATEGORY_DEATH,
 
 TEST(TEST_CATEGORY_DEATH,
      mdspan_space_aware_accessor_invalid_access_from_device) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
 
   using ExecutionSpace = TEST_EXECSPACE;
 

--- a/core/unit_test/TestViewMemoryAccessViolation.hpp
+++ b/core/unit_test/TestViewMemoryAccessViolation.hpp
@@ -153,7 +153,7 @@ TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_host) {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_memory_access_violations_from_device) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
 
   using ExecutionSpace = TEST_EXECSPACE;
 

--- a/core/unit_test/TestViewOutOfBoundsAccess.hpp
+++ b/core/unit_test/TestViewOutOfBoundsAccess.hpp
@@ -133,7 +133,7 @@ void test_view_out_of_bounds_access() {
 }
 
 TEST(TEST_CATEGORY_DEATH, view_out_of_bounds_access) {
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
 
   using ExecutionSpace = TEST_EXECSPACE;
 

--- a/core/unit_test/UnitTestMain.cpp
+++ b/core/unit_test/UnitTestMain.cpp
@@ -10,7 +10,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/core/unit_test/UnitTestMainInit.cpp
+++ b/core/unit_test/UnitTestMainInit.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
 
   int result = RUN_ALL_TESTS();

--- a/simd/unit_tests/UnitTestMain.cpp
+++ b/simd/unit_tests/UnitTestMain.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   // We want to use "threadsafe" by default while the default in GTest on Linux
   // is "fast"
   if (!std::getenv("GTEST_DEATH_TEST_STYLE"))
-    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
   ::testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   Kokkos::finalize();


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
~~Oversight in https://github.com/kokkos/kokkos/pull/9422 ?~~
Repurposing the PR to use the GTest sanctioned way to set the flag.
Use `GTEST_FLAG_SET(death_test_style, ...)` and avoid directly to the global variable since its name is technically an implementation detail.
See https://google.github.io/googletest/advanced.html#death-test-styles

### Related issues / PRs

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
N/A

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
N/A
