### PR TITLE
nextsilicon: unpin memory in `PageAlignedData` destructor

### DIFF
--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.cpp
@@ -5,34 +5,59 @@
 
 #include <Kokkos_Abort.hpp>
 
+#include <cstddef>
+#include <limits>
 #include <optional>
-#include <utility>  // std::in_place
+#include <utility>  // std::move
 #include <vector>
 
 namespace Kokkos::Impl {
 
 namespace {
-std::optional<std::vector<std::function<void()>>> pending{std::in_place};
+using CallbackEntry = std::optional<std::function<void()>>;
+
+std::vector<CallbackEntry>& pending_callbacks() {
+  static std::vector<CallbackEntry> pending;
+  return pending;
+}
 }  // namespace
 
-void register_nextsilicon_initialization_callback(
-    std::function<void()> callback) {
-  if (!pending)
+NextSiliconInitializationCallbackHandle
+register_nextsilicon_initialization_callback(std::function<void()> callback) {
+  auto& pending = pending_callbacks();
+  if (pending.size() >
+      static_cast<std::size_t>(
+          std::numeric_limits<NextSiliconInitializationCallbackHandle>::max()))
     Kokkos::abort(
-        "nextsilicon: initialization callbacks improperly initialized (1). "
-        "Please report this.");
-  pending->push_back(std::move(callback));
+        "nextsilicon: initialization callback handle overflow. Please report "
+        "this.");
+  NextSiliconInitializationCallbackHandle handle =
+      static_cast<NextSiliconInitializationCallbackHandle>(pending.size());
+  pending.push_back(std::move(callback));
+  return handle;
+}
+
+std::optional<std::function<void()>>
+retrieve_nextsilicon_initialization_callback(
+    NextSiliconInitializationCallbackHandle handle) {
+  auto& pending = pending_callbacks();
+  if (handle < 0 || static_cast<std::size_t>(handle) >= pending.size()) {
+    return std::nullopt;
+  }
+  auto callback = std::move(pending[static_cast<std::size_t>(handle)]);
+  pending[static_cast<std::size_t>(handle)] = std::nullopt;
+  return callback;
 }
 
 void run_nextsilicon_initialization_callbacks() {
-  if (!pending)
-    Kokkos::abort(
-        "nextsilicon: initialization callbacks improperly initialized (2). "
-        "Please report this.");
-  for (auto& callback : *pending) {
-    callback();
+  auto& pending = pending_callbacks();
+  for (auto& callback : pending) {
+    if (callback) {
+      auto callback_to_run = std::move(callback);
+      callback             = std::nullopt;
+      (*callback_to_run)();
+    }
   }
-  pending->clear();
 }
 
 }  // namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp
@@ -4,13 +4,26 @@
 #ifndef KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP
 #define KOKKOS_NEXTSILICON_INITIALIZATION_CALLBACKS_HPP
 
+#include <cstdint>
 #include <functional>
+#include <optional>
 
 namespace Kokkos::Impl {
 
+using NextSiliconInitializationCallbackHandle = std::int64_t;
+
+inline constexpr NextSiliconInitializationCallbackHandle
+    invalid_nextsilicon_initialization_callback_handle = -1;
+
 // Callbacks must not register additional initialization callbacks.
-void register_nextsilicon_initialization_callback(
-    std::function<void()> callback);
+NextSiliconInitializationCallbackHandle
+register_nextsilicon_initialization_callback(std::function<void()> callback);
+
+// Retrieve the callback associated with handle and clear its entry. Returns
+// nullopt if the callback was already retrieved/run or if handle is invalid.
+std::optional<std::function<void()>>
+retrieve_nextsilicon_initialization_callback(
+    NextSiliconInitializationCallbackHandle handle);
 
 void run_nextsilicon_initialization_callbacks();
 

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.cpp
@@ -8,32 +8,80 @@
 
 #include <nextapi/memory.h>
 
+#include <utility>
+
 namespace {
-void impl_migrate_after_initialize(void *obj, size_t size, auto loc) {
-  auto pin = [=] { nextapi_mem_migrate(obj, size, loc, /*pin=*/true); };
+Kokkos::Impl::NextSiliconInitializationCallbackHandle
+impl_migrate_after_initialize(void* obj, std::size_t size, auto loc) {
+  auto pin = [obj, size, loc] {
+    nextapi_mem_migrate(obj, size, loc, /*pin=*/true);
+  };
   if (Kokkos::is_initialized()) {
     pin();
+    return Kokkos::Impl::invalid_nextsilicon_initialization_callback_handle;
   } else {
-    Kokkos::Impl::register_nextsilicon_initialization_callback(std::move(pin));
+    return Kokkos::Impl::register_nextsilicon_initialization_callback(
+        std::move(pin));
   }
+}
+
+void impl_release_page_migration(
+    Kokkos::Impl::NextSiliconInitializationCallbackHandle handle, void* obj,
+    std::size_t size, auto loc) {
+  if (handle ==
+      Kokkos::Impl::invalid_nextsilicon_initialization_callback_handle) {
+    // ctor after Kokkos initialization: no callback; pinned immediately; unpin
+    // now.
+    nextapi_mem_migrate(obj, size, loc, /*pin=*/false);
+  } else if (!Kokkos::Impl::retrieve_nextsilicon_initialization_callback(
+                 handle)) {
+    // ctor before Kokkos initialization, dtor after callback ran: unpin now.
+    nextapi_mem_migrate(obj, size, loc, /*pin=*/false);
+  }
+  // ctor before Kokkos initialization, dtor before initialization: retrieving
+  // callback above destroys it, and we are not pinned. Nothing to do.
 }
 }  // namespace
 
 namespace Kokkos::Impl {
 
 template <>
-void migrate_after_initialize<PageLocation::Any>(void *, size_t) {
+NextSiliconInitializationCallbackHandle
+migrate_after_initialize<PageLocation::Any>(void*, std::size_t) {
+  // no specific migration requested
+  return invalid_nextsilicon_initialization_callback_handle;
+}
+
+template <>
+NextSiliconInitializationCallbackHandle
+migrate_after_initialize<PageLocation::Host>(void* obj, std::size_t size) {
+  return impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_HOST);
+}
+
+template <>
+NextSiliconInitializationCallbackHandle
+migrate_after_initialize<PageLocation::Device>(void* obj, std::size_t size) {
+  return impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_DEVICE);
+}
+
+template <>
+void release_page_migration<PageLocation::Any>(
+    NextSiliconInitializationCallbackHandle, void*, std::size_t) {
   // no specific migration requested
 }
 
 template <>
-void migrate_after_initialize<PageLocation::Host>(void *obj, size_t size) {
-  impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_HOST);
+void release_page_migration<PageLocation::Host>(
+    NextSiliconInitializationCallbackHandle handle, void* obj,
+    std::size_t size) {
+  impl_release_page_migration(handle, obj, size, NEXTAPI_PAGE_LOC_HOST);
 }
 
 template <>
-void migrate_after_initialize<PageLocation::Device>(void *obj, size_t size) {
-  impl_migrate_after_initialize(obj, size, NEXTAPI_PAGE_LOC_DEVICE);
+void release_page_migration<PageLocation::Device>(
+    NextSiliconInitializationCallbackHandle handle, void* obj,
+    std::size_t size) {
+  impl_release_page_migration(handle, obj, size, NEXTAPI_PAGE_LOC_DEVICE);
 }
 
 }  //  namespace Kokkos::Impl

--- a/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
+++ b/core/src/NextSilicon/Kokkos_NextSilicon_PageAlignedData.hpp
@@ -4,6 +4,9 @@
 #ifndef KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 #define KOKKOS_NEXTSILICON_PAGE_ALIGNED_DATA_HPP
 
+#include <NextSilicon/Kokkos_NextSilicon_InitializationCallbacks.hpp>
+
+#include <cstddef>
 #include <type_traits>
 #include <utility>
 
@@ -18,7 +21,12 @@ enum class PageLocation {
 };
 
 template <PageLocation>
-void migrate_after_initialize(void* obj, size_t size);
+NextSiliconInitializationCallbackHandle migrate_after_initialize(
+    void* obj, std::size_t size);
+
+template <PageLocation>
+void release_page_migration(NextSiliconInitializationCallbackHandle handle,
+                            void* obj, std::size_t size);
 
 // This struct is aligned to 4096 bytes (page size) to work around
 // issues with NextSilicon page migration. It can be pinned to the host
@@ -29,6 +37,8 @@ struct alignas(PAGE_SIZE) PageAlignedData {
   static constexpr PageLocation location = Location;
 
   T data;
+  NextSiliconInitializationCallbackHandle initialization_callback_handle =
+      invalid_nextsilicon_initialization_callback_handle;
 
   operator T&() { return data; }
   operator const T&() const { return data; }
@@ -37,12 +47,18 @@ struct alignas(PAGE_SIZE) PageAlignedData {
     requires(!(sizeof...(Args) == 1 &&
                (std::is_same_v<std::decay_t<Args>, PageAlignedData> && ...)))
   PageAlignedData(Args&&... args) : data{std::forward<Args>(args)...} {
-    migrate_after_initialize<location>(this, sizeof(*this));
+    initialization_callback_handle =
+        migrate_after_initialize<location>(this, sizeof(*this));
   }
 
   PageAlignedData& operator=(const T& data_) {
     data = data_;
     return *this;
+  }
+
+  ~PageAlignedData() {
+    release_page_migration<location>(initialization_callback_handle, this,
+                                     sizeof(*this));
   }
 
   PageAlignedData(const PageAlignedData&)            = delete;

--- a/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
+++ b/core/unit_test/nextsilicon/TestNextSilicon_InitializationCallbacks.cpp
@@ -8,9 +8,18 @@
 
 namespace {
 
-int callback_ran = 0;
+int callback_ran          = 0;
+int canceled_callback_ran = 0;
 
 TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_EQ(callback_ran, 1); }
+
+TEST(nextsilicon, InitializationCallbacksCanBeCanceled) {
+  EXPECT_EQ(canceled_callback_ran, 0);
+}
+
+TEST(nextsilicon, InitializationCallbacksCanOnlyBeRetrievedOnce) {
+  EXPECT_FALSE(Kokkos::Impl::retrieve_nextsilicon_initialization_callback(0));
+}
 
 }  // namespace
 
@@ -19,6 +28,17 @@ TEST(nextsilicon, InitializationCallbacksRun) { EXPECT_EQ(callback_ran, 1); }
 int main(int argc, char* argv[]) {
   Kokkos::Impl::register_nextsilicon_initialization_callback(
       [] { ++callback_ran; });
+  auto canceled_handle =
+      Kokkos::Impl::register_nextsilicon_initialization_callback(
+          [] { ++canceled_callback_ran; });
+  auto canceled_callback =
+      Kokkos::Impl::retrieve_nextsilicon_initialization_callback(
+          canceled_handle);
+  if (!canceled_callback) {
+    Kokkos::abort(
+        "nextsilicon: initialization callback unexpectedly missing. Please "
+        "report this.");
+  }
 
   Kokkos::initialize(argc, argv);
 


### PR DESCRIPTION
Make sure the virtual address ranges pinned by `PageAlignedData` are unpinned when those objects go away. Those VA ranges may be used by other stuff that wants to migrate in the future.

The interaction with Kokkos::initialize is the complicated part. It's possible for a PageAlignedData to be in a state where it's registered a callback to be pinned in the future, but that callback hasn't happened yet when the destructor is invoked ( for example, threads being created and destroyed before `Kokkos::initialize`.

PageAlignedData is used in 3 places right now:
- exec space instance mutex
- thread-local KOKKOS_IF_ON_HOST/DEVICE machinery
- SharedAllocationRecord tracking variable

The last two are the places where we can cause VA ranges to be permanently pinned by accident. The first is not as problematic because the `PageAlignedData` lifetime is scoped to `Kokkos::initialize` - `Kokkos::finalize`


@kc9jud 