### PR TITLE
Revert "Make `push_finalize_hook` thread-safe"

### DIFF
--- a/core/src/impl/Kokkos_Core.cpp
+++ b/core/src/impl/Kokkos_Core.cpp
@@ -24,7 +24,6 @@
 #include <stack>
 #include <functional>
 #include <cerrno>
-#include <mutex>
 #include <random>
 #include <regex>
 #ifndef _WIN32
@@ -42,16 +41,7 @@ bool g_show_warnings       = true;
 bool g_tune_internals      = false;
 
 using hook_function_type = std::function<void()>;
-
-std::mutex& finalize_hooks_mutex() {
-  static std::mutex mutex;
-  return mutex;
-}
-
-std::stack<hook_function_type>& finalize_hooks() {
-  static std::stack<hook_function_type> hooks;
-  return hooks;
-}
+std::stack<hook_function_type> finalize_hooks;
 
 /**
  * The category is only used in printing, tools
@@ -779,14 +769,10 @@ void initialize_internal(const Kokkos::InitializationSettings& settings) {
 // function throws
 // NOLINTNEXTLINE(bugprone-exception-escape)
 void call_registered_finalize_hook_functions() noexcept {
-  std::function<void()> func;
-  while (!finalize_hooks().empty()) {
-    {
-      std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
-      func = std::move(finalize_hooks().top());
-      finalize_hooks().pop();
-    }
+  while (!finalize_hooks.empty()) {
+    auto const& func = finalize_hooks.top();
     func();
+    finalize_hooks.pop();
   }
 }
 
@@ -1080,8 +1066,7 @@ void Kokkos::Impl::pre_finalize() { pre_finalize_internal(); }
 void Kokkos::Impl::post_finalize() { post_finalize_internal(); }
 
 void Kokkos::push_finalize_hook(std::function<void()> f) {
-  std::lock_guard<std::mutex> lock(finalize_hooks_mutex());
-  finalize_hooks().push(std::move(f));
+  finalize_hooks.push(f);
 }
 
 void Kokkos::finalize() {

--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -14,7 +14,6 @@ import kokkos.core;
 #include <exception>
 #include <iostream>
 #include <string>
-#include <thread>
 
 #include "KokkosExecutionEnvironmentNeverInitializedFixture.hpp"
 
@@ -109,55 +108,6 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
         Kokkos::push_finalize_hook(
             [] { throw std::runtime_error("never actually thrown"); });
         std::exit(EXIT_SUCCESS);
-      },
-      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
-}
-
-TEST_F(PushFinalizeHook_DeathTest, thread_safe) {
-  EXPECT_EXIT(
-      ([] {
-        constexpr int num_pushes_1 = 8;
-        constexpr int num_pushes_2 = 4;
-        constexpr int num_pushes_3 = 2;
-        int count                  = 0;
-        // generates a nullary callable that pushes n times a callback to
-        // increment the counter by one
-        auto push_increment_n = [&count](int n) {
-          return [&count, n] {
-            for (int i = 0; i < n; ++i)
-              Kokkos::push_finalize_hook([&count] { ++count; });
-          };
-        };
-        Kokkos::initialize(
-            Kokkos::InitializationSettings().set_disable_warnings(true));
-        std::thread t1(push_increment_n(num_pushes_1));
-        std::thread t2(push_increment_n(num_pushes_2));
-        std::thread t3(push_increment_n(num_pushes_3));
-        t1.join();
-        t2.join();
-        t3.join();
-        Kokkos::finalize();
-        std::exit(count == num_pushes_1 + num_pushes_2 + num_pushes_3
-                      ? EXIT_SUCCESS
-                      : EXIT_FAILURE);
-      }()),
-      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
-}
-
-// Registering a hook from within a running finalize hook must not deadlock,
-// since finalize_hooks_mutex is not held while a hook is being called.
-TEST_F(PushFinalizeHook_DeathTest, recursive) {
-  EXPECT_EXIT(
-      {
-        bool hook_from_hook_ran = false;
-        Kokkos::push_finalize_hook([&hook_from_hook_ran] {
-          Kokkos::push_finalize_hook(
-              [&hook_from_hook_ran] { hook_from_hook_ran = true; });
-        });
-        Kokkos::initialize(
-            Kokkos::InitializationSettings().set_disable_warnings(true));
-        Kokkos::finalize();
-        std::exit(hook_from_hook_ran ? EXIT_SUCCESS : EXIT_FAILURE);
       },
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }


### PR DESCRIPTION
Reverts kokkos/kokkos#9484

Causing segfaults downstream with
```C++
std::atexit([]{ Kokkos::finalize(); });
```

I can reproduce locally.  The fix is nonobvious so I propose to play it safe and revert.
I will come back with test coverage.