### PR TITLE
remove unused alias ReferenceCountedDataHandle::reference

### DIFF
--- a/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
+++ b/core/src/View/MDSpan/Kokkos_MDSpan_Accessor.hpp
@@ -279,7 +279,6 @@ class ReferenceCountedDataHandle {
  public:
   using value_type   = ElementType;
   using pointer      = value_type*;
-  using reference    = value_type&;
   using memory_space = MemorySpace;
 
   KOKKOS_DEFAULTED_FUNCTION

--- a/core/unit_test/view/TestReferenceCountedDataHandle.hpp
+++ b/core/unit_test/view/TestReferenceCountedDataHandle.hpp
@@ -29,7 +29,6 @@ using const_data_handle_anonym_t =
 TEST(TEST_CATEGORY, RefCountedDataHandle_Typedefs) {
   static_assert(std::is_same_v<data_handle_t::value_type, element_t>);
   static_assert(std::is_same_v<data_handle_t::pointer, element_t*>);
-  static_assert(std::is_same_v<data_handle_t::reference, element_t&>);
   static_assert(std::is_same_v<data_handle_t::memory_space, mem_t>);
 }
 


### PR DESCRIPTION
Didn't use this thing anywhere, and not required for accessor::data_handle_type as far as I know:



> typename A::data_handle_type
Result: A type that models copyable, and for which is_nothrow_move_constructible_v<A​::​data_handle_type> is true, is_nothrow_move_assignable_v<A​::​data_handle_type> is true, and is_nothrow_swappable_v<A​::​data_handle_type> is true.
The type of data_handle_type need not be element_type*

[source](https://eel.is/c++draft/mdspan.accessor#reqmts-itemdecl:2)