### PR TITLE
Add test for finalize via atexit with push_finalize_hook

### DIFF
--- a/core/unit_test/TestPushFinalizeHook.cpp
+++ b/core/unit_test/TestPushFinalizeHook.cpp
@@ -112,4 +112,20 @@ TEST_F(PushFinalizeHook_DeathTest, ignore_late_registration) {
       ::testing::ExitedWithCode(EXIT_SUCCESS), "");
 }
 
+TEST_F(PushFinalizeHook_DeathTest, finalizes_at_exit) {
+  EXPECT_EXIT(
+      {
+        static bool finalize_hook_called = false;
+        std::atexit([] {
+          if (!finalize_hook_called) std::_Exit(EXIT_FAILURE);
+        });
+        Kokkos::initialize(
+            Kokkos::InitializationSettings().set_disable_warnings(true));
+        Kokkos::push_finalize_hook([] { finalize_hook_called = true; });
+        std::atexit([] { Kokkos::finalize(); });
+        std::exit(EXIT_SUCCESS);
+      },
+      ::testing::ExitedWithCode(EXIT_SUCCESS), "");
+}
+
 }  // namespace


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.6-terra

I asked Codex to improve the test I wrote. The agent suggested better names and using [std::_Exit](https://en.cppreference.com/cpp/utility/program/_Exit) instead of throwing an exception.

This test fails with #9484.  It covers some downstream use cases, notably in Kokkos Kernels.
<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs
#9484 
#9506
<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
N/A

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
N/A
