### PR TITLE
[CUDA-Tile] Add TileMDRangePolicy and parallel_for specialization

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -487,4 +487,8 @@ class ParallelReduce<CombinedFunctorReducerType,
 }  // namespace Kokkos::Impl
 #endif
 
+#ifdef KOKKOS_ENABLE_CUDA_TILE
+#include <Cuda/Kokkos_Cuda_Parallel_MDRangeTile.hpp>
+#endif
+
 #endif  // KOKKOS_CUDA_PARALLEL_MD_RANGE_HPP

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRangeTile.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRangeTile.hpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright Contributors to the Kokkos project
+
+#ifndef KOKKOS_CUDA_PARALLEL_MDRANGETILE_HPP
+#define KOKKOS_CUDA_PARALLEL_MDRANGETILE_HPP
+
+#include <algorithm>
+
+#include <Kokkos_Macros.hpp>
+#include <Kokkos_Parallel.hpp>
+#include <KokkosExp_MDRangePolicy.hpp>
+#include <Cuda/Kokkos_Cuda_KernelLaunchTile.hpp>
+
+#include <cuda_tile.h>
+
+namespace Kokkos::Impl {
+
+template <class FunctorType, class... Traits>
+class ParallelFor<FunctorType,
+                  Kokkos::Experimental::TileMDRangePolicy<Traits...>,
+                  Kokkos::Cuda> {
+ public:
+  using Policy       = Kokkos::Experimental::TileMDRangePolicy<Traits...>;
+  using functor_type = FunctorType;
+
+ private:
+  using array_index_type = typename Policy::array_index_type;
+  using index_type       = typename Policy::index_type;
+  using MaxGridSize      = Kokkos::Array<array_index_type, 3>;
+  using array_type       = typename Policy::point_type;
+
+  const FunctorType m_functor;
+  const Policy m_policy;
+  const MaxGridSize m_max_grid_size;
+
+  array_type m_lower;
+  array_type m_upper;
+  array_type m_extent;
+
+ public:
+  Policy const& get_policy() const { return m_policy; }
+
+  inline __tile__ void operator()() const {
+    if constexpr (Policy::rank() == 1) {
+      m_functor(cuda::tiles::bid().x + m_lower[0]);
+    } else if constexpr (Policy::rank() == 2) {
+      m_functor(cuda::tiles::bid().x + m_lower[0],
+                cuda::tiles::bid().y + m_lower[1]);
+    } else if constexpr (Policy::rank() == 3) {
+      m_functor(cuda::tiles::bid().x + m_lower[0],
+                cuda::tiles::bid().y + m_lower[1],
+                cuda::tiles::bid().z + m_lower[2]);
+    }
+  }
+
+  inline void execute() const {
+    // make sure the grid dimensions don't exceed the max number of blocks
+    // allowed
+    const auto check_grid_sizes = [&]([[maybe_unused]] const dim3& grid) {
+      KOKKOS_ASSERT(grid.x > 0 &&
+                    grid.x <= static_cast<unsigned int>(m_max_grid_size[0]));
+      KOKKOS_ASSERT(grid.y > 0 &&
+                    grid.y <= static_cast<unsigned int>(m_max_grid_size[1]));
+      KOKKOS_ASSERT(grid.z > 0 &&
+                    grid.z <= static_cast<unsigned int>(m_max_grid_size[2]));
+    };
+
+    dim3 grid;
+    if constexpr (Policy::rank() == 1) {
+      grid = dim3{static_cast<unsigned>(m_extent[0]), 1u, 1u};
+    } else if constexpr (Policy::rank() == 2) {
+      grid = dim3{static_cast<unsigned>(m_extent[0]),
+                  static_cast<unsigned>(m_extent[1]), 1u};
+    } else if constexpr (Policy::rank() == 3) {
+      grid = dim3{static_cast<unsigned>(m_extent[0]),
+                  static_cast<unsigned>(m_extent[1]),
+                  static_cast<unsigned>(m_extent[2])};
+    } else {
+      // Will not happen since we static assert in the TileMDRangePolicy
+      Kokkos::abort("Unsupported TileMDRangePolicy Rank");
+    }
+    // ensure we don't exceed the capability of the device
+    check_grid_sizes(grid);
+
+    using impl_launch_invoker =
+        Kokkos::Impl::CudaParallelLaunchTileKernelInvoker<
+            ParallelFor, Kokkos::Impl::CudaLaunchMechanism::GlobalMemory>;
+
+    impl_launch_invoker::invoke_kernel(
+        *this, grid, m_policy.space().impl_internal_space_instance());
+  }  // end execute
+
+  //  inline
+  ParallelFor(const FunctorType& arg_functor, Policy arg_policy)
+      : m_functor(arg_functor),
+        m_policy(arg_policy),
+        m_max_grid_size({
+            m_policy.space().cuda_device_prop().maxGridSize[0],
+            m_policy.space().cuda_device_prop().maxGridSize[1],
+            m_policy.space().cuda_device_prop().maxGridSize[2],
+        }) {
+    // Initialize begins and ends based on layout
+    // Swap the fastest indexes to x dimension
+    for (array_index_type i = 0; i < Policy::rank(); ++i) {
+      m_lower[i]  = m_policy.lower(i);
+      m_upper[i]  = m_policy.upper(i);
+      m_extent[i] = m_upper[i] - m_lower[i];
+    }
+  }
+};
+
+}  // namespace Kokkos::Impl
+
+#endif  // KOKKOS_CUDA_PARALLEL_MDRANGETILE_HPP

--- a/core/src/KokkosExp_MDRangePolicy.hpp
+++ b/core/src/KokkosExp_MDRangePolicy.hpp
@@ -532,4 +532,63 @@ MDRangePolicy(ES const&, Array<T, N> const&, Array<T, N> const&,
 
 }  // namespace Kokkos
 
+// TODO: this should become KOKKOS_ENABLE_TILE when we have a fallback impl
+#ifdef KOKKOS_ENABLE_CUDA_TILE
+// TileMDRangePolicy
+namespace Kokkos::Experimental {
+
+// TODO: inherit privately, and explicitly pull in base class members
+template <class... Properties>
+class TileMDRangePolicy : private MDRangePolicy<Properties...> {
+  using base_t = MDRangePolicy<Properties...>;
+
+ public:
+  using execution_policy = TileMDRangePolicy;
+
+  // import for now the members we actually need, since we are throwing away
+  // tiling
+  using execution_space  = base_t::execution_space;
+  using array_index_type = base_t::array_index_type;
+  using index_type       = base_t::index_type;
+  using point_type       = base_t::point_type;
+  using work_tag         = base_t::work_tag;
+  using base_t::inner_direction;
+
+  using base_t::space;
+
+  KOKKOS_FUNCTION
+  static constexpr size_t rank() { return base_t::rank; }
+
+  static_assert(rank() > 0 && rank() < 3,
+                "TileMDRangePolicy only supports rank 1-3");
+
+  template <class T>
+  TileMDRangePolicy(const execution_space& work_space,
+                    Kokkos::Array<T, rank()> const& lower,
+                    Kokkos::Array<T, rank()> const& upper)
+      : base_t(work_space, lower, upper, []() {
+          Kokkos::Array<T, rank()> a;
+          for (int i = 0; i < rank(); i++) a[i] = 1;
+          return a;
+        }()) {}
+
+  TileMDRangePolicy(const execution_space& work_space, point_type const& lower,
+                    point_type const& upper)
+      : base_t(work_space, lower, upper, []() {
+          point_type a;
+          for (int i = 0; i < rank(); i++) a[i] = 1;
+          return a;
+        }()) {}
+
+  auto lower(size_t r) const { return base_t::m_lower[r]; }
+  auto upper(size_t r) const { return base_t::m_upper[r]; }
+  auto num_tiles() const { return base_t::m_num_tiles; }
+
+  static_assert(
+      std::is_same_v<typename base_t::execution_space, Kokkos::Cuda>,
+      "TileMDRangePolicy is only supported for the Cuda execution space");
+};
+}  // namespace Kokkos::Experimental
+#endif
+
 #endif  // KOKKOS_CORE_EXP_MD_RANGE_POLICY_HPP

--- a/core/src/Kokkos_Array.hpp
+++ b/core/src/Kokkos_Array.hpp
@@ -78,14 +78,26 @@ struct Array {
     return N;
   }
 
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   KOKKOS_INLINE_FUNCTION constexpr reference operator[](size_type i) {
+// FIXME-TILE: we can't support bounds checking in tile mode yet,
+// and there is no way to distinguish tile compilation vs
+// CUDA scalar compilation
+#ifndef KOKKOS_ENABLE_CUDA_TILE
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
+#endif
     return m_internal_implementation_private_member_data[i];
   }
 
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
   KOKKOS_INLINE_FUNCTION constexpr const_reference operator[](
       size_type i) const {
+// FIXME-TILE: we can't support bounds checking in tile mode yet,
+// and there is no way to distinguish tile compilation vs
+// CUDA scalar compilation
+#ifndef KOKKOS_ENABLE_CUDA_TILE
     KOKKOS_ARRAY_BOUNDS_CHECK(i, N);
+#endif
     return m_internal_implementation_private_member_data[i];
   }
 

--- a/core/unit_test/cuda/TestCuda_Tile.cpp
+++ b/core/unit_test/cuda/TestCuda_Tile.cpp
@@ -161,4 +161,66 @@ void cuda_tile_kernel_invoker() {
 
 TEST(cuda, tile_kernel_invoker) { cuda_tile_kernel_invoker(); }
 
+template <size_t TileSize>
+struct TileVectorAddFunctor {
+  float* a;
+  float* b;
+  float* out;
+  int N, M;
+
+  KOKKOS_EXPERIMENTAL_TILE_FUNCTION
+  void operator()(int i, int j) const {
+    namespace ct = cuda::tiles;
+    using namespace ct::literals;
+
+    auto shape  = ct::shape<TileSize, TileSize>{};
+    auto extent = ct::extents{N, M};
+
+    auto a_view = ct::partition_view{ct::tensor_span{a, extent}, shape};
+    auto b_view = ct::partition_view{ct::tensor_span{b, extent}, shape};
+    auto o_view = ct::partition_view{ct::tensor_span{out, extent}, shape};
+
+    auto a_plus_b = a_view.load(i, j) + b_view.load(i, j);
+    o_view.store(a_plus_b, i, j);
+  }
+};
+
+void cuda_tile_parallel_for() {
+  int N = 32;
+  int M = 24;
+
+  constexpr int tile_size = 8;
+
+  Kokkos::View<float**, Kokkos::Cuda> a("A", N, M);
+  Kokkos::View<float**, Kokkos::Cuda> b("B", N, M);
+  Kokkos::View<float**, Kokkos::Cuda> out("Out", N, M);
+
+  Kokkos::Cuda cuda_instance;
+
+  Kokkos::parallel_for(
+      Kokkos::MDRangePolicy<Kokkos::Cuda, Kokkos::Rank<2>>(cuda_instance,
+                                                           {0, 0}, {N, M}),
+      KOKKOS_LAMBDA(int i, int j) {
+        a(i, j) = 1000 * i + j;
+        b(i, j) = 2000 * i + 2 * j;
+      });
+
+  Kokkos::parallel_for(
+      Kokkos::Experimental::TileMDRangePolicy<Kokkos::Cuda, Kokkos::Rank<2>>(
+          cuda_instance, {0, 0}, {N / tile_size, M / tile_size}),
+      TileVectorAddFunctor<tile_size>{a.data(), b.data(), out.data(), N, M});
+
+  int errors;
+  Kokkos::parallel_reduce(
+      Kokkos::MDRangePolicy<Kokkos::Cuda, Kokkos::Rank<2>>(cuda_instance,
+                                                           {0, 0}, {N, M}),
+      KOKKOS_LAMBDA(int i, int j, int& error) {
+        if (out(i, j) != 3000 * i + 3 * j) error++;
+      },
+      errors);
+  ASSERT_EQ(errors, 0);
+}
+
+TEST(cuda, tile_parallel_for) { cuda_tile_parallel_for(); }
+
 }  // namespace Test


### PR DESCRIPTION
This introduces parallel_for with a TileMDRangePolicy. The policy type inherits privately from MDRangePolicy, and then makes public some members we actually need right now.

Tiling doesn't make sense for example.

I also only support 1-3D right now and only 2D is tested. 