### PR TITLE
View alloc without initializing in MD stream benchmark

### DIFF
--- a/core/perf_test/PerfTestMDRange_Stream.hpp
+++ b/core/perf_test/PerfTestMDRange_Stream.hpp
@@ -196,17 +196,27 @@ struct MDStreamTest {
     long N6 = N3 * N3;
     std::string view_name(name);
     if constexpr (Rank == 1) {
-      return view_type(view_name, N6);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N6);
     } else if constexpr (Rank == 2) {
-      return view_type(view_name, N3, N3);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N3, N3);
     } else if constexpr (Rank == 3) {
-      return view_type(view_name, N2, N2, N2);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N2, N2,
+          N2);
     } else if constexpr (Rank == 4) {
-      return view_type(view_name, N2, N1, N1, N2);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N2, N1,
+          N1, N2);
     } else if constexpr (Rank == 5) {
-      return view_type(view_name, N1, N1, N2, N1, N1);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N1, N1,
+          N2, N1, N1);
     } else if constexpr (Rank == 6) {
-      return view_type(view_name, N1, N1, N1, N1, N1, N1);
+      return view_type(
+          Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N1, N1,
+          N1, N1, N1, N1);
     }
   }
 

--- a/core/perf_test/PerfTestMDRange_Stream.hpp
+++ b/core/perf_test/PerfTestMDRange_Stream.hpp
@@ -195,6 +195,11 @@ struct MDStreamTest {
     long N3 = N2 * N1;
     long N6 = N3 * N3;
     std::string view_name(name);
+    // FIXME: First-touch allocation of Views via the execution of
+    // `hostspace_parallel_zeromemset` in
+    // `core/src/impl/Kokkos_HostSpace_deepcopy.cpp` needs to be investigated
+    // such that MDRangePolicy can be optimally run on zero-initialized
+    // Views, instead of first defining uninitialized Views.
     if constexpr (Rank == 1) {
       return view_type(
           Kokkos::view_alloc(view_name, Kokkos::WithoutInitializing), N6);


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->

In the Stream benchmark, we are currently allocating the Views when they are getting defined. Later we initialize the Views with an MDRangePolicy that executes in the same manner as the MDRangePolicy for the performance tests.

Earlier, the understanding was that the underlying `RangePolicy` based `parallel_for` that is used for allocating the Views (refer to this [PR](https://github.com/kokkos/kokkos/pull/8178)), will be good enough to take care of NUMA effects. However, we have been seeing that it is not the case. For example, check [this branch](https://github.com/crtrott/kokkos/tree/triad-benchmark) of @crtrott. There are some subtleties involving the tile dimensions etc and how the elements are distributed in `MDRangePolicy`, as compared to `RangePolicy`.

Performance numbers have been generated with and without this change, for the following different settings, on an AMD EPYC 9654 CPU:
* `OMP_PROC_BIND` = `close` or `spread`
* Input Views having 16<sup>6</sup> or 32<sup>6</sup> elements.

The element type was `double` in all cases.

~The performance numbers can be compiled and shared here if needed.~ But the change is quite straightforward to appreciate why it is needed.
[Here](https://github.com/kokkos/kokkos/pull/9492#issuecomment-5479385950) are the numbers for `OMP_PROC_BIND=close` for 16<sup>6</sup> elements of type `double` with 64 threads on OpenMP backend.

The code changes needed for the Stencil benchmark have also been made. But it has to be benchmarked.

### Changelog Entry
  - Not required

### Documentation PR
  - Not required
