### PR TITLE
Force finding GTest in Config mode

### DIFF
--- a/cmake/kokkos_tribits.cmake
+++ b/cmake/kokkos_tribits.cmake
@@ -7,7 +7,7 @@ include(GNUInstallDirs)
 message(STATUS "The project name is: ${PROJECT_NAME}")
 
 if(Kokkos_ENABLE_TESTS OR Kokkos_INSTALL_TESTING)
-  find_package(GTest QUIET 1.14.0)
+  find_package(GTest 1.14.0 CONFIG QUIET)
   if(GTest_FOUND)
     message(STATUS "Found external GoogleTest: ${GTest_DIR} (version \"${GTest_VERSION}\")")
   else()


### PR DESCRIPTION
Our `icpx` CI is currently failing because it find a `GTest` version without proper version or exporting `GTest_DIR`.
This pull request proposes to switch to `CONFIG` mode for detection which still works in the Windows CI where we are explicitly requesting to find an external GTest.

### Related issues / PRs

- Follow-up to #9473 and #9475