### PR TITLE
[CUDA-Tile] Kokkos::TileView

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -5,6 +5,7 @@
 #define KOKKOS_CUDA_TILEVIEW_HPP
 
 #include <Kokkos_Macros.hpp>
+#include <Kokkos_Assert.hpp>
 
 #ifdef KOKKOS_ENABLE_CUDA_TILE
 
@@ -67,6 +68,27 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
   using type = ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>;
 };
 
+// Returns whether each of the View's runtime extents is evenly
+// divisible by the corresponding (static) extent of TileShapeType.
+// Tile loads and stores indices in units of whole tiles, so a View
+// whose extents aren't multiples of the tile shape would leave a
+// partial tile at the boundary.  partition_view can handle that with
+// load_masked and store_masked, but we don't want to require that
+// TileView be able to handle that case for now.
+template <class TileShapeType, class ViewType, size_t... Ranks>
+KOKKOS_INLINE_FUNCTION bool view_extents_evenly_divisible_by_tile_shape(
+    ViewType const& view, std::index_sequence<Ranks...>) {
+  return ((view.extent(Ranks) % TileShapeType::static_extent(Ranks) == 0) &&
+          ...);
+}
+
+// Returns whether all of TileShapeType's (static) extents are nonzero.
+// A tile shape with a zero extent can't represent any tiles.
+template <class TileShapeType, size_t... Ranks>
+constexpr bool tile_shape_extents_all_nonzero(std::index_sequence<Ranks...>) {
+  return ((TileShapeType::static_extent(Ranks) != 0) && ...);
+}
+
 }  // namespace Impl
 
 /// \brief Applies a tile partitioning to a Kokkos::View
@@ -117,10 +139,19 @@ class TileView {
   using view_shape_type = typename partition_view_type::view_shape_type;
   using view_tile_type  = typename partition_view_type::view_tile_type;
 
-  // Construct from a Kokkos::View and a tile shape on the host.
+  /// \brief Construct from a Kokkos::View and a tile shape on the host.
+  ///
+  /// \param view Kokkos::View such that each extent is a nonzero
+  ///   multiple of the corresponding extent of \c ts
+  ///
+  /// \param ts cuda::tiles::shape whose extents are all nonzero
+  ///
+  /// For now, Kokkos requires that each extent of \c view is a
+  /// nonzero multiple of each extent of \c ts.  This lets Kokkos
+  /// defer providing masked variants of loads and stores.
   template <class ViewType>
     requires(Kokkos::is_view_v<ViewType>)
-  TileView(ViewType const& view, tile_shape_type) noexcept
+  TileView(ViewType const& view, [[maybe_unused]] tile_shape_type ts) noexcept
       : span_(view.data(),
               mapping_type(
                   Impl::cuda_tile_extents_from_view<extents_type>(
@@ -134,6 +165,13 @@ class TileView {
         std::is_same_v<typename ViewType::non_const_value_type, value_type>,
         "Kokkos::TileView: View's value_type must match TileType's "
         "element_type");
+    static_assert(
+        Impl::tile_shape_extents_all_nonzero<tile_shape_type>(
+            std::make_index_sequence<tile_shape_type::rank()>{}),
+        "Kokkos::TileView: TileShape's extents must all be nonzero");
+    KOKKOS_ASSERT(
+        (Impl::view_extents_evenly_divisible_by_tile_shape<tile_shape_type>(
+            view, std::make_index_sequence<ViewType::rank()>{})));
   }
 
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_CUDA_TILEVIEW_HPP
+#define KOKKOS_CUDA_TILEVIEW_HPP
+
+#include <Kokkos_Macros.hpp>
+
+#ifdef KOKKOS_ENABLE_CUDA_TILE
+
+#include <cuda_tile.h>
+
+#ifndef KOKKOS_IMPL_PUBLIC_INCLUDE
+#define KOKKOS_IMPL_PUBLIC_INCLUDE
+#define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TILEVIEW
+#endif
+
+#include <Kokkos_Layout.hpp>
+#include <Kokkos_View.hpp>
+
+#ifdef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TILEVIEW
+#undef KOKKOS_IMPL_PUBLIC_INCLUDE
+#undef KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TILEVIEW
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+namespace Kokkos {
+namespace Impl {
+
+namespace ct = cuda::tiles;
+
+// Builds a cuda::tiles::extents object matching a View's rank, with every
+// dimension dynamic, filled in from the View's runtime extents.
+template <class ViewType, size_t... Ranks>
+KOKKOS_INLINE_FUNCTION auto cuda_tile_extents_from_view(
+    ViewType const& view, std::index_sequence<Ranks...>) {
+  return ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>(
+      static_cast<uint32_t>(view.extent(Ranks))...);
+}
+
+// Builds a cuda::tiles::extents object (used as a strides descriptor)
+// matching a View's rank, with every dimension dynamic, filled in from the
+// View's runtime strides.
+template <class ViewType, size_t... Ranks>
+KOKKOS_INLINE_FUNCTION auto cuda_tile_strides_from_view(
+    ViewType const& view, std::index_sequence<Ranks...>) {
+  return ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>(
+      static_cast<uint32_t>(view.stride(Ranks))...);
+}
+
+}  // namespace Impl
+
+/// \brief Bridges a Kokkos::View, constructed on the host, with cuTile's
+///        tensor_span/partition_view so its data can be used from CUDA
+///        Tile kernels.
+///
+/// A TileView is constructed on the host from a Kokkos::View and a
+/// compile-time tile shape.  It stores a cuda::tiles::tensor_span (a raw
+/// device pointer plus the View's runtime extents and strides) and a
+/// cuda::tiles::shape tag describing how to partition the tensor into
+/// register tiles.  The tensor_span's layout is always
+/// cuda::tiles::layout_strided, built from the View's runtime strides,
+/// regardless of the View's array_layout (Kokkos::LayoutLeft,
+/// Kokkos::LayoutRight, and Kokkos::LayoutStride do not correspond to
+/// cuda::tiles::layout_left/layout_right).  Both are trivially copyable,
+/// so a TileView may be
+/// embedded by value in a Driver struct handed to
+/// Kokkos::Impl::CudaParallelLaunchTileKernelInvoker (see
+/// Kokkos_Cuda_KernelLaunchTile.hpp), which forbids passing struct
+/// arguments directly to a __tile_global__ kernel.
+///
+/// Inside the Driver's operator(), TileView::partition() builds the actual
+/// cuda::tiles::partition_view used to load/store register tiles.
+template <class ViewType, class TileShape>
+class TileView {
+  static_assert(Kokkos::is_view_v<ViewType>,
+                "Kokkos::TileView requires a Kokkos::View");
+  static_assert(TileShape::rank() == ViewType::rank(),
+                "Kokkos::TileView: TileShape rank must match View rank");
+
+ public:
+  using view_type       = ViewType;
+  using element_type    = typename ViewType::value_type;
+  using value_type      = typename ViewType::non_const_value_type;
+  using tile_shape_type = TileShape;
+  using extents_type    = decltype(Impl::cuda_tile_extents_from_view(
+      std::declval<ViewType const&>(),
+      std::make_index_sequence<ViewType::rank()>{}));
+  using strides_type = decltype(Impl::cuda_tile_strides_from_view(
+      std::declval<ViewType const&>(),
+      std::make_index_sequence<ViewType::rank()>{}));
+  using layout_type  = Impl::ct::layout_strided<strides_type>;
+  using mapping_type = typename layout_type::template mapping<extents_type>;
+  using span_type =
+      Impl::ct::tensor_span<element_type, extents_type, layout_type>;
+  using partition_view_type =
+      Impl::ct::partition_view<span_type, TileShape>;
+  using data_handle_type = typename span_type::data_handle_type;
+
+  TileView() = default;
+
+  // Construct from a Kokkos::View on the host.
+  TileView(ViewType const& view, tile_shape_type shape = {})
+      : span_(view.data(),
+              mapping_type(
+                  Impl::cuda_tile_extents_from_view(
+                      view, std::make_index_sequence<ViewType::rank()>{}),
+                  Impl::cuda_tile_strides_from_view(
+                      view, std::make_index_sequence<ViewType::rank()>{}))),
+        shape_(shape) {}
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  span_type span() const noexcept { return span_; }
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  tile_shape_type shape() const noexcept { return shape_; }
+
+  // Builds the cuda::tiles::partition_view used inside a tile kernel body
+  // to load/store register tiles.
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  operator partition_view_type() const noexcept {
+    return partition_view_type(span_, shape_);
+  }
+
+ private:
+  span_type span_;
+  tile_shape_type shape_;
+};
+
+}  // namespace Kokkos
+
+#endif  // KOKKOS_ENABLE_CUDA_TILE
+#endif  // KOKKOS_CUDA_TILEVIEW_HPP

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -69,36 +69,21 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
 
 }  // namespace Impl
 
-/// \brief Bridges a Kokkos::View, constructed on the host, with cuTile's
-///        tensor_span/partition_view so its data can be used from CUDA
-///        Tile kernels.
+/// \brief Applies a tile partitioning to a Kokkos::View
 ///
-/// TileView is templated on \c TileType, a cuda::tiles::tile
-/// specialization (e.g. cuda::tiles::tile<float, cuda::tiles::shape<8>>)
-/// describing the element type and shape of the register tiles it will be
-/// partitioned into, and on \c Extents, a cuda::tiles::extents
-/// specialization describing the index space of the whole tensor that
-/// gets partitioned into those tiles.
+/// \tparam TileType cuda::tiles::tile specialization describing the
+///   element type and shape of the tiles into which the View will be
+///   partitioned
 ///
-/// A TileView is constructed on the host from a Kokkos::View and a
-/// cuda::tiles tile shape tag (e.g. cuda::tiles::shape<8>{}); template
-/// argument deduction picks TileType and Extents automatically, so
-/// callers need not spell out TileView<TileType, Extents> explicitly.
-/// It stores
-/// a cuda::tiles::tensor_span (a raw device pointer plus the View's
-/// runtime extents and strides), which is trivially copyable, so a
-/// TileView may be embedded by value in a Driver struct handed to
-/// Kokkos::Impl::CudaParallelLaunchTileKernelInvoker (see
-/// Kokkos_Cuda_KernelLaunchTile.hpp), which forbids passing struct
-/// arguments directly to a __tile_global__ kernel.
+/// \tparam Extents cuda::tiles::extents specialization describing the
+///    "tile index space type," that is, the type of the index space
+///    over which tile loads and stores iterate
 ///
-/// The tensor_span's layout is always cuda::tiles::layout_strided,
-/// built from the View's runtime strides, regardless of the View's
-/// array_layout (Kokkos::Layout{Left,Right} do not correspond exactly
-/// to cuda::tiles::layout_{left,right}).
-///
-/// Inside a tile kernel body, a TileView converts implicitly to the
-/// cuda::tiles::partition_view used to load/store register tiles.
+/// Idiomatic construction happens on host from a Kokkos::View (the
+/// array to partition) and a cuda::tiles::shape (the shape of each
+/// tile in the partition).  The resulting object can be cudaMemcpy'd
+/// to device for use in a Tile kernel.  There, it behaves like a
+/// cuda::tiles::partition_view.
 template <class TileType, class Extents>
 class TileView {
   static_assert(Impl::ct::tile_shape<typename TileType::shape_type>,
@@ -123,12 +108,18 @@ class TileView {
   using partition_view_type =
       Impl::ct::partition_view<span_type, tile_shape_type>;
 
-  // Construct from a Kokkos::View and a tile shape tag on the host.  The
-  // shape argument's type must match tile_shape_type; its value is
-  // unused (cuda::tiles shapes are stateless tags), but the parameter is
-  // required so that TileView's template arguments can be deduced via
-  // CTAD -- see the deduction guide below.
+  // The remaining public type aliases mirror
+  // cuda::tiles::partition_view's, so that TileView can be used
+  // anywhere a partition_view would be, both for type introspection and
+  // for the member functions below.
+  using index_type      = typename partition_view_type::index_type;
+  using rank_type       = typename partition_view_type::rank_type;
+  using view_shape_type = typename partition_view_type::view_shape_type;
+  using view_tile_type  = typename partition_view_type::view_tile_type;
+
+  // Construct from a Kokkos::View and a tile shape on the host.
   template <class ViewType>
+    requires(Kokkos::is_view_v<ViewType>)
   TileView(ViewType const& view, tile_shape_type) noexcept
       : span_(view.data(),
               mapping_type(
@@ -136,8 +127,6 @@ class TileView {
                       view, std::make_index_sequence<ViewType::rank()>{}),
                   Impl::cuda_tile_strides_from_view<strides_type>(
                       view, std::make_index_sequence<ViewType::rank()>{}))) {
-    static_assert(Kokkos::is_view_v<ViewType>,
-                  "Kokkos::TileView requires a Kokkos::View");
     static_assert(static_cast<size_t>(ViewType::rank()) ==
                       extents_type::rank(),
                   "Kokkos::TileView: View rank must match Extents rank");
@@ -153,23 +142,52 @@ class TileView {
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   tile_shape_type shape() const noexcept { return tile_shape_type{}; }
 
-  // Builds the cuda::tiles::partition_view used inside a tile kernel body
-  // to load/store register tiles.
+  /// \brief Convert this object into a partition_view.
+  ///
+  /// Use this only if you need to call an interface that expects a
+  /// partition_view.  Otherwise, just call load and store directly on
+  /// this object.
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   operator partition_view_type() const noexcept {
     return partition_view_type(span_, tile_shape_type{});
+  }
+
+  // The remaining member functions mirror cuda::tiles::partition_view's
+  // load/store interface (same names, template parameters, and function
+  // parameters), each forwarding to the partition_view built by the
+  // conversion operator above.  This lets a TileView be used directly in
+  // a tile kernel body wherever a partition_view would be.
+  //
+  // TileView doesn't yet implement masked loads or stores.  For now,
+  // we would like to explore an interface that only exposes in-bounds
+  // loads and stores.  On the other hand, masking is useful for
+  // reasons other than simplifying boundary handling.
+  //
+  // TileView doesn't yet implement atomic loads or stores.
+
+  template <class... Idx>
+    requires (sizeof...(Idx) == extents_type::rank())
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION view_tile_type
+  load(Idx... idx) const noexcept {
+    return static_cast<partition_view_type>(*this).load(idx...);
+  }
+
+  template <Impl::ct::tile_like Value, class... Idx>
+    requires (
+      sizeof...(Idx) == extents_type::rank()
+      // && is_convertible_v<Value, view_tile_type>
+    )
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION void
+  store(Value tile_value, Idx... idx) const noexcept {
+    static_cast<partition_view_type>(*this).store(tile_value, idx...);
   }
 
  private:
   span_type span_;
 };
 
-// Deduces TileView's template arguments from a Kokkos::View and a
-// cuda::tiles tile shape tag, so that callers can write, e.g.,
-// Kokkos::TileView(view, cuda::tiles::shape<8>{}) without spelling out
-// TileView<TileType, Extents> explicitly.  This can't be synthesized from
-// the constructor alone, since neither TileType nor Extents appears
-// directly among the constructor's parameter types.
+// TileView needs a deduction guide because the constructor's
+// parameters don't have the same types as its template parameters.
 template <class ViewType, class TileShape>
 TileView(ViewType const&, TileShape) -> TileView<
     Impl::ct::tile<typename ViewType::non_const_value_type, TileShape>,

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -33,24 +33,39 @@ namespace Impl {
 
 namespace ct = cuda::tiles;
 
-// Builds a cuda::tiles::extents object matching a View's rank, with every
-// dimension dynamic, filled in from the View's runtime extents.
-template <class ViewType, size_t... Ranks>
-KOKKOS_INLINE_FUNCTION auto cuda_tile_extents_from_view(
+// Builds an instance of TargetExtents (a cuda::tiles::extents
+// specialization, possibly with some static dimensions) matching a View's
+// rank, from the View's runtime extents.  This works regardless of which
+// of TargetExtents's dimensions are static, because
+// cuda::tiles::extents's constructor accepts either exactly
+// rank_dynamic() values (one per dynamic dimension) or exactly rank()
+// values (one per dimension, ignoring the ones at static positions); we
+// always supply rank() values here.
+template <class TargetExtents, class ViewType, size_t... Ranks>
+KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_extents_from_view(
     ViewType const& view, std::index_sequence<Ranks...>) {
-  return ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>(
-      static_cast<uint32_t>(view.extent(Ranks))...);
+  return TargetExtents(
+      static_cast<typename TargetExtents::index_type>(view.extent(Ranks))...);
 }
 
-// Builds a cuda::tiles::extents object (used as a strides descriptor)
-// matching a View's rank, with every dimension dynamic, filled in from the
-// View's runtime strides.
-template <class ViewType, size_t... Ranks>
-KOKKOS_INLINE_FUNCTION auto cuda_tile_strides_from_view(
+// Same as cuda_tile_extents_from_view, but pulls values from the View's
+// runtime strides instead of its extents.
+template <class TargetExtents, class ViewType, size_t... Ranks>
+KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_strides_from_view(
     ViewType const& view, std::index_sequence<Ranks...>) {
-  return ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>(
-      static_cast<uint32_t>(view.stride(Ranks))...);
+  return TargetExtents(
+      static_cast<typename TargetExtents::index_type>(view.stride(Ranks))...);
 }
+
+// A cuda::tiles::extents specialization with the given rank, all of whose
+// dimensions are dynamic.
+template <size_t Rank, class Ranks = std::make_index_sequence<Rank>>
+struct AllDynamicCudaTileExtents;
+
+template <size_t Rank, size_t... Ranks>
+struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
+  using type = ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>;
+};
 
 }  // namespace Impl
 
@@ -58,77 +73,90 @@ KOKKOS_INLINE_FUNCTION auto cuda_tile_strides_from_view(
 ///        tensor_span/partition_view so its data can be used from CUDA
 ///        Tile kernels.
 ///
-/// A TileView is constructed on the host from a Kokkos::View and a
-/// compile-time tile shape.  It stores a cuda::tiles::tensor_span (a raw
-/// device pointer plus the View's runtime extents and strides) and a
-/// cuda::tiles::shape tag describing how to partition the tensor into
-/// register tiles.  The tensor_span's layout is always
-/// cuda::tiles::layout_strided, built from the View's runtime strides,
-/// regardless of the View's array_layout (Kokkos::LayoutLeft,
-/// Kokkos::LayoutRight, and Kokkos::LayoutStride do not correspond to
-/// cuda::tiles::layout_left/layout_right).  Both are trivially copyable,
-/// so a TileView may be
-/// embedded by value in a Driver struct handed to
+/// TileView is templated on \c TileType, a cuda::tiles::tile
+/// specialization (e.g. cuda::tiles::tile<float, cuda::tiles::shape<8>>)
+/// describing the element type and shape of the register tiles it will be
+/// partitioned into, and on \c Extents, a cuda::tiles::extents
+/// specialization describing the index space of the whole tensor that
+/// gets partitioned into those tiles.
+///
+/// A TileView is constructed on the host from a Kokkos::View.  It stores
+/// a cuda::tiles::tensor_span (a raw device pointer plus the View's
+/// runtime extents and strides), which is trivially copyable, so a
+/// TileView may be embedded by value in a Driver struct handed to
 /// Kokkos::Impl::CudaParallelLaunchTileKernelInvoker (see
 /// Kokkos_Cuda_KernelLaunchTile.hpp), which forbids passing struct
 /// arguments directly to a __tile_global__ kernel.
 ///
-/// Inside the Driver's operator(), TileView::partition() builds the actual
+/// The tensor_span's layout is always cuda::tiles::layout_strided, built
+/// from the View's runtime strides, regardless of the View's
+/// array_layout (Kokkos::LayoutLeft, Kokkos::LayoutRight, and
+/// Kokkos::LayoutStride do not correspond to
+/// cuda::tiles::layout_left/layout_right).
+///
+/// Inside a tile kernel body, a TileView converts implicitly to the
 /// cuda::tiles::partition_view used to load/store register tiles.
-template <class ViewType, class TileShape>
+template <class TileType, class Extents>
 class TileView {
-  static_assert(Kokkos::is_view_v<ViewType>,
-                "Kokkos::TileView requires a Kokkos::View");
-  static_assert(TileShape::rank() == ViewType::rank(),
-                "Kokkos::TileView: TileShape rank must match View rank");
+  static_assert(Impl::ct::tile_shape<typename TileType::shape_type>,
+                "Kokkos::TileView: TileType::shape_type must be a "
+                "cuda::tiles::tile_shape");
+  static_assert(TileType::shape_type::rank() == Extents::rank(),
+                "Kokkos::TileView: TileType's shape rank must match "
+                "Extents rank");
 
  public:
-  using view_type       = ViewType;
-  using element_type    = typename ViewType::value_type;
-  using value_type      = typename ViewType::non_const_value_type;
-  using tile_shape_type = TileShape;
-  using extents_type    = decltype(Impl::cuda_tile_extents_from_view(
-      std::declval<ViewType const&>(),
-      std::make_index_sequence<ViewType::rank()>{}));
-  using strides_type = decltype(Impl::cuda_tile_strides_from_view(
-      std::declval<ViewType const&>(),
-      std::make_index_sequence<ViewType::rank()>{}));
+  using tile_type       = TileType;
+  using element_type    = typename TileType::element_type;
+  using value_type      = std::remove_cv_t<element_type>;
+  using tile_shape_type = typename TileType::shape_type;
+  using extents_type    = Extents;
+  using strides_type    = typename Impl::AllDynamicCudaTileExtents<
+      extents_type::rank()>::type;
   using layout_type  = Impl::ct::layout_strided<strides_type>;
   using mapping_type = typename layout_type::template mapping<extents_type>;
   using span_type =
       Impl::ct::tensor_span<element_type, extents_type, layout_type>;
   using partition_view_type =
-      Impl::ct::partition_view<span_type, TileShape>;
-  using data_handle_type = typename span_type::data_handle_type;
+      Impl::ct::partition_view<span_type, tile_shape_type>;
 
   TileView() = default;
 
   // Construct from a Kokkos::View on the host.
-  TileView(ViewType const& view, tile_shape_type shape = {})
+  template <class ViewType>
+  TileView(ViewType const& view) noexcept
       : span_(view.data(),
               mapping_type(
-                  Impl::cuda_tile_extents_from_view(
+                  Impl::cuda_tile_extents_from_view<extents_type>(
                       view, std::make_index_sequence<ViewType::rank()>{}),
-                  Impl::cuda_tile_strides_from_view(
-                      view, std::make_index_sequence<ViewType::rank()>{}))),
-        shape_(shape) {}
+                  Impl::cuda_tile_strides_from_view<strides_type>(
+                      view, std::make_index_sequence<ViewType::rank()>{}))) {
+    static_assert(Kokkos::is_view_v<ViewType>,
+                  "Kokkos::TileView requires a Kokkos::View");
+    static_assert(static_cast<size_t>(ViewType::rank()) ==
+                      extents_type::rank(),
+                  "Kokkos::TileView: View rank must match Extents rank");
+    static_assert(
+        std::is_same_v<typename ViewType::non_const_value_type, value_type>,
+        "Kokkos::TileView: View's value_type must match TileType's "
+        "element_type");
+  }
 
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   span_type span() const noexcept { return span_; }
 
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
-  tile_shape_type shape() const noexcept { return shape_; }
+  tile_shape_type shape() const noexcept { return tile_shape_type{}; }
 
   // Builds the cuda::tiles::partition_view used inside a tile kernel body
   // to load/store register tiles.
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   operator partition_view_type() const noexcept {
-    return partition_view_type(span_, shape_);
+    return partition_view_type(span_, tile_shape_type{});
   }
 
  private:
   span_type span_;
-  tile_shape_type shape_;
 };
 
 }  // namespace Kokkos

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -16,6 +16,7 @@
 #define KOKKOS_IMPL_PUBLIC_INCLUDE_NOTDEFINED_TILEVIEW
 #endif
 
+#include <Kokkos_Concepts.hpp>
 #include <Kokkos_Layout.hpp>
 #include <Kokkos_View.hpp>
 
@@ -161,6 +162,8 @@ constexpr bool tile_shape_extents_all_nonzero(std::index_sequence<Ranks...>) {
 ///    for a View with 256 elements partitioned into tiles of shape
 ///    <8>, Extents' (runtime) extent is 32, not 256.
 ///
+/// \tparam MemorySpace Kokkos memory space in which the data live
+///
 /// Construct this on host from a Kokkos::View (the array to
 /// partition) and a cuda::tiles::shape (the shape of each tile in the
 /// partition).  The resulting object is a nonowning view of the
@@ -174,7 +177,7 @@ constexpr bool tile_shape_extents_all_nonzero(std::index_sequence<Ranks...>) {
 /// with masked loads and stores.  The cuda::tiles::tensor_span that
 /// it exposes may thus have extents reduced to be elementwise
 /// multiples of the tile extents.
-template <class TileType, class Extents>
+template <class TileType, class Extents, Kokkos::MemorySpace MemorySpace>
 class TileView {
   static_assert(Impl::ct::tile_shape<typename TileType::shape_type>,
                 "Kokkos::TileView: TileType::shape_type must be a "
@@ -189,6 +192,7 @@ public:
   using value_type      = std::remove_cv_t<element_type>;
   using tile_shape_type = typename TileType::shape_type;
   using extents_type    = Extents;
+  using memory_space    = MemorySpace;
 
 private:
   using strides_type = Impl::cuda_tile_dextents<extents_type::rank()>;
@@ -235,6 +239,10 @@ public:
         std::is_same_v<typename ViewType::non_const_value_type, value_type>,
         "Kokkos::TileView: View's value_type must match TileType's "
         "element_type");
+    static_assert(
+        std::is_same_v<typename ViewType::memory_space, memory_space>,
+        "Kokkos::TileView: View's memory_space must match TileView's "
+        "MemorySpace");
     static_assert(
         Impl::tile_shape_extents_all_nonzero<tile_shape_type>(
             std::make_index_sequence<tile_shape_type::rank()>{}),
@@ -303,13 +311,11 @@ public:
 
 // TileView needs a deduction guide because the constructor's
 // parameters don't have the same types as its template parameters.
-// This deduces Extents as the View's tile index space: a static extent
-// (the View's static extent divided by TileShape's) wherever the View
-// itself has a static extent, and a dynamic extent elsewhere.
 template <class ViewType, class TileShape>
 TileView(ViewType const&, TileShape) -> TileView<
     Impl::ct::tile<typename ViewType::non_const_value_type, TileShape>,
-    Impl::CudaTileIndexSpaceExtentsFromView<ViewType, TileShape>>;
+    Impl::CudaTileIndexSpaceExtentsFromView<ViewType, TileShape>,
+    typename ViewType::memory_space>;
 
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -68,6 +68,67 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
   using type = ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>;
 };
 
+// Declared, but never defined -- only usable in an unevaluated context
+// (e.g., decltype) -- so that its trailing return type can be extracted
+// as a cuda::tiles::extents specialization via CudaTileExtentsProduct.
+// Requires that, in every extent where both Extents1 and Extents2 are
+// static, their product doesn't need to be (and isn't) computed with any
+// remainder -- multiplication is always exact, unlike the division in
+// cuda_tile_index_space_extents_from_view below.
+template <class Extents1, class Extents2, size_t... Ranks>
+auto cuda_tile_extents_product(std::index_sequence<Ranks...>) -> ct::extents<
+    uint32_t,
+    (Extents1::static_extent(Ranks) == ct::dynamic_extent ||
+             Extents2::static_extent(Ranks) == ct::dynamic_extent
+         ? ct::dynamic_extent
+         : Extents1::static_extent(Ranks) * Extents2::static_extent(Ranks))...>;
+
+// The cuda::tiles::extents specialization for the elementwise product of
+// Extents1 and Extents2 (which must have the same rank), static wherever
+// both are static.
+//
+// TileView needs this because it discards the input Kokkos::View's
+// extents type, and only keeps the tile index space type and the tile
+// shape.  If TileView ever needs to support input extents that aren't
+// elementwise divisible by the tile shape (which it would do via
+// masked loads and stores), it needs some way to hang on to the input
+// Kokkos::View's extents type.
+template <class Extents1, class Extents2>
+using CudaTileExtentsProduct =
+    decltype(cuda_tile_extents_product<Extents1, Extents2>(
+        std::make_index_sequence<Extents1::rank()>{}));
+
+// Declared, but never defined -- only usable in an unevaluated context
+// (e.g., decltype) -- so that its trailing return type can be extracted
+// as a cuda::tiles::extents specialization via
+// CudaTileIndexSpaceExtentsFromView.  The requires clause rejects
+// ViewType/TileShape combinations where a static View extent isn't an
+// exact multiple of the corresponding tile shape extent, rather than
+// silently truncating; a dynamic View extent is checked at run time
+// instead, in TileView's constructor.
+template <class ViewType, class TileShape, size_t... Ranks>
+  requires ((ViewType::static_extent(Ranks) == 0 ||
+             ViewType::static_extent(Ranks) % TileShape::static_extent(Ranks) ==
+                 0) &&
+            ...)
+auto cuda_tile_index_space_extents_from_view(std::index_sequence<Ranks...>)
+    -> ct::extents<uint32_t,
+                    (ViewType::static_extent(Ranks) == 0
+                         ? ct::dynamic_extent
+                         : ViewType::static_extent(Ranks) /
+                               TileShape::static_extent(Ranks))...>;
+
+// The cuda::tiles::extents specialization for the tile index space of a
+// View partitioned according to TileShape: static in each dimension
+// where ViewType has a static extent (in which case that extent must be
+// an exact multiple of TileShape's corresponding extent), and dynamic
+// elsewhere.  TileView's CTAD deduction guide uses this to deduce
+// Extents from the View and tile shape passed to TileView's constructor.
+template <class ViewType, class TileShape>
+using CudaTileIndexSpaceExtentsFromView =
+    decltype(cuda_tile_index_space_extents_from_view<ViewType, TileShape>(
+        std::make_index_sequence<ViewType::rank()>{}));
+
 // Returns whether each of the View's runtime extents is evenly
 // divisible by the corresponding (static) extent of TileShapeType.
 // Tile loads and stores indices in units of whole tiles, so a View
@@ -99,7 +160,11 @@ constexpr bool tile_shape_extents_all_nonzero(std::index_sequence<Ranks...>) {
 ///
 /// \tparam Extents cuda::tiles::extents specialization describing the
 ///    "tile index space type," that is, the type of the index space
-///    over which tile loads and stores iterate
+///    over which tile loads and stores iterate.  This is the space of
+///    tile indices (how many tiles fit along each dimension), not the
+///    space of element indices into the underlying Kokkos::View; e.g.,
+///    for a View with 256 elements partitioned into tiles of shape
+///    <8>, Extents' (runtime) extent is 32, not 256.
 ///
 /// Idiomatic construction happens on host from a Kokkos::View (the
 /// array to partition) and a cuda::tiles::shape (the shape of each
@@ -120,13 +185,16 @@ class TileView {
   using element_type    = typename TileType::element_type;
   using value_type      = std::remove_cv_t<element_type>;
   using tile_shape_type = typename TileType::shape_type;
-  using extents_type    = Extents;
-  using strides_type    = typename Impl::AllDynamicCudaTileExtents<
+  // extents_type is the tile index space, not the input index space.
+  using extents_type = Extents;
+  using strides_type = typename Impl::AllDynamicCudaTileExtents<
       extents_type::rank()>::type;
   using layout_type  = Impl::ct::layout_strided<strides_type>;
-  using mapping_type = typename layout_type::template mapping<extents_type>;
-  using span_type =
-      Impl::ct::tensor_span<element_type, extents_type, layout_type>;
+  using mapping_type = typename layout_type::template mapping<
+      Impl::CudaTileExtentsProduct<extents_type, tile_shape_type>>;
+  using span_type = Impl::ct::tensor_span<
+      element_type, Impl::CudaTileExtentsProduct<extents_type, tile_shape_type>,
+      layout_type>;
   using partition_view_type =
       Impl::ct::partition_view<span_type, tile_shape_type>;
 
@@ -154,7 +222,8 @@ class TileView {
   TileView(ViewType const& view, [[maybe_unused]] tile_shape_type ts) noexcept
       : span_(view.data(),
               mapping_type(
-                  Impl::cuda_tile_extents_from_view<extents_type>(
+                  Impl::cuda_tile_extents_from_view<
+                      Impl::CudaTileExtentsProduct<extents_type, tile_shape_type>>(
                       view, std::make_index_sequence<ViewType::rank()>{}),
                   Impl::cuda_tile_strides_from_view<strides_type>(
                       view, std::make_index_sequence<ViewType::rank()>{}))) {
@@ -226,10 +295,13 @@ class TileView {
 
 // TileView needs a deduction guide because the constructor's
 // parameters don't have the same types as its template parameters.
+// This deduces Extents as the View's tile index space: a static extent
+// (the View's static extent divided by TileShape's) wherever the View
+// itself has a static extent, and a dynamic extent elsewhere.
 template <class ViewType, class TileShape>
 TileView(ViewType const&, TileShape) -> TileView<
     Impl::ct::tile<typename ViewType::non_const_value_type, TileShape>,
-    typename Impl::AllDynamicCudaTileExtents<ViewType::rank()>::type>;
+    Impl::CudaTileIndexSpaceExtentsFromView<ViewType, TileShape>>;
 
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -80,7 +80,11 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
 /// specialization describing the index space of the whole tensor that
 /// gets partitioned into those tiles.
 ///
-/// A TileView is constructed on the host from a Kokkos::View.  It stores
+/// A TileView is constructed on the host from a Kokkos::View and a
+/// cuda::tiles tile shape tag (e.g. cuda::tiles::shape<8>{}); template
+/// argument deduction picks TileType and Extents automatically, so
+/// callers need not spell out TileView<TileType, Extents> explicitly.
+/// It stores
 /// a cuda::tiles::tensor_span (a raw device pointer plus the View's
 /// runtime extents and strides), which is trivially copyable, so a
 /// TileView may be embedded by value in a Driver struct handed to
@@ -88,11 +92,10 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
 /// Kokkos_Cuda_KernelLaunchTile.hpp), which forbids passing struct
 /// arguments directly to a __tile_global__ kernel.
 ///
-/// The tensor_span's layout is always cuda::tiles::layout_strided, built
-/// from the View's runtime strides, regardless of the View's
-/// array_layout (Kokkos::LayoutLeft, Kokkos::LayoutRight, and
-/// Kokkos::LayoutStride do not correspond to
-/// cuda::tiles::layout_left/layout_right).
+/// The tensor_span's layout is always cuda::tiles::layout_strided,
+/// built from the View's runtime strides, regardless of the View's
+/// array_layout (Kokkos::Layout{Left,Right} do not correspond exactly
+/// to cuda::tiles::layout_{left,right}).
 ///
 /// Inside a tile kernel body, a TileView converts implicitly to the
 /// cuda::tiles::partition_view used to load/store register tiles.
@@ -120,11 +123,13 @@ class TileView {
   using partition_view_type =
       Impl::ct::partition_view<span_type, tile_shape_type>;
 
-  TileView() = default;
-
-  // Construct from a Kokkos::View on the host.
+  // Construct from a Kokkos::View and a tile shape tag on the host.  The
+  // shape argument's type must match tile_shape_type; its value is
+  // unused (cuda::tiles shapes are stateless tags), but the parameter is
+  // required so that TileView's template arguments can be deduced via
+  // CTAD -- see the deduction guide below.
   template <class ViewType>
-  TileView(ViewType const& view) noexcept
+  TileView(ViewType const& view, tile_shape_type) noexcept
       : span_(view.data(),
               mapping_type(
                   Impl::cuda_tile_extents_from_view<extents_type>(
@@ -158,6 +163,17 @@ class TileView {
  private:
   span_type span_;
 };
+
+// Deduces TileView's template arguments from a Kokkos::View and a
+// cuda::tiles tile shape tag, so that callers can write, e.g.,
+// Kokkos::TileView(view, cuda::tiles::shape<8>{}) without spelling out
+// TileView<TileType, Extents> explicitly.  This can't be synthesized from
+// the constructor alone, since neither TileType nor Extents appears
+// directly among the constructor's parameter types.
+template <class ViewType, class TileShape>
+TileView(ViewType const&, TileShape) -> TileView<
+    Impl::ct::tile<typename ViewType::non_const_value_type, TileShape>,
+    typename Impl::AllDynamicCudaTileExtents<ViewType::rank()>::type>;
 
 }  // namespace Kokkos
 

--- a/core/src/Cuda/Kokkos_Cuda_TileView.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_TileView.hpp
@@ -34,14 +34,8 @@ namespace Impl {
 
 namespace ct = cuda::tiles;
 
-// Builds an instance of TargetExtents (a cuda::tiles::extents
-// specialization, possibly with some static dimensions) matching a View's
-// rank, from the View's runtime extents.  This works regardless of which
-// of TargetExtents's dimensions are static, because
-// cuda::tiles::extents's constructor accepts either exactly
-// rank_dynamic() values (one per dynamic dimension) or exactly rank()
-// values (one per dimension, ignoring the ones at static positions); we
-// always supply rank() values here.
+// Returns the TargetExtents (cuda::tiles::extents) object with the
+// same extents as the input Kokkos::View's extents.
 template <class TargetExtents, class ViewType, size_t... Ranks>
 KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_extents_from_view(
     ViewType const& view, std::index_sequence<Ranks...>) {
@@ -49,8 +43,8 @@ KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_extents_from_view(
       static_cast<typename TargetExtents::index_type>(view.extent(Ranks))...);
 }
 
-// Same as cuda_tile_extents_from_view, but pulls values from the View's
-// runtime strides instead of its extents.
+// Returns the TargetExtents (cuda::tiles::extents) object with the
+// same extents as the input Kokkos::View's strides.
 template <class TargetExtents, class ViewType, size_t... Ranks>
 KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_strides_from_view(
     ViewType const& view, std::index_sequence<Ranks...>) {
@@ -58,15 +52,16 @@ KOKKOS_INLINE_FUNCTION TargetExtents cuda_tile_strides_from_view(
       static_cast<typename TargetExtents::index_type>(view.stride(Ranks))...);
 }
 
-// A cuda::tiles::extents specialization with the given rank, all of whose
-// dimensions are dynamic.
-template <size_t Rank, class Ranks = std::make_index_sequence<Rank>>
-struct AllDynamicCudaTileExtents;
 
-template <size_t Rank, size_t... Ranks>
-struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
-  using type = ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>;
-};
+template <size_t... Ranks>
+constexpr auto cuda_tile_dextents_impl(std::index_sequence<Ranks...>) ->
+  ct::extents<uint32_t, ((void)Ranks, ct::dynamic_extent)...>;
+
+// cuda::tiles::extents specialization with rank Rank,
+// all of whose extents are dynamic.
+template <size_t Rank>
+using cuda_tile_dextents =
+  decltype(cuda_tile_dextents_impl(std::make_index_sequence<Rank>()));
 
 // Declared, but never defined -- only usable in an unevaluated context
 // (e.g., decltype) -- so that its trailing return type can be extracted
@@ -76,7 +71,7 @@ struct AllDynamicCudaTileExtents<Rank, std::index_sequence<Ranks...>> {
 // remainder -- multiplication is always exact, unlike the division in
 // cuda_tile_index_space_extents_from_view below.
 template <class Extents1, class Extents2, size_t... Ranks>
-auto cuda_tile_extents_product(std::index_sequence<Ranks...>) -> ct::extents<
+constexpr auto cuda_tile_extents_product(std::index_sequence<Ranks...>) -> ct::extents<
     uint32_t,
     (Extents1::static_extent(Ranks) == ct::dynamic_extent ||
              Extents2::static_extent(Ranks) == ct::dynamic_extent
@@ -111,7 +106,7 @@ template <class ViewType, class TileShape, size_t... Ranks>
              ViewType::static_extent(Ranks) % TileShape::static_extent(Ranks) ==
                  0) &&
             ...)
-auto cuda_tile_index_space_extents_from_view(std::index_sequence<Ranks...>)
+constexpr auto cuda_tile_index_space_extents_from_view(std::index_sequence<Ranks...>)
     -> ct::extents<uint32_t,
                     (ViewType::static_extent(Ranks) == 0
                          ? ct::dynamic_extent
@@ -166,11 +161,19 @@ constexpr bool tile_shape_extents_all_nonzero(std::index_sequence<Ranks...>) {
 ///    for a View with 256 elements partitioned into tiles of shape
 ///    <8>, Extents' (runtime) extent is 32, not 256.
 ///
-/// Idiomatic construction happens on host from a Kokkos::View (the
-/// array to partition) and a cuda::tiles::shape (the shape of each
-/// tile in the partition).  The resulting object can be cudaMemcpy'd
-/// to device for use in a Tile kernel.  There, it behaves like a
-/// cuda::tiles::partition_view.
+/// Construct this on host from a Kokkos::View (the array to
+/// partition) and a cuda::tiles::shape (the shape of each tile in the
+/// partition).  The resulting object is a nonowning view of the
+/// Kokkos::View's data.
+///
+/// The TileView object can be bytewise copied to device for use in
+/// Tile kernels.  There, it supports load and store operations, just
+/// like a cuda::tiles::partition_view.
+///
+/// TileView does not currently support partial out-of-bounds access
+/// with masked loads and stores.  The cuda::tiles::tensor_span that
+/// it exposes may thus have extents reduced to be elementwise
+/// multiples of the tile extents.
 template <class TileType, class Extents>
 class TileView {
   static_assert(Impl::ct::tile_shape<typename TileType::shape_type>,
@@ -180,28 +183,26 @@ class TileView {
                 "Kokkos::TileView: TileType's shape rank must match "
                 "Extents rank");
 
- public:
+public:
   using tile_type       = TileType;
   using element_type    = typename TileType::element_type;
   using value_type      = std::remove_cv_t<element_type>;
   using tile_shape_type = typename TileType::shape_type;
-  // extents_type is the tile index space, not the input index space.
-  using extents_type = Extents;
-  using strides_type = typename Impl::AllDynamicCudaTileExtents<
-      extents_type::rank()>::type;
+  using extents_type    = Extents;
+
+private:
+  using strides_type = Impl::cuda_tile_dextents<extents_type::rank()>;
   using layout_type  = Impl::ct::layout_strided<strides_type>;
   using mapping_type = typename layout_type::template mapping<
       Impl::CudaTileExtentsProduct<extents_type, tile_shape_type>>;
+  
+public:
   using span_type = Impl::ct::tensor_span<
-      element_type, Impl::CudaTileExtentsProduct<extents_type, tile_shape_type>,
+      element_type, typename mapping_type::extents_type,
       layout_type>;
   using partition_view_type =
       Impl::ct::partition_view<span_type, tile_shape_type>;
 
-  // The remaining public type aliases mirror
-  // cuda::tiles::partition_view's, so that TileView can be used
-  // anywhere a partition_view would be, both for type introspection and
-  // for the member functions below.
   using index_type      = typename partition_view_type::index_type;
   using rank_type       = typename partition_view_type::rank_type;
   using view_shape_type = typename partition_view_type::view_shape_type;
@@ -243,9 +244,16 @@ class TileView {
             view, std::make_index_sequence<ViewType::rank()>{})));
   }
 
+  /// \brief Underlying cuda::tiles::tensor_span that this object views
+  ///
+  /// TileView does not currently support partial out-of-bounds access
+  /// with masked loads and stores.  The tensor_span that it exposes
+  /// may thus have extents reduced to be elementwise multiples of the
+  /// tile extents.
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   span_type span() const noexcept { return span_; }
 
+  /// \brief The tile shape
   KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   tile_shape_type shape() const noexcept { return tile_shape_type{}; }
 

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -213,9 +213,12 @@ void cuda_tile_view_kernel_invoker() {
         b(i) = 2 * i;
       });
 
-  using TileViewType = TileViewVectorAddDriver::TileViewType;
-  TileViewVectorAddDriver driver{TileViewType(a), TileViewType(b),
-                                  TileViewType(out), N};
+  // CTAD deduces Kokkos::TileView's template arguments from the View and
+  // shape arguments here.
+  TileViewVectorAddDriver::ShapeType shape;
+  TileViewVectorAddDriver driver{Kokkos::TileView(a, shape),
+                                  Kokkos::TileView(b, shape),
+                                  Kokkos::TileView(out, shape), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewVectorAddDriver,
@@ -298,9 +301,10 @@ void cuda_tile_view_noncontiguous_rank1_add() {
   auto b   = Kokkos::subview(b_full, Kokkos::ALL, 0);
   auto out = Kokkos::subview(out_full, Kokkos::ALL, 0);
 
-  using TileViewType = TileViewNoncontiguousRank1AddDriver::TileViewType;
+  TileViewNoncontiguousRank1AddDriver::ShapeType shape;
   TileViewNoncontiguousRank1AddDriver driver{
-      TileViewType(a), TileViewType(b), TileViewType(out), N};
+      Kokkos::TileView(a, shape), Kokkos::TileView(b, shape),
+      Kokkos::TileView(out, shape), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewNoncontiguousRank1AddDriver,
@@ -394,9 +398,10 @@ void cuda_tile_view_noncontiguous_rank2_add() {
   auto b   = Kokkos::subview(b_full, Kokkos::ALL, Kokkos::ALL, 0);
   auto out = Kokkos::subview(out_full, Kokkos::ALL, Kokkos::ALL, 0);
 
-  using TileViewType = TileViewNoncontiguousRank2AddDriver::TileViewType;
+  TileViewNoncontiguousRank2AddDriver::ShapeType shape;
   TileViewNoncontiguousRank2AddDriver driver{
-      TileViewType(a), TileViewType(b), TileViewType(out), N};
+      Kokkos::TileView(a, shape), Kokkos::TileView(b, shape),
+      Kokkos::TileView(out, shape), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewNoncontiguousRank2AddDriver,

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -167,9 +167,10 @@ TEST(cuda, tile_kernel_invoker) { cuda_tile_kernel_invoker(); }
 // constructed on the host from a Kokkos::View, then embedded by value in
 // the Driver struct that gets memcpy'd to device scratch memory.
 struct TileViewVectorAddDriver {
-  using ViewType   = Kokkos::View<float*, Kokkos::Cuda>;
-  using ShapeType  = cuda::tiles::shape<8>;
-  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+  using ShapeType     = cuda::tiles::shape<8>;
+  using TileType      = cuda::tiles::tile<float, ShapeType>;
+  using ExtentsType   = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
 
   TileViewType a;
   TileViewType b;
@@ -212,11 +213,9 @@ void cuda_tile_view_kernel_invoker() {
         b(i) = 2 * i;
       });
 
-  using ShapeType = TileViewVectorAddDriver::ShapeType;
-  TileViewVectorAddDriver driver{
-      Kokkos::TileView<decltype(a), ShapeType>(a),
-      Kokkos::TileView<decltype(b), ShapeType>(b),
-      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+  using TileViewType = TileViewVectorAddDriver::TileViewType;
+  TileViewVectorAddDriver driver{TileViewType(a), TileViewType(b),
+                                  TileViewType(out), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewVectorAddDriver,
@@ -244,11 +243,10 @@ TEST(cuda, tile_view_vector_add) { cuda_tile_view_kernel_invoker(); }
 struct TileViewNoncontiguousRank1AddDriver {
   using BackingViewType =
       Kokkos::View<float* [2], Kokkos::LayoutRight, Kokkos::Cuda>;
-  using ViewType =
-      decltype(Kokkos::subview(std::declval<BackingViewType const&>(),
-                                Kokkos::ALL, 0));
-  using ShapeType    = cuda::tiles::shape<8>;
-  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+  using ShapeType     = cuda::tiles::shape<8>;
+  using TileType      = cuda::tiles::tile<float, ShapeType>;
+  using ExtentsType   = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
 
   TileViewType a;
   TileViewType b;
@@ -300,11 +298,9 @@ void cuda_tile_view_noncontiguous_rank1_add() {
   auto b   = Kokkos::subview(b_full, Kokkos::ALL, 0);
   auto out = Kokkos::subview(out_full, Kokkos::ALL, 0);
 
-  using ShapeType = TileViewNoncontiguousRank1AddDriver::ShapeType;
+  using TileViewType = TileViewNoncontiguousRank1AddDriver::TileViewType;
   TileViewNoncontiguousRank1AddDriver driver{
-      Kokkos::TileView<decltype(a), ShapeType>(a),
-      Kokkos::TileView<decltype(b), ShapeType>(b),
-      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+      TileViewType(a), TileViewType(b), TileViewType(out), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewNoncontiguousRank1AddDriver,
@@ -338,11 +334,11 @@ TEST(cuda, tile_view_noncontiguous_rank1_add) {
 struct TileViewNoncontiguousRank2AddDriver {
   using BackingViewType =
       Kokkos::View<float* [4][2], Kokkos::LayoutRight, Kokkos::Cuda>;
-  using ViewType =
-      decltype(Kokkos::subview(std::declval<BackingViewType const&>(),
-                                Kokkos::ALL, Kokkos::ALL, 0));
-  using ShapeType    = cuda::tiles::shape<8, 4>;
-  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+  using ShapeType   = cuda::tiles::shape<8, 4>;
+  using TileType    = cuda::tiles::tile<float, ShapeType>;
+  using ExtentsType = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent,
+                                            cuda::tiles::dynamic_extent>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
 
   TileViewType a;
   TileViewType b;
@@ -398,11 +394,9 @@ void cuda_tile_view_noncontiguous_rank2_add() {
   auto b   = Kokkos::subview(b_full, Kokkos::ALL, Kokkos::ALL, 0);
   auto out = Kokkos::subview(out_full, Kokkos::ALL, Kokkos::ALL, 0);
 
-  using ShapeType = TileViewNoncontiguousRank2AddDriver::ShapeType;
+  using TileViewType = TileViewNoncontiguousRank2AddDriver::TileViewType;
   TileViewNoncontiguousRank2AddDriver driver{
-      Kokkos::TileView<decltype(a), ShapeType>(a),
-      Kokkos::TileView<decltype(b), ShapeType>(b),
-      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+      TileViewType(a), TileViewType(b), TileViewType(out), N};
 
   using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
       TileViewNoncontiguousRank2AddDriver,

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -431,4 +431,107 @@ TEST(cuda, tile_view_noncontiguous_rank2_add) {
   cuda_tile_view_noncontiguous_rank2_add();
 }
 
+// This driver is templated on the "view-like" type used for its a/b/out
+// members, and its operator() only ever calls .load(idx...) and
+// .store(tile, idx...) on them.  Both cuda::tiles::partition_view and
+// Kokkos::TileView implement that interface, so this same driver
+// template -- unmodified -- can be instantiated with either one.  That's
+// exactly what it means for TileView to be usable in place of a
+// partition_view for load and store operations.
+template <class ViewLikeType>
+struct GenericVectorAddDriver {
+  ViewLikeType a;
+  ViewLikeType b;
+  ViewLikeType out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    constexpr std::size_t tile_size = 8;
+    const size_t n_tile             = n / tile_size;
+    const size_t n_tile_block       = n_tile / ct::num_blocks().x;
+    const size_t tile_start         = ct::bid().x * n_tile_block;
+    const size_t tile_end           = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b = a.load(tile_index) + b.load(tile_index);
+      out.store(a_plus_b, tile_index);
+    }
+  }
+};
+
+template <class ViewLikeType>
+void run_generic_vector_add(ViewLikeType a, ViewLikeType b, ViewLikeType out,
+                             std::size_t n, Kokkos::Cuda& cuda_instance) {
+  using Driver = GenericVectorAddDriver<ViewLikeType>;
+  Driver driver{a, b, out, n};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      Driver, Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+}
+
+void cuda_tile_view_substitutes_for_partition_view() {
+  constexpr std::size_t N = 256;
+
+  Kokkos::View<float*, Kokkos::Cuda> a("A", N);
+  Kokkos::View<float*, Kokkos::Cuda> b("B", N);
+  Kokkos::View<float*, Kokkos::Cuda> out_via_tile_view("OutTileView", N);
+  Kokkos::View<float*, Kokkos::Cuda> out_via_partition_view(
+      "OutPartitionView", N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        a(i) = i;
+        b(i) = 2 * i;
+      });
+
+  // Run the generic driver with Kokkos::TileView, built on the host from
+  // Kokkos::Views via CTAD.
+  cuda::tiles::shape<8> shape;
+  run_generic_vector_add(Kokkos::TileView(a, shape), Kokkos::TileView(b, shape),
+                          Kokkos::TileView(out_via_tile_view, shape), N,
+                          cuda_instance);
+
+  // Run the exact same generic driver template, instantiated instead
+  // with cuda::tiles::partition_view built directly from raw device
+  // pointers (mirroring the low-level cuda.tile_vector_add test above),
+  // to prove Kokkos::TileView is a drop-in substitute for
+  // cuda::tiles::partition_view.
+  namespace ct = cuda::tiles;
+  using ExtentsType = ct::extents<uint32_t, ct::dynamic_extent>;
+  using SpanType    = ct::tensor_span<float, ExtentsType>;
+  using PartitionViewType = ct::partition_view<SpanType, ct::shape<8>>;
+
+  ExtentsType extents(static_cast<uint32_t>(N));
+  PartitionViewType pv_a(SpanType(a.data(), extents), ct::shape<8>{});
+  PartitionViewType pv_b(SpanType(b.data(), extents), ct::shape<8>{});
+  PartitionViewType pv_out(
+      SpanType(out_via_partition_view.data(), extents), ct::shape<8>{});
+  run_generic_vector_add(pv_a, pv_b, pv_out, N, cuda_instance);
+
+  auto h_out_tile_view = Kokkos::create_mirror_view_and_copy(out_via_tile_view);
+  auto h_out_partition_view =
+      Kokkos::create_mirror_view_and_copy(out_via_partition_view);
+  int errors = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    float expected = float(3 * i);
+    if (h_out_tile_view(i) != expected) errors++;
+    if (h_out_partition_view(i) != expected) errors++;
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_substitutes_for_partition_view) {
+  cuda_tile_view_substitutes_for_partition_view();
+}
+
 }  // namespace Test

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -181,19 +181,19 @@ struct TileViewVectorAddDriver {
   void operator()() const {
     namespace ct = cuda::tiles;
 
-    TileViewType::partition_view_type a_view = a;
-    TileViewType::partition_view_type b_view = b;
-    TileViewType::partition_view_type o_view = out;
-
+    // Calling load/store directly on TileView (rather than first
+    // converting to a cuda::tiles::partition_view) exercises the member
+    // functions TileView forwards from partition_view.  N is an exact
+    // multiple of the tile size, so every tile is fully in bounds and
+    // plain (unmasked) load/store are safe to use.
     constexpr std::size_t tile_size = 8;
     const size_t n_tile             = n / tile_size;
     const size_t n_tile_block       = n_tile / ct::num_blocks().x;
     const size_t tile_start         = ct::bid().x * n_tile_block;
     const size_t tile_end           = tile_start + n_tile_block;
     for (size_t tile_index : ct::irange(tile_start, tile_end)) {
-      auto a_plus_b =
-          a_view.load_masked(tile_index) + b_view.load_masked(tile_index);
-      o_view.store_masked(a_plus_b, tile_index);
+      auto a_plus_b = a.load(tile_index) + b.load(tile_index);
+      out.store(a_plus_b, tile_index);
     }
   }
 };
@@ -260,19 +260,19 @@ struct TileViewNoncontiguousRank1AddDriver {
   void operator()() const {
     namespace ct = cuda::tiles;
 
-    TileViewType::partition_view_type a_view = a;
-    TileViewType::partition_view_type b_view = b;
-    TileViewType::partition_view_type o_view = out;
-
+    // Calling load/store directly on TileView (rather than first
+    // converting to a cuda::tiles::partition_view) exercises the member
+    // functions TileView forwards from partition_view.  N is an exact
+    // multiple of the tile size, so every tile is fully in bounds and
+    // plain (unmasked) load/store are safe to use.
     constexpr std::size_t tile_size = 8;
     const size_t n_tile             = n / tile_size;
     const size_t n_tile_block       = n_tile / ct::num_blocks().x;
     const size_t tile_start         = ct::bid().x * n_tile_block;
     const size_t tile_end           = tile_start + n_tile_block;
     for (size_t tile_index : ct::irange(tile_start, tile_end)) {
-      auto a_plus_b =
-          a_view.load_masked(tile_index) + b_view.load_masked(tile_index);
-      o_view.store_masked(a_plus_b, tile_index);
+      auto a_plus_b = a.load(tile_index) + b.load(tile_index);
+      out.store(a_plus_b, tile_index);
     }
   }
 };
@@ -353,10 +353,12 @@ struct TileViewNoncontiguousRank2AddDriver {
   void operator()() const {
     namespace ct = cuda::tiles;
 
-    TileViewType::partition_view_type a_view = a;
-    TileViewType::partition_view_type b_view = b;
-    TileViewType::partition_view_type o_view = out;
-
+    // Calling load/store directly on TileView (rather than first
+    // converting to a cuda::tiles::partition_view) exercises the member
+    // functions TileView forwards from partition_view.  N is an exact
+    // multiple of the tile size, so every tile is fully in bounds and
+    // plain (unmasked) load/store are safe to use.
+    //
     // The second dimension has static extent 4, which fits in a single
     // tile of shape <8, 4>; only the first dimension needs to be tiled.
     constexpr std::size_t tile_size = 8;
@@ -365,9 +367,8 @@ struct TileViewNoncontiguousRank2AddDriver {
     const size_t tile_start         = ct::bid().x * n_tile_block;
     const size_t tile_end           = tile_start + n_tile_block;
     for (size_t tile_index : ct::irange(tile_start, tile_end)) {
-      auto a_plus_b = a_view.load_masked(tile_index, 0) +
-                       b_view.load_masked(tile_index, 0);
-      o_view.store_masked(a_plus_b, tile_index, 0);
+      auto a_plus_b = a.load(tile_index, 0) + b.load(tile_index, 0);
+      out.store(a_plus_b, tile_index, 0);
     }
   }
 };

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -15,6 +15,7 @@ import kokkos.core;
 #include <cstddef>
 
 #include <Cuda/Kokkos_Cuda_KernelLaunchTile.hpp>
+#include <Cuda/Kokkos_Cuda_TileView.hpp>
 
 namespace Test {
 
@@ -160,5 +161,274 @@ void cuda_tile_kernel_invoker() {
 }
 
 TEST(cuda, tile_kernel_invoker) { cuda_tile_kernel_invoker(); }
+
+// This struct shows how Kokkos::TileView bridges Kokkos::View data with
+// cuTile's partition_view inside a tile kernel driver.  Each TileView is
+// constructed on the host from a Kokkos::View, then embedded by value in
+// the Driver struct that gets memcpy'd to device scratch memory.
+struct TileViewVectorAddDriver {
+  using ViewType   = Kokkos::View<float*, Kokkos::Cuda>;
+  using ShapeType  = cuda::tiles::shape<8>;
+  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+
+  TileViewType a;
+  TileViewType b;
+  TileViewType out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    TileViewType::partition_view_type a_view = a;
+    TileViewType::partition_view_type b_view = b;
+    TileViewType::partition_view_type o_view = out;
+
+    constexpr std::size_t tile_size = 8;
+    const size_t n_tile             = n / tile_size;
+    const size_t n_tile_block       = n_tile / ct::num_blocks().x;
+    const size_t tile_start         = ct::bid().x * n_tile_block;
+    const size_t tile_end           = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b =
+          a_view.load_masked(tile_index) + b_view.load_masked(tile_index);
+      o_view.store_masked(a_plus_b, tile_index);
+    }
+  }
+};
+
+void cuda_tile_view_kernel_invoker() {
+  constexpr std::size_t N = 256;
+
+  Kokkos::View<float*, Kokkos::Cuda> a("A", N);
+  Kokkos::View<float*, Kokkos::Cuda> b("B", N);
+  Kokkos::View<float*, Kokkos::Cuda> out("Out", N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        a(i) = i;
+        b(i) = 2 * i;
+      });
+
+  using ShapeType = TileViewVectorAddDriver::ShapeType;
+  TileViewVectorAddDriver driver{
+      Kokkos::TileView<decltype(a), ShapeType>(a),
+      Kokkos::TileView<decltype(b), ShapeType>(b),
+      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileViewVectorAddDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out = Kokkos::create_mirror_view_and_copy(out);
+  int errors = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (h_out(i) != float(3 * i)) errors++;
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_vector_add) { cuda_tile_view_kernel_invoker(); }
+
+// Exercises Kokkos::TileView with a noncontiguous, rank-1 Kokkos::View:
+// a and b are columns of rank-2 backing views, picked out with a subview,
+// so consecutive elements are actually two floats apart in memory.
+struct TileViewNoncontiguousRank1AddDriver {
+  using BackingViewType =
+      Kokkos::View<float* [2], Kokkos::LayoutRight, Kokkos::Cuda>;
+  using ViewType =
+      decltype(Kokkos::subview(std::declval<BackingViewType const&>(),
+                                Kokkos::ALL, 0));
+  using ShapeType    = cuda::tiles::shape<8>;
+  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+
+  TileViewType a;
+  TileViewType b;
+  TileViewType out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    TileViewType::partition_view_type a_view = a;
+    TileViewType::partition_view_type b_view = b;
+    TileViewType::partition_view_type o_view = out;
+
+    constexpr std::size_t tile_size = 8;
+    const size_t n_tile             = n / tile_size;
+    const size_t n_tile_block       = n_tile / ct::num_blocks().x;
+    const size_t tile_start         = ct::bid().x * n_tile_block;
+    const size_t tile_end           = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b =
+          a_view.load_masked(tile_index) + b_view.load_masked(tile_index);
+      o_view.store_masked(a_plus_b, tile_index);
+    }
+  }
+};
+
+void cuda_tile_view_noncontiguous_rank1_add() {
+  constexpr std::size_t N = 256;
+
+  TileViewNoncontiguousRank1AddDriver::BackingViewType a_full("a_full", N);
+  TileViewNoncontiguousRank1AddDriver::BackingViewType b_full("b_full", N);
+  TileViewNoncontiguousRank1AddDriver::BackingViewType out_full("out_full",
+                                                                 N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        a_full(i, 0)   = i;
+        a_full(i, 1)   = -1;
+        b_full(i, 0)   = 2 * i;
+        b_full(i, 1)   = -1;
+        out_full(i, 0) = -1;
+        out_full(i, 1) = -1;
+      });
+
+  auto a   = Kokkos::subview(a_full, Kokkos::ALL, 0);
+  auto b   = Kokkos::subview(b_full, Kokkos::ALL, 0);
+  auto out = Kokkos::subview(out_full, Kokkos::ALL, 0);
+
+  using ShapeType = TileViewNoncontiguousRank1AddDriver::ShapeType;
+  TileViewNoncontiguousRank1AddDriver driver{
+      Kokkos::TileView<decltype(a), ShapeType>(a),
+      Kokkos::TileView<decltype(b), ShapeType>(b),
+      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileViewNoncontiguousRank1AddDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out_full = Kokkos::create_mirror_view_and_copy(out_full);
+  int errors       = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (h_out_full(i, 0) != float(3 * i)) errors++;
+    // The untouched neighbor column must be unaffected; if TileView were
+    // treating the strided view as contiguous, this would be clobbered.
+    if (h_out_full(i, 1) != -1.0f) errors++;
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_noncontiguous_rank1_add) {
+  cuda_tile_view_noncontiguous_rank1_add();
+}
+
+// Exercises Kokkos::TileView with a noncontiguous, rank-2 Kokkos::View:
+// a and b are 2-D "slabs" of rank-3 backing views, picked out with a
+// subview, so consecutive elements along the second dimension are two
+// floats apart in memory.
+struct TileViewNoncontiguousRank2AddDriver {
+  using BackingViewType =
+      Kokkos::View<float* [4][2], Kokkos::LayoutRight, Kokkos::Cuda>;
+  using ViewType =
+      decltype(Kokkos::subview(std::declval<BackingViewType const&>(),
+                                Kokkos::ALL, Kokkos::ALL, 0));
+  using ShapeType    = cuda::tiles::shape<8, 4>;
+  using TileViewType = Kokkos::TileView<ViewType, ShapeType>;
+
+  TileViewType a;
+  TileViewType b;
+  TileViewType out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    TileViewType::partition_view_type a_view = a;
+    TileViewType::partition_view_type b_view = b;
+    TileViewType::partition_view_type o_view = out;
+
+    // The second dimension has static extent 4, which fits in a single
+    // tile of shape <8, 4>; only the first dimension needs to be tiled.
+    constexpr std::size_t tile_size = 8;
+    const size_t n_tile             = n / tile_size;
+    const size_t n_tile_block       = n_tile / ct::num_blocks().x;
+    const size_t tile_start         = ct::bid().x * n_tile_block;
+    const size_t tile_end           = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b = a_view.load_masked(tile_index, 0) +
+                       b_view.load_masked(tile_index, 0);
+      o_view.store_masked(a_plus_b, tile_index, 0);
+    }
+  }
+};
+
+void cuda_tile_view_noncontiguous_rank2_add() {
+  constexpr std::size_t N = 256;
+
+  TileViewNoncontiguousRank2AddDriver::BackingViewType a_full("a_full", N);
+  TileViewNoncontiguousRank2AddDriver::BackingViewType b_full("b_full", N);
+  TileViewNoncontiguousRank2AddDriver::BackingViewType out_full("out_full",
+                                                                 N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        for (int j = 0; j < 4; ++j) {
+          a_full(i, j, 0)   = i * 4 + j;
+          a_full(i, j, 1)   = -1;
+          b_full(i, j, 0)   = 2 * (i * 4 + j);
+          b_full(i, j, 1)   = -1;
+          out_full(i, j, 0) = -1;
+          out_full(i, j, 1) = -1;
+        }
+      });
+
+  auto a   = Kokkos::subview(a_full, Kokkos::ALL, Kokkos::ALL, 0);
+  auto b   = Kokkos::subview(b_full, Kokkos::ALL, Kokkos::ALL, 0);
+  auto out = Kokkos::subview(out_full, Kokkos::ALL, Kokkos::ALL, 0);
+
+  using ShapeType = TileViewNoncontiguousRank2AddDriver::ShapeType;
+  TileViewNoncontiguousRank2AddDriver driver{
+      Kokkos::TileView<decltype(a), ShapeType>(a),
+      Kokkos::TileView<decltype(b), ShapeType>(b),
+      Kokkos::TileView<decltype(out), ShapeType>(out), N};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileViewNoncontiguousRank2AddDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out_full = Kokkos::create_mirror_view_and_copy(out_full);
+  int errors       = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      if (h_out_full(i, j, 0) != float(3 * (i * 4 + j))) errors++;
+      // The untouched neighbor slab must be unaffected; if TileView were
+      // treating the strided view as contiguous, this would be clobbered.
+      if (h_out_full(i, j, 1) != -1.0f) errors++;
+    }
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_noncontiguous_rank2_add) {
+  cuda_tile_view_noncontiguous_rank2_add();
+}
 
 }  // namespace Test

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -13,11 +13,64 @@ import kokkos.core;
 
 #include <array>
 #include <cstddef>
+#include <type_traits>
+#include <utility>
 
 #include <Cuda/Kokkos_Cuda_KernelLaunchTile.hpp>
 #include <Cuda/Kokkos_Cuda_TileView.hpp>
 
 namespace Test {
+
+template<size_t... Indices>
+constexpr
+cuda::tiles::extents<uint32_t, ((void) Indices, cuda::tiles::dynamic_extent)...>
+all_dynamic_extents_impl(std::index_sequence<Indices...>) {
+  return {};
+}
+
+template<size_t Rank>
+constexpr decltype(all_dynamic_extents_impl(std::make_index_sequence<Rank>()))
+all_dynamic_extents() {
+  return {};
+}
+
+template<size_t Rank>
+using all_dynamic_extents_t = decltype(all_dynamic_extents<Rank>());
+
+static_assert(
+    std::is_same_v<
+        decltype(Kokkos::TileView(
+            std::declval<Kokkos::View<float*, Kokkos::Cuda> const&>(),
+            cuda::tiles::shape<8>{}))::extents_type,
+        all_dynamic_extents_t<1>>);
+
+static_assert(
+    std::is_same_v<
+        decltype(Kokkos::TileView(
+            std::declval<Kokkos::View<float***, Kokkos::Cuda> const&>(),
+            cuda::tiles::shape<8, 16, 32>{}))::extents_type,
+        all_dynamic_extents_t<3>>);
+
+static_assert(
+    std::is_same_v<
+        decltype(Kokkos::TileView(
+            std::declval<Kokkos::View<float[32], Kokkos::Cuda> const&>(),
+            cuda::tiles::shape<8>{}))::extents_type,
+        cuda::tiles::extents<uint32_t, 4>>);
+
+static_assert(
+    std::is_same_v<
+        decltype(Kokkos::TileView(
+            std::declval<Kokkos::View<float[128][32], Kokkos::Cuda> const&>(),
+            cuda::tiles::shape<2, 8>{}))::extents_type,
+        cuda::tiles::extents<uint32_t, 64, 4>>);
+
+static_assert(
+    std::is_same_v<
+        decltype(Kokkos::TileView(
+            std::declval<Kokkos::View<float*[128], Kokkos::Cuda> const&>(),
+            cuda::tiles::shape<8, 4>{}))::extents_type,
+        cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent, 32>>);
 
 __tile_global__ void tile_vector_add(float* __restrict__ a,
                                      float* __restrict__ b,
@@ -338,10 +391,15 @@ TEST(cuda, tile_view_noncontiguous_rank1_add) {
 struct TileViewNoncontiguousRank2AddDriver {
   using BackingViewType =
       Kokkos::View<float* [4][2], Kokkos::LayoutRight, Kokkos::Cuda>;
-  using ShapeType   = cuda::tiles::shape<8, 4>;
-  using TileType    = cuda::tiles::tile<float, ShapeType>;
-  using ExtentsType = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent,
-                                            cuda::tiles::dynamic_extent>;
+  using ShapeType = cuda::tiles::shape<8, 4>;
+  using TileType  = cuda::tiles::tile<float, ShapeType>;
+  // The subview keeps the second dimension's static extent (4) from
+  // BackingViewType, and the tile shape's corresponding extent is also
+  // 4, so that dimension is exactly one tile wide: TileView's deduction
+  // guide deduces a static tile index space extent of 1 here (not 4,
+  // and not dynamic).
+  using ExtentsType =
+      cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent, 1>;
   using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
 
   TileViewType a;
@@ -429,6 +487,162 @@ void cuda_tile_view_noncontiguous_rank2_add() {
 
 TEST(cuda, tile_view_noncontiguous_rank2_add) {
   cuda_tile_view_noncontiguous_rank2_add();
+}
+
+// Exercises Kokkos::TileView with a fully static, rank-1 Kokkos::View:
+// TileView's deduced Extents (tile index space) is fully static too, and
+// its runtime extent (4 tiles) has to be recovered correctly purely from
+// compile-time information -- there's no dynamic View extent to fall
+// back on.
+struct TileViewStaticExtentAddDriver {
+  using ViewType    = Kokkos::View<float[32], Kokkos::LayoutRight, Kokkos::Cuda>;
+  using ShapeType   = cuda::tiles::shape<8>;
+  using TileType    = cuda::tiles::tile<float, ShapeType>;
+  using ExtentsType = cuda::tiles::extents<uint32_t, 4>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+
+  TileViewType a;
+  TileViewType b;
+  TileViewType out;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    constexpr std::size_t n_tile       = 4;
+    const size_t n_tile_block          = n_tile / ct::num_blocks().x;
+    const size_t tile_start            = ct::bid().x * n_tile_block;
+    const size_t tile_end              = tile_start + n_tile_block;
+    for (size_t tile_index : ct::irange(tile_start, tile_end)) {
+      auto a_plus_b = a.load(tile_index) + b.load(tile_index);
+      out.store(a_plus_b, tile_index);
+    }
+  }
+};
+
+void cuda_tile_view_static_extent_add() {
+  constexpr std::size_t N = 32;
+
+  TileViewStaticExtentAddDriver::ViewType a("A");
+  TileViewStaticExtentAddDriver::ViewType b("B");
+  TileViewStaticExtentAddDriver::ViewType out("Out");
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        a(i) = i;
+        b(i) = 2 * i;
+      });
+
+  TileViewStaticExtentAddDriver::ShapeType shape;
+  TileViewStaticExtentAddDriver driver{Kokkos::TileView(a, shape),
+                                        Kokkos::TileView(b, shape),
+                                        Kokkos::TileView(out, shape)};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileViewStaticExtentAddDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out = Kokkos::create_mirror_view_and_copy(out);
+  int errors = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    if (h_out(i) != float(3 * i)) errors++;
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_static_extent_add) { cuda_tile_view_static_extent_add(); }
+
+// Exercises Kokkos::TileView with a rank-2 Kokkos::View whose first
+// dimension is dynamic and whose second dimension is static, where the
+// static dimension spans *more than one* tile (16 / 4 = 4 tiles) --
+// unlike cuda_tile_view_noncontiguous_rank2_add above, whose static
+// dimension is exactly one tile wide.
+struct TileViewMultiTileStaticDimAddDriver {
+  using ViewType =
+      Kokkos::View<float* [16], Kokkos::LayoutRight, Kokkos::Cuda>;
+  using ShapeType   = cuda::tiles::shape<8, 4>;
+  using TileType    = cuda::tiles::tile<float, ShapeType>;
+  using ExtentsType = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent, 4>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+
+  TileViewType a;
+  TileViewType b;
+  TileViewType out;
+  std::size_t n;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()() const {
+    namespace ct = cuda::tiles;
+
+    constexpr std::size_t tile_size0 = 8;
+    constexpr std::size_t n_tile1    = 4;
+    const size_t n_tile0             = n / tile_size0;
+    const size_t n_tile0_block       = n_tile0 / ct::num_blocks().x;
+    const size_t tile0_start         = ct::bid().x * n_tile0_block;
+    const size_t tile0_end           = tile0_start + n_tile0_block;
+    for (size_t tile0_index : ct::irange(tile0_start, tile0_end)) {
+      for (size_t tile1_index = 0; tile1_index < n_tile1; ++tile1_index) {
+        auto a_plus_b = a.load(tile0_index, tile1_index) +
+                         b.load(tile0_index, tile1_index);
+        out.store(a_plus_b, tile0_index, tile1_index);
+      }
+    }
+  }
+};
+
+void cuda_tile_view_multi_tile_static_dim_add() {
+  constexpr std::size_t N = 256;
+
+  TileViewMultiTileStaticDimAddDriver::ViewType a("A", N);
+  TileViewMultiTileStaticDimAddDriver::ViewType b("B", N);
+  TileViewMultiTileStaticDimAddDriver::ViewType out("Out", N);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      N, KOKKOS_LAMBDA(int i) {
+        for (int j = 0; j < 16; ++j) {
+          a(i, j)   = i * 16 + j;
+          b(i, j)   = 2 * (i * 16 + j);
+          out(i, j) = -1;
+        }
+      });
+
+  TileViewMultiTileStaticDimAddDriver::ShapeType shape;
+  TileViewMultiTileStaticDimAddDriver driver{
+      Kokkos::TileView(a, shape), Kokkos::TileView(b, shape),
+      Kokkos::TileView(out, shape), N};
+
+  using impl_launch_invoker = Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+      TileViewMultiTileStaticDimAddDriver,
+      Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+  dim3 grid{1, 1, 1};
+  impl_launch_invoker::invoke_kernel(
+      driver, grid, cuda_instance.impl_internal_space_instance());
+
+  cuda_instance.fence();
+
+  auto h_out = Kokkos::create_mirror_view_and_copy(out);
+  int errors = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    for (int j = 0; j < 16; ++j) {
+      if (h_out(i, j) != float(3 * (i * 16 + j))) errors++;
+    }
+  }
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_view_multi_tile_static_dim_add) {
+  cuda_tile_view_multi_tile_static_dim_add();
 }
 
 // This driver is templated on the "view-like" type used for its a/b/out

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -284,7 +284,7 @@ struct TileViewVectorAddDriver {
   using ShapeType    = cuda::tiles::shape<8>;
   using TileType     = cuda::tiles::tile<float, ShapeType>;
   using ExtentsType  = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent>;
-  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType, Kokkos::CudaSpace>;
 
   TileViewType a;
   TileViewType b;
@@ -360,7 +360,7 @@ struct TileViewNoncontiguousRank1AddDriver {
   using ShapeType     = cuda::tiles::shape<8>;
   using TileType      = cuda::tiles::tile<float, ShapeType>;
   using ExtentsType   = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent>;
-  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType, Kokkos::CudaSpace>;
 
   TileViewType a;
   TileViewType b;
@@ -454,7 +454,7 @@ struct TileViewNoncontiguousRank2AddDriver {
   // and not dynamic).
   using ExtentsType =
       cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent, 1>;
-  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType, Kokkos::CudaSpace>;
 
   TileViewType a;
   TileViewType b;
@@ -541,7 +541,7 @@ struct TileViewStaticExtentAddDriver {
   using ShapeType   = cuda::tiles::shape<8>;
   using TileType    = cuda::tiles::tile<float, ShapeType>;
   using ExtentsType = cuda::tiles::extents<uint32_t, 4>;
-  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType, Kokkos::CudaSpace>;
 
   TileViewType a;
   TileViewType b;
@@ -612,7 +612,7 @@ struct TileViewMultiTileStaticDimAddDriver {
   using ShapeType   = cuda::tiles::shape<8, 4>;
   using TileType    = cuda::tiles::tile<float, ShapeType>;
   using ExtentsType = cuda::tiles::extents<uint32_t, cuda::tiles::dynamic_extent, 4>;
-  using TileViewType = Kokkos::TileView<TileType, ExtentsType>;
+  using TileViewType = Kokkos::TileView<TileType, ExtentsType, Kokkos::CudaSpace>;
 
   TileViewType a;
   TileViewType b;


### PR DESCRIPTION
# Add `Kokkos::TileView`

## Summary

`Kokkos::TileView` is like a `partition_view`, but it's constructed on host from a `Kokkos::View` and a tile shape.  It presents a subset of `partition_view`'s interface in Tile kernels.  `TileView` does not allocate storage; it is a nonowning view of the input `Kokkos::View`.

`TileView`'s template parameters are the `cuda::tiles::tile` specialization (not the shape, but the actual tile type) and the tile index space extents (that is, the valid index space of load and store indices).

Since `partition_view` can only be created in tile functions, `TileView`'s `load` and `store` functions currently rely on the compiler's ability to optimize out creation of `partition_view` on the fly.  (Tile Python doesn't even expose the analog of `partition_view`, so this is a reasonable implementation choice.)  `TileView` also has a conversion to `partition_view` so users can bypass this.

`TileView`'s constructor checks divisibility restrictions at compile time if possible.  Run-time values are checked via `KOKKOS_ASSERT`.

## Current restrictions

1. `TileView` requires that the `Kokkos::View`'s extents are elementwise exact multiples of the tile's extents.
2. `TileView` only presents unmasked, nonatomic `load` and `store`.  (This is related to (1).  A key use case for masked loads and stores is partial out-of-bounds access.  Fully out-of-bounds access is UB for `partition_view`.)
3. `TileView`'s underlying `tensor_view` is always `layout_strided`, because `Kokkos::LayoutLeft` and `Kokkos::LayoutRight` actually mean `std::layout_left_padded<std::dynamic_extent>` and `std::layout_right_padded<std::dynamic_extent>`, respectively.

## TODO list

- [x] Can create `Kokkos::TileView` on host and use it in tile kernels
- [x] Can get a `ct::partition_view` from it
- [x] It actually implements the load and store functions from `partition_view`'s interface.
- [x] `TileView`'s constructor checks divisibility preconditions.
- [x] CTAD works (this requires a deduction guide).
- [x] `TileView` is templated on the `ct::tile` specialization and the tile index space `ct::extents` specialization.
- [x] `TileView` has a `MemorySpace` template parameter.  `TileView` is a nonallocating view of its input `Kokkos::View`, so it only needs a `MemorySpace` template parameter, not an `ExecutionSpace`.

## To figure out

- [ ] `TileView` has template parameters (TileType, TileIndexSpaceExtentsType, Layout, MemorySpace).  
 
What should the Layout be?  Presumably this is the layout of the input `Kokkos::View`.  This would preserve `Kokkos::LayoutLeft` / `Kokkos::LayoutRight` information at compile time, even though `partition_view` cannot because of the aforementioned restriction.  However, we could create an `explicit` constructor that takes a `cuda::tiles` layout in order for users to assert that the input `Kokkos::View` is not padded.

## Future work

We might like to tile up an arbitrary subset of input extents.  Examples:

* `<M, N, P>` -> `<M/B0, N/B1, P/B2>`
* `<M, N, P, B0, B1>` -> `<M, N, P> x <B0, B1>`
* `<M, N, P>` -> `<M, N/B0, P/B1>`

`partition_view` requires that the `tensor_span` and tile shape have the same rank.  We could implement this by adjusting the tile shape internally so that "untiled" extents have compile-time extent 1, and by adjusting loads and stores to fill in compile-time 0 for indices of untiled extents.