### PR TITLE
Remove a duplicate `find_package(GTest)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkos_configure_trilinos.cmake)
 
 if(Kokkos_ENABLE_TESTS)
-  find_package(GTest QUIET)
+  find_package(GTest QUIET 1.14.0)
 endif()
 
 if(Kokkos_ENABLE_BENCHMARKS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,10 +187,6 @@ endif()
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/kokkos_configure_trilinos.cmake)
 
-if(Kokkos_ENABLE_TESTS)
-  find_package(GTest QUIET 1.14.0)
-endif()
-
 if(Kokkos_ENABLE_BENCHMARKS)
   find_package(benchmark QUIET 1.8.3)
 endif()


### PR DESCRIPTION
#8593 raised the minimum version of googletest to 1.14 but only updated the `find_package(GTest)` in kokkos_tribits.cmake, while the one in CMakeLists.txt doesn't have a version, leading to configuration succeeding with older gtest versions (this is the case in the linux/ubuntu icpx job https://github.com/kokkos/kokkos/actions/runs/32921746659/job/98036892684?pr=9473#step:8:31)

~~This is a quick fix, but ideally we would want to deduplicate this `find_package` call.~~
This PR removes the toplevel find_package call, leaving only the currently correct one.

### Related issues / PRs


### Changelog Entry

Not needed

### Documentation PR

Not needed
