### PR TITLE
Combine tagged and untagged cases in KokkosExp_Host_IterateTile.hpp

### DIFF
--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -21,283 +21,6 @@
 namespace Kokkos {
 namespace Impl {
 
-// New Loop Macros...
-// parallel_for, non-tagged
-#define KOKKOS_IMPL_APPLY(func, ...) func(__VA_ARGS__);
-
-// LayoutRight
-// d = 0 to start
-#define KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d, ...)   \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
-    KOKKOS_IMPL_APPLY(func, __VA_ARGS__, i0 + m_offset[d])           \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d, ...)         \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {       \
-    KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i1 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d, ...)         \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {       \
-    KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i2 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d, ...)         \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {       \
-    KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i3 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d, ...)         \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {       \
-    KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i4 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d, ...)         \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {       \
-    KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i5 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d, ...)         \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {       \
-    KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i6 + m_offset[d])                                 \
-  }
-
-#define KOKKOS_IMPL_LOOP_R_8(func, type, m_offset, extent, d, ...)         \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {       \
-    KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, d + 1, __VA_ARGS__, \
-                         i7 + m_offset[d])                                 \
-  }
-
-// LayoutLeft
-// d = rank-1 to start
-#define KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d, ...)   \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                        \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) { \
-    KOKKOS_IMPL_APPLY(func, i0 + m_offset[d], __VA_ARGS__)           \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d, ...)   \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) { \
-    KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, d - 1,        \
-                         i1 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d, ...)   \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) { \
-    KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, d - 1,        \
-                         i2 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d, ...)   \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) { \
-    KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, d - 1,        \
-                         i3 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d, ...)   \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) { \
-    KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, d - 1,        \
-                         i4 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d, ...)   \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) { \
-    KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, d - 1,        \
-                         i5 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d, ...)   \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) { \
-    KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, d - 1,        \
-                         i6 + m_offset[d], __VA_ARGS__)              \
-  }
-
-#define KOKKOS_IMPL_LOOP_L_8(func, type, m_offset, extent, d, ...)   \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) { \
-    KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, d - 1,        \
-                         i7 + m_offset[d], __VA_ARGS__)              \
-  }
-
-// Left vs Right
-// TODO: rank not necessary to pass through, can hardcode the values
-#define KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent, rank) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {           \
-    KOKKOS_IMPL_APPLY(func, i0 + m_offset[0])                                  \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
-      KOKKOS_IMPL_LOOP_L_1(func, type, m_offset, extent, rank - 2,             \
-                           i1 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
-      KOKKOS_IMPL_LOOP_R_1(func, type, m_offset, extent, 1, i1 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
-      KOKKOS_IMPL_LOOP_L_2(func, type, m_offset, extent, rank - 2,             \
-                           i2 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
-      KOKKOS_IMPL_LOOP_R_2(func, type, m_offset, extent, 1, i2 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
-      KOKKOS_IMPL_LOOP_L_3(func, type, m_offset, extent, rank - 2,             \
-                           i3 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
-      KOKKOS_IMPL_LOOP_R_3(func, type, m_offset, extent, 1, i3 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
-      KOKKOS_IMPL_LOOP_L_4(func, type, m_offset, extent, rank - 2,             \
-                           i4 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
-      KOKKOS_IMPL_LOOP_R_4(func, type, m_offset, extent, 1, i4 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
-      KOKKOS_IMPL_LOOP_L_5(func, type, m_offset, extent, rank - 2,             \
-                           i5 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
-      KOKKOS_IMPL_LOOP_R_5(func, type, m_offset, extent, 1, i5 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
-      KOKKOS_IMPL_LOOP_L_6(func, type, m_offset, extent, rank - 2,             \
-                           i6 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
-      KOKKOS_IMPL_LOOP_R_6(func, type, m_offset, extent, 1, i6 + m_offset[0])  \
-    }                                                                          \
-  }
-
-#define KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent, rank) \
-  if (is_left) {                                                               \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
-      KOKKOS_IMPL_LOOP_L_7(func, type, m_offset, extent, rank - 2,             \
-                           i7 + m_offset[rank - 1])                            \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
-      KOKKOS_IMPL_LOOP_R_7(func, type, m_offset, extent, 1, i7 + m_offset[0])  \
-    }                                                                          \
-  }
-
-// Partial vs Full Tile
-#define KOKKOS_IMPL_TILE_LOOP_1(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_1(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_2(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_2(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_3(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_3(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_4(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_4(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_5(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_5(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_6(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_6(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_7(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_7(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
-#define KOKKOS_IMPL_TILE_LOOP_8(func, type, is_left, cond, m_offset,         \
-                                extent_full, extent_partial, rank)           \
-  if (cond) {                                                                \
-    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_full,    \
-                              rank)                                          \
-  } else {                                                                   \
-    KOKKOS_IMPL_LOOP_LAYOUT_8(func, type, is_left, m_offset, extent_partial, \
-                              rank)                                          \
-  }
-
 // parallel_reduce, non-tagged
 // Reduction version
 #define KOKKOS_IMPL_APPLY_REDUX(val, func, ...) func(__VA_ARGS__, val);
@@ -596,305 +319,301 @@ namespace Impl {
     KOKKOS_IMPL_LOOP_LAYOUT_8_REDUX(val, func, type, is_left, m_offset,      \
                                     extent_partial, rank)                    \
   }
-// end New Loop Macros
 
-// tagged macros
-#define KOKKOS_IMPL_TAGGED_APPLY(tag, func, ...) func(tag, __VA_ARGS__);
+// parallel_for macros: combine tagged and non-tagged
+
+#define KOKKOS_IMPL_APPLY(tag, func, ...) \
+  if constexpr (std::is_void_v<tag>)      \
+    func(__VA_ARGS__);                    \
+  else                                    \
+    func(tag{}, __VA_ARGS__);
 
 // LayoutRight
 // d = 0 to start
-#define KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d, ...) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, __VA_ARGS__, i0 + m_offset[d])         \
+#define KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                           \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {    \
+    KOKKOS_IMPL_APPLY(tag, func, __VA_ARGS__, i0 + m_offset[d])         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d, ...) \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i1 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {    \
+    KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i1 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d, ...) \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i2 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {    \
+    KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i2 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d, ...) \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i3 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {    \
+    KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i3 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d, ...) \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i4 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {    \
+    KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i4 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d, ...) \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i5 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {    \
+    KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i5 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d, ...) \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i6 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {    \
+    KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i6 + m_offset[d])                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_R_8(tag, func, type, m_offset, extent, d, ...) \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, d + 1,      \
-                                __VA_ARGS__, i7 + m_offset[d])                 \
+#define KOKKOS_IMPL_LOOP_R_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {    \
+    KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, d + 1,      \
+                         __VA_ARGS__, i7 + m_offset[d])                 \
   }
 
 // LayoutLeft
 // d = rank-1 to start
-#define KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d, ...) \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                  \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {           \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[d], __VA_ARGS__)         \
+#define KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, d, ...) \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                           \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[d]); ++i0) {    \
+    KOKKOS_IMPL_APPLY(tag, func, i0 + m_offset[d], __VA_ARGS__)         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d, ...) \
-  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, d - 1,      \
-                                i1 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, d, ...) \
+  for (type i1 = (type)0; i1 < static_cast<type>(extent[d]); ++i1) {    \
+    KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, d - 1,      \
+                         i1 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d, ...) \
-  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, d - 1,      \
-                                i2 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, d, ...) \
+  for (type i2 = (type)0; i2 < static_cast<type>(extent[d]); ++i2) {    \
+    KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, d - 1,      \
+                         i2 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d, ...) \
-  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, d - 1,      \
-                                i3 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, d, ...) \
+  for (type i3 = (type)0; i3 < static_cast<type>(extent[d]); ++i3) {    \
+    KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, d - 1,      \
+                         i3 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d, ...) \
-  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, d - 1,      \
-                                i4 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, d, ...) \
+  for (type i4 = (type)0; i4 < static_cast<type>(extent[d]); ++i4) {    \
+    KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, d - 1,      \
+                         i4 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d, ...) \
-  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, d - 1,      \
-                                i5 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, d, ...) \
+  for (type i5 = (type)0; i5 < static_cast<type>(extent[d]); ++i5) {    \
+    KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, d - 1,      \
+                         i5 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d, ...) \
-  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, d - 1,      \
-                                i6 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, d, ...) \
+  for (type i6 = (type)0; i6 < static_cast<type>(extent[d]); ++i6) {    \
+    KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, d - 1,      \
+                         i6 + m_offset[d], __VA_ARGS__)                 \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_L_8(tag, func, type, m_offset, extent, d, ...) \
-  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {           \
-    KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, d - 1,      \
-                                i7 + m_offset[d], __VA_ARGS__)                 \
+#define KOKKOS_IMPL_LOOP_L_8(tag, func, type, m_offset, extent, d, ...) \
+  for (type i7 = (type)0; i7 < static_cast<type>(extent[d]); ++i7) {    \
+    KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, d - 1,      \
+                         i7 + m_offset[d], __VA_ARGS__)                 \
   }
 
 // Left vs Right
 // TODO: rank not necessary to pass through, can hardcode the values
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, \
-                                         extent, rank)                       \
-  KOKKOS_ENABLE_IVDEP_MDRANGE                                                \
-  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {         \
-    KOKKOS_IMPL_TAGGED_APPLY(tag, func, i0 + m_offset[0])                    \
+#define KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  KOKKOS_ENABLE_IVDEP_MDRANGE                                                 \
+  for (type i0 = (type)0; i0 < static_cast<type>(extent[0]); ++i0) {          \
+    KOKKOS_IMPL_APPLY(tag, func, i0 + m_offset[0])                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_1(tag, func, type, m_offset, extent, rank - 2, \
-                                  i1 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_1(tag, func, type, m_offset, extent, 1,        \
-                                  i1 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[rank - 1]); ++i1) { \
+      KOKKOS_IMPL_LOOP_L_1(tag, func, type, m_offset, extent, rank - 2,       \
+                           i1 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i1 = (type)0; i1 < static_cast<type>(extent[0]); ++i1) {        \
+      KOKKOS_IMPL_LOOP_R_1(tag, func, type, m_offset, extent, 1,              \
+                           i1 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_2(tag, func, type, m_offset, extent, rank - 2, \
-                                  i2 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_2(tag, func, type, m_offset, extent, 1,        \
-                                  i2 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[rank - 1]); ++i2) { \
+      KOKKOS_IMPL_LOOP_L_2(tag, func, type, m_offset, extent, rank - 2,       \
+                           i2 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i2 = (type)0; i2 < static_cast<type>(extent[0]); ++i2) {        \
+      KOKKOS_IMPL_LOOP_R_2(tag, func, type, m_offset, extent, 1,              \
+                           i2 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_3(tag, func, type, m_offset, extent, rank - 2, \
-                                  i3 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_3(tag, func, type, m_offset, extent, 1,        \
-                                  i3 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[rank - 1]); ++i3) { \
+      KOKKOS_IMPL_LOOP_L_3(tag, func, type, m_offset, extent, rank - 2,       \
+                           i3 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i3 = (type)0; i3 < static_cast<type>(extent[0]); ++i3) {        \
+      KOKKOS_IMPL_LOOP_R_3(tag, func, type, m_offset, extent, 1,              \
+                           i3 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_4(tag, func, type, m_offset, extent, rank - 2, \
-                                  i4 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_4(tag, func, type, m_offset, extent, 1,        \
-                                  i4 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[rank - 1]); ++i4) { \
+      KOKKOS_IMPL_LOOP_L_4(tag, func, type, m_offset, extent, rank - 2,       \
+                           i4 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i4 = (type)0; i4 < static_cast<type>(extent[0]); ++i4) {        \
+      KOKKOS_IMPL_LOOP_R_4(tag, func, type, m_offset, extent, 1,              \
+                           i4 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_5(tag, func, type, m_offset, extent, rank - 2, \
-                                  i5 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_5(tag, func, type, m_offset, extent, 1,        \
-                                  i5 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[rank - 1]); ++i5) { \
+      KOKKOS_IMPL_LOOP_L_5(tag, func, type, m_offset, extent, rank - 2,       \
+                           i5 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i5 = (type)0; i5 < static_cast<type>(extent[0]); ++i5) {        \
+      KOKKOS_IMPL_LOOP_R_5(tag, func, type, m_offset, extent, 1,              \
+                           i5 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_6(tag, func, type, m_offset, extent, rank - 2, \
-                                  i6 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_6(tag, func, type, m_offset, extent, 1,        \
-                                  i6 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[rank - 1]); ++i6) { \
+      KOKKOS_IMPL_LOOP_L_6(tag, func, type, m_offset, extent, rank - 2,       \
+                           i6 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i6 = (type)0; i6 < static_cast<type>(extent[0]); ++i6) {        \
+      KOKKOS_IMPL_LOOP_R_6(tag, func, type, m_offset, extent, 1,              \
+                           i6 + m_offset[0])                                  \
+    }                                                                         \
   }
 
-#define KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,   \
-                                         extent, rank)                         \
-  if (is_left) {                                                               \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) {  \
-      KOKKOS_IMPL_TAGGED_LOOP_L_7(tag, func, type, m_offset, extent, rank - 2, \
-                                  i7 + m_offset[rank - 1])                     \
-    }                                                                          \
-  } else {                                                                     \
-    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {         \
-      KOKKOS_IMPL_TAGGED_LOOP_R_7(tag, func, type, m_offset, extent, 1,        \
-                                  i7 + m_offset[0])                            \
-    }                                                                          \
+#define KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset, extent, \
+                                  rank)                                       \
+  if (is_left) {                                                              \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[rank - 1]); ++i7) { \
+      KOKKOS_IMPL_LOOP_L_7(tag, func, type, m_offset, extent, rank - 2,       \
+                           i7 + m_offset[rank - 1])                           \
+    }                                                                         \
+  } else {                                                                    \
+    for (type i7 = (type)0; i7 < static_cast<type>(extent[0]); ++i7) {        \
+      KOKKOS_IMPL_LOOP_R_7(tag, func, type, m_offset, extent, 1,              \
+                           i7 + m_offset[0])                                  \
+    }                                                                         \
   }
 
 // Partial vs Full Tile
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_1(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_1(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_1(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_2(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_2(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_2(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_3(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_3(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_3(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_4(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_4(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_4(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_5(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_5(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_5(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_6(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_6(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_6(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_7(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_7(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_7(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
-#define KOKKOS_IMPL_TAGGED_TILE_LOOP_8(tag, func, type, is_left, cond,        \
-                                       m_offset, extent_full, extent_partial, \
-                                       rank)                                  \
-  if (cond) {                                                                 \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
-                                     extent_full, rank)                       \
-  } else {                                                                    \
-    KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,      \
-                                     extent_partial, rank)                    \
+#define KOKKOS_IMPL_TILE_LOOP_8(tag, func, type, is_left, cond, m_offset,      \
+                                extent_full, extent_partial, rank)             \
+  if (cond) {                                                                  \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset, extent_full, \
+                              rank)                                            \
+  } else {                                                                     \
+    KOKKOS_IMPL_LOOP_LAYOUT_8(tag, func, type, is_left, m_offset,              \
+                              extent_partial, rank)                            \
   }
 
 // parallel_reduce, tagged
@@ -1229,156 +948,26 @@ template <int Rank, bool IsLeft, typename IType, typename Tagged,
           typename Enable = void>
 struct Tile_Loop_Type;
 
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<1, IsLeft, IType, void, void> {
+template <bool IsLeft, typename IType, typename Tagged>
+struct Tile_Loop_Type<1, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_1(func, IType, IsLeft, cond, offset, a, b, 1);
+    KOKKOS_IMPL_TILE_LOOP_1(Tagged, func, IType, IsLeft, cond, offset, a, b, 1);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TILE_LOOP_1_REDUX(value, func, IType, IsLeft, cond, offset, a,
                                   b, 1);
   }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<2, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_2(func, IType, IsLeft, cond, offset, a, b, 2);
-  }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_2_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 2);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<3, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_3(func, IType, IsLeft, cond, offset, a, b, 3);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_3_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 3);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<4, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_4(func, IType, IsLeft, cond, offset, a, b, 4);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_4_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 4);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<5, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_5(func, IType, IsLeft, cond, offset, a, b, 5);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_5_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 5);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<6, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_6(func, IType, IsLeft, cond, offset, a, b, 6);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_6_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 6);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<7, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_7(func, IType, IsLeft, cond, offset, a, b, 7);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_7_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 7);
-  }
-};
-
-template <bool IsLeft, typename IType>
-struct Tile_Loop_Type<8, IsLeft, IType, void, void> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_8(func, IType, IsLeft, cond, offset, a, b, 8);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
-  static void apply(ValType& value, Func const& func, bool cond,
-                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TILE_LOOP_8_REDUX(value, func, IType, IsLeft, cond, offset, a,
-                                  b, 8);
-  }
-};
-
-// tagged versions
-
-template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
-  template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
-  static void apply(Func const& func, bool cond, Offset const& offset,
-                    ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_1(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 1);
-  }
-
-  template <typename ValType, typename Func, typename Offset, typename ExtentA,
-            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_1_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1387,17 +976,25 @@ struct Tile_Loop_Type<1, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<2, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_2(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 2);
+    KOKKOS_IMPL_TILE_LOOP_2(Tagged, func, IType, IsLeft, cond, offset, a, b, 2);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_2_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 2);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_2_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1406,17 +1003,25 @@ struct Tile_Loop_Type<2, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<3, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_3(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 3);
+    KOKKOS_IMPL_TILE_LOOP_3(Tagged, func, IType, IsLeft, cond, offset, a, b, 3);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_3_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 3);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_3_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1425,17 +1030,25 @@ struct Tile_Loop_Type<3, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<4, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_4(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 4);
+    KOKKOS_IMPL_TILE_LOOP_4(Tagged, func, IType, IsLeft, cond, offset, a, b, 4);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_4_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 4);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_4_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1444,17 +1057,25 @@ struct Tile_Loop_Type<4, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<5, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_5(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 5);
+    KOKKOS_IMPL_TILE_LOOP_5(Tagged, func, IType, IsLeft, cond, offset, a, b, 5);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_5_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 5);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_5_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1463,17 +1084,25 @@ struct Tile_Loop_Type<5, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<6, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_6(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 6);
+    KOKKOS_IMPL_TILE_LOOP_6(Tagged, func, IType, IsLeft, cond, offset, a, b, 6);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_6_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 6);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_6_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1482,17 +1111,25 @@ struct Tile_Loop_Type<6, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<7, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_7(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 7);
+    KOKKOS_IMPL_TILE_LOOP_7(Tagged, func, IType, IsLeft, cond, offset, a, b, 7);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_7_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 7);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_7_REDUX(value, Tagged(), func, IType, IsLeft,
@@ -1501,23 +1138,32 @@ struct Tile_Loop_Type<7, IsLeft, IType, Tagged,
 };
 
 template <bool IsLeft, typename IType, typename Tagged>
-struct Tile_Loop_Type<8, IsLeft, IType, Tagged,
-                      std::enable_if_t<!std::is_void_v<Tagged>>> {
+struct Tile_Loop_Type<8, IsLeft, IType, Tagged> {
   template <typename Func, typename Offset, typename ExtentA, typename ExtentB>
   static void apply(Func const& func, bool cond, Offset const& offset,
                     ExtentA const& a, ExtentB const& b) {
-    KOKKOS_IMPL_TAGGED_TILE_LOOP_8(Tagged(), func, IType, IsLeft, cond, offset,
-                                   a, b, 8);
+    KOKKOS_IMPL_TILE_LOOP_8(Tagged, func, IType, IsLeft, cond, offset, a, b, 8);
   }
 
   template <typename ValType, typename Func, typename Offset, typename ExtentA,
             typename ExtentB>
+    requires(std::is_void_v<Tagged>)
+  static void apply(ValType& value, Func const& func, bool cond,
+                    Offset const& offset, ExtentA const& a, ExtentB const& b) {
+    KOKKOS_IMPL_TILE_LOOP_8_REDUX(value, func, IType, IsLeft, cond, offset, a,
+                                  b, 8);
+  }
+
+  template <typename ValType, typename Func, typename Offset, typename ExtentA,
+            typename ExtentB>
+    requires(!std::is_void_v<Tagged>)
   static void apply(ValType& value, Func const& func, bool cond,
                     Offset const& offset, ExtentA const& a, ExtentB const& b) {
     KOKKOS_IMPL_TAGGED_TILE_LOOP_8_REDUX(value, Tagged(), func, IType, IsLeft,
                                          cond, offset, a, b, 8);
   }
 };
+
 // end Structs for calling loops
 
 template <typename RP, typename Functor, typename Tag, typename ReferenceType>
@@ -1693,39 +1339,6 @@ struct HostIterateTile {
 #undef KOKKOS_IMPL_TILE_LOOP_6_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_7_REDUX
 #undef KOKKOS_IMPL_TILE_LOOP_8_REDUX
-#undef KOKKOS_IMPL_TAGGED_APPLY
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_R_8
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_L_8
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_1
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_2
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_3
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_4
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_5
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_6
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_7
-#undef KOKKOS_IMPL_TAGGED_LOOP_LAYOUT_8
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_1
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_2
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_3
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_4
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_5
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_6
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_7
-#undef KOKKOS_IMPL_TAGGED_TILE_LOOP_8
 #undef KOKKOS_IMPL_TAGGED_APPLY_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_1_REDUX
 #undef KOKKOS_IMPL_TAGGED_LOOP_R_2_REDUX

--- a/core/src/impl/KokkosExp_Host_IterateTile.hpp
+++ b/core/src/impl/KokkosExp_Host_IterateTile.hpp
@@ -944,8 +944,7 @@ namespace Impl {
 // end tagged macros
 
 // Structs for calling loops
-template <int Rank, bool IsLeft, typename IType, typename Tagged,
-          typename Enable = void>
+template <int Rank, bool IsLeft, typename IType, typename Tagged>
 struct Tile_Loop_Type;
 
 template <bool IsLeft, typename IType, typename Tagged>


### PR DESCRIPTION
In `core/src/impl/KokkosExp_Host_IterateTile.hpp`, there is a macros based approach to generate the nested for loops that execute a tile in host backends.

The user-defined kernel can be either tagged or untagged. So far, each of these cases have been handled by a separate set of macros. There is a lot of commanility between the two sets of macros. This PR attempts to have only one set of macros and handle the two different calls to the user-defined kernel with an `if constexpr` in the inner-most loop.

There is no performance regression observed so far.

The following numbers where obtained on an AMD EPYC 9654 CPU.

The following two are for the OpenMP backend with 8 threads and `OMP_PROC_BIND=close` and `OMP_PLACES=cores`.

[STREAM benchmark](https://github.com/kokkos/kokkos/pull/9509#issuecomment-5543078180).

[Stencil benchmark](https://github.com/kokkos/kokkos/pull/9509#issuecomment-5543095187).

The following are for Serial backend.

[Trilinos/packages/intrepid2/perf-test/Sierra/Intrepid2_SierraGradProjection.exe](https://github.com/kokkos/kokkos/pull/9509#issuecomment-5543151641)

Also, please, refer to [this result](https://github.com/kokkos/kokkos/pull/9296#issuecomment-5530296125) obtained by @tcclevenger for the same Intrepid-2 perf-test run on Eclipse.

Changes have been made for `parallel_for` alone so far. Similar changes (and reduction in code size) will be done for `parallel_reduce`, once we are sure that these changes don't cause performance regression for downstream users.

### Related issues / PRs

[9296](https://github.com/kokkos/kokkos/pull/9296)

### Changelog Entry
  - Unsure

### Documentation PR
  - Unsure