### PR TITLE
Put constexpr In case of AtomicAccessorRelaxed for offset and access

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -244,9 +244,9 @@ struct AtomicAccessorRelaxed {
   KOKKOS_FUNCTION explicit operator default_accessor<OtherElementType>() const {
     return default_accessor<OtherElementType>{};
   }
-
+  
   KOKKOS_FUNCTION
-  reference access(
+  constexpr reference access(
 #ifndef KOKKOS_ENABLE_OPENACC
       const data_handle_type& p,
 #else
@@ -258,7 +258,7 @@ struct AtomicAccessorRelaxed {
   }
 
   KOKKOS_FUNCTION
-  data_handle_type offset(
+  constexpr data_handle_type offset(
 #ifndef KOKKOS_ENABLE_OPENACC
       const data_handle_type& p,
 #else

--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -244,7 +244,7 @@ struct AtomicAccessorRelaxed {
   KOKKOS_FUNCTION explicit operator default_accessor<OtherElementType>() const {
     return default_accessor<OtherElementType>{};
   }
-  
+
   KOKKOS_FUNCTION
   constexpr reference access(
 #ifndef KOKKOS_ENABLE_OPENACC

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -116,6 +116,13 @@ void test_ref_counted_data_handle() {
   ASSERT_FALSE(h_errors & 8);
   ASSERT_FALSE(h_errors & 16);
 }
+TEST(TEST_CATEGORY, AtomicAccessor_Constexpr_Error) {
+  constexpr Kokkos::Impl::AtomicAccessorRelaxed<float> atomic_acc{};
+  static float dummy_data[10] = {}; 
+  constexpr float* dummy_ptr = dummy_data;
+  constexpr float* offset_ptr = atomic_acc.offset(dummy_ptr, 5); 
+  (void)offset_ptr; 
+}
 // clang-format on
 
 TEST(TEST_CATEGORY, RefCountedDataHandle) {

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -118,10 +118,10 @@ void test_ref_counted_data_handle() {
 }
 TEST(TEST_CATEGORY, AtomicAccessor_Constexpr_Error) {
   constexpr Kokkos::Impl::AtomicAccessorRelaxed<float> atomic_acc{};
-  static float dummy_data[10] = {}; 
+  static float dummy_data[10] = {};
   constexpr float* dummy_ptr = dummy_data;
-  constexpr float* offset_ptr = atomic_acc.offset(dummy_ptr, 5); 
-  (void)offset_ptr; 
+  constexpr float* offset_ptr = atomic_acc.offset(dummy_ptr, 5);
+  (void)offset_ptr;
 }
 // clang-format on
 


### PR DESCRIPTION
While reviewing  accessor in  `/Kokkos_MDSpan_Accessor.hpp`, I noticed there was missing function specifier which limits the compile time usage. This PR add those cases.

adding `constexpr`  in front of offset and access.
Also added the Test case for that.

Assisted-by: Gemini-3.1
### Related issues / PRs



### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
   Not required

-->

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
