### PR TITLE
Make `push_finalize_hook` thread-safe

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -24,6 +24,7 @@
 #include <stack>
 #include <functional>
 #include <cerrno>
+#include <mutex>
 #include <random>
 #include <regex>
 #ifndef _WIN32
@@ -41,7 +42,16 @@ bool g_show_warnings       = true;
 bool g_tune_internals      = false;
 
 using hook_function_type = std::function<void()>;
-std::stack<hook_function_type> finalize_hooks;
+
+std::mutex& finalize_hooks_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::stack<hook_function_type>& finalize_hooks() {
+  static std::stack<hook_function_type> hooks;
+  return hooks;
+}
 
 /**
  * The category is only used in printing, tools
@@ -769,10 +779,11 @@ void initialize_internal(const Kokkos::InitializationSettings& settings) {
 // function throws
 // NOLINTNEXTLINE(bugprone-exception-escape)
 void call_registered_finalize_hook_functions() noexcept {
-  while (!finalize_hooks.empty()) {
-    auto const& func = finalize_hooks.top();
+  std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
+  while (!finalize_hooks().empty()) {
+    auto const& func = finalize_hooks().top();
     func();
-    finalize_hooks.pop();
+    finalize_hooks().pop();
   }
 }
 
@@ -1066,7 +1077,8 @@ void Kokkos::Impl::pre_finalize() { pre_finalize_internal(); }
 void Kokkos::Impl::post_finalize() { post_finalize_internal(); }
 
 void Kokkos::push_finalize_hook(std::function<void()> f) {
-  finalize_hooks.push(f);
+  std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
+  finalize_hooks().push(std::move(f));
 }
 
 void Kokkos::finalize() {

--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -779,11 +779,14 @@ void initialize_internal(const Kokkos::InitializationSettings& settings) {
 // function throws
 // NOLINTNEXTLINE(bugprone-exception-escape)
 void call_registered_finalize_hook_functions() noexcept {
-  std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
+  std::function<void()> func;
   while (!finalize_hooks().empty()) {
-    auto const& func = finalize_hooks().top();
+    {
+      std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
+      func = std::move(finalize_hooks().top());
+      finalize_hooks().pop();
+    }
     func();
-    finalize_hooks().pop();
   }
 }
 

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -144,4 +144,22 @@ TEST_F(PushFinalizeHook_DeathTest, thread_safe) {
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
+// Registering a hook from within a running finalize hook must not deadlock,
+// since finalize_hooks_mutex is not held while a hook is being called.
+TEST_F(PushFinalizeHook_DeathTest, recursive) {
+  EXPECT_EXIT(
+      {
+        bool hook_from_hook_ran = false;
+        Kokkos::push_finalize_hook([&hook_from_hook_ran] {
+          Kokkos::push_finalize_hook(
+              [&hook_from_hook_ran] { hook_from_hook_ran = true; });
+        });
+        Kokkos::initialize(
+            Kokkos::InitializationSettings().set_disable_warnings(true));
+        Kokkos::finalize();
+        std::exit(hook_from_hook_ran ? EXIT_SUCCESS : EXIT_FAILURE);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+
 }  // namespace

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -115,7 +115,7 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
 
 TEST_F(PushFinalizeHook_DeathTest, thread_safe) {
   EXPECT_EXIT(
-      ({
+      ([] {
         constexpr int num_pushes_1 = 8;
         constexpr int num_pushes_2 = 4;
         constexpr int num_pushes_3 = 2;
@@ -140,7 +140,7 @@ TEST_F(PushFinalizeHook_DeathTest, thread_safe) {
         std::exit(count == num_pushes_1 + num_pushes_2 + num_pushes_3
                       ? EXIT_SUCCESS
                       : EXIT_FAILURE);
-      }),
+      }()),
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -113,12 +113,14 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
-TEST_F(PushFinalizeHook_DeathTest, tread_safe) {
-  GTEST_FLAG_SET(death_test_style, "fast");
+TEST_F(PushFinalizeHook_DeathTest, thread_safe) {
   EXPECT_EXIT(
       ({
-        int count = 0;
-        // generates a nullary callable that push n times a callback to
+        constexpr int num_pushes_1 = 8;
+        constexpr int num_pushes_2 = 4;
+        constexpr int num_pushes_3 = 2;
+        int count                  = 0;
+        // generates a nullary callable that pushes n times a callback to
         // increment the counter by one
         auto push_increment_n = [&count](int n) {
           return [&count, n] {
@@ -128,16 +130,18 @@ TEST_F(PushFinalizeHook_DeathTest, tread_safe) {
         };
         Kokkos::initialize(
             Kokkos::InitializationSettings().set_disable_warnings(true));
-        std::thread t1(push_increment_n(8));
-        std::thread t2(push_increment_n(4));
-        std::thread t3(push_increment_n(2));
+        std::thread t1(push_increment_n(num_pushes_1));
+        std::thread t2(push_increment_n(num_pushes_2));
+        std::thread t3(push_increment_n(num_pushes_3));
         t1.join();
         t2.join();
         t3.join();
         Kokkos::finalize();
-        std::exit(14 - count);
+        std::exit(count == num_pushes_1 + num_pushes_2 + num_pushes_3
+                      ? EXIT_SUCCESS
+                      : EXIT_FAILURE);
       }),
-      ::testing::ExitedWithCode(0), "");
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
 }  // namespace

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -14,6 +14,7 @@ import kokkos.core;
 #include <exception>
 #include <iostream>
 #include <string>
+#include <thread>
 
 #include "KokkosExecutionEnvironmentNeverInitializedFixture.hpp"
 
@@ -110,6 +111,33 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+
+TEST_F(PushFinalizeHook_DeathTest, tread_safe) {
+  GTEST_FLAG_SET(death_test_style, "fast");
+  EXPECT_EXIT(
+      ({
+        int count = 0;
+        // generates a nullary callable that push n times a callback to
+        // increment the counter by one
+        auto push_increment_n = [&count](int n) {
+          return [&count, n] {
+            for (int i = 0; i < n; ++i)
+              Kokkos::push_finalize_hook([&count] { ++count; });
+          };
+        };
+        Kokkos::initialize(
+            Kokkos::InitializationSettings().set_disable_warnings(true));
+        std::thread t1(push_increment_n(8));
+        std::thread t2(push_increment_n(4));
+        std::thread t3(push_increment_n(2));
+        t1.join();
+        t2.join();
+        t3.join();
+        Kokkos::finalize();
+        std::exit(14 - count);
+      }),
+      ::testing::ExitedWithCode(0), "");
 }
 
 }  // namespace


### PR DESCRIPTION
Addressing https://github.com/kokkos/kokkos/issues/9479#issuecomment-5431002640
Make `push_finalize_hook` thread-safe to align it with `std::atexit`.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs
#9479 
<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
* Make `push_finalize_hook` thread-safe 

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
* kokkos/kokkos-core-wiki#915
