### PR TITLE
Add CUDA Tile Kernel Launch Implementation

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_KernelLaunchTile.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_KernelLaunchTile.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_CUDA_KERNELLAUNCHTILE_HPP
+#define KOKKOS_CUDA_KERNELLAUNCHTILE_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#include <Cuda/Kokkos_Cuda_Instance.hpp>
+
+namespace Kokkos::Impl {
+
+template <class DriverType>
+__tile_global__ static void cuda_tile_launch_global_memory(
+    const DriverType* driver) {
+  driver->operator()();
+}
+
+// CUDA Tile Kernels neither support constant cache nor
+// struct arguments to the __tile_global__ functions.
+// So for now we only support GlobalLaunch
+template <class DriverType, CudaLaunchMechanism LaunchMechanism>
+struct CudaParallelLaunchTileKernelInvoker;
+
+template <class DriverType>
+struct CudaParallelLaunchTileKernelInvoker<DriverType,
+                                           CudaLaunchMechanism::GlobalMemory> {
+  static void invoke_kernel(DriverType const& driver, dim3 const& grid,
+                            CudaInternal const* cuda_instance) {
+    DriverType* driver_ptr = reinterpret_cast<DriverType*>(
+        cuda_instance->scratch_functor(sizeof(DriverType)));
+
+    KOKKOS_IMPL_CUDA_SAFE_CALL((cuda_instance->cuda_memcpy_async_wrapper(
+        driver_ptr, &driver, sizeof(DriverType), cudaMemcpyDefault)));
+
+    // The 1 might be able to go away
+    cuda_tile_launch_global_memory<<<grid, 1, 0, cuda_instance->m_stream>>>(
+        driver_ptr);
+  }
+};
+}  // namespace Kokkos::Impl
+
+#endif

--- a/core/src/Kokkos_Macros.hpp
+++ b/core/src/Kokkos_Macros.hpp
@@ -396,6 +396,12 @@
 #define KOKKOS_RELOCATABLE_FUNCTION KOKKOS_IMPL_RELOCATABLE_FUNCTION
 #endif
 
+#if defined(KOKKOS_IMPL_TILE_FUNCTION)
+#define KOKKOS_EXPERIMENTAL_TILE_FUNCTION KOKKOS_IMPL_TILE_FUNCTION
+#else
+#define KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+#endif
+
 //----------------------------------------------------------------------------
 // Define empty macro for restrict if necessary:
 

--- a/core/src/setup/Kokkos_Setup_Cuda.hpp
+++ b/core/src/setup/Kokkos_Setup_Cuda.hpp
@@ -60,6 +60,10 @@
 #define KOKKOS_IMPL_HOST_FUNCTION __host__
 #define KOKKOS_IMPL_DEVICE_FUNCTION __device__
 
+#ifdef KOKKOS_ENABLE_CUDA_TILE
+#define KOKKOS_IMPL_TILE_FUNCTION __tile__
+#endif
+
 // clang-format off
 #ifdef KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE
 #define KOKKOS_IMPL_RELOCATABLE_FUNCTION __device__ __host__

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -14,6 +14,8 @@ import kokkos.core;
 #include <array>
 #include <cstddef>
 
+#include <Cuda/Kokkos_Cuda_KernelLaunchTile.hpp>
+
 namespace Test {
 
 __tile_global__ void tile_vector_add(float* __restrict__ a,
@@ -78,13 +80,85 @@ TEST(cuda, tile_vector_add) {
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemcpy(h_out.data(), d_out, sizeof(float) * N,
                                         cudaMemcpyDeviceToHost));
 
+  int errors = 0;
   for (std::size_t i = 0; i < N; ++i) {
-    ASSERT_FLOAT_EQ(h_out[i], h_a[i] + h_b[i]);
+    if (h_out[i] != h_a[i] + h_b[i]) errors++;
   }
+  errors = 0;
 
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(d_a));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(d_b));
   KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree(d_out));
 }
+
+// This struct implements the minimal compatibility requirements for Driver
+// handed to the implementation tile launch function
+struct TileVectorAddDummyDriver {
+  float* a;
+  float* b;
+  float* out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+    using namespace ct::literals;
+
+    constexpr auto tile_size = 8_ic;
+    auto shape               = ct::shape{tile_size};
+    auto extent              = ct::extents{n};
+
+    auto a_view = ct::partition_view{ct::tensor_span{a, extent}, shape};
+    auto b_view = ct::partition_view{ct::tensor_span{b, extent}, shape};
+    auto o_view = ct::partition_view{ct::tensor_span{out, extent}, shape};
+
+    const size_t n_tile       = n / tile_size;
+    const size_t n_tile_block = n_tile / ct::num_blocks().x;
+    const size_t tile_start   = ct::bid().x * n_tile_block;
+    const size_t tile_end     = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b =
+          a_view.load_masked(tile_index) + b_view.load_masked(tile_index);
+      o_view.store_masked(a_plus_b, tile_index);
+    }
+  }
+};
+
+void cuda_tile_kernel_invoker() {
+  constexpr std::size_t N = 256;
+
+  Kokkos::View<float*, Kokkos::Cuda> a("A", N);
+  Kokkos::View<float*, Kokkos::Cuda> b("A", N);
+  Kokkos::View<float*, Kokkos::Cuda> out("A", N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        a(i) = i;
+        b(i) = 2 * i;
+      });
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileVectorAddDummyDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  TileVectorAddDummyDriver driver{a.data(), b.data(), out.data(), N};
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out = Kokkos::create_mirror_view_and_copy(out);
+  int errors = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (h_out(i) != float(3 * i)) errors++;
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_kernel_invoker) { cuda_tile_kernel_invoker(); }
 
 }  // namespace Test


### PR DESCRIPTION
This adds the implementation detail for launching a CUDA Tile Kernel, which reuses the CudaInternal instance facilities for Kernel staging.

For now we can ONLY do this with global memory because the CUDA Tile programming model does not allow either functors as arguments to the tile global function, nor supports explicit constant cache use.
