### PR TITLE
Fix clang-tidy-23 warnings 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-random-generator-seed,
+  -bugprone-signed-bitwise,
   -bugprone-suspicious-include,
   -bugprone-throwing-static-initialization,
   cppcoreguidelines-pro-type-cstyle-cast,

--- a/benchmarks/bytes_and_flops/main.cpp
+++ b/benchmarks/bytes_and_flops/main.cpp
@@ -62,12 +62,12 @@ int main(int argc, char* argv[]) {
 
   int B = 2;
   if (argc >= 11) {
-    B = std::atoi(argv[10]);
+    B = std::stoi(argv[10]);
   }
 
   int I = 10;
   if (argc >= 12) {
-    I = std::atoi(argv[11]);
+    I = std::stoi(argv[11]);
   }
 
   if (U > 8) {

--- a/benchmarks/gups/gups.cpp
+++ b/benchmarks/gups/gups.cpp
@@ -160,13 +160,13 @@ int main(int argc, char* argv[]) {
 
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--indices") == 0) {
-      indices = std::atoll(argv[i + 1]);
+      indices = std::stoll(argv[i + 1]);
       ++i;
     } else if (strcmp(argv[i], "--data") == 0) {
-      data = std::atoll(argv[i + 1]);
+      data = std::stoll(argv[i + 1]);
       ++i;
     } else if (strcmp(argv[i], "--repeats") == 0) {
-      repeats = std::atoll(argv[i + 1]);
+      repeats = std::stoll(argv[i + 1]);
       ++i;
     } else if (strcmp(argv[i], "--atomics") == 0) {
       useAtomics = true;

--- a/benchmarks/launch_latency/launch_latency.cpp
+++ b/benchmarks/launch_latency/launch_latency.cpp
@@ -245,11 +245,11 @@ int main(int argc, char* argv[]) {
         // signing off that arg.data() is null terminated
         // NOLINTBEGIN(bugprone-suspicious-stringview-data-usage)
         if (i == 1)
-          N = atoi(arg.data());
+          N = std::stoi(arg.data());
         else if (i == 2)
-          M = atoi(arg.data());
+          M = std::stoi(arg.data());
         else if (i == 3)
-          K = atoi(arg.data());
+          K = std::stoi(arg.data());
         // NOLINTEND(bugprone-suspicious-stringview-data-usage)
         else {
           Kokkos::abort("unexpected argument!");

--- a/benchmarks/view_copy_constructor/view_copy_constructor.cpp
+++ b/benchmarks/view_copy_constructor/view_copy_constructor.cpp
@@ -260,13 +260,13 @@ int main(int argc, char* argv[]) {
 
   for (int i = 0; i < argc; i++) {
     if ((strcmp(argv[i], "-N") == 0)) {
-      N = atoi(argv[++i]);
+      N = std::stoi(argv[++i]);
       if (N < 1) {
         std::cout << "Array extent must be >= 1" << std::endl;
         exit(1);
       }
     } else if (strcmp(argv[i], "-i") == 0) {
-      num_iter = atoi(argv[++i]);
+      num_iter = std::stoi(argv[++i]);
       if (num_iter < 1) {
         std::cout << "Number of iterations must be >= 1" << std::endl;
         exit(1);

--- a/core/src/Kokkos_GraphNode.hpp
+++ b/core/src/Kokkos_GraphNode.hpp
@@ -519,8 +519,7 @@ class GraphNodeRef {
 
     //----------------------------------------
     // This is a disaster, but I guess it's not a my disaster to fix right now
-    using return_type_remove_cvref =
-        std::remove_cv_t<std::remove_reference_t<ReturnType>>;
+    using return_type_remove_cvref = std::remove_cvref_t<ReturnType>;
     static_assert(Kokkos::is_view<return_type_remove_cvref>::value ||
                       Kokkos::is_reducer<return_type_remove_cvref>::value,
                   "Output argument to parallel reduce in a graph must be a "

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -105,7 +105,8 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
         Kokkos::initialize();
         Kokkos::finalize();
         // legal to register after finalize but will never be called
-        Kokkos::push_finalize_hook([] { throw std::runtime_error("42"); });
+        Kokkos::push_finalize_hook(
+            [] { throw std::runtime_error("never actually thrown"); });
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -105,7 +105,7 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
         Kokkos::initialize();
         Kokkos::finalize();
         // legal to register after finalize but will never be called
-        Kokkos::push_finalize_hook([] { throw 42; });
+        Kokkos::push_finalize_hook([] { throw std::runtime_error("42"); });
         std::exit(EXIT_SUCCESS);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");


### PR DESCRIPTION
This should fix the extra clang-tidy warnings, we are now seeing after the Mac OS X build switched to clang++-23.
The addressed checks are:
- bugprone-signed-bitwise: ignore
- bugprone-unchecked-string-to-number-conversion: replace `std::ato.*` with `std::sto*`.
- modernize-type-traits: Use `std::remove_cvref_t`.
- bugprone-std-exception-baseclass: Don't throw `int` but `std::runtime_error`. We don't catch it anyway.

All but the first a very easy to address and this pull requests just ignores it to get our CI going again.

### Related issues / PRs

- All pull requests since Friday
- #7575

### Changelog Entry

- No

### Documentation PR

- No