### PR TITLE
CUDA: Increase grid size for MDRangePolicy reductions

### DIFF
--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -421,8 +421,9 @@ class ParallelReduce<CombinedFunctorReducerType,
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
       const auto cc = m_policy.space().concurrency() / block_size;
-      const dim3 grid(std::min(index_type(cc), index_type(nwork)), 1, 1);
-
+      const dim3 grid(
+          static_cast<uint32_t>(std::min(index_type(cc), index_type(nwork))), 1,
+          1);
       m_scratch_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
               m_policy.space(),

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -412,11 +412,6 @@ class ParallelReduce<CombinedFunctorReducerType,
       std::scoped_lock<std::mutex> scratch_buffers_lock(
           m_policy.space().impl_internal_space_instance()->m_mutexScratchSpace);
 
-      m_scratch_space =
-          reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
-              m_policy.space(),
-              m_functor_reducer.get_reducer().value_size() *
-                  block_size /* block_size == max block_count */));
       m_scratch_flags =
           cuda_internal_scratch_flags(m_policy.space(), sizeof(size_type));
       m_unified_space =
@@ -425,8 +420,13 @@ class ParallelReduce<CombinedFunctorReducerType,
 
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
-      // Required grid.x <= block.y
-      const dim3 grid(std::min(int(block.y), int(nwork)), 1, 1);
+      const auto cc = m_policy.space().concurrency() / block_size;
+      const dim3 grid(std::min(index_type(cc), index_type(nwork)), 1, 1);
+
+      m_scratch_space =
+          reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
+              m_policy.space(),
+              m_functor_reducer.get_reducer().value_size() * grid.x));
 
       // TODO @graph We need to effectively insert this in to the graph
       const int shmem =

--- a/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
+++ b/core/src/Cuda/Kokkos_Cuda_Parallel_MDRange.hpp
@@ -392,7 +392,7 @@ class ParallelReduce<CombinedFunctorReducerType,
   }
 
   inline void execute() {
-    const auto nwork = m_policy.m_num_tiles;
+    const index_type nwork = m_policy.m_num_tiles;
     if (nwork) {
       int block_size = m_policy.m_prod_tile_dims;
       // CONSTRAINT: Algorithm requires block_size >= product of tile dimensions
@@ -420,10 +420,9 @@ class ParallelReduce<CombinedFunctorReducerType,
 
       // REQUIRED ( 1 , N , 1 )
       const dim3 block(1, block_size, 1);
-      const auto cc = m_policy.space().concurrency() / block_size;
-      const dim3 grid(
-          static_cast<uint32_t>(std::min(index_type(cc), index_type(nwork))), 1,
-          1);
+      const int cc = m_policy.space().concurrency() / block_size;
+      const dim3 grid(static_cast<uint32_t>(std::min(index_type(cc), nwork)), 1,
+                      1);
       m_scratch_space =
           reinterpret_cast<word_size_type*>(cuda_internal_scratch_space(
               m_policy.space(),


### PR DESCRIPTION
<!-- Provide a short summary of the changes in this pull request. -->
Increase the grid size used for reductions with `MDRangePolicy` on the CUDA backend. This ports the same patch already applied to `RangePolicy` in #7823

Previously on NVIDIA H100:
  * `RangePolicy` typically uses 1056 blocks per grid `(num_SMs * 1024 / block_size)`.
  * `MDRangePolicy` uses 256 blocks per grid (equal to the block size).

### Related issues / PRs
Same patch applied to `RangePolicy` https://github.com/kokkos/kokkos/pull/7823

<!-- Link any related issues or PRs. -->

### Changelog Entry
<!--
If this PR would require a changelog entry, add one here, or choose one of the following to add:
  - Not required
  - Unsure
-->

### Documentation PR
  - Not required
