### PR TITLE
actually test atomics on float

### DIFF
--- a/core/unit_test/TestAtomicOperations_float.hpp
+++ b/core/unit_test/TestAtomicOperations_float.hpp
@@ -13,7 +13,7 @@ TEST(TEST_CATEGORY, atomic_operations_float) {
       // issues with division atomics still compile it though
       if (t != 5 || sizeof(void*) == 8) {
         ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
-                     double, TEST_EXECSPACE>(i, end - i + start, t)));
+                     float, TEST_EXECSPACE>(i, end - i + start, t)));
       }
   }
 }


### PR DESCRIPTION
in core/unit_test/TestAtomicOperations_double.hpp, we specialized the test struct on `double` instead of `float`.

I think this was probably a copy-paste error (or something like that) in #6435.