### PR TITLE
Fix warnings for self similar RangePolicy interface when instantiating for a host execution space in a CUDA build

### DIFF
--- a/core/src/HPX/Kokkos_HPX.hpp
+++ b/core/src/HPX/Kokkos_HPX.hpp
@@ -187,8 +187,12 @@ class HPX {
 
 #pragma GCC diagnostic pop
 
-  ~HPX() {
-    Kokkos::Impl::check_execution_space_destructor_precondition(name());
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~HPX() {
+    KOKKOS_IF_ON_HOST(
+        (Kokkos::Impl::check_execution_space_destructor_precondition(name());))
   }
   explicit HPX(instance_mode mode)
       : m_instance_data(

--- a/core/src/OpenMP/Kokkos_OpenMP.cpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.cpp
@@ -19,10 +19,6 @@
 
 namespace Kokkos {
 
-OpenMP::~OpenMP() {
-  Impl::check_execution_space_destructor_precondition(name());
-}
-
 OpenMP::OpenMP()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),

--- a/core/src/OpenMP/Kokkos_OpenMP.hpp
+++ b/core/src/OpenMP/Kokkos_OpenMP.hpp
@@ -18,6 +18,7 @@ static_assert(false,
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_Parallel.hpp>
 #include <Kokkos_Layout.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_HostSharedPtr.hpp>
 #include <impl/Kokkos_Profiling_Interface.hpp>
 #include <impl/Kokkos_InitializationSettings.hpp>
@@ -59,7 +60,14 @@ class OpenMP {
   KOKKOS_FUNCTION OpenMP& operator=(OpenMP&& other) noexcept {
     return *this = static_cast<const OpenMP&>(other);
   }
-  ~OpenMP();
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~OpenMP() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
+
   OpenMP();
 
   explicit OpenMP(int pool_size);

--- a/core/src/Serial/Kokkos_Serial.cpp
+++ b/core/src/Serial/Kokkos_Serial.cpp
@@ -152,10 +152,6 @@ void SerialInternal::resize_thread_team_data(size_t pool_reduce_bytes,
 }
 }  // namespace Impl
 
-Serial::~Serial() {
-  Impl::check_execution_space_destructor_precondition(name());
-}
-
 Serial::Serial()
     : m_space_instance(
           (Impl::check_execution_space_constructor_precondition(name()),

--- a/core/src/Serial/Kokkos_Serial.hpp
+++ b/core/src/Serial/Kokkos_Serial.hpp
@@ -25,6 +25,7 @@ static_assert(false,
 #include <Kokkos_HostSpace.hpp>
 #include <Kokkos_ScratchSpace.hpp>
 #include <Kokkos_MemoryTraits.hpp>
+#include <impl/Kokkos_CheckUsage.hpp>
 #include <impl/Kokkos_HostThreadTeam.hpp>
 #include <impl/Kokkos_FunctorAnalysis.hpp>
 #include <impl/Kokkos_Tools.hpp>
@@ -107,7 +108,14 @@ class Serial {
   KOKKOS_FUNCTION Serial& operator=(Serial&& other) noexcept {
     return *this = static_cast<const Serial&>(other);
   }
-  ~Serial();
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~Serial() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
+
   Serial();
 
   explicit Serial(NewInstance);

--- a/core/src/Threads/Kokkos_Threads.hpp
+++ b/core/src/Threads/Kokkos_Threads.hpp
@@ -110,7 +110,13 @@ class Threads {
     return *this = static_cast<const Threads&>(other);
   }
 
-  ~Threads() { Impl::check_execution_space_destructor_precondition(name()); }
+  // Must be __host__ __device__ for the implicitly defined
+  // ~RangePolicy<ExecSpace>(); see the comment on ~Cuda() in
+  // Cuda/Kokkos_Cuda.hpp.
+  KOKKOS_FUNCTION ~Threads() {
+    KOKKOS_IF_ON_HOST(
+        (Impl::check_execution_space_destructor_precondition(name());))
+  }
 
   Threads() { Impl::check_execution_space_constructor_precondition(name()); }
 

--- a/core/unit_test/range_policy/TestRangePolicyExecutionTypes.hpp
+++ b/core/unit_test/range_policy/TestRangePolicyExecutionTypes.hpp
@@ -22,22 +22,21 @@ KOKKOS_INLINE_FUNCTION int check_runtime_inputs(
 }
 
 void test_self_similar_range_policy_runtime() {
-  using IndexType = typename Kokkos::DefaultExecutionSpace::size_type;
+  using IndexType = typename TEST_EXECSPACE::size_type;
 
   IndexType beg        = 5;
   IndexType end        = 15;
   IndexType chunk_size = 10;
 
-  auto p_execspace =
-      Kokkos::RangePolicy(Kokkos::DefaultExecutionSpace(), beg, end);
+  auto p_execspace = Kokkos::RangePolicy<TEST_EXECSPACE>(beg, end);
   auto nerrs_exec_space =
       check_runtime_inputs(p_execspace, beg, end, chunk_size);
   ASSERT_EQ(nerrs_exec_space, 0);
 
   int nerrs_team_handle;
-  using team_t = typename Kokkos::TeamPolicy<>::member_type;
+  using team_t = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
   Kokkos::parallel_reduce(
-      "check_runtime", Kokkos::TeamPolicy(1, Kokkos::AUTO()),
+      "check_runtime", Kokkos::TeamPolicy<TEST_EXECSPACE>(1, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const team_t& team, int& nerrs) {
         auto p_teamhandle = Kokkos::RangePolicy(team, beg, end);
         auto tvr          = Kokkos::TeamVectorRange(team, beg, end);
@@ -59,27 +58,28 @@ void test_self_similar_range_policy_computation() {
   size_t N         = 7;
   size_t num_teams = 5;
 
-  Kokkos::View<float*> v_x("v_x", N), v_y("v_y", N);
-  Kokkos::View<float**> M_x("M_x", num_teams, N), M_y("M_y", num_teams, N);
+  Kokkos::View<float*, TEST_EXECSPACE> v_x("v_x", N), v_y("v_y", N);
+  Kokkos::View<float**, TEST_EXECSPACE> M_x("M_x", num_teams, N),
+      M_y("M_y", num_teams, N);
 
   // Initialize v_x and v_y with values from 1 to N
   Kokkos::parallel_for(
-      "init_v_x", Kokkos::RangePolicy<>(0, N),
+      "init_v_x", Kokkos::RangePolicy<TEST_EXECSPACE>(0, N),
       KOKKOS_LAMBDA(const int& i) { v_x(i) = static_cast<float>(i + 1); });
   Kokkos::parallel_for(
-      "init_v_y", Kokkos::RangePolicy<>(0, N),
+      "init_v_y", Kokkos::RangePolicy<TEST_EXECSPACE>(0, N),
       KOKKOS_LAMBDA(const int& i) { v_y(i) = static_cast<float>(i + 1); });
 
   // Initialize M_x and M_y with values from 1 to M (flattened index)
   Kokkos::parallel_for(
-      "init_M_x", Kokkos::RangePolicy<>(0, num_teams),
+      "init_M_x", Kokkos::RangePolicy<TEST_EXECSPACE>(0, num_teams),
       KOKKOS_LAMBDA(const int& i) {
         for (size_t j = 0; j < N; j++) {
           M_x(i, j) = static_cast<float>(i * N + j + 1);
         }
       });
   Kokkos::parallel_for(
-      "init_M_y", Kokkos::RangePolicy<>(0, num_teams),
+      "init_M_y", Kokkos::RangePolicy<TEST_EXECSPACE>(0, num_teams),
       KOKKOS_LAMBDA(const int& i) {
         for (size_t j = 0; j < N; j++) {
           M_y(i, j) = static_cast<float>(i * N + j + 1);
@@ -87,12 +87,13 @@ void test_self_similar_range_policy_computation() {
       });
 
   // Call sum_views(ExecSpace):
-  sum_views(Kokkos::DefaultExecutionSpace(), v_x, v_y);
+  sum_views(TEST_EXECSPACE(), v_x, v_y);
 
   // Call sum_views(TeamHandle)
-  using team_t = typename Kokkos::TeamPolicy<>::member_type;
+  using team_t = typename Kokkos::TeamPolicy<TEST_EXECSPACE>::member_type;
   Kokkos::parallel_for(
-      "apxyFromTeam", Kokkos::TeamPolicy(num_teams, Kokkos::AUTO()),
+      "apxyFromTeam",
+      Kokkos::TeamPolicy<TEST_EXECSPACE>(num_teams, Kokkos::AUTO()),
       KOKKOS_LAMBDA(const team_t& team) {
         sum_views(team, Kokkos::subview(M_x, team.league_rank(), Kokkos::ALL()),
                   Kokkos::subview(M_y, team.league_rank(), Kokkos::ALL()));
@@ -101,14 +102,14 @@ void test_self_similar_range_policy_computation() {
   // Check v_x
   size_t result = 0;
   Kokkos::parallel_reduce(
-      "Check1", v_x.extent(0),
+      "Check1", Kokkos::RangePolicy<TEST_EXECSPACE>(0, v_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& val) { val += v_x(i); }, result);
   size_t expected_v_x = N * (N + 1);
   ASSERT_EQ(result, expected_v_x);
 
   // Check individual elements of v_x
   Kokkos::parallel_reduce(
-      "Check1_elements", v_x.extent(0),
+      "Check1_elements", Kokkos::RangePolicy<TEST_EXECSPACE>(0, v_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& errors) {
         float expected = static_cast<float>(2 * (i + 1));
         if (v_x(i) != expected) ++errors;
@@ -119,7 +120,7 @@ void test_self_similar_range_policy_computation() {
   // Check M_x
   result = 0;
   Kokkos::parallel_reduce(
-      "Check2", M_x.extent(0),
+      "Check2", Kokkos::RangePolicy<TEST_EXECSPACE>(0, M_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& val) {
         for (int j = 0; j < M_x.extent_int(1); j++) val += M_x(i, j);
       },
@@ -130,7 +131,7 @@ void test_self_similar_range_policy_computation() {
 
   // Check individual elements of M_x
   Kokkos::parallel_reduce(
-      "Check2_elements", M_x.extent(0),
+      "Check2_elements", Kokkos::RangePolicy<TEST_EXECSPACE>(0, M_x.extent(0)),
       KOKKOS_LAMBDA(int i, size_t& errors) {
         for (int j = 0; j < M_x.extent_int(1); j++) {
           float expected = static_cast<float>(2 * (i * N + j + 1));


### PR DESCRIPTION
This PR fixes warnings related to the self similar interface of RangePolicy where we had a lack in testing.
The PR also adds the tests. ~This is a cleanup of #9458~

Alternative approaches got to convoluted/didn't reliably work. I went back to what Patrick did initially - work around the issue in the dtors of the Host execution spaces.  