### PR TITLE
[5.2.2] Workaround warnings with std::pair as subview slice specifiers in relaxed constexpr mode

### DIFF
--- a/core/src/Kokkos_Pair.hpp
+++ b/core/src/Kokkos_Pair.hpp
@@ -84,7 +84,7 @@ struct pair {
 
   // from std::pair<U,V>
   template <class U, class V>
-  pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
+  constexpr pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
 
   /// \brief Return the std::pair version of this object.
   ///
@@ -129,7 +129,7 @@ struct pair<T1&, T2&> {
 
   // from std::pair<U,V>
   template <class U, class V>
-  pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
+  constexpr pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
 
   /// \brief Assignment operator.
   ///
@@ -186,7 +186,7 @@ struct pair<T1, T2&> {
 
   // from std::pair<U,V>
   template <class U, class V>
-  pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
+  constexpr pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
 
   /// \brief Assignment operator.
   ///
@@ -243,7 +243,7 @@ struct pair<T1&, T2> {
 
   // from std::pair<U,V>
   template <class U, class V>
-  pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
+  constexpr pair(const std::pair<U, V>& p) : first(p.first), second(p.second) {}
 
   /// \brief Assignment operator.
   ///
@@ -382,7 +382,7 @@ template <typename T1, typename T2>
 struct is_std_pair<std::pair<T1, T2>> : std::true_type {};
 
 template <typename T>
-auto convert_to_kokkos_pair_if_std_pair(T t) {
+constexpr auto convert_to_kokkos_pair_if_std_pair(T t) {
   if constexpr (is_std_pair<T>::value)
     return Kokkos::pair<typename T::first_type, typename T::second_type>{t};
   else

--- a/core/src/Kokkos_View.hpp
+++ b/core/src/Kokkos_View.hpp
@@ -970,8 +970,22 @@ class View
   // Compatible subview constructor
   // may assign unmanaged from managed.
 
+// This annotation lets std::pair slice arguments be used from device code
+// when relaxed constexpr support is enabled, while avoiding warnings about
+// calling a host function from a host device function: constexpr alone is
+// enough to silence that warning, including when using Clang (and its
+// derivatives, e.g. hipcc, amdclang++) as the device compiler.  NVCC is the
+// exception: there, constexpr alone instead triggers the warning, so we use
+// KOKKOS_FUNCTION in that specific configuration.
+#if defined(KOKKOS_COMPILER_NVCC) && defined(KOKKOS_ENABLE_CUDA_CONSTEXPR)
+#define KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER KOKKOS_FUNCTION
+#else
+#define KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER constexpr
+#endif
+
   template <class RT, class... RP, class Arg0, class... Args>
-  View(const View<RT, RP...>& src_view, const Arg0 arg0, Args... args)
+  KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER View(const View<RT, RP...>& src_view,
+                                              const Arg0 arg0, Args... args)
       : base_t(Impl::subview_ctor_tag, src_view,
                Impl::convert_to_kokkos_pair_if_std_pair(arg0),
                Impl::convert_to_kokkos_pair_if_std_pair(args)...) {}
@@ -1639,9 +1653,12 @@ struct ApplyToViewOfStaticRank {
 //----------------------------------------------------------------------------
 
 template <class D, class... P, class... Args>
-auto subview(const View<D, P...>& src, Args... args) {
+KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER auto subview(const View<D, P...>& src,
+                                                    Args... args) {
   return subview(src, Impl::convert_to_kokkos_pair_if_std_pair(args)...);
 }
+
+#undef KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER
 
 // std::pair isn't device-compatible
 template <class D, class... P, class... Args>

--- a/core/src/View/Kokkos_ViewMapping.hpp
+++ b/core/src/View/Kokkos_ViewMapping.hpp
@@ -374,11 +374,27 @@ struct SubviewExtents {
 
 #endif
 
+// This annotation lets std::pair slice arguments be used from device code
+// when relaxed constexpr support is enabled, while avoiding warnings about
+// calling a host function from a host device function: constexpr alone is
+// enough to silence that warning, including when using Clang (and its
+// derivatives, e.g. hipcc, amdclang++) as the device compiler.  NVCC is the
+// exception: there, constexpr alone instead triggers the warning, so we use
+// KOKKOS_FUNCTION in that specific configuration.
+#if defined(KOKKOS_COMPILER_NVCC) && defined(KOKKOS_ENABLE_CUDA_CONSTEXPR)
+#define KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER KOKKOS_FUNCTION
+#else
+#define KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER constexpr
+#endif
+
  public:
   template <size_t... DimArgs, class... Args>
-  SubviewExtents(const ViewDimension<DimArgs...>& dim, Args... args)
+  KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER SubviewExtents(
+      const ViewDimension<DimArgs...>& dim, Args... args)
       : SubviewExtents(dim, Impl::convert_to_kokkos_pair_if_std_pair(args)...) {
   }
+
+#undef KOKKOS_IMPL_SUBVIEW_STD_PAIR_SPECIFIER
 
   // std::pair isn't device-compatible
   template <size_t... DimArgs, class... Args>

--- a/core/unit_test/TestSubView_c13.hpp
+++ b/core/unit_test/TestSubView_c13.hpp
@@ -11,5 +11,12 @@ TEST(TEST_CATEGORY, view_test_unmanaged_subview_reset) {
   TestViewSubview::test_unmanaged_subview_reset<TEST_EXECSPACE>();
 }
 
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_CONSTEXPR)
+TEST(TEST_CATEGORY, view_subview_std_pair_in_kernel) {
+  TEST_EXECSPACE::execution_space exec;
+  (void)TestViewSubview::TestSubviewStdPairInKernel(exec);
+}
+#endif
+
 }  // namespace Test
 #endif

--- a/core/unit_test/TestViewSubview.hpp
+++ b/core/unit_test/TestViewSubview.hpp
@@ -2100,6 +2100,40 @@ void test_unmanaged_subview_reset() {
 
 //----------------------------------------------------------------------------
 
+// std::pair slice arguments to Kokkos::subview are only usable from device
+// code when relying on relaxed constexpr support (see
+// https://github.com/kokkos/kokkos/issues/9460).
+#if !defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_CUDA_CONSTEXPR)
+template <class Space>
+struct TestSubviewStdPairInKernel {
+  Kokkos::View<int*, Space> a;
+
+  KOKKOS_FUNCTION void operator()(int) const {
+    auto sa = Kokkos::View<int*, Space>(a, std::pair<int, int>{0, 1});
+    sa(0)   = 3;
+    sa      = Kokkos::subview(a, std::pair<int, int>{1, 3});
+    sa(0)   = 2;
+    sa(1)   = 1;
+  }
+
+  TestSubviewStdPairInKernel(Space const& exec)
+      : a(Kokkos::view_alloc(exec, "a"), 3) {
+    run(exec);
+  }
+
+  void run(Space const& exec) {
+    Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 1), *this);
+    auto ha = Kokkos::create_mirror_view_and_copy(a);
+    EXPECT_EQ(ha[0], 3);
+    EXPECT_EQ(ha[1], 2);
+    EXPECT_EQ(ha[2], 1);
+  }
+};
+
+#endif
+
+//----------------------------------------------------------------------------
+
 template <std::underlying_type_t<Kokkos::MemoryTraitsFlags> MTF>
 struct TestSubviewMemoryTraitsConstruction {
   void operator()() const {


### PR DESCRIPTION
Cherry-picking #9467 into the 5.2.2 RC branch

Note that because `develop` had removed the legacy view implementation, the cherry-pick had conflicts which I resolved hastily so you might want to review carefully.

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs
PR being back ported: #9467
Original work that caused the warnings: #9264
<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
Pick from the original PR or the 5.3 changelog

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
N/A