### PR TITLE
Guard fpclassify subnormal checks with runtime FTZ/DAZ detection

### DIFF
--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -18,6 +18,7 @@ import kokkos.core;
 #include <type_traits>
 #include <cstdint>
 #include <cfloat>
+#include <limits>
 
 #include "KokkosTest_Utils.hpp"
 
@@ -2366,6 +2367,34 @@ TEST(TEST_CATEGORY, mathematical_functions_isinf) {
   TestIsInf<TEST_EXECSPACE>();
 }
 
+// Determine, at runtime, whether the floating-point environment flushes
+// subnormal (denormal) values to zero (FTZ/DAZ).
+//
+// This cannot be answered by the preprocessor: some compilers (notably
+// NVHPC/nvc++) enable FTZ/DAZ by default -- at every optimization level --
+// WITHOUT defining __FINITE_MATH_ONLY__ (and while __STDC_IEC_559__,
+// std::numeric_limits<T>::is_iec559, has_denorm, etc. all still report that
+// subnormals exist). Flushing is a property of the runtime FP environment, so
+// it must be detected by actually exercising it. The same reasoning applies to
+// device execution, so the probe runs wherever the test does.
+//
+// We probe once (thread-safe Meyers-singleton initialization) by forcing
+// subnormal values through 'volatile' storage -- which defeats constant folding
+// so the real runtime FP environment governs the result -- and checking whether
+// they read back as zero.
+KOKKOS_INLINE_FUNCTION bool runtime_fp_env_flushes_to_zero() {
+  static bool ret = [] {
+    volatile float fdenorm  = Kokkos::denorm_min_v<float>;
+    volatile double ddenorm = Kokkos::denorm_min_v<double>;
+    volatile float fmin     = Kokkos::norm_min_v<float>;
+    volatile double dmin    = Kokkos::norm_min_v<double>;
+    bool flushed            = (fdenorm == 0.0f) || (ddenorm == 0.0) ||
+                   ((fmin / 2.0f) == 0.0f) || ((dmin / 2.0) == 0.0);
+    return flushed;
+  }();
+  return ret;
+}
+
 template <class Space>
 struct TestFpClassify {
   TestFpClassify() { run(); }
@@ -2391,10 +2420,10 @@ struct TestFpClassify {
 #if !__FINITE_MATH_ONLY__
         || fpclassify(signaling_NaN<float>::value) != FP_NAN ||
         fpclassify(quiet_NaN<float>::value) != FP_NAN ||
-        fpclassify(infinity<float>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<float>::value) != FP_SUBNORMAL
+        fpclassify(infinity<float>::value) != FP_INFINITE
 #endif
-    ) {
+        || (!runtime_fp_env_flushes_to_zero() &&
+            fpclassify(denorm_min<float>::value) != FP_SUBNORMAL)) {
       ++e;
       Kokkos::printf("failed fpclassify(float)\n");
     }
@@ -2404,10 +2433,10 @@ struct TestFpClassify {
 #if !__FINITE_MATH_ONLY__
         || fpclassify(signaling_NaN<double>::value) != FP_NAN ||
         fpclassify(quiet_NaN<double>::value) != FP_NAN ||
-        fpclassify(infinity<double>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<double>::value) != FP_SUBNORMAL
+        fpclassify(infinity<double>::value) != FP_INFINITE
 #endif
-    ) {
+        || (!runtime_fp_env_flushes_to_zero() &&
+            fpclassify(denorm_min<double>::value) != FP_SUBNORMAL)) {
       ++e;
       Kokkos::printf("failed fpclassify(double)\n");
     }
@@ -2418,10 +2447,10 @@ struct TestFpClassify {
 #if !__FINITE_MATH_ONLY__
         || fpclassify(signaling_NaN<long double>::value) != FP_NAN ||
         fpclassify(quiet_NaN<long double>::value) != FP_NAN ||
-        fpclassify(infinity<long double>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<long double>::value) != FP_SUBNORMAL
+        fpclassify(infinity<long double>::value) != FP_INFINITE
 #endif
-    ) {
+        || (!runtime_fp_env_flushes_to_zero() &&
+            fpclassify(denorm_min<long double>::value) != FP_SUBNORMAL)) {
       ++e;
       Kokkos::printf("failed fpclassify(long double)\n");
     }
@@ -2437,9 +2466,15 @@ struct TestFpClassify {
         // FIXME internal compiler error for Clang+Cuda and RDC
         || fpclassify(signaling_NaN<KE::half_t>::value) != FP_NAN ||
         fpclassify(quiet_NaN<KE::half_t>::value) != FP_NAN ||
-        fpclassify(infinity<KE::half_t>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<KE::half_t>::value) != FP_SUBNORMAL
+        fpclassify(infinity<KE::half_t>::value) != FP_INFINITE
 #endif
+#endif
+#if !(defined(KOKKOS_ENABLE_CUDA) &&                         \
+      defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) && \
+      defined(KOKKOS_COMPILER_CLANG))
+        // FIXME_CUDA internal compiler error for Clang+Cuda and RDC
+        || (!runtime_fp_env_flushes_to_zero() &&
+            fpclassify(denorm_min<KE::half_t>::value) != FP_SUBNORMAL)
 #endif
     ) {
       ++e;
@@ -2452,10 +2487,10 @@ struct TestFpClassify {
 #if !__FINITE_MATH_ONLY__
         || fpclassify(signaling_NaN<KE::bhalf_t>::value) != FP_NAN ||
         fpclassify(quiet_NaN<KE::bhalf_t>::value) != FP_NAN ||
-        fpclassify(infinity<KE::bhalf_t>::value) != FP_INFINITE ||
-        fpclassify(denorm_min<KE::bhalf_t>::value) != FP_SUBNORMAL
+        fpclassify(infinity<KE::bhalf_t>::value) != FP_INFINITE
 #endif
-    ) {
+        || (!runtime_fp_env_flushes_to_zero() &&
+            fpclassify(denorm_min<KE::bhalf_t>::value) != FP_SUBNORMAL)) {
       ++e;
       Kokkos::printf("failed fpclassify(Kokkos::Experimental::bhalf_t)\n");
     }

--- a/core/unit_test/TestMathematicalFunctions.hpp
+++ b/core/unit_test/TestMathematicalFunctions.hpp
@@ -2383,16 +2383,13 @@ TEST(TEST_CATEGORY, mathematical_functions_isinf) {
 // so the real runtime FP environment governs the result -- and checking whether
 // they read back as zero.
 KOKKOS_INLINE_FUNCTION bool runtime_fp_env_flushes_to_zero() {
-  static bool ret = [] {
-    volatile float fdenorm  = Kokkos::denorm_min_v<float>;
-    volatile double ddenorm = Kokkos::denorm_min_v<double>;
-    volatile float fmin     = Kokkos::norm_min_v<float>;
-    volatile double dmin    = Kokkos::norm_min_v<double>;
-    bool flushed            = (fdenorm == 0.0f) || (ddenorm == 0.0) ||
-                   ((fmin / 2.0f) == 0.0f) || ((dmin / 2.0) == 0.0);
-    return flushed;
-  }();
-  return ret;
+  volatile float fdenorm  = Kokkos::denorm_min_v<float>;
+  volatile double ddenorm = Kokkos::denorm_min_v<double>;
+  volatile float fmin     = Kokkos::norm_min_v<float>;
+  volatile double dmin    = Kokkos::norm_min_v<double>;
+  bool flushed            = (fdenorm == 0.0f) || (ddenorm == 0.0) ||
+                 ((fmin / 2.0f) == 0.0f) || ((dmin / 2.0) == 0.0);
+  return flushed;
 }
 
 template <class Space>


### PR DESCRIPTION
## Summary

`mathematical_functions_fpclassify` fails on compilers that flush subnormals to
zero (FTZ/DAZ) by default — notably **NVHPC (`nvc++`)**. The test checks
`fpclassify(denorm_min) == FP_SUBNORMAL`, but when subnormals are flushed the
`denorm_min` value is treated as `0`, so `fpclassify` returns `FP_ZERO` and the
test reports e.g. `failed fpclassify(float)`.

These subnormal checks were guarded by `__FINITE_MATH_ONLY__`, which is **not a
reliable indicator of subnormal flushing**:

- NVHPC enables FTZ/DAZ **by default** *without* defining `__FINITE_MATH_ONLY__`
  (or `__FAST_MATH__`), so the guard does not fire and the test fails.
- Conversely, `__FINITE_MATH_ONLY__` can be defined without any change to
  subnormal handling (it concerns NaN/Inf, i.e. finite-math-only semantics, not
  denormal flushing).

Subnormal flushing is a property of the **runtime floating-point environment**,
so it must be detected by *running* code, not by inspecting a preprocessor macro.

## What this PR does

- Adds a new function, `runtime_fp_env_flushes_to_zero()` to the test header.  This
  function checks the current state of FTZ/DAZ in the given compiler and reports
  whether FTZ is in effect.  Then the test is modified to call this function and report
  accordingly.

## Reproducer

```cpp
#include <cmath>
#include <limits>
#include <cstdio>
int main() {
  volatile float d = std::numeric_limits<float>::denorm_min();
  std::printf("FP_SUBNORMAL? %d\n", std::fpclassify(d) == FP_SUBNORMAL);
}
```

With NVHPC 26.5 at `-O1` this prints `FP_SUBNORMAL? 0` (misclassified); with
`-Kieee` it prints `1`. In both cases `__FINITE_MATH_ONLY__` is **undefined**.

## Test

- **Compilers:** NVHPC `nvc++` 26.5-0 (reproduced on a newer internal dev build too);
  GCC 13.3.0 / Clang 18.1.3 for the macro/flush comparison.
- **Backend/arch:** Serial, x86-64 (`-tp znver1` / `Kokkos_ARCH_NATIVE`).
- Before: `serial.mathematical_functions_fpclassify` fails under NVHPC defaults.
- After: configure reports `Subnormal floating-point values are FLUSHED to zero`
  and defines `KOKKOS_IMPL_FLUSH_SUBNORMAL 1`; the test passes. With `-Kieee`
  configure reports subnormals preserved, the macro is `0`, and the denorm checks
  run as before.

## Related issues / PRs

Fixes #9501 

## Changelog Entry
The mathematical_functions_fpclassify unit test checks that fpclassify(denorm_min) == FP_SUBNORMAL. This fails on compilers that flush subnormals to zero (FTZ/DAZ) by default -- notably NVHPC (nvc++) -- because the subnormal input is treated as zero and fpclassify returns FP_ZERO.

These checks were previously guarded by __FINITE_MATH_ONLY__, but that macro is not a reliable indicator of subnormal flushing. NVHPC enables FTZ/DAZ by default without defining __FINITE_MATH_ONLY__ (or __FAST_MATH__), and conversely the macro can be defined without changing subnormal handling. Subnormal flushing is a property of the runtime floating-point environment, not of finite-math-only semantics, so it must be detected by running code rather than by inspecting a preprocessor macro.

Detect subnormal flushing at runtime by calling a new function, `runtime_fp_env_flushes_to_zero()`,  which has been added to the test header.  This function checks the current state of FTZ/DAZ in the given compiler and reports whether FTZ is in effect.  Then the test is modified to call this function and report accordingly.

## Documentation PR
Unsure
