### PR TITLE
modules: export FunctorPatternInterface, don't include in TestFuntorAnalysis

### DIFF
--- a/core/src/Kokkos_Core_Impl.cppm
+++ b/core/src/Kokkos_Core_Impl.cppm
@@ -97,6 +97,7 @@ export {
   // miscellaneous
   namespace Impl {
   using ::Kokkos::Impl::FunctorAnalysis;
+  using ::Kokkos::Impl::FunctorPatternInterface;
   using ::Kokkos::Impl::integral_constant;
   using ::Kokkos::Impl::python_view_type_impl_t;
   using ::Kokkos::Impl::throw_runtime_exception;

--- a/core/unit_test/TestFunctorAnalysis.hpp
+++ b/core/unit_test/TestFunctorAnalysis.hpp
@@ -11,9 +11,9 @@ import kokkos.core;
 import kokkos.core_impl;
 #else
 #include <Kokkos_Core.hpp>
-#endif
 
 #include <impl/Kokkos_FunctorAnalysis.hpp>
+#endif
 
 /*--------------------------------------------------------------------------*/
 


### PR DESCRIPTION
#9510 added `#include <Kokkos_Concepts.hpp>` to `impl/Kokkos_FunctorAnalysis.hpp`

Add `FunctorPatternInterface` to the impl module rather than doing the `#include`