### PR TITLE
Fixing issue_9511 for crayCC compiler and HIP targets - also works with amdclang++

### DIFF
--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -143,11 +143,27 @@ struct HIPReductionsFunctor<FunctorType, false> {
   {
     int const lane_id =
         (threadIdx.y * blockDim.x + threadIdx.x) % HIPTraits::WarpSize;
+// HIP added support for __syncwarp() in version 7.0
+#if HIP_VERSION_MAJOR >= 7
+    size_t mask =
+       width == HIPTraits::WarpSize
+           ? 0xffffffffffffffff
+           : ((1 << width) - 1)
+                 << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
+    __syncwarp(mask);
+#else
+    __syncthreads();
+#endif
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
       if (lane_id + delta < width && (lane_id % (delta * 2) == 0)) {
         functor.join(value, value + delta);
       }
     }
+#if HIP_VERSION_MAJOR >= 7
+    __syncwarp(mask);
+#else
+    __syncthreads();
+#endif
     *value = *(value - lane_id);
   }
 

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -146,10 +146,10 @@ struct HIPReductionsFunctor<FunctorType, false> {
 // HIP added support for __syncwarp() in version 7.0
 #if HIP_VERSION_MAJOR >= 7
     size_t mask =
-       width == HIPTraits::WarpSize
-           ? 0xffffffffffffffff
-           : ((1 << width) - 1)
-                 << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
+        width == HIPTraits::WarpSize
+            ? 0xffffffffffffffff
+            : ((1 << width) - 1)
+                  << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
     __syncwarp(mask);
 #else
     __syncthreads();

--- a/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
+++ b/core/src/HIP/Kokkos_HIP_ReduceScan.hpp
@@ -145,14 +145,17 @@ struct HIPReductionsFunctor<FunctorType, false> {
         (threadIdx.y * blockDim.x + threadIdx.x) % HIPTraits::WarpSize;
 // HIP added support for __syncwarp() in version 7.0
 #if HIP_VERSION_MAJOR >= 7
-    size_t mask =
+    unsigned long long mask =
         width == HIPTraits::WarpSize
-            ? 0xffffffffffffffff
-            : ((1 << width) - 1)
+            ? 0xffffffffffffffffULL
+            : ((1ULL << width) - 1ULL)
                   << ((threadIdx.y * blockDim.x + threadIdx.x) / width) * width;
     __syncwarp(mask);
 #else
-    __syncthreads();
+#if defined(__HIP_DEVICE_COMPILE__) && \
+    __has_builtin(__builtin_amdgcn_wave_barrier)
+    __builtin_amdgcn_wave_barrier();
+#endif
 #endif
     for (int delta = skip_vector ? blockDim.x : 1; delta < width; delta *= 2) {
       if (lane_id + delta < width && (lane_id % (delta * 2) == 0)) {
@@ -162,7 +165,10 @@ struct HIPReductionsFunctor<FunctorType, false> {
 #if HIP_VERSION_MAJOR >= 7
     __syncwarp(mask);
 #else
-    __syncthreads();
+#if defined(__HIP_DEVICE_COMPILE__) && \
+    __has_builtin(__builtin_amdgcn_wave_barrier)
+    __builtin_amdgcn_wave_barrier();
+#endif
 #endif
     *value = *(value - lane_id);
   }


### PR DESCRIPTION
Adding __syncwarp/thread for reductions to prevent correctness errors. ROCm 7 added support for __syncwarp, and this change matches what the CUDA implementation does.

### Related issues / PRs
#9511

### Changelog Entry
  - Unsure

### Documentation PR
  - Unsure
