### PR TITLE
Push OLCF and ALCF benchmark results

### DIFF
--- a/.gitlab/alcf-gitlab-ci.yml
+++ b/.gitlab/alcf-gitlab-ci.yml
@@ -12,7 +12,7 @@ Polaris:
     - module load PrgEnv-gnu
     - module load spack-pe-base
     - module load cmake
-    - module load cudatoolkit-standalone/12.8.1
+    - module load cudatoolkit-standalone/13.0.1
     - module list
     - export CMAKE_BUILD_PARALLEL_LEVEL=48
     - export ENV_CMAKE_OPTIONS=""
@@ -20,8 +20,9 @@ Polaris:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_VERBOSE_MAKEFILE=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Werror=all-warnings -Werror'"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_AMPERE80=ON"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_CUDA=ON;"
-    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON;"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_BENCHMARKS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_CUDA=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - ctest -VV
         -D CDASH_MODEL=Nightly
@@ -30,6 +31,14 @@ Polaris:
         -S scripts/CTestRun.cmake
         -D CTEST_SITE="gitlab-ci.alcf.anl.gov"
         -D CTEST_BUILD_NAME="Polaris-A100"
+    - git clone https://github.com/kokkos/kokkos-benchmark-results.git
+    - mkdir -p kokkos-benchmark-results/Polaris
+    - find build/core/perf_test/ build/algorithms/perf_test/ build/simd/perf_tests/ -name "*.json" -exec mv {} kokkos-benchmark-results/Polaris/ \;
+    - cd kokkos-benchmark-results
+    - git add Polaris/*
+    - git commit -m "Polaris performance run"
+    - git status
+    - git push https://"$GH_BENCHMARK_PAT"@github.com/kokkos/kokkos-benchmark-results.git
   artifacts:
     when: always
     paths:
@@ -55,6 +64,7 @@ Aurora:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_SYCL=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_INTEL_PVC=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ARCH_NATIVE=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_BENCHMARKS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D Kokkos_ENABLE_TESTS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-D CMAKE_CXX_FLAGS='-Wno-zero-length-array -Wno-pass-failed -fp-model=precise'"
     - ctest -VV
@@ -64,6 +74,14 @@ Aurora:
         -S scripts/CTestRun.cmake
         -D CTEST_SITE="gitlab-ci.alcf.anl.gov"
         -D CTEST_BUILD_NAME="INTEL-DATA-CENTER-MAX-1550"
+    - git clone https://github.com/kokkos/kokkos-benchmark-results.git
+    - mkdir -p kokkos-benchmark-results/Aurora
+    - find build/core/perf_test/ build/algorithms/perf_test/ build/simd/perf_tests/ -name "*.json" -exec mv {} kokkos-benchmark-results/Aurora/ \;
+    - cd kokkos-benchmark-results
+    - git add Aurora/*
+    - git commit -m "Aurora performance run"
+    - git status
+    - git push https://"$GH_BENCHMARK_PAT"@github.com/kokkos/kokkos-benchmark-results.git
   artifacts:
     when: always
     paths:

--- a/.gitlab/olcf-gitlab-ci.yml
+++ b/.gitlab/olcf-gitlab-ci.yml
@@ -21,7 +21,16 @@ hipcc:
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_HIP=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_COMPILER_WARNINGS=ON"
     - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_TESTS=ON"
+    - export ENV_CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS};-DKokkos_ENABLE_BENCHMARKS=ON"
     - ctest -VV -E Kokkos_CoreUnitTest_DeviceAndThreads -D CDASH_MODEL="Nightly" -D CMAKE_OPTIONS="${ENV_CMAKE_OPTIONS}" -S scripts/CTestRun.cmake -D CTEST_SITE="frontier" -D CTEST_BUILD_NAME="hipcc-rocm/6.3.1"
+    - git clone https://github.com/kokkos/kokkos-benchmark-results.git
+    - mkdir -p kokkos-benchmark-results/Frontier
+    - find build/core/perf_test/ build/algorithms/perf_test/ build/simd/perf_tests/ -name "*.json" -exec mv {} kokkos-benchmark-results/Frontier/ \;
+    - cd kokkos-benchmark-results
+    - git add Frontier/*
+    - git commit -m "Frontier performance run"
+    - git status
+    - git push https://"$GH_BENCHMARK_PAT"@github.com/kokkos/kokkos-benchmark-results.git
 
 amdclang:
   stage: test


### PR DESCRIPTION
This pull request pushes Polaris, Aurora, and Frontier (only hipcc) benchmark results to https://github.com/kokkos/kokkos-benchmark-results. Test runs on all the relevant runners have already added some results in the respective directories.

The results can be viewed using warden at https://785a82b8-bde6-44f2-a269-01697306f102.plotly.app.

### Related issues / PRs

### Changelog Entry
- No

### Documentation PR
- No