### PR TITLE
accomodate 80-bit x87 reference in 32-bit atomic tests

### DIFF
--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -13,6 +13,7 @@ import kokkos.core;
 #include <desul/atomics.hpp>
 
 #include <iostream>
+#include <limits>
 
 namespace TestAtomicOperations {
 
@@ -323,7 +324,36 @@ struct DecModAtomicTest {
   static const char* name() { return "dec_mod"; }
 };
 
-template <class Op, class T, class ExecSpace>
+template <class T>
+KOKKOS_FUNCTION bool atomic_values_equal_2ulp(T actual, T expected) {
+  T next_up = Kokkos::nextafter(expected, std::numeric_limits<T>::infinity());
+  T next_down =
+      Kokkos::nextafter(expected, -std::numeric_limits<T>::infinity());
+  T next_next_up =
+      Kokkos::nextafter(next_up, std::numeric_limits<T>::infinity());
+  T next_next_down =
+      Kokkos::nextafter(next_down, -std::numeric_limits<T>::infinity());
+  return actual == expected || actual == next_up || actual == next_down ||
+         actual == next_next_up || actual == next_next_down;
+}
+
+template <class T>
+KOKKOS_FUNCTION bool atomic_values_equal_2ulp(Kokkos::complex<T> actual,
+                                              Kokkos::complex<T> expected) {
+  return atomic_values_equal_2ulp(actual.real(), expected.real()) &&
+         atomic_values_equal_2ulp(actual.imag(), expected.imag());
+}
+
+template <bool AllowTwoUlps, class T>
+KOKKOS_FUNCTION bool atomic_values_equal(T actual, T expected) {
+  if constexpr (AllowTwoUlps) {
+    return atomic_values_equal_2ulp(actual, expected);
+  } else {
+    return actual == expected;
+  }
+}
+
+template <class Op, class T, class ExecSpace, bool AllowTwoUlps = false>
 bool atomic_op_test(T old_val, T update) {
   Kokkos::View<T[3], ExecSpace> op_data("op_data");
   Kokkos::deep_copy(op_data, old_val);
@@ -335,11 +365,16 @@ bool atomic_op_test(T old_val, T update) {
             Op::atomic_op(&op_data(0), &op_data(1), &op_data(2), update);
         T expected_val = Op::op(old_val, update);
         Kokkos::memory_fence();
-        if (op_data(0) != expected_val) local_result += 1;
-        if (op_data(1) != expected_val) local_result += 2;
-        if (op_data(2) != expected_val) local_result += 4;
+        if (!atomic_values_equal<AllowTwoUlps>(op_data(0), expected_val))
+          local_result += 1;
+        if (!atomic_values_equal<AllowTwoUlps>(op_data(1), expected_val))
+          local_result += 2;
+        if (!atomic_values_equal<AllowTwoUlps>(op_data(2), expected_val))
+          local_result += 4;
         if (fetch_result.first != old_val) local_result += 8;
-        if (fetch_result.second != expected_val) local_result += 16;
+        if (!atomic_values_equal<AllowTwoUlps>(fetch_result.second,
+                                               expected_val))
+          local_result += 16;
       },
       result);
   if ((result & 1) != 0)
@@ -495,7 +530,7 @@ bool AtomicOperationsTestUnsignedIntegralType(int old_val_in, int update_in,
   return true;
 }
 
-template <class T, class ExecSpace>
+template <class T, class ExecSpace, bool AllowTwoUlps = false>
 bool AtomicOperationsTestNonIntegralType(int old_val_in, int update_in,
                                          int test) {
   T old_val = static_cast<T>(old_val_in);
@@ -517,7 +552,8 @@ bool AtomicOperationsTestNonIntegralType(int old_val_in, int update_in,
 #else
     case 5:
       return update != 0
-                 ? atomic_op_test<DivAtomicTest, T, ExecSpace>(old_val, update)
+                 ? atomic_op_test<DivAtomicTest, T, ExecSpace, AllowTwoUlps>(
+                       old_val, update)
                  : true;
 #endif
     case 6:

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -326,9 +326,9 @@ struct DecModAtomicTest {
 
 template <class T>
 KOKKOS_FUNCTION bool atomic_values_equal_1ulp(T actual, T expected) {
-  T next_up = Kokkos::nextafter(expected, std::numeric_limits<T>::infinity());
+  T next_up = Kokkos::nextafter(expected, Kokkos::infinity_v<T>);
   T next_down =
-      Kokkos::nextafter(expected, -std::numeric_limits<T>::infinity());
+      Kokkos::nextafter(expected, -Kokkos::infinity_v<T>);
   return actual == expected || actual == next_up || actual == next_down;
 }
 

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -326,9 +326,8 @@ struct DecModAtomicTest {
 
 template <class T>
 KOKKOS_FUNCTION bool atomic_values_equal_1ulp(T actual, T expected) {
-  T next_up = Kokkos::nextafter(expected, Kokkos::infinity_v<T>);
-  T next_down =
-      Kokkos::nextafter(expected, -Kokkos::infinity_v<T>);
+  T next_up   = Kokkos::nextafter(expected, Kokkos::infinity_v<T>);
+  T next_down = Kokkos::nextafter(expected, -Kokkos::infinity_v<T>);
   return actual == expected || actual == next_up || actual == next_down;
 }
 

--- a/core/unit_test/TestAtomicOperations.hpp
+++ b/core/unit_test/TestAtomicOperations.hpp
@@ -325,35 +325,30 @@ struct DecModAtomicTest {
 };
 
 template <class T>
-KOKKOS_FUNCTION bool atomic_values_equal_2ulp(T actual, T expected) {
+KOKKOS_FUNCTION bool atomic_values_equal_1ulp(T actual, T expected) {
   T next_up = Kokkos::nextafter(expected, std::numeric_limits<T>::infinity());
   T next_down =
       Kokkos::nextafter(expected, -std::numeric_limits<T>::infinity());
-  T next_next_up =
-      Kokkos::nextafter(next_up, std::numeric_limits<T>::infinity());
-  T next_next_down =
-      Kokkos::nextafter(next_down, -std::numeric_limits<T>::infinity());
-  return actual == expected || actual == next_up || actual == next_down ||
-         actual == next_next_up || actual == next_next_down;
+  return actual == expected || actual == next_up || actual == next_down;
 }
 
 template <class T>
-KOKKOS_FUNCTION bool atomic_values_equal_2ulp(Kokkos::complex<T> actual,
+KOKKOS_FUNCTION bool atomic_values_equal_1ulp(Kokkos::complex<T> actual,
                                               Kokkos::complex<T> expected) {
-  return atomic_values_equal_2ulp(actual.real(), expected.real()) &&
-         atomic_values_equal_2ulp(actual.imag(), expected.imag());
+  return atomic_values_equal_1ulp(actual.real(), expected.real()) &&
+         atomic_values_equal_1ulp(actual.imag(), expected.imag());
 }
 
-template <bool AllowTwoUlps, class T>
+template <bool AllowOneUlp, class T>
 KOKKOS_FUNCTION bool atomic_values_equal(T actual, T expected) {
-  if constexpr (AllowTwoUlps) {
-    return atomic_values_equal_2ulp(actual, expected);
+  if constexpr (AllowOneUlp) {
+    return atomic_values_equal_1ulp(actual, expected);
   } else {
     return actual == expected;
   }
 }
 
-template <class Op, class T, class ExecSpace, bool AllowTwoUlps = false>
+template <class Op, class T, class ExecSpace, bool AllowOneUlp = false>
 bool atomic_op_test(T old_val, T update) {
   Kokkos::View<T[3], ExecSpace> op_data("op_data");
   Kokkos::deep_copy(op_data, old_val);
@@ -365,15 +360,15 @@ bool atomic_op_test(T old_val, T update) {
             Op::atomic_op(&op_data(0), &op_data(1), &op_data(2), update);
         T expected_val = Op::op(old_val, update);
         Kokkos::memory_fence();
-        if (!atomic_values_equal<AllowTwoUlps>(op_data(0), expected_val))
+        if (!atomic_values_equal<AllowOneUlp>(op_data(0), expected_val))
           local_result += 1;
-        if (!atomic_values_equal<AllowTwoUlps>(op_data(1), expected_val))
+        if (!atomic_values_equal<AllowOneUlp>(op_data(1), expected_val))
           local_result += 2;
-        if (!atomic_values_equal<AllowTwoUlps>(op_data(2), expected_val))
+        if (!atomic_values_equal<AllowOneUlp>(op_data(2), expected_val))
           local_result += 4;
         if (fetch_result.first != old_val) local_result += 8;
-        if (!atomic_values_equal<AllowTwoUlps>(fetch_result.second,
-                                               expected_val))
+        if (!atomic_values_equal<AllowOneUlp>(fetch_result.second,
+                                              expected_val))
           local_result += 16;
       },
       result);
@@ -530,7 +525,7 @@ bool AtomicOperationsTestUnsignedIntegralType(int old_val_in, int update_in,
   return true;
 }
 
-template <class T, class ExecSpace, bool AllowTwoUlps = false>
+template <class T, class ExecSpace, bool AllowOneUlp = false>
 bool AtomicOperationsTestNonIntegralType(int old_val_in, int update_in,
                                          int test) {
   T old_val = static_cast<T>(old_val_in);
@@ -552,7 +547,7 @@ bool AtomicOperationsTestNonIntegralType(int old_val_in, int update_in,
 #else
     case 5:
       return update != 0
-                 ? atomic_op_test<DivAtomicTest, T, ExecSpace, AllowTwoUlps>(
+                 ? atomic_op_test<DivAtomicTest, T, ExecSpace, AllowOneUlp>(
                        old_val, update)
                  : true;
 #endif

--- a/core/unit_test/TestAtomicOperations_complexdouble.hpp
+++ b/core/unit_test/TestAtomicOperations_complexdouble.hpp
@@ -27,7 +27,7 @@ TEST(TEST_CATEGORY, atomic_operations_complexdouble) {
 
     if (sizeof(void*) == 4) {
       // 32-bit x86 may do reference division in 80-bit x87, so allow up to
-      // two ULPs.
+      // one ULP.
       ASSERT_TRUE((update != 0
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE, true>(
                              old_val, update)

--- a/core/unit_test/TestAtomicOperations_complexdouble.hpp
+++ b/core/unit_test/TestAtomicOperations_complexdouble.hpp
@@ -25,9 +25,14 @@ TEST(TEST_CATEGORY, atomic_operations_complexdouble) {
     ASSERT_TRUE(
         (atomic_op_test<MulAtomicTest, T, TEST_EXECSPACE>(old_val, update)));
 
-    // FIXME_32BIT disable division test for 32bit where we have accuracy issues
-    // with division atomics still compile it though
-    if (sizeof(void*) == 8) {
+    if (sizeof(void*) == 4) {
+      // 32-bit x86 may do reference division in 80-bit x87, so allow up to
+      // two ULPs.
+      ASSERT_TRUE((update != 0
+                       ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE, true>(
+                             old_val, update)
+                       : true));
+    } else {
       ASSERT_TRUE((update != 0
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE>(
                              old_val, update)

--- a/core/unit_test/TestAtomicOperations_complexfloat.hpp
+++ b/core/unit_test/TestAtomicOperations_complexfloat.hpp
@@ -20,9 +20,14 @@ TEST(TEST_CATEGORY, atomic_operations_complexfloat) {
     ASSERT_TRUE(
         (atomic_op_test<MulAtomicTest, T, TEST_EXECSPACE>(old_val, update)));
 
-    // FIXME_32BIT disable division test for 32bit where we have accuracy issues
-    // with division atomics still compile it though
-    if (sizeof(void*) == 8) {
+    if (sizeof(void*) == 4) {
+      // 32-bit x86 may do reference division in 80-bit x87, so allow up to
+      // two ULPs.
+      ASSERT_TRUE((update != 0
+                       ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE, true>(
+                             old_val, update)
+                       : true));
+    } else {
       ASSERT_TRUE((update != 0
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE>(
                              old_val, update)

--- a/core/unit_test/TestAtomicOperations_complexfloat.hpp
+++ b/core/unit_test/TestAtomicOperations_complexfloat.hpp
@@ -22,7 +22,7 @@ TEST(TEST_CATEGORY, atomic_operations_complexfloat) {
 
     if (sizeof(void*) == 4) {
       // 32-bit x86 may do reference division in 80-bit x87, so allow up to
-      // two ULPs.
+      // one ULP.
       ASSERT_TRUE((update != 0
                        ? atomic_op_test<DivAtomicTest, T, TEST_EXECSPACE, true>(
                              old_val, update)

--- a/core/unit_test/TestAtomicOperations_double.hpp
+++ b/core/unit_test/TestAtomicOperations_double.hpp
@@ -8,13 +8,17 @@ TEST(TEST_CATEGORY, atomic_operations_double) {
   const int start = -5;
   const int end   = 11;
   for (int i = start; i < end; ++i) {
-    for (int t = 0; t < 7; t++)
-      // FIXME_32BIT disable division test for 32bit where we have accuracy
-      // issues with division atomics still compile it though
-      if (t != 5 || sizeof(void*) == 8) {
+    for (int t = 0; t < 7; t++) {
+      if (t == 5 && sizeof(void*) == 4) {
+        // 32-bit x86 may do reference division in 80-bit x87, so allow up to
+        // two ULPs.
+        ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
+                     double, TEST_EXECSPACE, true>(i, end - i + start, t)));
+      } else {
         ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                      double, TEST_EXECSPACE>(i, end - i + start, t)));
       }
+    }
   }
 }
 }  // namespace Test

--- a/core/unit_test/TestAtomicOperations_double.hpp
+++ b/core/unit_test/TestAtomicOperations_double.hpp
@@ -11,7 +11,7 @@ TEST(TEST_CATEGORY, atomic_operations_double) {
     for (int t = 0; t < 7; t++) {
       if (t == 5 && sizeof(void*) == 4) {
         // 32-bit x86 may do reference division in 80-bit x87, so allow up to
-        // two ULPs.
+        // one ULP.
         ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                      double, TEST_EXECSPACE, true>(i, end - i + start, t)));
       } else {

--- a/core/unit_test/TestAtomicOperations_float.hpp
+++ b/core/unit_test/TestAtomicOperations_float.hpp
@@ -11,7 +11,7 @@ TEST(TEST_CATEGORY, atomic_operations_float) {
     for (int t = 0; t < 7; t++) {
       if (t == 5 && sizeof(void*) == 4) {
         // 32-bit x86 may do reference division in 80-bit x87, so allow up to
-        // two ULPs.
+        // one ULP.
         ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                      double, TEST_EXECSPACE, true>(i, end - i + start, t)));
       } else {

--- a/core/unit_test/TestAtomicOperations_float.hpp
+++ b/core/unit_test/TestAtomicOperations_float.hpp
@@ -8,13 +8,17 @@ TEST(TEST_CATEGORY, atomic_operations_float) {
   const int start = -5;
   const int end   = 11;
   for (int i = start; i < end; ++i) {
-    for (int t = 0; t < 7; t++)
-      // FIXME_32BIT disable division test for 32bit where we have accuracy
-      // issues with division atomics still compile it though
-      if (t != 5 || sizeof(void*) == 8) {
+    for (int t = 0; t < 7; t++) {
+      if (t == 5 && sizeof(void*) == 4) {
+        // 32-bit x86 may do reference division in 80-bit x87, so allow up to
+        // two ULPs.
+        ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
+                     double, TEST_EXECSPACE, true>(i, end - i + start, t)));
+      } else {
         ASSERT_TRUE((TestAtomicOperations::AtomicOperationsTestNonIntegralType<
                      double, TEST_EXECSPACE>(i, end - i + start, t)));
       }
+    }
   }
 }
 }  // namespace Test


### PR DESCRIPTION
In 32-bit builds, gcc defaults to `-mfpmath=387`, which lets the reference operations happen in 80-bit x87, while the atomics are stuck in 32 or 64 bit for `float` or `double`. Tolerate up to 2 ULP of difference in 32-bit x86 builds.