### PR TITLE
Vendor mdspan through FetchContent

### DIFF
--- a/.github/workflows/mdspan-version-check.yml
+++ b/.github/workflows/mdspan-version-check.yml
@@ -21,6 +21,19 @@ jobs:
         ref: ${{ env.ref }}
         path: kokkos-mdspan
     - run: |
-        rm kokkos-mdspan/include/experimental/mdarray
-        rm kokkos-mdspan/include/experimental/mdspan
-        diff --unified=3 --recursive tpls/mdspan/include kokkos-mdspan/include
+        diff --unified=3 --recursive \
+          --exclude=.clang-tidy \
+          --exclude=.git \
+          --exclude=.github \
+          --exclude=.gitignore \
+          --exclude=benchmarks \
+          --exclude=comp_bench \
+          --exclude=compilation_tests \
+          --exclude=examples \
+          --exclude=LICENSE_FILE_HEADER \
+          --exclude=make_single_header.py \
+          --exclude=metabench.cmake \
+          --exclude=README.md \
+          --exclude=scripts \
+          --exclude=tests \
+          tpls/mdspan kokkos-mdspan

--- a/cmake/kokkos_tpls.cmake
+++ b/cmake/kokkos_tpls.cmake
@@ -79,6 +79,30 @@ endif()
 if(Kokkos_ENABLE_MDSPAN_EXTERNAL)
   find_package(mdspan REQUIRED)
   kokkos_export_cmake_tpl(mdspan REQUIRED)
+else()
+  include(FetchContent)
+
+  FetchContent_Declare(mdspan SOURCE_DIR ${KOKKOS_SOURCE_DIR}/tpls/mdspan)
+  set(MDSPAN_CXX_STANDARD ${KOKKOS_CXX_STANDARD})
+  # FIXME CPMP016 was introduced in CMake version 3.21
+  if(DEFINED CMAKE_POLICY_DEFAULT_CMP0126)
+    set(KOKKOS_MDSPAN_CMP0126_DEFAULT "${CMAKE_POLICY_DEFAULT_CMP0126}")
+  endif()
+  set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+  FetchContent_MakeAvailable(mdspan)
+  if(DEFINED KOKKOS_MDSPAN_CMP0126_DEFAULT)
+    set(CMAKE_POLICY_DEFAULT_CMP0126 "${KOKKOS_MDSPAN_CMP0126_DEFAULT}")
+    unset(KOKKOS_MDSPAN_CMP0126_DEFAULT)
+  else()
+    unset(CMAKE_POLICY_DEFAULT_CMP0126)
+  endif()
+
+  # Treat the bundled mdspan headers as system headers for Kokkos consumers.
+  get_target_property(KOKKOS_MDSPAN_INCLUDE_DIRECTORIES mdspan INTERFACE_INCLUDE_DIRECTORIES)
+  set_property(
+    TARGET mdspan APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${KOKKOS_MDSPAN_INCLUDE_DIRECTORIES}"
+  )
+  kokkos_export_imported_tpl(mdspan)
 endif()
 
 if(Kokkos_ENABLE_OPENMP)

--- a/cmake/kokkos_tpls.cmake
+++ b/cmake/kokkos_tpls.cmake
@@ -102,7 +102,8 @@ else()
   set_property(
     TARGET mdspan APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${KOKKOS_MDSPAN_INCLUDE_DIRECTORIES}"
   )
-  kokkos_export_imported_tpl(mdspan)
+  kokkos_create_imported_tpl(MDSPAN INTERFACE LINK_LIBRARIES mdspan::mdpsan)
+  kokkos_export_cmake_tpl(mdspan REQUIRED)
 endif()
 
 if(Kokkos_ENABLE_OPENMP)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -152,25 +152,12 @@ endif()
 if(Kokkos_ENABLE_MDSPAN_EXTERNAL)
   global_set(KOKKOS_MDSPAN_VERSION "unknown")
   message(STATUS "Using external mdspan")
-  target_link_libraries(kokkoscore PUBLIC mdspan::mdspan)
 else()
-  target_include_directories(kokkoscore SYSTEM PUBLIC $<BUILD_INTERFACE:${KOKKOS_SOURCE_DIR}/tpls/mdspan/include>)
-
-  append_glob(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/experimental/__p0009_bits/*.hpp)
-  append_glob(KOKKOS_CORE_HEADERS ${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/experimental/mdspan)
-
-  install(
-    DIRECTORY "${KOKKOS_SOURCE_DIR}/tpls/mdspan/include/"
-    DESTINATION ${KOKKOS_HEADER_DIR}
-    FILES_MATCHING
-    PATTERN "mdspan"
-    PATTERN "*.hpp"
-  )
-
   file(STRINGS "${KOKKOS_SOURCE_DIR}/tpls/mdspan-hash.txt" KOKKOS_MDSPAN_HASH)
   global_set(KOKKOS_MDSPAN_VERSION "${KOKKOS_MDSPAN_HASH}")
   message(STATUS "Using bundled mdspan copy (kokkos/mdspan@${KOKKOS_MDSPAN_HASH})")
 endif()
+target_link_libraries(kokkoscore PUBLIC mdspan::mdspan)
 
 kokkos_link_tpl(kokkoscore PUBLIC HWLOC)
 kokkos_link_tpl(kokkoscore PUBLIC CUDA)

--- a/tpls/mdspan/CMakeLists.txt
+++ b/tpls/mdspan/CMakeLists.txt
@@ -1,0 +1,226 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(MDSpan
+  VERSION 0.6.0
+  LANGUAGES CXX
+)
+
+include(GNUInstallDirs)
+
+################################################################################
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+################################################################################
+
+option(MDSPAN_ENABLE_TESTS "Enable tests." Off)
+option(MDSPAN_ENABLE_EXAMPLES "Build examples." Off)
+option(MDSPAN_ENABLE_BENCHMARKS "Enable benchmarks." Off)
+option(MDSPAN_ENABLE_COMP_BENCH "Enable compilation benchmarks." Off)
+option(MDSPAN_ENABLE_CUDA "Enable Cuda tests/benchmarks/examples if tests/benchmarks/examples are enabled." Off)
+option(MDSPAN_ENABLE_SYCL "Enable SYCL tests/benchmarks/examples if tests/benchmarks/examples are enabled." Off)
+option(MDSPAN_ENABLE_HIP "Enable HIP tests/benchmarks/examples if tests/benchmarks/examples are enabled." Off)
+option(MDSPAN_ENABLE_OPENMP "Enable OpenMP benchmarks if benchmarks are enabled." On)
+option(MDSPAN_USE_SYSTEM_GTEST "Use system-installed GoogleTest library for tests." Off)
+option(MDSPAN_USE_SYSTEM_BENCHMARK "Use system-installed Google Benchmark library for benchmarks." On)
+option(MDSPAN_INSTALL_STDMODE_HEADERS "Whether to install headers to emulate standard library headers and namespaces" Off)
+option(MDSPAN_GENERATE_STD_NAMESPACE_TARGETS "Whether to generate and install targets with the std:: namespace instead of the mdspan:: namespace" Off)
+
+# Option to override which C++ standard to use
+set(MDSPAN_CXX_STANDARD DETECT CACHE STRING "Override the default CXX_STANDARD to compile with.")
+set_property(CACHE MDSPAN_CXX_STANDARD PROPERTY STRINGS DETECT 14 17 20 23 26)
+
+option(MDSPAN_ENABLE_CONCEPTS "Try to enable concepts support by giving extra flags." On)
+
+option(MDSPAN_IMPL_ENABLE_P3663 "Enable implementation of P3663 (Future-proof submdspan_mapping)." On)
+
+################################################################################
+
+# Decide on the standard to use
+if(MDSPAN_CXX_STANDARD STREQUAL "17")
+  if("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++17 standard")
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"17\" not supported by provided C++ compiler")
+  endif()
+elseif(MDSPAN_CXX_STANDARD STREQUAL "14")
+  if("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++14 standard")
+    set(CMAKE_CXX_STANDARD 14)
+  else()
+    message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"14\" not supported by provided C++ compiler")
+  endif()
+elseif(MDSPAN_CXX_STANDARD STREQUAL "20")
+  if("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++20 standard")
+    set(CMAKE_CXX_STANDARD 20)
+  else()
+    message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"20\" not supported by provided C++ compiler")
+  endif()
+elseif(MDSPAN_CXX_STANDARD STREQUAL "23")
+  if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++23 standard")
+    set(CMAKE_CXX_STANDARD 23)
+  else()
+    message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"23\" not supported by provided C++ compiler")
+  endif()
+elseif(MDSPAN_CXX_STANDARD STREQUAL "26")
+  if("cxx_std_26" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++26 standard")
+    set(CMAKE_CXX_STANDARD 26)
+  else()
+    message(WARNING "Requested MDSPAN_CXX_STANDARD \"26\" not supported by provided C++ compiler")
+  endif()
+else()
+  if("cxx_std_26" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 26)
+    message(STATUS "Detected support for C++26 standard")
+  elseif("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 23)
+    message(STATUS "Detected support for C++23 standard")
+  elseif("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 20)
+    message(STATUS "Detected support for C++20 standard")
+  elseif("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 17)
+    message(STATUS "Detected support for C++17 standard")
+  elseif("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 14)
+    message(STATUS "Detected support for C++14 standard")
+  else()
+    message(FATAL_ERROR "Cannot detect CXX_STANDARD of C++14 or newer.")
+  endif()
+endif()
+
+################################################################################
+
+if(MDSPAN_ENABLE_CUDA)
+  include(CheckLanguage)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    message(STATUS "Using ${CMAKE_CXX_STANDARD} as CMAKE_CUDA_STANDARD")
+    set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    enable_language(CUDA)
+  else()
+    message(FATAL_ERROR "Requested CUDA support, but no CMAKE_CUDA_COMPILER available")
+  endif()
+  if(MDSPAN_ENABLE_TESTS)
+    set(MDSPAN_TEST_LANGUAGE CUDA)
+  endif()
+endif()
+
+if(MDSPAN_ENABLE_HIP)
+  include(CheckLanguage)
+  check_language(HIP)
+  if(CMAKE_HIP_COMPILER)
+    message(STATUS "Using ${CMAKE_CXX_STANDARD} as CMAKE_HIP_STANDARD")
+    set(CMAKE_HIP_STANDARD ${CMAKE_CXX_STANDARD})
+    set(CMAKE_HIP_STANDARD_REQUIRED ON)
+    enable_language(HIP)
+  else()
+    message(FATAL_ERROR "Requested HIP support, but no CMAKE_HIP_COMPILER available")
+  endif()
+  if(MDSPAN_ENABLE_TESTS)
+    set(MDSPAN_TEST_LANGUAGE HIP)
+  endif()
+endif()
+
+################################################################################
+
+add_library(mdspan INTERFACE)
+add_library(mdspan::mdspan ALIAS mdspan)
+if (MDSPAN_GENERATE_STD_NAMESPACE_TARGETS)
+  add_library(std::mdspan ALIAS mdspan)
+endif()
+
+if(MDSPAN_ENABLE_SYCL)
+  target_compile_options(mdspan INTERFACE "-fsycl")
+  target_link_options(mdspan INTERFACE "-fsycl")
+endif()
+
+target_include_directories(mdspan INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+################################################################################
+
+install(TARGETS mdspan EXPORT mdspanTargets
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT mdspanTargets
+    FILE mdspanTargets.cmake
+    NAMESPACE mdspan::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mdspan
+)
+
+export(TARGETS mdspan
+    NAMESPACE mdspan::
+    FILE mdspanTargets.cmake
+)
+
+if (MDSPAN_GENERATE_STD_NAMESPACE_TARGETS)
+  install(TARGETS mdspan EXPORT mdspanStdTargets
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+  install(EXPORT mdspanStdTargets
+      FILE mdspanStdTargets.cmake
+      NAMESPACE std::
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mdspan
+  )
+
+  export(TARGETS mdspan
+      NAMESPACE std::
+      FILE mdspanStdTargets.cmake
+  )
+endif()
+
+install(DIRECTORY include/mdspan DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (MDSPAN_INSTALL_STDMODE_HEADERS)
+  install(DIRECTORY include/experimental DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+else()
+  install(DIRECTORY include/experimental DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+          REGEX "/mdspan$|/mdarray$" EXCLUDE)
+endif()
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/mdspanConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/mdspanConfig.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mdspan
+)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/mdspanConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+  ARCH_INDEPENDENT
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mdspanConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/mdspanConfigVersion.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mdspan
+)
+
+################################################################################
+
+if(MDSPAN_ENABLE_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+  add_subdirectory(compilation_tests)
+endif()
+
+if(MDSPAN_ENABLE_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+if(MDSPAN_ENABLE_BENCHMARKS)
+  if(NOT MDSPAN_CXX_STANDARD STREQUAL "14" AND NOT MDSPAN_CXX_STANDARD STREQUAL "23")
+    add_subdirectory(benchmarks)
+  else()
+    MESSAGE(FATAL_ERROR "Benchmarks are not available in C++14 or C++23 mode. Turn MDSPAN_ENABLE_BENCHMARKS OFF or use C++17 or C++20.")
+  endif()
+endif()
+
+if(MDSPAN_ENABLE_COMP_BENCH)
+  add_subdirectory(comp_bench)
+endif()

--- a/tpls/mdspan/LICENSE
+++ b/tpls/mdspan/LICENSE
@@ -1,0 +1,238 @@
+ ************************************************************************
+ 
+                        Kokkos v. 4.0
+       Copyright (2022) National Technology & Engineering
+               Solutions of Sandia, LLC (NTESS).
+ 
+ Under the terms of Contract DE-NA0003525 with NTESS,
+ the U.S. Government retains certain rights in this software.
+
+
+ ==============================================================================
+ Kokkos is under the Apache License v2.0 with LLVM Exceptions:
+ ==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS Apache 2.0
+
+ ---- LLVM Exceptions to the Apache 2.0 License ----
+
+ As an exception, if, as a result of your compiling your source code, portions
+ of this Software are embedded into an Object form of such source code, you
+ may redistribute such embedded portions in such Object form without complying
+ with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+ In addition, if you combine or link compiled forms of this Software with
+ software that is licensed under the GPLv2 ("Combined Software") and if a
+ court of competent jurisdiction determines that the patent provision (Section
+ 3), the indemnity provision (Section 9) or other Section of the License
+ conflicts with the conditions of the GPLv2, you may retroactively and
+ prospectively choose to deem waived or otherwise exclude such Section(s) of
+ the License, but only in their entirety and only with respect to the Combined
+ Software.
+
+ ==============================================================================
+ Software from third parties included in Kokkos:
+ ==============================================================================
+
+ Kokkos contains third party software which is under different license
+ terms. All such code will be identified clearly using at least one of two
+ mechanisms:
+ 1) It will be in a separate directory tree with its own `LICENSE.txt` or
+    `LICENSE` file at the top containing the specific license and restrictions
+    which apply to that software, or
+ 2) It will contain specific license and restriction terms at the top of every
+    file.
+
+
+ THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Questions? Contact: 
+   Christian R. Trott (crtrott@sandia.gov) and
+   Damien T. Lebrun-Grandie (lebrungrandt@ornl.gov)
+
+ ************************************************************************

--- a/tpls/mdspan/cmake/mdspanConfig.cmake.in
+++ b/tpls/mdspan/cmake/mdspanConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/mdspanTargets.cmake")
+
+if (@MDSPAN_GENERATE_STD_NAMESPACE_TARGETS@)
+  include("${CMAKE_CURRENT_LIST_DIR}/mdspanStdTargets.cmake")
+endif()

--- a/tpls/mdspan/include/experimental/mdarray
+++ b/tpls/mdspan/include/experimental/mdarray
@@ -1,0 +1,28 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#ifndef MDSPAN_IMPL_STANDARD_NAMESPACE
+  #define MDSPAN_IMPL_STANDARD_NAMESPACE std
+#endif
+
+#ifndef MDSPAN_IMPL_PROPOSED_NAMESPACE
+  #define MDSPAN_IMPL_PROPOSED_NAMESPACE experimental
+#endif
+
+#include "mdspan"
+#include "../mdspan/mdarray.hpp"

--- a/tpls/mdspan/include/experimental/mdspan
+++ b/tpls/mdspan/include/experimental/mdspan
@@ -1,0 +1,39 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#pragma once
+
+#ifndef MDSPAN_IMPL_STANDARD_NAMESPACE
+  #define MDSPAN_IMPL_STANDARD_NAMESPACE std
+#endif
+
+#ifndef MDSPAN_IMPL_PROPOSED_NAMESPACE
+  #define MDSPAN_IMPL_PROPOSED_NAMESPACE experimental
+#endif
+
+#include "../mdspan/mdspan.hpp"
+
+// backward compatibility import into experimental
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+  namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan;
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::layout_left;
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::layout_stride;
+    using ::MDSPAN_IMPL_STANDARD_NAMESPACE::default_accessor;
+  }
+}


### PR DESCRIPTION
Do not bypass kokkos/mdspan build system, to make bundled version no different from an external one.
In support of external mdspan with package managers.

Assisted-by: Codex:aws-gov.gpt-5.6-terra

<!-- Provide a short summary of the changes in this pull request. -->

### Related issues / PRs
kokkos/mdspan#469
<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->
Unsure (technically this is transparent to users but we should probably start talking about kokkos/mdspan being vendored with Kokkos Core)

### Documentation PR
<!--
If this PR requires documentation and you have a draft PR, add a link to the draft PR for it here. Otherwise choose one of the following to add:
  - Required
  - Not required
  - Unsure
-->
N/A
